### PR TITLE
[Driver4] Add statement handlers for mutation

### DIFF
--- a/src/main/java/com/scalar/database/storage/cassandra4driver/ConditionSetter.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/ConditionSetter.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 /**
  * A visitor class to configure condition-specific statement
  *
- * @author Hiroyuki Yamada
+ * @author Hiroyuki Yamada, Yuji Ito
  */
 @NotThreadSafe
 public class ConditionSetter implements MutationConditionVisitor {

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/ConditionSetter.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/ConditionSetter.java
@@ -1,0 +1,129 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+
+import com.datastax.oss.driver.api.querybuilder.BuildableQuery;
+import com.datastax.oss.driver.api.querybuilder.condition.Condition;
+import com.datastax.oss.driver.api.querybuilder.delete.Delete;
+import com.datastax.oss.driver.api.querybuilder.insert.Insert;
+import com.datastax.oss.driver.api.querybuilder.update.Update;
+import com.scalar.database.api.ConditionalExpression;
+import com.scalar.database.api.DeleteIf;
+import com.scalar.database.api.DeleteIfExists;
+import com.scalar.database.api.MutationConditionVisitor;
+import com.scalar.database.api.PutIf;
+import com.scalar.database.api.PutIfExists;
+import com.scalar.database.api.PutIfNotExists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A visitor class to configure condition-specific statement
+ *
+ * @author Hiroyuki Yamada
+ */
+@NotThreadSafe
+public class ConditionSetter implements MutationConditionVisitor {
+  private BuildableQuery query;
+
+  /**
+   * Constructs {@code ConditionSetter} with the specified {@code BuildableQuery}
+   *
+   * @param query {@code BuildableQuery} to set conditions
+   */
+  public ConditionSetter(BuildableQuery query) {
+    this.query = query;
+  }
+
+  public BuildableQuery getQuery() {
+    return query;
+  }
+
+  /**
+   * Adds {@code PutIf}-specific conditions to the statement
+   *
+   * @param condition {@code PutIf} condition
+   */
+  @Override
+  public void visit(PutIf condition) {
+    List<ConditionalExpression> expressions = condition.getExpressions();
+    List<Condition> conditions = new ArrayList<>();
+    IntStream.range(0, expressions.size())
+        .forEach(
+            i -> {
+              conditions.add(createConditionWith(expressions.get(i)));
+            });
+
+    query = ((Update) query).if_(conditions);
+  }
+
+  /**
+   * Adds {@code PutIfExists}-specific conditions to the statement
+   *
+   * @param condition {@code PutIfExists} condition
+   */
+  @Override
+  public void visit(PutIfExists condition) {
+    query = ((Update) query).ifExists();
+  }
+
+  /**
+   * Adds {@code PutIfNotExists}-specific conditions to the statement
+   *
+   * @param condition {@code PutIfNotExists} condition
+   */
+  @Override
+  public void visit(PutIfNotExists condition) {
+    query = ((Insert) query).ifNotExists();
+  }
+
+  /**
+   * Adds {@code DeleteIf}-specific conditions to the statement
+   *
+   * @param condition {@code DeleteIf} condition
+   */
+  @Override
+  public void visit(DeleteIf condition) {
+    List<ConditionalExpression> expressions = condition.getExpressions();
+    List<Condition> conditions = new ArrayList<>();
+    IntStream.range(0, expressions.size())
+        .forEach(
+            i -> {
+              conditions.add(createConditionWith(expressions.get(i)));
+            });
+
+    query = ((Delete) query).if_(conditions);
+  }
+
+  /**
+   * Adds {@code DeleteIfExists}-specific conditions to the statement
+   *
+   * @param condition {@code DeleteIfExists} condition
+   */
+  @Override
+  public void visit(DeleteIfExists condition) {
+    query = ((Delete) query).ifExists();
+  }
+
+  private Condition createConditionWith(ConditionalExpression e) {
+    switch (e.getOperator()) {
+      case EQ:
+        return Condition.column(e.getName()).isEqualTo(bindMarker());
+      case NE:
+        return Condition.column(e.getName()).isNotEqualTo(bindMarker());
+      case GT:
+        return Condition.column(e.getName()).isGreaterThan(bindMarker());
+      case GTE:
+        return Condition.column(e.getName()).isGreaterThanOrEqualTo(bindMarker());
+      case LT:
+        return Condition.column(e.getName()).isLessThan(bindMarker());
+      case LTE:
+        return Condition.column(e.getName()).isLessThanOrEqualTo(bindMarker());
+      default:
+        // never comes here because ConditionalExpression accepts only above operators
+        throw new IllegalArgumentException(e.getOperator() + " is not supported");
+    }
+  }
+}

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/DeleteStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/DeleteStatementHandler.java
@@ -20,7 +20,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A handler class for delete statements
  *
- * @author Hiroyuki Yamada
+ * @author Hiroyuki Yamada, Yuji Ito
  */
 @ThreadSafe
 public class DeleteStatementHandler extends MutateStatementHandler {

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/DeleteStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/DeleteStatementHandler.java
@@ -1,0 +1,89 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.deleteFrom;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.querybuilder.delete.Delete;
+import com.datastax.oss.driver.api.querybuilder.delete.DeleteSelection;
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import com.scalar.database.api.Operation;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A handler class for delete statements
+ *
+ * @author Hiroyuki Yamada
+ */
+@ThreadSafe
+public class DeleteStatementHandler extends MutateStatementHandler {
+
+  /**
+   * Constructs a {@code DeleteStatementHandler} with the specified {@code CqlSession}
+   *
+   * @param session session to be used with this statement
+   */
+  public DeleteStatementHandler(CqlSession session) {
+    super(session);
+  }
+
+  @Override
+  @Nonnull
+  protected PreparedStatement prepare(Operation operation) {
+    checkArgument(operation, com.scalar.database.api.Delete.class);
+
+    com.scalar.database.api.Delete del = (com.scalar.database.api.Delete) operation;
+    Delete delete = prepare(del);
+
+    return prepare(delete.asCql());
+  }
+
+  @Override
+  @Nonnull
+  protected BoundStatementBuilder bind(PreparedStatement prepared, Operation operation) {
+    checkArgument(operation, com.scalar.database.api.Delete.class);
+
+    BoundStatementBuilder builder = prepared.boundStatementBuilder();
+    bind(builder, (com.scalar.database.api.Delete) operation);
+
+    return builder;
+  }
+
+  @Override
+  @Nonnull
+  protected ResultSet execute(BoundStatement bound, Operation operation) {
+    return session.execute(bound);
+  }
+
+  private Delete prepare(com.scalar.database.api.Delete del) {
+    DeleteSelection delete = deleteFrom(del.forNamespace().get(), del.forTable().get());
+
+    List<Relation> relations = new ArrayList<Relation>();
+    del.getPartitionKey()
+        .forEach(v -> relations.add(Relation.column(v.getName()).isEqualTo(bindMarker())));
+    del.getClusteringKey()
+        .ifPresent(
+            k -> {
+              k.forEach(v -> relations.add(Relation.column(v.getName()).isEqualTo(bindMarker())));
+            });
+
+    return (Delete) setCondition(delete.where(relations), del);
+  }
+
+  private void bind(BoundStatementBuilder builder, com.scalar.database.api.Delete del) {
+    ValueBinder binder = new ValueBinder(builder);
+
+    // bind in the prepared order
+    del.getPartitionKey().forEach(v -> v.accept(binder));
+    del.getClusteringKey().ifPresent(k -> k.forEach(v -> v.accept(binder)));
+
+    bindCondition(binder, del);
+  }
+}

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/InsertStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/InsertStatementHandler.java
@@ -21,7 +21,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A handler class for insert statements
  *
- * @author Hiroyuki Yamada
+ * @author Hiroyuki Yamada, Yuji Ito
  */
 @ThreadSafe
 public class InsertStatementHandler extends MutateStatementHandler {

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/InsertStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/InsertStatementHandler.java
@@ -1,0 +1,92 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.querybuilder.insert.Insert;
+import com.datastax.oss.driver.api.querybuilder.insert.OngoingValues;
+import com.datastax.oss.driver.api.querybuilder.term.Term;
+import com.scalar.database.api.Operation;
+import com.scalar.database.api.Put;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A handler class for insert statements
+ *
+ * @author Hiroyuki Yamada
+ */
+@ThreadSafe
+public class InsertStatementHandler extends MutateStatementHandler {
+
+  /**
+   * Constructs an {@code InsertStatementHandler} with the specified {@code CqlSession}
+   *
+   * @param session session to be used with this statement
+   */
+  public InsertStatementHandler(CqlSession session) {
+    super(session);
+  }
+
+  @Override
+  @Nonnull
+  protected PreparedStatement prepare(Operation operation) {
+    checkArgument(operation, Put.class);
+
+    Put put = (Put) operation;
+    Insert insert = prepare(put);
+
+    return prepare(insert.asCql());
+  }
+
+  @Override
+  @Nonnull
+  protected BoundStatementBuilder bind(PreparedStatement prepared, Operation operation) {
+    checkArgument(operation, Put.class);
+
+    BoundStatementBuilder builder = prepared.boundStatementBuilder();
+    bind(builder, (Put) operation);
+
+    return builder;
+  }
+
+  @Override
+  @Nonnull
+  protected ResultSet execute(BoundStatement bound, Operation operation) {
+    return session.execute(bound);
+  }
+
+  private Insert prepare(Put put) {
+    OngoingValues insert = insertInto(put.forNamespace().get(), put.forTable().get());
+    Map<String, Term> values = new LinkedHashMap<>();
+
+    put.getPartitionKey().forEach(v -> values.put(v.getName(), bindMarker()));
+    put.getClusteringKey()
+        .ifPresent(
+            k -> {
+              k.forEach(v -> values.put(v.getName(), bindMarker()));
+            });
+    put.getValues().forEach((k, v) -> values.put(v.getName(), bindMarker()));
+
+    return (Insert) setCondition(insert.values(values), put);
+  }
+
+  private void bind(BoundStatementBuilder builder, Put put) {
+    ValueBinder binder = new ValueBinder(builder);
+
+    // bind in the prepared order
+    put.getPartitionKey().forEach(v -> v.accept(binder));
+    put.getClusteringKey().ifPresent(k -> k.forEach(v -> v.accept(binder)));
+    put.getValues().forEach((k, v) -> v.accept(binder));
+
+    // it calls for consistency, but actually nothing to bind here
+    bindCondition(binder, put);
+  }
+}

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/MutateStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/MutateStatementHandler.java
@@ -1,0 +1,103 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
+import com.datastax.oss.driver.api.core.servererrors.WriteType;
+import com.datastax.oss.driver.api.querybuilder.BuildableQuery;
+import com.scalar.database.api.Mutation;
+import com.scalar.database.api.Operation;
+import com.scalar.database.exception.storage.ExecutionException;
+import com.scalar.database.exception.storage.NoMutationException;
+import com.scalar.database.exception.storage.ReadRepairableExecutionException;
+import com.scalar.database.exception.storage.RetriableExecutionException;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** An abstraction for handler classes for mutate statements */
+@ThreadSafe
+public abstract class MutateStatementHandler extends StatementHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MutateStatementHandler.class);
+
+  public MutateStatementHandler(CqlSession session) {
+    super(session);
+  }
+
+  /**
+   * Executes the specified {@link Mutation} {@link Operation}
+   *
+   * @param operation {@link Mutation} operation
+   * @return a {@code ResultSet}
+   * @throws RetriableExecutionException if the execution failed, but it can be retriable
+   * @throws ReadRepairableExecutionException if the execution partially failed, which can be
+   *     repaired by a following read
+   */
+  @Override
+  @Nonnull
+  public ResultSet handle(Operation operation) throws ExecutionException {
+    try {
+      ResultSet results = handleInternal(operation);
+
+      Mutation mutation = (Mutation) operation;
+      if (mutation.getCondition().isPresent() && !results.one().getBoolean(0)) {
+        throw new NoMutationException("no mutation was applied.");
+      }
+      return results;
+
+    } catch (WriteTimeoutException e) {
+      LOGGER.warn("write timeout happened during mutate operation.", e);
+      if (e.getWriteType() == WriteType.CAS) {
+        // retry needs to be done if applications need to do the operation exactly
+        throw new RetriableExecutionException("paxos phase in CAS operation failed.", e);
+      } else if (e.getWriteType() == WriteType.SIMPLE) {
+        Mutation mutation = (Mutation) operation;
+        if (mutation.getCondition().isPresent()) {
+          // learn phase needs to be repaired (by re-reading)
+          throw new ReadRepairableExecutionException("learn phase in CAS operation failed.", e);
+        } else {
+          // retry needs to be done if applications need to do the operation exactly
+          throw new RetriableExecutionException("simple write operation failed.", e);
+        }
+      } else {
+        throw new ExecutionException("something wrong because it is neither CAS nor SIMPLE", e);
+      }
+    } catch (RuntimeException e) {
+      LOGGER.warn(e.getMessage(), e);
+      throw new RetriableExecutionException(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  protected void overwriteConsistency(BoundStatementBuilder builder, Operation operation) {
+    ((Mutation) operation)
+        .getCondition()
+        .ifPresent(
+            c -> {
+              builder.setConsistencyLevel(ConsistencyLevel.QUORUM); // for learn phase
+              builder.setSerialConsistencyLevel(ConsistencyLevel.SERIAL); // for paxos phase
+            });
+  }
+
+  protected BuildableQuery setCondition(BuildableQuery query, Mutation mutation) {
+    if (mutation.getCondition().isPresent()) {
+      ConditionSetter setter = new ConditionSetter(query);
+      mutation.getCondition().get().accept(setter);
+      return setter.getQuery();
+    }
+    return query;
+  }
+
+  protected void bindCondition(ValueBinder binder, Mutation mutation) {
+    mutation
+        .getCondition()
+        .ifPresent(
+            c -> {
+              c.getExpressions().forEach(e -> e.getValue().accept(binder));
+            });
+  }
+}

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/StatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/StatementHandler.java
@@ -1,0 +1,146 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.google.common.base.Joiner;
+import com.scalar.database.api.Consistency;
+import com.scalar.database.api.Operation;
+import com.scalar.database.api.Selection;
+import com.scalar.database.exception.storage.ExecutionException;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A handler class for statements */
+@ThreadSafe
+public abstract class StatementHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StatementHandler.class);
+  protected final CqlSession session;
+
+  /**
+   * Constructs a {@code StatementHandler} with the specified {@link CqlSession}
+   *
+   * @param session {@code CqlSession}
+   */
+  protected StatementHandler(CqlSession session) {
+    this.session = checkNotNull(session);
+  }
+
+  /**
+   * Executes the specified {@code Operation}
+   *
+   * @param operation an {@code Operation} to execute
+   * @return a {@code ResultSet}
+   * @throws ExecutionException if the execution failed
+   */
+  @Nonnull
+  public ResultSet handle(Operation operation) throws ExecutionException {
+    try {
+      LOGGER.debug(operation + " is started.");
+      ResultSet results = handleInternal(operation);
+      LOGGER.debug(operation + " is executed normally.");
+      return results;
+
+    } catch (RuntimeException e) {
+      LOGGER.error(e.getMessage());
+      throw new ExecutionException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Executes the specified {@code Operation}
+   *
+   * @param operation an {@code Operation} to execute
+   * @return a {@code ResultSet}
+   */
+  @Nonnull
+  protected ResultSet handleInternal(Operation operation) {
+    PreparedStatement prepared = prepare(operation);
+    BoundStatementBuilder builder = bind(prepared, operation);
+    setConsistency(builder, operation);
+    return execute(builder.build(), operation);
+  }
+
+  /**
+   * Returns a {@link PreparedStatement} based on the given query string
+   *
+   * @param queryString
+   * @return a {@code PreparedStatement}
+   */
+  @Nonnull
+  protected PreparedStatement prepare(String queryString) {
+    LOGGER.debug("query to prepare : [" + queryString + "].");
+    return session.prepare(queryString);
+  }
+
+  /**
+   * Sets the consistency level for the specified {@link BoundStatementBuilder} and {@link Operation}
+   *
+   * @param builder a {@code BoundStatementBuilder}
+   * @param operation an {@code Operation}
+   */
+  protected void setConsistency(BoundStatementBuilder builder, Operation operation) {
+    builder.setConsistencyLevel(StatementHandler.convert(operation, operation.getConsistency()));
+    // set preferable consistency for the operation
+    overwriteConsistency(builder, operation);
+  }
+
+  protected abstract PreparedStatement prepare(Operation operation);
+
+  protected abstract BoundStatementBuilder bind(PreparedStatement prepared, Operation operation);
+
+  protected abstract ResultSet execute(BoundStatement bound, Operation operation);
+
+  protected abstract void overwriteConsistency(BoundStatementBuilder builder, Operation operation);
+
+  /**
+   * Returns a {@link ConsistencyLevel} based on the specified {@link Operation} and {@link
+   * Consistency}
+   *
+   * @param operation an {@code Operation}
+   * @param consistency a {@code Consistency}
+   * @return a {@code ConsistencyLevel}
+   */
+  public static ConsistencyLevel convert(Operation operation, Consistency consistency) {
+    switch (consistency) {
+      case SEQUENTIAL:
+        return ConsistencyLevel.QUORUM;
+      case EVENTUAL:
+        return ConsistencyLevel.ONE;
+      case LINEARIZABLE:
+        if (operation instanceof Selection) {
+          // setConsistencyLevel() with SERIAL is only valid when an operation is read.
+          // when an operation is write, it comes with conditional update and consistency level is
+          // automatically set in overwriteConsistency().
+          return ConsistencyLevel.SERIAL;
+        } else {
+          return ConsistencyLevel.QUORUM;
+        }
+      default:
+        LOGGER.warn("Unsupported consistency is specified. SEQUENTIAL is being used instead.");
+        return ConsistencyLevel.QUORUM;
+    }
+  }
+
+  public static void checkArgument(Operation actual, Class<? extends Operation>... expected) {
+    for (Class<? extends Operation> e : expected) {
+      if (e.isInstance(actual)) {
+        return;
+      }
+    }
+    throw new IllegalArgumentException(
+        Joiner.on(" ")
+            .join(
+                new String[] {
+                  actual.getClass().toString(), "is passed where something like",
+                  expected[0].toString(), "is expected."
+                }));
+  }
+}

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/UpdateStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/UpdateStatementHandler.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A handler class for update statement
  *
- * @author Hiroyuki Yamada
+ * @author Hiroyuki Yamada, Yuji Ito
  */
 @ThreadSafe
 public class UpdateStatementHandler extends MutateStatementHandler {

--- a/src/main/java/com/scalar/database/storage/cassandra4driver/UpdateStatementHandler.java
+++ b/src/main/java/com/scalar/database/storage/cassandra4driver/UpdateStatementHandler.java
@@ -1,0 +1,96 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.update;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import com.datastax.oss.driver.api.querybuilder.update.Assignment;
+import com.datastax.oss.driver.api.querybuilder.update.Update;
+import com.datastax.oss.driver.api.querybuilder.update.UpdateStart;
+import com.scalar.database.api.Operation;
+import com.scalar.database.api.Put;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A handler class for update statement
+ *
+ * @author Hiroyuki Yamada
+ */
+@ThreadSafe
+public class UpdateStatementHandler extends MutateStatementHandler {
+
+  /**
+   * Constructs an {@code UpdateStatementHandler} with the specified {@code CqlSession}
+   *
+   * @param session session to be used with this statement
+   */
+  public UpdateStatementHandler(CqlSession session) {
+    super(session);
+  }
+
+  @Override
+  @Nonnull
+  protected PreparedStatement prepare(Operation operation) {
+    checkArgument(operation, Put.class);
+
+    Put put = (Put) operation;
+    Update update = prepare(put);
+
+    return prepare(update.asCql());
+  }
+
+  @Override
+  @Nonnull
+  protected BoundStatementBuilder bind(PreparedStatement prepared, Operation operation) {
+    checkArgument(operation, Put.class);
+
+    BoundStatementBuilder builder = prepared.boundStatementBuilder();
+    bind(builder, (Put) operation);
+
+    return builder;
+  }
+
+  @Override
+  @Nonnull
+  protected ResultSet execute(BoundStatement bound, Operation operation) {
+    return session.execute(bound);
+  }
+
+  private Update prepare(Put put) {
+    UpdateStart update = update(put.forNamespace().get(), put.forTable().get());
+
+    List<Assignment> assignments = new ArrayList<>();
+    put.getValues().forEach((k, v) -> assignments.add(Assignment.setColumn(k, bindMarker())));
+
+    List<Relation> relations = new ArrayList<>();
+    put.getPartitionKey()
+        .forEach(v -> relations.add(Relation.column(v.getName()).isEqualTo(bindMarker())));
+
+    put.getClusteringKey()
+        .ifPresent(
+            k -> {
+              k.forEach(v -> relations.add(Relation.column(v.getName()).isEqualTo(bindMarker())));
+            });
+
+    return (Update) setCondition(update.set(assignments).where(relations), put);
+  }
+
+  private void bind(BoundStatementBuilder builder, Put put) {
+    ValueBinder binder = new ValueBinder(builder);
+
+    // bind from the front in the statement
+    put.getValues().forEach((k, v) -> v.accept(binder));
+    put.getPartitionKey().forEach(v -> v.accept(binder));
+    put.getClusteringKey().ifPresent(k -> k.forEach(v -> v.accept(binder)));
+
+    bindCondition(binder, put);
+  }
+}

--- a/src/test/java/com/scalar/database/storage/cassandra4driver/DeleteStatementHandlerTest.java
+++ b/src/test/java/com/scalar/database/storage/cassandra4driver/DeleteStatementHandlerTest.java
@@ -1,0 +1,363 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.scalar.database.api.ConditionalExpression.Operator;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.google.common.base.Joiner;
+import com.scalar.database.api.ConditionalExpression;
+import com.scalar.database.api.Consistency;
+import com.scalar.database.api.Delete;
+import com.scalar.database.api.DeleteIf;
+import com.scalar.database.api.DeleteIfExists;
+import com.scalar.database.api.Operation;
+import com.scalar.database.api.Put;
+import com.scalar.database.io.IntValue;
+import com.scalar.database.io.Key;
+import com.scalar.database.io.TextValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** */
+public class DeleteStatementHandlerTest {
+  private static final String ANY_KEYSPACE_NAME = "ks";
+  private static final String ANY_TABLE_NAME = "tbl";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_4 = "name4";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final int ANY_INT_1 = 1;
+  private static final int ANY_INT_2 = 2;
+  private DeleteStatementHandler handler;
+  private Delete del;
+  @Mock private CqlSession session;
+  @Mock private PreparedStatement prepared;
+  @Mock private BoundStatementBuilder builder;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    handler = new DeleteStatementHandler(session);
+  }
+
+  private Delete prepareDelete() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Delete del = new Delete(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+    return del;
+  }
+
+  private Delete prepareDeleteWithClusteringKey() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    Delete del =
+        new Delete(partitionKey, clusteringKey)
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    return del;
+  }
+
+  private void configureBehavior(String expected) {
+    when(session.prepare(expected == null ? anyString() : expected)).thenReturn(prepared);
+
+    when(prepared.boundStatementBuilder()).thenReturn(builder);
+    when(builder.setString(anyInt(), anyString())).thenReturn(builder);
+    when(builder.setInt(anyInt(), anyInt())).thenReturn(builder);
+    when(builder.setConsistencyLevel(any(ConsistencyLevel.class))).thenReturn(builder);
+  }
+
+  @Test
+  public void prepare_DeleteOperationWithoutClusteringKeyGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "DELETE",
+                  "FROM",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "WHERE",
+                  ANY_NAME_1 + "=?"
+                });
+    configureBehavior(expected);
+    del = prepareDelete();
+
+    // Act
+    handler.prepare(del);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithClusteringKeyGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "DELETE",
+                  "FROM",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "WHERE",
+                  ANY_NAME_1 + "=?",
+                  "AND",
+                  ANY_NAME_2 + "=?"
+                });
+    configureBehavior(expected);
+    del = prepareDeleteWithClusteringKey();
+
+    // Act
+    handler.prepare(del);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_DeleteOperationWithIfExistsGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "DELETE",
+                  "FROM",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "WHERE",
+                  ANY_NAME_1 + "=?",
+                  "AND",
+                  ANY_NAME_2 + "=?",
+                  "IF EXISTS"
+                });
+    configureBehavior(expected);
+    del = prepareDeleteWithClusteringKey();
+    del.withCondition(new DeleteIfExists());
+
+    // Act
+    handler.prepare(del);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_DeleteOperationWithIfGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "DELETE",
+                  "FROM",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "WHERE",
+                  ANY_NAME_1 + "=?",
+                  "AND",
+                  ANY_NAME_2 + "=?",
+                  "IF",
+                  ANY_NAME_3 + "=?",
+                  "AND",
+                  ANY_NAME_4 + "=?"
+                });
+    configureBehavior(expected);
+    del = prepareDeleteWithClusteringKey();
+    del.withCondition(
+        new DeleteIf(
+            new ConditionalExpression(ANY_NAME_3, new IntValue(ANY_INT_1), Operator.EQ),
+            new ConditionalExpression(ANY_NAME_4, new TextValue(ANY_TEXT_3), Operator.EQ)));
+
+    // Act
+    handler.prepare(del);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_DeleteOperationWithIfExistsGiven_ShouldCallAccept() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    DeleteIfExists deleteIfExists = spy(new DeleteIfExists());
+    del.withCondition(deleteIfExists);
+
+    // Act
+    handler.prepare(del);
+
+    // Assert
+    verify(deleteIfExists).accept(any(ConditionSetter.class));
+  }
+
+  @Test
+  public void prepare_DeleteOperationWithIfGiven_ShouldCallAccept() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    DeleteIf deleteIf =
+        spy(
+            new DeleteIf(
+                new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ)));
+    del.withCondition(deleteIf);
+
+    // Act
+    handler.prepare(del);
+
+    // Assert
+    verify(deleteIf).accept(any(ConditionSetter.class));
+  }
+
+  @Test
+  public void bind_DeleteOperationGiven_ShouldBindProperly() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+
+    // Act
+    handler.bind(prepared, del);
+
+    // Assert
+    verify(builder).setString(0, ANY_TEXT_1);
+    verify(builder).setString(1, ANY_TEXT_2);
+  }
+
+  @Test
+  public void bind_DeleteOperationWithIfGiven_ShouldBindProperly() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    del.withCondition(
+        new DeleteIf(
+            new ConditionalExpression(ANY_NAME_3, new IntValue(ANY_INT_1), Operator.EQ),
+            new ConditionalExpression(ANY_NAME_4, new TextValue(ANY_TEXT_3), Operator.EQ)));
+
+    // Act
+    handler.bind(prepared, del);
+
+    // Assert
+    verify(builder).setString(0, ANY_TEXT_1);
+    verify(builder).setString(1, ANY_TEXT_2);
+    verify(builder).setInt(2, ANY_INT_1);
+    verify(builder).setString(3, ANY_TEXT_3);
+  }
+
+  @Test
+  public void setConsistency_DeleteOperationWithStrongConsistencyGiven_ShouldBoundWithQuorum() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    del.withConsistency(Consistency.SEQUENTIAL);
+
+    // Act
+    handler.setConsistency(builder, del);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+  }
+
+  @Test
+  public void setConsistency_DeleteOperationWithEventualConsistencyGiven_ShouldPrepareWithOne() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    del.withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, del);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.ONE);
+  }
+
+  @Test
+  public void
+      setConsistency_DeleteOperationWithLinearizableConsistencyGiven_ShouldPrepareWithQuorum() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    del.withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    handler.setConsistency(builder, del);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+  }
+
+  @Test
+  public void setConsistency_DeleteOperationWithIfExistsGiven_ShouldPrepareWithQuorumAndSerial() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    del.withCondition(new DeleteIfExists()).withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, del);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+    verify(builder).setSerialConsistencyLevel(ConsistencyLevel.SERIAL);
+  }
+
+  @Test
+  public void setConsistency_DeleteOperationWithIfGiven_ShouldPrepareWithQuorumAndSerial() {
+    // Arrange
+    configureBehavior(null);
+    del = prepareDeleteWithClusteringKey();
+    del.withCondition(
+            new DeleteIf(
+                new ConditionalExpression(ANY_NAME_3, new IntValue(ANY_INT_1), Operator.EQ),
+                new ConditionalExpression(ANY_NAME_4, new TextValue(ANY_TEXT_3), Operator.EQ)))
+        .withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, del);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+    verify(builder).setSerialConsistencyLevel(ConsistencyLevel.SERIAL);
+  }
+
+  /** Unit testing for handle() method is covered in InsertStatementHandlerTest */
+  @Test
+  public void checkArgument_WrongOperationGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Operation operation = mock(Put.class);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              StatementHandler.checkArgument(operation, Delete.class);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_NullGiven_ShouldThrowNullPointerException() {
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              new DeleteStatementHandler(null);
+            })
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/src/test/java/com/scalar/database/storage/cassandra4driver/InsertStatementHandlerTest.java
+++ b/src/test/java/com/scalar/database/storage/cassandra4driver/InsertStatementHandlerTest.java
@@ -1,0 +1,420 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
+import com.datastax.oss.driver.api.core.servererrors.WriteType;
+import com.google.common.base.Joiner;
+import com.scalar.database.api.Consistency;
+import com.scalar.database.api.Get;
+import com.scalar.database.api.Operation;
+import com.scalar.database.api.Put;
+import com.scalar.database.api.PutIfNotExists;
+import com.scalar.database.exception.storage.ExecutionException;
+import com.scalar.database.exception.storage.NoMutationException;
+import com.scalar.database.exception.storage.ReadRepairableExecutionException;
+import com.scalar.database.exception.storage.RetriableExecutionException;
+import com.scalar.database.io.IntValue;
+import com.scalar.database.io.Key;
+import com.scalar.database.io.TextValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** */
+public class InsertStatementHandlerTest {
+  private static final String ANY_KEYSPACE_NAME = "ks";
+  private static final String ANY_TABLE_NAME = "tbl";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final int ANY_INT_1 = 1;
+  private static final int ANY_INT_2 = 2;
+  private InsertStatementHandler handler;
+  private Put put;
+  private InsertStatementHandler spy;
+  @Mock private CqlSession session;
+  @Mock private PreparedStatement prepared;
+  @Mock private BoundStatement bound;
+  @Mock private BoundStatementBuilder builder;
+  @Mock private ResultSet results;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    handler = new InsertStatementHandler(session);
+  }
+
+  private Put preparePut() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Put put =
+        new Put(partitionKey)
+            .withValue(new IntValue(ANY_NAME_2, ANY_INT_1))
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_2))
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    return put;
+  }
+
+  private Put preparePutWithClusteringKey() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_1))
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    return put;
+  }
+
+  private InsertStatementHandler prepareSpiedInsertStatementHandler() {
+    InsertStatementHandler spy = spy(new InsertStatementHandler(session));
+    doReturn(prepared).when(spy).prepare(put);
+    doReturn(builder).when(spy).bind(prepared, put);
+    return spy;
+  }
+
+  private void configureBehavior(String expected) {
+    when(session.prepare(expected == null ? anyString() : expected)).thenReturn(prepared);
+
+    when(prepared.boundStatementBuilder()).thenReturn(builder);
+    when(builder.setString(anyInt(), anyString())).thenReturn(builder);
+    when(builder.setInt(anyInt(), anyInt())).thenReturn(builder);
+    when(builder.setConsistencyLevel(any(ConsistencyLevel.class))).thenReturn(builder);
+  }
+
+  @Test
+  public void prepare_PutOperationWithoutClusteringKeyGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "INSERT INTO",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "(" + ANY_NAME_1 + "," + ANY_NAME_2 + "," + ANY_NAME_3 + ")",
+                  "VALUES",
+                  "(?,?,?)",
+                });
+    configureBehavior(expected);
+    put = preparePut();
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithClusteringKeyGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "INSERT INTO",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "(" + ANY_NAME_1 + "," + ANY_NAME_2 + "," + ANY_NAME_3 + ")",
+                  "VALUES",
+                  "(?,?,?)",
+                });
+    configureBehavior(expected);
+    put = preparePutWithClusteringKey();
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithIfNotExistsGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "INSERT INTO",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "(" + ANY_NAME_1 + "," + ANY_NAME_2 + "," + ANY_NAME_3 + ")",
+                  "VALUES",
+                  "(?,?,?)",
+                  "IF NOT EXISTS"
+                });
+    configureBehavior(expected);
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfNotExists());
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithIfNotExistsGiven_ShouldCallAccept() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    PutIfNotExists putIfNotExists = spy(new PutIfNotExists());
+    put.withCondition(putIfNotExists);
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(putIfNotExists).accept(any(ConditionSetter.class));
+  }
+
+  @Test
+  public void bind_PutOperationGiven_ShouldBindProperly() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+
+    // Act
+    handler.bind(prepared, put);
+
+    // Assert
+    verify(builder).setString(0, ANY_TEXT_1);
+    verify(builder).setString(1, ANY_TEXT_2);
+    verify(builder).setInt(2, ANY_INT_1);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithStrongConsistencyGiven_ShouldPrepareWithQuorum() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withConsistency(Consistency.SEQUENTIAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithEventualConsistencyGiven_ShouldPrepareWithOne() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.ONE);
+  }
+
+  @Test
+  public void
+      setConsistency_PutOperationWithLinearizableConsistencyGiven_ShouldPrepareWithQuorum() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithIfNotExistsGiven_ShouldPrepareWithQuorumAndSerial() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfNotExists()).withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+    verify(builder).setSerialConsistencyLevel(ConsistencyLevel.SERIAL);
+  }
+
+  @Test
+  public void handle_WTEWithCasThrown_ShouldThrowProperExecutionException()
+      throws ExecutionException {
+    // Arrange
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfNotExists());
+    spy = prepareSpiedInsertStatementHandler();
+
+    WriteTimeoutException toThrow = mock(WriteTimeoutException.class);
+    when(toThrow.getWriteType()).thenReturn(WriteType.CAS);
+    doThrow(toThrow).when(spy).handleInternal(put);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              spy.handle(put);
+            })
+        .isInstanceOf(RetriableExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void
+      handle_PutWithConditionGivenAndWTEWithSimpleThrown_ShouldThrowProperExecutionException()
+          throws ExecutionException {
+    // Arrange
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfNotExists());
+    spy = prepareSpiedInsertStatementHandler();
+
+    WriteTimeoutException toThrow = mock(WriteTimeoutException.class);
+    when(toThrow.getWriteType()).thenReturn(WriteType.SIMPLE);
+    doThrow(toThrow).when(spy).handleInternal(put);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              spy.handle(put);
+            })
+        .isInstanceOf(ReadRepairableExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void
+      handle_PutWithoutConditionGivenAndWTEWithSimpleThrown_ShouldThrowProperExecutionException()
+          throws ExecutionException {
+    // Arrange
+    put = preparePutWithClusteringKey();
+    spy = prepareSpiedInsertStatementHandler();
+
+    WriteTimeoutException toThrow = mock(WriteTimeoutException.class);
+    when(toThrow.getWriteType()).thenReturn(WriteType.SIMPLE);
+    doThrow(toThrow).when(spy).handleInternal(put);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              spy.handle(put);
+            })
+        .isInstanceOf(RetriableExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_DriverExceptionThrown_ShouldThrowProperExecutionException()
+      throws ExecutionException {
+    // Arrange
+    put = preparePutWithClusteringKey();
+    spy = prepareSpiedInsertStatementHandler();
+
+    DriverException toThrow = mock(DriverException.class);
+    doThrow(toThrow).when(spy).handleInternal(put);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              spy.handle(put);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_PutWithConditionButNoMutationApplied_ShouldThrowProperExecutionException()
+      throws ExecutionException {
+    // Arrange
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfNotExists());
+    spy = prepareSpiedInsertStatementHandler();
+
+    ResultSet results = mock(ResultSet.class);
+    Row row = mock(Row.class);
+    when(results.one()).thenReturn(row);
+    when(row.getBoolean(0)).thenReturn(false);
+    when(builder.build()).thenReturn(bound);
+    doReturn(results).when(spy).execute(bound, put);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              spy.handle(put);
+            })
+        .isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void handle_PutWithoutConditionButNoMutationApplied_ShouldThrowProperExecutionException()
+      throws ExecutionException {
+    // Arrange
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfNotExists());
+    spy = prepareSpiedInsertStatementHandler();
+
+    ResultSet results = mock(ResultSet.class);
+    Row row = mock(Row.class);
+    when(results.one()).thenReturn(row);
+    when(row.getBoolean(0)).thenReturn(false);
+    when(builder.build()).thenReturn(bound);
+    doReturn(results).when(spy).execute(bound, put);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              spy.handle(put);
+            })
+        .isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void checkArgument_WrongOperationGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Operation operation = mock(Get.class);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              StatementHandler.checkArgument(operation, Put.class);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_NullGiven_ShouldThrowNullPointerException() {
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              new InsertStatementHandler(null);
+            })
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/src/test/java/com/scalar/database/storage/cassandra4driver/UpdateStatementHandlerTest.java
+++ b/src/test/java/com/scalar/database/storage/cassandra4driver/UpdateStatementHandlerTest.java
@@ -1,0 +1,371 @@
+package com.scalar.database.storage.cassandra4driver;
+
+import static com.scalar.database.api.ConditionalExpression.Operator;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.google.common.base.Joiner;
+import com.scalar.database.api.ConditionalExpression;
+import com.scalar.database.api.Consistency;
+import com.scalar.database.api.Put;
+import com.scalar.database.api.PutIf;
+import com.scalar.database.api.PutIfExists;
+import com.scalar.database.io.IntValue;
+import com.scalar.database.io.Key;
+import com.scalar.database.io.TextValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/** */
+public class UpdateStatementHandlerTest {
+  private static final String ANY_KEYSPACE_NAME = "ks";
+  private static final String ANY_TABLE_NAME = "tbl";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_4 = "name4";
+  private static final String ANY_NAME_5 = "name5";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final int ANY_INT_1 = 1;
+  private static final int ANY_INT_2 = 2;
+  private UpdateStatementHandler handler;
+  private Put put;
+  @Mock private CqlSession session;
+  @Mock private PreparedStatement prepared;
+  @Mock private BoundStatementBuilder builder;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    handler = new UpdateStatementHandler(session);
+  }
+
+  private Put preparePut() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Put put =
+        new Put(partitionKey)
+            .withValue(new IntValue(ANY_NAME_2, ANY_INT_1))
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_2))
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    return put;
+  }
+
+  private Put preparePutWithClusteringKey() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_1))
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    return put;
+  }
+
+  private void configureBehavior(String expected) {
+    when(session.prepare(expected == null ? anyString() : expected)).thenReturn(prepared);
+
+    when(prepared.boundStatementBuilder()).thenReturn(builder);
+    when(builder.setString(anyInt(), anyString())).thenReturn(builder);
+    when(builder.setInt(anyInt(), anyInt())).thenReturn(builder);
+    when(builder.setConsistencyLevel(any(ConsistencyLevel.class))).thenReturn(builder);
+  }
+
+  @Test
+  public void prepare_PutOperationWithoutClusteringKeyGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "UPDATE",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "SET",
+                  ANY_NAME_2 + "=?, " + ANY_NAME_3 + "=?",
+                  "WHERE",
+                  ANY_NAME_1 + "=?"
+                });
+    configureBehavior(expected);
+    put = preparePut();
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithClusteringKeyGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "UPDATE",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "SET",
+                  ANY_NAME_3 + "=?",
+                  "WHERE",
+                  ANY_NAME_1 + "=?",
+                  "AND",
+                  ANY_NAME_2 + "=?"
+                });
+    configureBehavior(expected);
+    put = preparePutWithClusteringKey();
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithIfExistsGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "UPDATE",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "SET",
+                  ANY_NAME_3 + "=?",
+                  "WHERE",
+                  ANY_NAME_1 + "=?",
+                  "AND",
+                  ANY_NAME_2 + "=?",
+                  "IF EXISTS"
+                });
+    configureBehavior(expected);
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfExists());
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithIfGiven_ShouldPrepareProperQuery() {
+    // Arrange
+    String expected =
+        Joiner.on(" ")
+            .skipNulls()
+            .join(
+                new String[] {
+                  "UPDATE",
+                  ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME,
+                  "SET",
+                  ANY_NAME_3 + "=?",
+                  "WHERE",
+                  ANY_NAME_1 + "=?",
+                  "AND",
+                  ANY_NAME_2 + "=?",
+                  "IF",
+                  ANY_NAME_4 + "=?",
+                  "AND",
+                  ANY_NAME_4 + "!=?",
+                  "AND",
+                  ANY_NAME_4 + ">?",
+                  "AND",
+                  ANY_NAME_4 + ">=?",
+                  "AND",
+                  ANY_NAME_4 + "<?",
+                  "AND",
+                  ANY_NAME_4 + "<=?"
+                });
+    configureBehavior(expected);
+    put = preparePutWithClusteringKey();
+    put.withCondition(
+        new PutIf(
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ),
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.NE),
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.GT),
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.GTE),
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.LT),
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.LTE)));
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(session).prepare(expected);
+  }
+
+  @Test
+  public void prepare_PutOperationWithIfExistsGiven_ShouldCallAccept() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    PutIfExists putIfExists = Mockito.spy(new PutIfExists());
+    put.withCondition(putIfExists);
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(putIfExists).accept(any(ConditionSetter.class));
+  }
+
+  @Test
+  public void prepare_PutOperationWithIfGiven_ShouldCallAccept() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    PutIf putIf =
+        Mockito.spy(
+            new PutIf(new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ)));
+    put.withCondition(putIf);
+
+    // Act
+    handler.prepare(put);
+
+    // Assert
+    verify(putIf).accept(any(ConditionSetter.class));
+  }
+
+  @Test
+  public void bind_PutOperationGiven_ShouldBindProperly() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+
+    // Act
+    handler.bind(prepared, put);
+
+    // Assert
+    verify(builder).setInt(0, ANY_INT_1);
+    verify(builder).setString(1, ANY_TEXT_1);
+    verify(builder).setString(2, ANY_TEXT_2);
+  }
+
+  @Test
+  public void bind_PutOperationWithIfGiven_ShouldBindProperly() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withCondition(
+        new PutIf(
+            new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ),
+            new ConditionalExpression(ANY_NAME_5, new TextValue(ANY_TEXT_3), Operator.EQ)));
+
+    // Act
+    handler.bind(prepared, put);
+
+    // Assert
+    verify(builder).setInt(0, ANY_INT_1);
+    verify(builder).setString(1, ANY_TEXT_1);
+    verify(builder).setString(2, ANY_TEXT_2);
+    verify(builder).setInt(3, ANY_INT_2);
+    verify(builder).setString(4, ANY_TEXT_3);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithStrongConsistencyGiven_ShouldPrepareWithQuorum() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withConsistency(Consistency.SEQUENTIAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithEventualConsistencyGiven_ShouldPrepareWithOne() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.ONE);
+  }
+
+  @Test
+  public void
+      setConsistency_PutOperationWithLinearizableConsistencyGiven_ShouldPrepareWithQuorum() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithIfExistsGiven_ShouldPrepareWithQuorumAndSerial() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withCondition(new PutIfExists()).withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+    verify(builder).setSerialConsistencyLevel(ConsistencyLevel.SERIAL);
+  }
+
+  @Test
+  public void setConsistency_PutOperationWithIfGiven_ShouldPrepareWithQuorumAndSerial() {
+    // Arrange
+    configureBehavior(null);
+    put = preparePutWithClusteringKey();
+    put.withCondition(
+            new PutIf(new ConditionalExpression(ANY_NAME_4, new IntValue(ANY_INT_2), Operator.EQ)))
+        .withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    handler.setConsistency(builder, put);
+
+    // Assert
+    verify(builder).setConsistencyLevel(ConsistencyLevel.QUORUM);
+    verify(builder).setSerialConsistencyLevel(ConsistencyLevel.SERIAL);
+  }
+
+  /** Unit testing for handle() method is covered in InsertStatementHandlerTest */
+
+  /** Unit testing for checkArgument() method is covered in InsertStatementHandlerTest */
+  @Test
+  public void constructor_NullGiven_ShouldThrowNullPointerException() {
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              new UpdateStatementHandler(null);
+            })
+        .isInstanceOf(NullPointerException.class);
+  }
+}


### PR DESCRIPTION
- Change the import paths
- Use [`Relation`](https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/querybuilder/relation/Relation.html) for where clause
- Modify `ConditionSetter` to use `BuildableQuery` and [`Condition`](https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/querybuilder/condition/Condition.html) and update it by replacing the `BuildableQuery` instance
  - Get `BuildableQuery` instance after all conditions are set
- `StatementHandler#bind()` returns [`BoundStatementBuilder`](https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.html)
  - A mutable `builder` will be set consistency level and will be built for execution
- Remove the cache of prepared statements because the driver 4.x caches them