### PR TITLE
fix write skew issue

### DIFF
--- a/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -327,6 +327,26 @@ public class ConsensusCommitWithCassandraIntegrationTest {
     test.commit_NonConflictingDeletesGivenForExisting_ShouldCommitBoth();
   }
 
+  @Test
+  public void commit_WriteSkewOnExistingRecordsWithSnapshot_ShouldProduceNonSerializableResult()
+      throws Exception {
+    test.commit_WriteSkewOnExistingRecordsWithSnapshot_ShouldProduceNonSerializableResult();
+  }
+
+  @Test
+  public void
+      commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException()
+          throws Exception {
+    test
+        .commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException();
+  }
+
+  @Test
+  public void commit_WriteSkewOnNonExistingRecordsWithSerializable_ShouldThrowCommitException()
+      throws Exception {
+    test.commit_WriteSkewOnNonExistingRecordsWithSerializable_ShouldThrowCommitException();
+  }
+
   @BeforeClass
   public static void setUpBeforeClass() throws IOException, InterruptedException {
     executeStatement(createNamespaceStatement(ConsensusCommitIntegrationTest.NAMESPACE));

--- a/src/main/java/com/scalar/db/exception/transaction/CommitRuntimeException.java
+++ b/src/main/java/com/scalar/db/exception/transaction/CommitRuntimeException.java
@@ -1,0 +1,12 @@
+package com.scalar.db.exception.transaction;
+
+public class CommitRuntimeException extends TransactionRuntimeException {
+
+  public CommitRuntimeException(String message) {
+    super(message);
+  }
+
+  public CommitRuntimeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -38,7 +38,7 @@ public class CommitHandler {
 
     try {
       prepareRecords(snapshot);
-    } catch (ExecutionException e) {
+    } catch (Exception e) {
       LOGGER.warn("preparing records failed", e);
       abort(id);
       recovery.rollback(snapshot);

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -45,11 +45,12 @@ public class CrudHandler {
 
     result = getFromStorage(get);
     if (!result.isPresent()) {
+      snapshot.put(key, result);
       return Optional.empty();
     }
 
     if (result.get().isCommitted()) {
-      snapshot.put(key, result.get());
+      snapshot.put(key, result);
       return Optional.of(result.get());
     }
     throw new UncommittedRecordException(result.get(), "this record needs recovery");
@@ -82,7 +83,7 @@ public class CrudHandler {
           if (snapshot.get(key).isPresent()) {
             LOGGER.warn("scanned records are already in snapshot. overwriting snapshot...");
           }
-          snapshot.put(key, (TransactionResult) r);
+          snapshot.put(key, Optional.of((TransactionResult) r));
         });
 
     return results;

--- a/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -118,7 +118,7 @@ public class CrudHandlerTest {
     Get get = prepareGet();
     Optional<Result> expected = Optional.of(prepareResult(true, TransactionState.COMMITTED));
     when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
-    doNothing().when(snapshot).put(any(Snapshot.Key.class), any(TransactionResult.class));
+    doNothing().when(snapshot).put(any(Snapshot.Key.class), any(Optional.class));
     when(storage.get(get)).thenReturn(expected);
 
     // Act
@@ -127,7 +127,7 @@ public class CrudHandlerTest {
     // Assert
     assertThat(result).isEqualTo(expected);
     verify(storage).get(get);
-    verify(snapshot).put(new Snapshot.Key(get), (TransactionResult) expected.get());
+    verify(snapshot).put(new Snapshot.Key(get), Optional.of((TransactionResult) expected.get()));
   }
 
   @Test
@@ -188,7 +188,7 @@ public class CrudHandlerTest {
     Scan scan = prepareScan();
     result = prepareResult(true, TransactionState.COMMITTED);
     when(snapshot.get(any(Snapshot.Key.class))).thenReturn(Optional.empty());
-    doNothing().when(snapshot).put(any(Snapshot.Key.class), any(TransactionResult.class));
+    doNothing().when(snapshot).put(any(Snapshot.Key.class), any(Optional.class));
     when(scanner.iterator()).thenReturn(Arrays.asList(result).iterator());
     // doCallRealMethod().when(scanner).forEach(any(Consumer.class));
     when(storage.scan(scan)).thenReturn(scanner);
@@ -204,7 +204,7 @@ public class CrudHandlerTest {
             scan.getPartitionKey(),
             result.getClusteringKey().get());
     TransactionResult expected = new TransactionResult(result);
-    verify(snapshot).put(key, expected);
+    verify(snapshot).put(key, Optional.of(expected));
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0)).isEqualTo(expected);
   }
@@ -227,7 +227,7 @@ public class CrudHandlerTest {
         .isInstanceOf(UncommittedRecordException.class);
 
     // Assert
-    verify(snapshot, never()).put(any(Snapshot.Key.class), any(TransactionResult.class));
+    verify(snapshot, never()).put(any(Snapshot.Key.class), any(Optional.class));
   }
 
   @Test

--- a/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -39,7 +39,7 @@ public class SnapshotTest {
   private static final String ANY_TEXT_5 = "text5";
   private static final String ANY_TEXT_6 = "text6";
   private Snapshot snapshot;
-  private Map<Snapshot.Key, TransactionResult> readSet;
+  private Map<Snapshot.Key, Optional<TransactionResult>> readSet;
   private Map<Snapshot.Key, Put> writeSet;
   private Map<Snapshot.Key, Delete> deleteSet;
 
@@ -119,10 +119,10 @@ public class SnapshotTest {
     Snapshot.Key key = new Snapshot.Key(prepareGet());
 
     // Act
-    snapshot.put(key, result);
+    snapshot.put(key, Optional.of(result));
 
     // Assert
-    assertThat(readSet.get(key)).isEqualTo(result);
+    assertThat(readSet.get(key)).isEqualTo(Optional.of(result));
   }
 
   @Test
@@ -159,7 +159,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Snapshot.Key key = new Snapshot.Key(prepareGet());
-    snapshot.put(key, result);
+    snapshot.put(key, Optional.of(result));
     snapshot.put(key, put);
 
     // Act Assert
@@ -175,7 +175,7 @@ public class SnapshotTest {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Snapshot.Key key = new Snapshot.Key(prepareGet());
-    snapshot.put(key, result);
+    snapshot.put(key, Optional.of(result));
 
     // Act
     Optional<TransactionResult> actual = snapshot.get(key);
@@ -203,7 +203,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Delete delete = prepareDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), result);
+    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     snapshot.put(new Snapshot.Key(delete), delete);
     configureBehavior();
@@ -223,8 +223,8 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE);
     Put put = preparePut();
     Delete delete = prepareDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), result);
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), result);
+    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     snapshot.put(new Snapshot.Key(delete), delete);
     configureBehavior();
@@ -245,7 +245,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Delete delete = prepareDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), result);
+    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     snapshot.put(new Snapshot.Key(delete), delete);
 
@@ -263,7 +263,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE);
     Put put = preparePut();
     Delete delete = prepareDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), result);
+    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     snapshot.put(new Snapshot.Key(delete), delete);
     configureBehavior();
@@ -283,7 +283,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Delete delete = prepareDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), result);
+    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     snapshot.put(new Snapshot.Key(delete), delete);
     configureBehavior();
@@ -303,7 +303,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE);
     Put put = preparePut();
     Delete delete = prepareDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), result);
+    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     snapshot.put(new Snapshot.Key(delete), delete);
     configureBehavior();


### PR DESCRIPTION
It fixes part of https://github.com/scalar-labs/scalardb/issues/65 .

The fix should probably be called workaround since it aborts if it reads empty record. So the write skew case with empty records can not happen in Scalar DB. 
It's a little limitation in the current implementation but I think there seems nothing else we can do since we detect conflicts by using records.