### PR TITLE
getMessage when readRecords fails

### DIFF
--- a/src/test/java/com/scalar/database/util/AccountBalanceTransferHandler.java
+++ b/src/test/java/com/scalar/database/util/AccountBalanceTransferHandler.java
@@ -125,6 +125,7 @@ public class AccountBalanceTransferHandler {
       try {
         return readRecords();
       } catch (Exception e) {
+        System.err.println(e.getMessage());
         ++i;
         TransactionUtility.exponentialBackoff(i);
       }


### PR DESCRIPTION
Added `getMessage()` when readRecords fails to investigate the failure of `readRecordsWithRetry`