### PR TITLE
add another serializable strategy

### DIFF
--- a/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -347,6 +347,14 @@ public class ConsensusCommitWithCassandraIntegrationTest {
   }
 
   @Test
+  public void
+      commit_WriteSkewOnExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException()
+          throws Exception {
+    test
+        .commit_WriteSkewOnExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException();
+  }
+
+  @Test
   public void commit_WriteSkewOnNonExistingRecordsWithSerializable_ShouldThrowCommitException()
       throws Exception {
     test.commit_WriteSkewOnNonExistingRecordsWithSerializable_ShouldThrowCommitException();
@@ -354,9 +362,33 @@ public class ConsensusCommitWithCassandraIntegrationTest {
 
   @Test
   public void
+      commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitException()
+          throws Exception {
+    test
+        .commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitException();
+  }
+
+  @Test
+  public void
       commit_WriteSkewWithScanOnNonExistingRecordsWithSerializable_ShouldThrowCommitException()
           throws Exception {
     test.commit_WriteSkewWithScanOnNonExistingRecordsWithSerializable_ShouldThrowCommitException();
+  }
+
+  @Test
+  public void
+      commit_WriteSkewWithScanOnNonExistingRecordsWithSerializableWithExtraRead_ShouldThrowCommitException()
+          throws Exception {
+    test
+        .commit_WriteSkewWithScanOnNonExistingRecordsWithSerializableWithExtraRead_ShouldThrowCommitException();
+  }
+
+  @Test
+  public void
+      commit_WriteSkewWithScanOnExistingRecordsWithSerializableWithExtraRead_ShouldThrowCommitException()
+          throws Exception {
+    test
+        .commit_WriteSkewWithScanOnExistingRecordsWithSerializableWithExtraRead_ShouldThrowCommitException();
   }
 
   @Test

--- a/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -41,6 +41,51 @@ public interface DistributedTransactionManager {
   DistributedTransaction start(String txId, Isolation isolation);
 
   /**
+   * Starts a new transaction with the specified {@link Isolation} level and {@link
+   * SerializableStrategy}. If the isolation is not SERIALIZABLE, the serializable strategy is
+   * ignored.
+   *
+   * @param isolation an isolation level
+   * @param strategy a serializable strategy
+   * @return {@link DistributedTransaction}
+   */
+  DistributedTransaction start(Isolation isolation, SerializableStrategy strategy);
+
+  /**
+   * Starts a new transaction with Serializable isolation level and the specified {@link
+   * SerializableStrategy}.
+   *
+   * @param strategy a serializable strategy
+   * @return {@link DistributedTransaction}
+   */
+  DistributedTransaction start(SerializableStrategy strategy);
+
+  /**
+   * Starts a new transaction with the specified transaction ID, Serializable isolation level and
+   * the specified {@link SerializableStrategy}. It is users' responsibility to guarantee uniqueness
+   * of the ID so it is not recommended to use this method unless you know exactly what you are
+   * doing.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @param strategy a serializable strategy
+   * @return {@link DistributedTransaction}
+   */
+  DistributedTransaction start(String txId, SerializableStrategy strategy);
+
+  /**
+   * Starts a new transaction with the specified transaction ID, {@link Isolation} level and {@link
+   * SerializableStrategy}. It is users' responsibility to guarantee uniqueness of the ID so it is
+   * not recommended to use this method unless you know exactly what you are doing. If the isolation
+   * is not SERIALIZABLE, the serializable strategy is ignored.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @param isolation an isolation level
+   * @param strategy a serializable strategy
+   * @return {@link DistributedTransaction}
+   */
+  DistributedTransaction start(String txId, Isolation isolation, SerializableStrategy strategy);
+
+  /**
    * Returns the state of a given transaction.
    *
    * @param txId a transaction ID

--- a/src/main/java/com/scalar/db/api/SerializableStrategy.java
+++ b/src/main/java/com/scalar/db/api/SerializableStrategy.java
@@ -1,0 +1,3 @@
+package com.scalar.db.api;
+
+public interface SerializableStrategy {}

--- a/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/src/main/java/com/scalar/db/service/TransactionService.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Isolation;
+import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
 import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
@@ -42,6 +43,27 @@ public class TransactionService implements DistributedTransactionManager {
   @Override
   public DistributedTransaction start(String txId, Isolation isolation) {
     return manager.start(txId, isolation);
+  }
+
+  @Override
+  public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy) {
+    return manager.start(isolation, strategy);
+  }
+
+  @Override
+  public DistributedTransaction start(SerializableStrategy strategy) {
+    return manager.start(strategy);
+  }
+
+  @Override
+  public DistributedTransaction start(String txId, SerializableStrategy strategy) {
+    return manager.start(txId, strategy);
+  }
+
+  @Override
+  public DistributedTransaction start(
+      String txId, Isolation isolation, SerializableStrategy strategy) {
+    return null;
   }
 
   @Override

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -48,6 +48,16 @@ public class CommitHandler {
       throw new CommitException("preparing records failed", e);
     }
 
+    // pre-commit validation is executed when SERIALIZABLE with EXTRA_READ strategy is chosen.
+    try {
+      snapshot.toSerializableWithExtraRead(storage);
+    } catch (Exception e) {
+      LOGGER.warn("pre-commit validation failed", e);
+      abort(id);
+      recovery.rollback(snapshot);
+      throw new CommitConflictException("pre-commit validation failed", e);
+    }
+
     try {
       commitState(snapshot.getId());
     } catch (CoordinatorException e) {

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -62,15 +62,39 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
 
   @Override
   public synchronized ConsensusCommit start(Isolation isolation) {
-    String txId = UUID.randomUUID().toString();
-    return start(txId, isolation);
+    return start(isolation, SerializableStrategy.EXTRA_WRITE);
   }
 
   @Override
   public synchronized ConsensusCommit start(String txId, Isolation isolation) {
+    return start(txId, isolation, SerializableStrategy.EXTRA_WRITE);
+  }
+
+  @Override
+  public synchronized ConsensusCommit start(
+      Isolation isolation, com.scalar.db.api.SerializableStrategy strategy) {
+    String txId = UUID.randomUUID().toString();
+    return start(txId, isolation, strategy);
+  }
+
+  @Override
+  public synchronized ConsensusCommit start(com.scalar.db.api.SerializableStrategy strategy) {
+    String txId = UUID.randomUUID().toString();
+    return start(txId, Isolation.SERIALIZABLE, strategy);
+  }
+
+  @Override
+  public synchronized ConsensusCommit start(
+      String txId, com.scalar.db.api.SerializableStrategy strategy) {
+    return start(txId, Isolation.SERIALIZABLE, strategy);
+  }
+
+  @Override
+  public synchronized ConsensusCommit start(
+      String txId, Isolation isolation, com.scalar.db.api.SerializableStrategy strategy) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     checkArgument(isolation != null);
-    Snapshot snapshot = new Snapshot(txId, isolation);
+    Snapshot snapshot = new Snapshot(txId, isolation, (SerializableStrategy) strategy);
     CrudHandler crud = new CrudHandler(storage, snapshot);
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
     consensus.with(namespace, tableName);

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
@@ -1,0 +1,17 @@
+package com.scalar.db.transaction.consensuscommit;
+
+/**
+ * A Serializable strategy used in Consensus Commit algorithm. Both strategies basically make
+ * transactions avoid anti-dependencies that is the root cause of the anomalies in Snapshot
+ * Isolation.
+ *
+ * <p>Extra-write strategy converts all read set into write set when preparing records to remove
+ * anti-dependencies.
+ *
+ * <p>>Extra-read strategy checks all read set after preparing records and before committing a state
+ * to actually find out if there is an anti-dependency.
+ */
+public enum SerializableStrategy implements com.scalar.db.api.SerializableStrategy {
+  EXTRA_WRITE,
+  EXTRA_READ,
+}

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
@@ -2,7 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 /**
  * A Serializable strategy used in Consensus Commit algorithm. Both strategies basically make
- * transactions avoid anti-dependencies that is the root cause of the anomalies in Snapshot
+ * transactions avoid an anti-dependency that is the root cause of the anomalies in Snapshot
  * Isolation.
  *
  * <p>Extra-write strategy converts all read set into write set when preparing records to remove

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -178,7 +178,6 @@ public class Snapshot {
             });
   }
 
-  @VisibleForTesting
   void toSerializableWithExtraRead(DistributedStorage storage)
       throws ExecutionException, CommitConflictException {
     if (isolation != Isolation.SERIALIZABLE || strategy != SerializableStrategy.EXTRA_READ) {
@@ -199,7 +198,7 @@ public class Snapshot {
       }
 
       for (Key key : entry.getValue().get()) {
-        if (writeSet.containsKey(key)) {
+        if (writeSet.containsKey(key) || deleteSet.containsKey(key)) {
           continue;
         }
         // Check if read records are not changed

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -178,7 +178,6 @@ public class Snapshot {
             });
   }
 
-  @VisibleForTesting
   void toSerializableWithExtraRead(DistributedStorage storage)
       throws ExecutionException, CommitConflictException {
     if (isolation != Isolation.SERIALIZABLE || strategy != SerializableStrategy.EXTRA_READ) {

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -199,7 +199,7 @@ public class Snapshot {
       }
 
       for (Key key : entry.getValue().get()) {
-        if (writeSet.containsKey(key)) {
+        if (writeSet.containsKey(key) || deleteSet.containsKey(key)) {
           continue;
         }
         // Check if read records are not changed

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -178,6 +178,7 @@ public class Snapshot {
             });
   }
 
+  @VisibleForTesting
   void toSerializableWithExtraRead(DistributedStorage storage)
       throws ExecutionException, CommitConflictException {
     if (isolation != Isolation.SERIALIZABLE || strategy != SerializableStrategy.EXTRA_READ) {
@@ -198,7 +199,7 @@ public class Snapshot {
       }
 
       for (Key key : entry.getValue().get()) {
-        if (writeSet.containsKey(key) || deleteSet.containsKey(key)) {
+        if (writeSet.containsKey(key)) {
           continue;
         }
         // Check if read records are not changed

--- a/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -296,6 +296,7 @@ public class CrudHandlerTest {
         new Snapshot(
             ANY_TX_ID,
             Isolation.SNAPSHOT,
+            null,
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),
@@ -354,6 +355,7 @@ public class CrudHandlerTest {
         new Snapshot(
             ANY_TX_ID,
             Isolation.SNAPSHOT,
+            null,
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),


### PR DESCRIPTION
This PR contains updates for another serializable strategy proposed by @Yonezawa-T2  in
https://github.com/scalar-labs/scalardb/pull/70 .

There are still some unknowns as discussed in #70  but I think it is a good alternative so I actually implemented it as yet another `SerializableStrategy` and named it `Extra Read` strategy (the existing strategy is now called `Extra Write` strategy). We will do benchmarking and verification once it is merged.