### PR TITLE
make it work with any scalardb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
             gradle testJar
             cqlsh -f scripts/sample_schema/tx_transfer.cql
             # run with 2 requesters for 30 seconds
-            java -cp "build/test-libs/*:build/libs/scalardb-tests.jar:build/libs/scalardb.jar" com.scalar.database.verification.TransactionVerification -c 2 -t 30
+            java -cp "build/test-libs/*:build/libs/*" com.scalar.database.verification.TransactionVerification -c 2 -t 30
 
       - run:
           name: Save Gradle test reports


### PR DESCRIPTION
The verification test in CircleCI assumes there is non-versioned scalardb library, so if a version is specified in the build.gradle, the CI fails. (This is what happening in the current CircieCI)
So, this PR makes it able to work in any version. 