### PR TITLE
New jepsen test

### DIFF
--- a/jepsen/scalardb/README.md
+++ b/jepsen/scalardb/README.md
@@ -18,31 +18,48 @@ $ cp -r ${SCALAR_DB_HOME}/jepsen/scalardb ${JEPSEN}/
 ```
 
 3. Start Jepsen with docker
-  - The script starts 5 nodes and a control node (jepsen-control)
 
-```
-$ cd ${JEPSEN}/docker
-$ ./up.sh
-```
+    Before you start docker you will need to edit the node ubuntu Dockerfile so that the `openjdk-8-jre` package is installed. That is, edit `${JEPSEN}/docker/node/Dockerfile-ubuntu` to look like
+    
+    ```docker
+    FROM       jacobmbr/ubuntu-jepsen:v0.1.0
+    
+    RUN rm /etc/apt/apt.conf.d/docker-clean && apt-get update
+    
+    # Install Jepsen dependencies
+    RUN apt-get install -y openssh-server \
+        curl faketime iproute2 iptables iputils-ping libzip4 \
+        logrotate man man-db net-tools ntpdate psmisc python rsyslog \
+        sudo unzip vim wget apt-transport-https \
+        openjdk-8-jre \
+        && apt-get remove -y --purge --auto-remove systemd
+    ```
+    
+    - Fire up docker. The script starts five nodes and a control node (jepsen-control)
 
-  - Login jepsen-control
+    ```
+    $ cd ${JEPSEN}/docker
+    $ ./up.sh --ubuntu
+    ```
 
-  ```
-  $ docker exec -it jepsen-control bash
-  ```
+    - Login to jepsen-control
 
-4. Install Cassandra test tool and Cassaforte (Clojure wrapper for Cassandra)
+    ```
+    $ docker exec -it jepsen-control bash
+    ```
+
+4. In jepsen-control install Cassaforte (Clojure wrapper for Cassandra) and the Cassandra test tool 
 
 ```
 # in jepsen-control
 
-# Cassandra test tool
-$ cd /jepsen/cassandra
-$ lein install
-
 # Cassaforte
 $ git clone -b driver-3.0-for-jepsen https://github.com/scalar-labs/cassaforte
 $ cd cassaforte
+$ lein install
+
+# Cassandra test tool
+$ cd /jepsen/cassandra
 $ lein install
 ```
 
@@ -63,4 +80,4 @@ $ cd /jepsen/scalardb
 $ lein run test --test transfer --nemesis crash --join decommission --time-limit 300
 ```
 
-  - Use `lein run test --help` to see a list of the full options
+Use `lein run test --help` to see a list of the full options

--- a/jepsen/scalardb/src/scalardb/runner.clj
+++ b/jepsen/scalardb/src/scalardb/runner.clj
@@ -7,11 +7,13 @@
              [core    :as cassandra]
              [runner  :as car]
              [nemesis :as can]]
