### PR TITLE
Remove perf and timeline for the checker to avoid OOM

### DIFF
--- a/jepsen/scalardb/src/scalardb/transfer.clj
+++ b/jepsen/scalardb/src/scalardb/transfer.clj
@@ -302,7 +302,5 @@
                                             (gen/clients (gen/once check-tx))
                                             (gen/clients (gen/once get-all)))
                                 :checker (checker/compose
-                                           {:perf    (checker/perf)
-                                            :timeline (timeline/html)
-                                            :details (consistency-checker)})})
+                                           {:details (consistency-checker)})})
          opts))


### PR DESCRIPTION
When a long test ran, the checker's timeline which made an HTML timeline of history failed due to OOM.
We haven't seen the HTML and perf for now.
So, I want to remove them.