### PR TITLE
Add "IF NOT EXISTS" in a number of places

### DIFF
--- a/scripts/sample_schema/tx_transfer.cql
+++ b/scripts/sample_schema/tx_transfer.cql
@@ -1,8 +1,8 @@
 DROP KEYSPACE IF EXISTS transfer;
-CREATE KEYSPACE transfer WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
-CREATE KEYSPACE coordinator WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+CREATE KEYSPACE IF NOT EXISTS transfer WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+CREATE KEYSPACE IF NOT EXISTS coordinator WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
 
-CREATE TABLE transfer.tx_transfer (
+CREATE TABLE IF NOT EXISTS transfer.tx_transfer (
     account_id int,
     account_type int,
     balance int,


### PR DESCRIPTION
I want to use the return value of applying this schema in a script and usually it is non-zero because the coordinator keyspace already exists and without the IF NOT EXISTS cqlsh will send a return value of 2.

This is 1/2 of the fix for https://scalar-labs.atlassian.net/browse/DLT-3413.