-            [scalardb.transfer :as transfer]))
+            [scalardb.transfer]
+            [scalardb.transfer_append]))
 
 (def tests
   "A map of test names to test constructors."
-  {"transfer"   transfer/transfer-test})
+  {"transfer"        scalardb.transfer/transfer-test
+   "transfer_append" scalardb.transfer_append/transfer-append-test})
 
 (def opt-spec
   [(jc/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)

--- a/jepsen/scalardb/src/scalardb/transfer_append.clj
+++ b/jepsen/scalardb/src/scalardb/transfer_append.clj
@@ -1,0 +1,328 @@
+(ns scalardb.transfer_append
+  (:require [jepsen
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [tests :as tests]]
+            [jepsen.checker.timeline :as timeline]
+            [cassandra
+             [core :as c]
+             [conductors :as conductors]]
+            [clojurewerkz.cassaforte
+             [client :as drv]
+             [cql :as cql]
+             [policies :refer :all]
+             [query :refer :all]]
+            [clojure.tools.logging :refer [debug info warn]]
+            [clojure.core.reducers :as r]
+            [knossos.op :as op]
+            [scalardb.core :as scalar])
+  (:import (java.util ArrayList)
+           (com.scalar.database.api Consistency
+                                    Get
+                                    Isolation
+                                    Put
+                                    Scan
+                                    Scan$Ordering
+                                    Scan$Ordering$Order
+                                    Result)
+           (com.scalar.database.io IntValue
+                                   Key)
+           (com.scalar.database.exception.transaction CommitException
+                                                      CrudException
+                                                      UnknownTransactionStatusException UncommittedRecordException)
+           (com.scalar.database.transaction.consensuscommit ConsensusCommit)
+           (com.scalar.database.exception.storage NoMutationException)))
+
+(def ^:const KEYSPACE "jepsen")
+(def ^:const TABLE "transfer")
+(def ^:const ACCOUNT_ID "account_id")
+(def ^:const BALANCE "balance")
+(def ^:const AGE "age")
+
+(def ^:const INITIAL_BALANCE 10000)
+(def ^:const NUM_ACCOUNTS 10)
+(def ^:const total-balance (* NUM_ACCOUNTS INITIAL_BALANCE))
+
+(def ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
+
+(defn- create-transfer-table!
+  [session test]
+  (cql/create-keyspace session KEYSPACE
+                       (if-not-exists)
+                       (with {:replication {"class" "SimpleStrategy"
+                                            "replication_factor" (:rf test)}}))
+  (cql/use-keyspace session KEYSPACE)
+  (cql/create-table session TABLE
+                    (if-not-exists)
+                    (column-definitions {:account_id             :int
+                                         :age                    :int
+                                         :balance                :int
+                                         :tx_id                  :text
+                                         :tx_prepared_at         :bigint
+                                         :tx_committed_at        :bigint
+                                         :tx_state               :int
+                                         :tx_version             :int
+                                         :before_balance         :int
+                                         :before_tx_committed_at :bigint
+                                         :before_tx_id           :text
+                                         :before_tx_prepared_at  :bigint
+                                         :before_tx_state        :int
+                                         :before_tx_version      :int
+                                         :primary-key            [:account_id :age]}))
+  (cql/alter-table session TABLE
+                   (with {:compaction-options (c/compaction-strategy)})))
+
+(defn prepare-scan
+  [id]
+  (-> (Key. [(IntValue. ACCOUNT_ID id)])
+      (Scan.)
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withConsistency Consistency/LINEARIZABLE)
+      (.withOrdering (Scan$Ordering. "age" Scan$Ordering$Order/DESC))
+      (.withLimit 1)))
+
+(defn scan-and-return-result
+  [tx scan]
+  (.get (.scan tx scan) 0))
+
+(defn prepare-get-with-age
+  [id age]
+  (-> ((Key. [(IntValue. ACCOUNT_ID id)]) (Key. [(IntValue. AGE age)]))
+      (Get.)
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withConsistency Consistency/LINEARIZABLE)))
+
+(defn prepare-put
+  [id age balance]
+  (-> (Put. (Key. [(IntValue. ACCOUNT_ID id)]) (Key. [(IntValue. AGE age)]))
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withValue (IntValue. BALANCE balance))
+      (.withConsistency Consistency/LINEARIZABLE)))
+
+(defn populate-accounts
+  "Insert initial records with transaction.
+  This method assumes that n is small (< 100)"
+  [test n balance]
+  (let [tx (scalar/start-transaction test)]
+    (try
+      (dotimes [i n]
+        (->>
+          (prepare-put i 0 balance)
+          (.put tx)))
+      (.commit tx)
+      (catch Exception e
+        (throw (RuntimeException. (.getMessage e)))))))
+
+(defn calc-new-balance
+  "Calculate the new value from the result of transaction.get()"
+  [^Result result amount]
+  (-> result (.getValue BALANCE) .get .get (+ amount)))
+
+(defn calc-new-age
+  "Calculate the new value from the result of transaction.get()"
+  [^Result result]
+  (-> result (.getValue AGE) .get .get inc))
+
+(defn tx-transfer
+  [tx from to amount]
+  (let [^Result fromResult (scan-and-return-result tx (prepare-scan from))
+        ^Result toResult (scan-and-return-result tx (prepare-scan to))]
+    (->> (prepare-put from (calc-new-age fromResult) (calc-new-balance fromResult (- amount)))
+         (.put tx))
+    (->> (prepare-put to (calc-new-age toResult) (calc-new-balance toResult amount))
+         (.put tx))
+    (.commit tx)))
+
+(defn read-record
+  "Read a record with a transaction. If read fails, this function returns nil."
+  [tx id]
+  (try
+    (first (.scan tx (prepare-scan id)))
+    (catch CrudException _ nil)))
+
+(defn read-all-records
+  "Read records from 0 .. (n - 1)"
+  [test n]
+  (let [tx (scalar/start-transaction test)]
+    (map #(read-record tx %) (range n))))
+
+(defn read-all-with-retry
+  "Read records from 0 .. (n - 1) and retry if needed"
+  [test n]
+  (loop [tries scalar/RETRIES]
+    (when (< tries scalar/RETRIES)
+      (scalar/exponential-backoff (- scalar/RETRIES tries)))
+    (when (zero? (mod tries scalar/RETRIES_FOR_RECONNECTION))
+      (scalar/prepare-transaction-service! test))
+    (let [results (read-all-records test n)]
+      (if (empty? (filter nil? results))
+        results
+        (if (pos? tries)
+          (recur (dec tries))
+          (throw (ex-info "Failed to read all records"
+                          {:cause "Failed to read all records"})))))))
+
+(defn get-balance
+  "Get the balance from a result"
+  [^Result result]
+  (-> result (.getValue BALANCE) .get .get))
+
+(defn get-version
+  "Get the version from a result"
+  [^Result result]
+  (-> result (.getValue scalar/VERSION) .get .get))
+
+(defn get-balances-and-versions
+  "Read all records with a transaction. Return only balances and versions."
+  [test n]
+  (let [results (read-all-with-retry test n)]
+    (map #(assoc {} :balance (get-balance %) :version (get-version %)) results)))
+
+(defn- try-reconnection!
+  [test]
+  (when (= (swap! (:failures test) inc) NUM_FAILURES_FOR_RECONNECTION)
+    (scalar/prepare-transaction-service! test)
+    (reset! (:failures test) 0)))
+
+(defrecord TransferClient [initialized? n initial-balance]
+  client/Client
+  (open! [_ _ _]
+    (TransferClient. initialized? n initial-balance))
+
+  (setup! [_ test]
+    (locking initialized?
+      (when (compare-and-set! initialized? false true)
+        (let [session (drv/connect (->> test :nodes (map name)))]
+          (create-transfer-table! session test)
+          (scalar/create-coordinator-table! session test)
+          (drv/disconnect! session))
+        (scalar/prepare-storage-service! test)
+        (scalar/prepare-transaction-service! test)
+        (populate-accounts test n initial-balance))))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :transfer (if-let [tx (scalar/start-transaction test)]
+                  (try
+                    (tx-transfer tx (-> op :value :from) (-> op :value :to) (-> op :value :amount))
+                    (assoc op :type :ok)
+                    (catch UnknownTransactionStatusException e
+                      (swap! (:unknown-tx test) conj (.getId tx))
+                      (assoc op :type :fail :error {:unknown-tx-status (.getId tx)}))
+                    (catch UncommittedRecordException e
+                      (assoc op :type :fail :error (:uncommitted-record (.getMessage e))))
+                    (catch NoMutationException e
+                      (assoc op :type :fail :error (:no-mutation (.getMessage e))))
+                    (catch Exception e
+                      (try-reconnection! test)
+                      (assoc op :type :fail :error (.getMessage e))))
+                  (do
+                    (try-reconnection! test)
+                    (assoc op :type :fail :error "Skipped due to no connection")))
+      :get-all  (if-let [results (get-balances-and-versions test (:num op))]
+                  (assoc op :type :ok :value results)
+                  (assoc op :type :fail :error "Failed to get balances"))
+      :check-tx (let [unknown (:unknown-tx test)]
+                  (if-let [num-committed (if (empty? @unknown)
+                                           0
+                                           (scalar/check-transaction-states test @unknown))]
+                    (assoc op :type :ok :value num-committed)
+                    (assoc op :type :fail :error "Failed to check status")))))
+
+  (close! [_ _])
+
+  (teardown! [_ test]
+    (scalar/close-all! test)))
+
+(defn transfer
+  [test _]
+  (let [n (-> test :model :num)]
+    {:type :invoke
+     :f :transfer
+     :value {:from (rand-int n)
+             :to (rand-int n)
+             :amount (+ 1 (rand-int 5))}}))
+
+(def diff-transfer
+  (gen/filter (fn [op] (not= (-> op :value :from)
+                             (-> op :value :to)))
+              transfer))
+
+(defn get-all
+  [test _]
+  {:type :invoke
+   :f :get-all
+   :num (-> test :model :num)})
+
+(defn check-tx
+  [test _]
+  {:type :invoke
+   :f :check-tx})
+
+(defn consistency-checker
+  []
+  (reify checker/Checker
+    (check [this test model history opts]
+      (let [read-result (->> history
+                             (r/filter op/ok?)
+                             (r/filter #(= :get-all (:f %)))
+                             (r/filter identity)
+                             (into [])
+                             last
+                             :value)
+            actual-balance (->> read-result
+                                (map :balance)
+                                (reduce +))
+            bad-balance (if-not (= actual-balance total-balance)
+                          {:type     :wrong-balance
+                           :expected total-balance
+                           :actual   actual-balance})
+            actual-version (->> read-result
+                                (map :version)
+                                (reduce +))
+            checked-committed (->> history
+                                   (r/filter #(= :check-tx (:f %)))
+                                   (r/filter identity)
+                                   (into [])
+                                   last
+                                   ((fn [x]
+                                      (if (= (:type x) :ok) (:value x) 0))))
+            total-ok (->> history
+                          (r/filter op/ok?)
+                          (r/filter #(= :transfer (:f %)))
+                          (r/filter identity)
+                          (into [])
+                          count
+                          (+ checked-committed))
+            expected-version (-> 10)       ; (-> total-ok (* 2) (+ (-> test :model :num)))
+            bad-version (if-not (= actual-version expected-version)
+                          {:type     :wrong-version
+                           :expected expected-version
+                           :actual   actual-version})]
+        {:valid? (and (empty? bad-balance) (empty? bad-version))
+         :total-version actual-version
+         :committed-unknown-tx checked-committed
+         :bad-balance bad-balance
+         :bad-version bad-version}))))
+
+(defn transfer-append-test
+  [opts]
+  (merge (scalar/scalardb-test (str "transfer-" (:suffix opts))
+                               {:client (TransferClient. (atom false) NUM_ACCOUNTS INITIAL_BALANCE)
+                                :model  {:num NUM_ACCOUNTS}
+                                :unknown-tx (atom #{})
+                                :failures (atom 0)
+                                :generator (gen/phases
+                                             (->> [diff-transfer]
+                                                  (conductors/std-gen opts))
+                                             (conductors/terminate-nemesis opts)
+                                             (gen/clients (gen/once check-tx))
+                                             (gen/clients (gen/once get-all)))
+                                :checker (checker/compose
+                                           {:details (consistency-checker)})})
+         opts))

--- a/jepsen/scalardb/src/scalardb/transfer_append.clj
+++ b/jepsen/scalardb/src/scalardb/transfer_append.clj
@@ -30,11 +30,9 @@
 (def ^:const ACCOUNT_ID "account_id")
 (def ^:const BALANCE "balance")
 (def ^:const AGE "age")
-
 (def ^:const INITIAL_BALANCE 10000)
 (def ^:const NUM_ACCOUNTS 10)
 (def ^:const total-balance (* NUM_ACCOUNTS INITIAL_BALANCE))
-
 (def ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
 
 (defn- create-transfer-table!
@@ -97,7 +95,7 @@
     (try
       (dotimes [i n]
         (->>
-          (prepare-put i 0 balance)
+          (prepare-put i 1 balance)
           (.put tx)))
       (.commit tx)
       (catch Exception e
@@ -281,12 +279,11 @@
             actual-age (->> read-result
                             (map :age)
                             (reduce +))
-            expected-age (let [num-records (->> history
-                                                (r/filter #(= :get-num-records (:f %)))
-                                                (into [])
-                                                last
-                                                :value)]
-                           (- num-records (:num (:model test)))) ; age starts at 0 so should be num-records minus num-accounts
+            expected-age (->> history
+                              (r/filter #(= :get-num-records (:f %)))
+                              (into [])
+                              last
+                              :value)
             bad-age (if-not (= actual-age expected-age)
                       {:type :wrong-age
                        :expected expected-age
@@ -297,12 +294,12 @@
                                    last
                                    ((fn [x]
                                       (if (= (:type x) :ok) (:value x) 0))))]
-        {:valid? (and (empty? bad-balance) (empty? bad-age))
-         :total-balance actual-balance
-         :total-age actual-age
+        {:valid?               (and (empty? bad-balance) (empty? bad-age))
+         :total-balance        actual-balance
+         :total-age            actual-age
          :committed-unknown-tx checked-committed
-         :bad-balance bad-balance
-         :bad-age bad-age}))))
+         :bad-balance          bad-balance
+         :bad-age              bad-age}))))
 
 (defn transfer-append-test
   [opts]

--- a/jepsen/scalardb/src/scalardb/transfer_append.clj
+++ b/jepsen/scalardb/src/scalardb/transfer_append.clj
@@ -299,7 +299,7 @@
                           (into [])
                           count
                           (+ checked-committed))
-            expected-version (-> 10)       ; (-> total-ok (* 2) (+ (-> test :model :num)))
+            expected-version (-> NUM_ACCOUNTS)
             bad-version (if-not (= actual-version expected-version)
                           {:type     :wrong-version
                            :expected expected-version


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-2052

Adds an append test to Jepsen, and slightly updates the readme so that getting in up and running can be done from one place.

By the way, is there any particular reason why the jepsen tests are in the scalardb directory? Is it possible to fork jepsen and keep the test in there, or alternatively, to fork and create a new branch and leave the test in there (similar to how Riptano kept its Cassandra tests in the cassandra branch: https://github.com/riptano/jepsen).

I ask because it quite inconvenient to have to clone two repos, jepsen and scalardb, then copy over the jepsen tests from scalardb to jepsen, in order to run the tests. Then after any changes, copying the files back to the scalardb directory.

Thank you!