### PR TITLE
Make extra-write strategy work for reading non-existing records

### DIFF
--- a/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -355,9 +355,19 @@ public class ConsensusCommitWithCassandraIntegrationTest {
   }
 
   @Test
-  public void commit_WriteSkewOnNonExistingRecordsWithSerializable_ShouldThrowCommitException()
-      throws Exception {
-    test.commit_WriteSkewOnNonExistingRecordsWithSerializable_ShouldThrowCommitException();
+  public void
+      commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitException()
+          throws Exception {
+    test
+        .commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitException();
+  }
+
+  @Test
+  public void
+      commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly()
+          throws Exception {
+    test
+        .commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly();
   }
 
   @Test


### PR DESCRIPTION
Decided not to introduce logical delete for now so make Extra-write work with non-existing read records.
https://github.com/scalar-labs/scalardb/issues/65
