### PR TITLE
start with an user-provided transaction ID

### DIFF
--- a/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
+++ b/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
@@ -12,7 +12,7 @@ public interface DistributedTransactionManager {
   DistributedTransaction start();
 
   /**
-   * Starts a new transaction with the specified transaction ID. It is a users' responsibility to
+   * Starts a new transaction with the specified transaction ID. It is users' responsibility to
    * guarantee uniqueness of the ID so it is not recommended to use this method unless you know
    * exactly what you are doing.
    *
@@ -30,7 +30,7 @@ public interface DistributedTransactionManager {
   DistributedTransaction start(Isolation isolation);
 
   /**
-   * Starts a new transaction with the specified transaction ID and {@link Isolation} level. It is a
+   * Starts a new transaction with the specified transaction ID and {@link Isolation} level. It is
    * users' responsibility to guarantee uniqueness of the ID so it is not recommended to use this
    * method unless you know exactly what you are doing.
    *

--- a/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
+++ b/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
@@ -6,7 +6,11 @@ public interface DistributedTransactionManager {
 
   DistributedTransaction start();
 
+  DistributedTransaction start(String txId);
+
   DistributedTransaction start(Isolation isolation);
+
+  DistributedTransaction start(String txId, Isolation isolation);
 
   /**
    * Closes connections to the cluster. The connections are shared among multiple services such as

--- a/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
+++ b/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
@@ -4,12 +4,39 @@ public interface DistributedTransactionManager {
 
   void with(String namespace, String tableName);
 
+  /**
+   * Starts a new transaction.
+   *
+   * @return {@link DistributedTransaction}
+   */
   DistributedTransaction start();
 
+  /**
+   * Starts a new transaction with the specified transaction ID. It is a users' responsibility to
+   * guarantee uniqueness of the ID so it is not recommended to use this method unless you know
+   * exactly what you are doing.
+   *
+   * @param txId
+   * @return {@link DistributedTransaction}
+   */
   DistributedTransaction start(String txId);
 
+  /**
+   * Starts a new transaction with the specified {@link Isolation} level.
+   *
+   * @param isolation
+   * @return {@link DistributedTransaction}
+   */
   DistributedTransaction start(Isolation isolation);
 
+  /**
+   * Starts a new transaction with the specified transaction ID and {@link Isolation} level. It is a
+   * users' responsibility to guarantee uniqueness of the ID so it is not recommended to use this
+   * method unless you know exactly what you are doing.
+   *
+   * @param isolation
+   * @return {@link DistributedTransaction}
+   */
   DistributedTransaction start(String txId, Isolation isolation);
 
   /**

--- a/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
+++ b/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
@@ -16,7 +16,7 @@ public interface DistributedTransactionManager {
    * guarantee uniqueness of the ID so it is not recommended to use this method unless you know
    * exactly what you are doing.
    *
-   * @param txId
+   * @param txId an user-provided unique transaction ID
    * @return {@link DistributedTransaction}
    */
   DistributedTransaction start(String txId);
@@ -24,7 +24,7 @@ public interface DistributedTransactionManager {
   /**
    * Starts a new transaction with the specified {@link Isolation} level.
    *
-   * @param isolation
+   * @param isolation an isolation level
    * @return {@link DistributedTransaction}
    */
   DistributedTransaction start(Isolation isolation);
@@ -34,7 +34,8 @@ public interface DistributedTransactionManager {
    * users' responsibility to guarantee uniqueness of the ID so it is not recommended to use this
    * method unless you know exactly what you are doing.
    *
-   * @param isolation
+   * @param txId an user-provided unique transaction ID
+   * @param isolation an isolation level
    * @return {@link DistributedTransaction}
    */
   DistributedTransaction start(String txId, Isolation isolation);

--- a/src/main/java/com/scalar/database/service/TransactionService.java
+++ b/src/main/java/com/scalar/database/service/TransactionService.java
@@ -29,8 +29,18 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
+  public DistributedTransaction start(String txId) {
+    return manager.start(txId);
+  }
+
+  @Override
   public DistributedTransaction start(Isolation isolation) {
     return manager.start(isolation);
+  }
+
+  @Override
+  public DistributedTransaction start(String txId, Isolation isolation) {
+    return manager.start(txId, isolation);
   }
 
   @Override

--- a/src/main/java/com/scalar/database/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/src/main/java/com/scalar/database/transaction/consensuscommit/ConsensusCommitManager.java
@@ -52,8 +52,18 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   }
 
   @Override
+  public ConsensusCommit start(String txId) {
+    return start(txId, Isolation.SNAPSHOT);
+  }
+
+  @Override
   public synchronized ConsensusCommit start(Isolation isolation) {
     String txId = UUID.randomUUID().toString();
+    return start(txId, isolation);
+  }
+
+  @Override
+  public synchronized ConsensusCommit start(String txId, Isolation isolation) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     checkArgument(isolation != null);
     Snapshot snapshot = new Snapshot(txId, isolation);


### PR DESCRIPTION
This is a scalardb part of [the story](https://scalar-labs.atlassian.net/browse/DLT-1691).

Usually we should use `start()` or `start(isolation)`, but accepting user-provided transaction id if user can be responsible for uniqueness of the transaction id.