### PR TITLE
refactor extra write and add/update some related tests

### DIFF
--- a/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTest.java
@@ -935,7 +935,7 @@ public class ConsensusCommitIntegrationTest {
   }
 
   public void commit_ConflictingPutsGivenForNonExisting_ShouldCommitOneAndAbortTheOther()
-      throws CrudException {
+      throws CrudException, CommitConflictException {
     // Arrange
     Value expected = new IntValue(BALANCE, INITIAL_BALANCE);
     List<Put> puts = preparePuts(NAMESPACE, TABLE_1);

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -98,7 +98,8 @@ public class CommitHandler {
     }
   }
 
-  private void prepareRecords(Snapshot snapshot) throws ExecutionException {
+  private void prepareRecords(Snapshot snapshot)
+      throws ExecutionException, CommitConflictException {
     PrepareMutationComposer composer = new PrepareMutationComposer(snapshot.getId());
     snapshot.to(composer);
     PartitionedMutations mutations = new PartitionedMutations(composer.get());
@@ -113,7 +114,7 @@ public class CommitHandler {
     coordinator.putState(state);
   }
 
-  private void commitRecords(Snapshot snapshot) throws ExecutionException {
+  private void commitRecords(Snapshot snapshot) throws ExecutionException, CommitConflictException {
     CommitMutationComposer composer = new CommitMutationComposer(snapshot.getId());
     snapshot.to(composer);
     PartitionedMutations mutations = new PartitionedMutations(composer.get());

--- a/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -10,6 +10,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.io.Key;
 import java.util.List;
@@ -51,7 +52,7 @@ public class RecoveryHandler {
     }
   }
 
-  public void rollback(Snapshot snapshot) {
+  public void rollback(Snapshot snapshot) throws CommitConflictException {
     LOGGER.info("rollback from snapshot for " + snapshot.getId());
     RollbackMutationComposer composer = new RollbackMutationComposer(snapshot.getId(), storage);
     snapshot.to(composer);

--- a/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -142,7 +142,7 @@ public class CommitHandlerTest {
 
   @Test
   public void commit_NoMutationExceptionThrownInPrepareRecords_ShouldThrowCCException()
-      throws ExecutionException, CoordinatorException {
+      throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     ExecutionException toThrow = mock(NoMutationException.class);
@@ -167,7 +167,7 @@ public class CommitHandlerTest {
 
   @Test
   public void commit_ExceptionThrownInPrepareRecords_ShouldAbortAndRollback()
-      throws ExecutionException, CoordinatorException {
+      throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     ExecutionException toThrow = mock(ExecutionException.class);
@@ -193,7 +193,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenAbortedReturnedInGetState_ShouldRollback()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     ExecutionException toThrow1 = mock(ExecutionException.class);
@@ -226,7 +226,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     ExecutionException toThrow1 = mock(ExecutionException.class);
@@ -256,7 +256,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     ExecutionException toThrow1 = mock(ExecutionException.class);
@@ -286,7 +286,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInCoordinatorCommitAndSucceededInCoordinatorAbort_ShouldRollback()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     CoordinatorException toThrow = mock(CoordinatorException.class);
@@ -346,7 +346,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInCoordinatorCommitAndAbortAndAbortedReturnedInGetState_ShouldRollback()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     CoordinatorException toThrow = mock(CoordinatorException.class);
@@ -381,7 +381,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInCoordinatorCommitAndAbortAndNothingReturnedInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     CoordinatorException toThrow = mock(CoordinatorException.class);
@@ -413,7 +413,7 @@ public class CommitHandlerTest {
   @Test
   public void
       commit_ExceptionThrownInCoordinatorCommitAndAbortAndExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
+          throws ExecutionException, CoordinatorException, CommitConflictException {
     // Arrange
     Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
     CoordinatorException toThrow = mock(CoordinatorException.class);


### PR DESCRIPTION
Basically renamed `toSerializable` to `toSerializableWithExtraWrite` and updated the for loop with usual `for` instead of using lambda `forEach` for consistency with extra read strategy added in #72. Note that the logic is not changed.

Additionally, some related unit tests are added.