### PR TITLE
Rename check

### DIFF
--- a/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
+++ b/src/main/java/com/scalar/database/api/DistributedTransactionManager.java
@@ -41,12 +41,12 @@ public interface DistributedTransactionManager {
   DistributedTransaction start(String txId, Isolation isolation);
 
   /**
-   * Checks the state of a given transaction.
+   * Returns the state of a given transaction.
    *
    * @param txId a transaction ID
    * @return {@link TransactionState}
    */
-  TransactionState check(String txId);
+  TransactionState getState(String txId);
 
   /**
    * Closes connections to the cluster. The connections are shared among multiple services such as

--- a/src/main/java/com/scalar/database/service/TransactionService.java
+++ b/src/main/java/com/scalar/database/service/TransactionService.java
@@ -45,8 +45,8 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
-  public TransactionState check(String txId) {
-    return manager.check(txId);
+  public TransactionState getState(String txId) {
+    return manager.getState(txId);
   }
 
   @Override

--- a/src/main/java/com/scalar/database/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/src/main/java/com/scalar/database/transaction/consensuscommit/ConsensusCommitManager.java
@@ -78,7 +78,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   }
 
   @Override
-  public TransactionState check(String txId) {
+  public TransactionState getState(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     try {
       Optional<State> state = coordinator.getState(txId);

--- a/src/test/java/com/scalar/database/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/src/test/java/com/scalar/database/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -95,7 +95,7 @@ public class ConsensusCommitManagerTest {
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.of(new State(ANY_TX_ID, expected)));
 
     // Act
-    TransactionState actual = manager.check(ANY_TX_ID);
+    TransactionState actual = manager.getState(ANY_TX_ID);
 
     // Assert
     assertThat(actual).isEqualTo(expected);
@@ -107,7 +107,7 @@ public class ConsensusCommitManagerTest {
     when(coordinator.getState(ANY_TX_ID)).thenReturn(Optional.empty());
 
     // Act
-    TransactionState actual = manager.check(ANY_TX_ID);
+    TransactionState actual = manager.getState(ANY_TX_ID);
 
     // Assert
     assertThat(actual).isEqualTo(TransactionState.UNKNOWN);
@@ -120,7 +120,7 @@ public class ConsensusCommitManagerTest {
     when(coordinator.getState(ANY_TX_ID)).thenThrow(toThrow);
 
     // Act
-    TransactionState actual = manager.check(ANY_TX_ID);
+    TransactionState actual = manager.getState(ANY_TX_ID);
 
     // Assert
     assertThat(actual).isEqualTo(TransactionState.UNKNOWN);


### PR DESCRIPTION
I just realized (after release...) that `check` might not be a clear method name for getting the state of a transaction.
