### PR TITLE
Fix the parsing error caused by the 3rd party parsing library update

### DIFF
--- a/tools/schema/internal/parser/parser.go
+++ b/tools/schema/internal/parser/parser.go
@@ -39,7 +39,7 @@ type Column struct {
 }
 
 func Parse(filePath *string) *Schema {
-	parser, err := participle.Build(&Schema{}, participle.UseLookahead())
+	parser, err := participle.Build(&Schema{})
 	kingpin.FatalIfError(err, "")
 	r, err := os.Open(*filePath)
 	kingpin.FatalIfError(err, "")


### PR DESCRIPTION
Remove the method to disambiguate the parsing input as it seems not necessary anymore with the participle version 0.2.0.