### PR TITLE
Terminate nemesis before checking the state of the end

### DIFF
--- a/jepsen/scalardb/src/scalardb/transfer.clj
+++ b/jepsen/scalardb/src/scalardb/transfer.clj
@@ -135,6 +135,8 @@
 (defn read-all-with-retry
   "Read records from 0 .. (n - 1) and retry if needed"
   [test n]
+  (when (nil? (:transaction test))
+    (scalar/prepare-transaction-service! test))
   (loop [tries scalar/RETRIES]
     (when (< tries scalar/RETRIES)
       (scalar/exponential-backoff (- scalar/RETRIES tries)))
@@ -299,6 +301,7 @@
                                 :generator (gen/phases
                                             (->> [diff-transfer]
                                                  (conductors/std-gen opts))
+                                            (conductors/terminate-nemesis opts)
                                             (gen/clients (gen/once check-tx))
                                             (gen/clients (gen/once get-all)))
                                 :checker (checker/compose


### PR DESCRIPTION
When unknown transactions are checked and all records are read by a transaction for checking the consistency, it sometimes fails because nemesis is still working.

To avoid this issue, [`terminate-nemesis`](https://github.com/scalar-labs/jepsen/blob/d1a49b1d256366c2b4a717c143e5d0656bef5eea/cassandra/src/cassandra/conductors.clj#L101) is inserted. This function stops the current failure.

And, I want to add checking if the transaction service exists before reading all records.