### PR TITLE
add hashCode to Operations

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -63,7 +63,7 @@ Please see the javadoc for more details and usage.
 ### Transaction
 
 Scalar DB executes transactions in a fully client-coordinated way so that it can do master-less transactions, which achieves almost linear scalability and high availability (especially when it is integrated with master-less Cassandra).
-It basically follows the Cherry Garcia protocol propsed in [3]. More specifically, Scalar DB achieves scalable distributed transaction by utilizing atomic conditional mutation for managing transaction state and storing WAL (Write-Ahead-Logging) records in distributed fashion in each record by using meta-data ability.
+It basically follows the Cherry Garcia protocol proposed in [3]. More specifically, Scalar DB achieves scalable distributed transaction by utilizing atomic conditional mutation for managing transaction state and storing WAL (Write-Ahead-Logging) records in distributed fashion in each record by using meta-data ability.
 It also has some similarity to paxos-commit [4].
 
 Please see the javadoc for more details and usage.

--- a/src/main/java/com/scalar/db/api/ConditionalExpression.java
+++ b/src/main/java/com/scalar/db/api/ConditionalExpression.java
@@ -1,6 +1,7 @@
 package com.scalar.db.api;
 
 import com.scalar.db.io.Value;
+import java.util.Objects;
 
 /**
  * A conditional expression used in {@link MutationCondition}.
@@ -78,6 +79,11 @@ public class ConditionalExpression {
     }
     ConditionalExpression other = (ConditionalExpression) o;
     return name.equals(other.name) && value.equals(other.value) && operator.equals(other.operator);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value, operator);
   }
 
   private void checkOperator(Operator op) {

--- a/src/main/java/com/scalar/db/api/Delete.java
+++ b/src/main/java/com/scalar/db/api/Delete.java
@@ -84,6 +84,11 @@ public class Delete extends Mutation {
   }
 
   @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("namespace", forNamespace())

--- a/src/main/java/com/scalar/db/api/DeleteIf.java
+++ b/src/main/java/com/scalar/db/api/DeleteIf.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -44,6 +45,11 @@ public class DeleteIf implements MutationCondition {
   @Override
   public void accept(MutationConditionVisitor visitor) {
     visitor.visit(this);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(expressions);
   }
 
   /**

--- a/src/main/java/com/scalar/db/api/DeleteIfExists.java
+++ b/src/main/java/com/scalar/db/api/DeleteIfExists.java
@@ -54,4 +54,9 @@ public class DeleteIfExists implements MutationCondition {
     }
     return true;
   }
+
+  @Override
+  public int hashCode() {
+    return DeleteIfExists.class.hashCode();
+  }
 }

--- a/src/main/java/com/scalar/db/api/Get.java
+++ b/src/main/java/com/scalar/db/api/Get.java
@@ -90,6 +90,11 @@ public class Get extends Selection {
   }
 
   @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("namespace", forNamespace())

--- a/src/main/java/com/scalar/db/api/Mutation.java
+++ b/src/main/java/com/scalar/db/api/Mutation.java
@@ -2,6 +2,7 @@ package com.scalar.db.api;
 
 import com.google.common.base.MoreObjects;
 import com.scalar.db.io.Key;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -67,6 +68,11 @@ public abstract class Mutation extends Operation {
     }
     Mutation other = (Mutation) o;
     return condition.equals(other.condition);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), condition);
   }
 
   @Override

--- a/src/main/java/com/scalar/db/api/Operation.java
+++ b/src/main/java/com/scalar/db/api/Operation.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 import com.scalar.db.io.Key;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -151,6 +152,11 @@ public abstract class Operation {
             .compare(consistency, other.consistency)
             .result()
         == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionKey, clusteringKey, namespace, tableName, consistency);
   }
 
   /**

--- a/src/main/java/com/scalar/db/api/Put.java
+++ b/src/main/java/com/scalar/db/api/Put.java
@@ -7,6 +7,7 @@ import com.scalar.db.io.Value;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -121,6 +122,11 @@ public class Put extends Mutation {
     }
     Put other = (Put) o;
     return values.equals(other.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), values);
   }
 
   @Override

--- a/src/main/java/com/scalar/db/api/PutIf.java
+++ b/src/main/java/com/scalar/db/api/PutIf.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -42,6 +43,11 @@ public class PutIf implements MutationCondition {
   @Override
   public void accept(MutationConditionVisitor visitor) {
     visitor.visit(this);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(expressions);
   }
 
   /**

--- a/src/main/java/com/scalar/db/api/PutIfExists.java
+++ b/src/main/java/com/scalar/db/api/PutIfExists.java
@@ -54,4 +54,9 @@ public class PutIfExists implements MutationCondition {
     }
     return true;
   }
+
+  @Override
+  public int hashCode() {
+    return PutIfExists.class.hashCode();
+  }
 }

--- a/src/main/java/com/scalar/db/api/PutIfNotExists.java
+++ b/src/main/java/com/scalar/db/api/PutIfNotExists.java
@@ -54,4 +54,9 @@ public class PutIfNotExists implements MutationCondition {
     }
     return true;
   }
+
+  @Override
+  public int hashCode() {
+    return PutIfNotExists.class.hashCode();
+  }
 }

--- a/src/main/java/com/scalar/db/api/Scan.java
+++ b/src/main/java/com/scalar/db/api/Scan.java
@@ -5,6 +5,7 @@ import com.scalar.db.io.Key;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
@@ -231,6 +232,18 @@ public class Scan extends Selection {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        startClusteringKey,
+        startInclusive,
+        endClusteringKey,
+        endInclusive,
+        orderings,
+        limit);
+  }
+
+  @Override
   public String toString() {
     return super.toString()
         + MoreObjects.toStringHelper(this)
@@ -301,6 +314,11 @@ public class Scan extends Selection {
       }
       Ordering other = (Ordering) o;
       return (name.equals(other.name) && order.equals(other.order));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, order);
     }
 
     @Override

--- a/src/main/java/com/scalar/db/api/Selection.java
+++ b/src/main/java/com/scalar/db/api/Selection.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
@@ -84,6 +85,11 @@ public abstract class Selection extends Operation {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), projections);
   }
 
   @Override

--- a/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -111,4 +111,18 @@ public class DeleteTest {
     assertThat(ret).isTrue();
     assertThat(delete.hashCode()).isEqualTo(another.hashCode());
   }
+
+  @Test
+  public void equals_SameDeleteWithDeleteIfExistsGiven_ShouldReturnTrue() {
+    // Arrange
+    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+    Delete another = prepareDelete().withCondition(new DeleteIfExists());
+
+    // Act
+    boolean ret = delete.equals(another);
+
+    // Assert
+    assertThat(ret).isTrue();
+    assertThat(delete.hashCode()).isEqualTo(another.hashCode());
+  }
 }

--- a/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -101,13 +101,14 @@ public class DeleteTest {
   @Test
   public void equals_SameDeleteGiven_ShouldReturnTrue() {
     // Arrange
-    Delete put = prepareDelete();
+    Delete delete = prepareDelete();
     Delete another = prepareDelete();
 
     // Act
-    boolean ret = put.equals(another);
+    boolean ret = delete.equals(another);
 
     // Assert
     assertThat(ret).isTrue();
+    assertThat(delete.hashCode()).isEqualTo(another.hashCode());
   }
 }

--- a/src/test/java/com/scalar/db/api/GetTest.java
+++ b/src/test/java/com/scalar/db/api/GetTest.java
@@ -170,6 +170,7 @@ public class GetTest {
 
     // Assert
     assertThat(ret).isTrue();
+    assertThat(get.hashCode()).isEqualTo(another.hashCode());
   }
 
   @Test

--- a/src/test/java/com/scalar/db/api/PutTest.java
+++ b/src/test/java/com/scalar/db/api/PutTest.java
@@ -162,6 +162,7 @@ public class PutTest {
 
     // Assert
     assertThat(ret).isTrue();
+    assertThat(put.hashCode()).isEqualTo(another.hashCode());
   }
 
   @Test

--- a/src/test/java/com/scalar/db/api/PutTest.java
+++ b/src/test/java/com/scalar/db/api/PutTest.java
@@ -166,6 +166,34 @@ public class PutTest {
   }
 
   @Test
+  public void equals_SamePutWithPutIfExistsGiven_ShouldReturnTrue() {
+    // Arrange
+    Put put = preparePut().withCondition(new PutIfExists());
+    Put another = preparePut().withCondition(new PutIfExists());
+
+    // Act
+    boolean ret = put.equals(another);
+
+    // Assert
+    assertThat(ret).isTrue();
+    assertThat(put.hashCode()).isEqualTo(another.hashCode());
+  }
+
+  @Test
+  public void equals_SamePutWithPutIfNotExistsGiven_ShouldReturnTrue() {
+    // Arrange
+    Put put = preparePut().withCondition(new PutIfNotExists());
+    Put another = preparePut().withCondition(new PutIfNotExists());
+
+    // Act
+    boolean ret = put.equals(another);
+
+    // Assert
+    assertThat(ret).isTrue();
+    assertThat(put.hashCode()).isEqualTo(another.hashCode());
+  }
+
+  @Test
   public void equals_PutWithDifferentValuesGiven_ShouldReturnFalse() {
     // Arrange
     Put put = preparePut();

--- a/src/test/java/com/scalar/db/api/ScanTest.java
+++ b/src/test/java/com/scalar/db/api/ScanTest.java
@@ -108,6 +108,7 @@ public class ScanTest {
 
     // Assert
     assertThat(ret).isTrue();
+    assertThat(scan.hashCode()).isEqualTo(another.hashCode());
   }
 
   @Test


### PR DESCRIPTION
I noticed Operations don't have hashCode, so this PR adds hashCode for all Operations related class.
(Scan.hashCode is needed to put Scan to Map in future PR for https://scalar-labs.atlassian.net/browse/DLT-5833 )
