### PR TITLE
add compaction strategy

### DIFF
--- a/src/test/java/com/scalar/database/util/TransactionUtility.java
+++ b/src/test/java/com/scalar/database/util/TransactionUtility.java
@@ -108,7 +108,13 @@ public class TransactionUtility {
         .skipNulls()
         .join(
             new String[] {
-              "CREATE TABLE", namespace + "." + table, "(", strAttributes, ",", strPrimaryKey, ")",
+              "CREATE TABLE",
+              namespace + "." + table,
+              "(",
+              strAttributes,
+              ",",
+              strPrimaryKey,
+              ") WITH compaction = { 'class' : 'LeveledCompactionStrategy' }",
             });
   }
 


### PR DESCRIPTION
To become the performance of Scalar DB stable, I've changed the compaction strategy of a user table to LCS as default in `TransactionUtility.java`