### PR TITLE
a client reconnects to the cluster when many failures

### DIFF
--- a/jepsen/scalardb/project.clj
+++ b/jepsen/scalardb/project.clj
@@ -7,6 +7,6 @@
                  [jepsen "0.1.10-SNAPSHOT"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"]
-                 [com.scalar-labs/scalardb "1.0.0-rc1" :exclusions [org.slf4j/slf4j-log4j12]]]
+                 [com.scalar-labs/scalardb "1.0.0" :exclusions [org.slf4j/slf4j-log4j12]]]
   :main scalardb.runner
   :aot [scalardb.runner])

--- a/jepsen/scalardb/src/scalardb/runner.clj
+++ b/jepsen/scalardb/src/scalardb/runner.clj
@@ -33,7 +33,7 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos? "Must be positive"]]
 
-   (jc/tarball-opt "http://www.us.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz")])
+   (jc/tarball-opt "https://archive.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz")])
 
 (defn test-cmd
    []

--- a/jepsen/scalardb/src/scalardb/runner.clj
+++ b/jepsen/scalardb/src/scalardb/runner.clj
@@ -33,7 +33,7 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos? "Must be positive"]]
 
-   (jc/tarball-opt "http://www.us.apache.org/dist/cassandra/3.11.3/apache-cassandra-3.11.3-bin.tar.gz")])
+   (jc/tarball-opt "http://www.us.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz")])
 
 (defn test-cmd
    []

--- a/jepsen/scalardb/src/scalardb/transfer.clj
+++ b/jepsen/scalardb/src/scalardb/transfer.clj
@@ -190,10 +190,9 @@
                       (swap! (:unknown-tx test) conj (.getId tx))
                       (assoc op :type :fail :error {:unknown-tx-status (.getId tx)}))
                     (catch Exception e
-                      (swap! (:failures test) inc)
-                      (locking (:failures test)
-                        (when (compare-and-set! (:failures test) NUM_FAILURES_FOR_RECONNECTION 0)
-                          (scalar/prepare-transaction-service! test))) ; reconnect
+                      (when (= (swap! (:failures test) inc) NUM_FAILURES_FOR_RECONNECTION)
+                        (scalar/prepare-transaction-service! test)
+                        (reset! (:failures test) 0)) ; reconnect
                       (assoc op :type :fail :error (.getMessage e)))))
       :get-all  (if-let [results (get-balances-and-versions test (:num op))]
                   (assoc op :type :ok :value results)


### PR DESCRIPTION
Jepsen crash tests often failed because a client couldn't get the final balances due to disconnection to the cluster.

I've added reconnection when many failures happen.
- A client has DistributedStorageService and DistributedTransactionService
- After many failures, a client tries to reconnect to the cluster
- Close all connections at the end
