### PR TITLE
add deref

### DIFF
--- a/jepsen/scalardb/src/scalardb/transfer.clj
+++ b/jepsen/scalardb/src/scalardb/transfer.clj
@@ -135,7 +135,7 @@
 (defn read-all-with-retry
   "Read records from 0 .. (n - 1) and retry if needed"
   [test n]
-  (when (nil? (:transaction test))
+  (when (nil? (deref (:transaction test)))
     (scalar/prepare-transaction-service! test))
   (loop [tries scalar/RETRIES]
     (when (< tries scalar/RETRIES)

--- a/jepsen/scalardb/src/scalardb/transfer_append.clj
+++ b/jepsen/scalardb/src/scalardb/transfer_append.clj
@@ -133,7 +133,7 @@
 (defn read-all-with-retry
   "Read records from 0 .. (n - 1) and retry if needed"
   [test n]
-  (when (nil? (:transaction test))
+  (when (nil? (deref (:transaction test)))
     (scalar/prepare-transaction-service! test))
   (loop [tries scalar/RETRIES]
     (when (< tries scalar/RETRIES)

--- a/jepsen/scalardb/src/scalardb/transfer_append.clj
+++ b/jepsen/scalardb/src/scalardb/transfer_append.clj
@@ -137,6 +137,8 @@
 (defn read-all-with-retry
   "Read records from 0 .. (n - 1) and retry if needed"
   [test n]
+  (when (nil? (:transaction test))
+    (scalar/prepare-transaction-service! test))
   (loop [tries scalar/RETRIES]
     (when (< tries scalar/RETRIES)
       (scalar/exponential-backoff (- scalar/RETRIES tries)))


### PR DESCRIPTION
To add `deref` for `:transaction` of `test` before `read-all`.

The final reading all records failed due to NullPointerException in Jepsen testing.
When no connection, the client should reconnect to the cluster before the read.
But the checking has a bug. The client tried to read records without a connection.