### PR TITLE
support tarball cassandra

### DIFF
--- a/jepsen/scalardb/src/scalardb/runner.clj
+++ b/jepsen/scalardb/src/scalardb/runner.clj
@@ -33,8 +33,7 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos? "Must be positive"]]
 
-   [nil "--cassandra VERSION" "C* version to use"
-    :default "3.11.3"]])
+   (jc/tarball-opt "http://www.us.apache.org/dist/cassandra/3.11.3/apache-cassandra-3.11.3-bin.tar.gz")])
 
 (defn test-cmd
    []


### PR DESCRIPTION
You can use any tarball cassandra for Jepsen testing

For example,

- local cassandra tarball
```
$ lein run test --test transfer --tarball file:///my/cassandra/cassandra.tar.gz
```

- other version
```
$ lein run test --test transfer --tarball http://archive.apache.org/dist/cassandra/3.11.1/apache-cassandra-3.11.1-bin.tar.gz
```