### PR TITLE
specify serializable strategy explicitly in tests and update test names based on it

### DIFF
--- a/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -340,10 +340,10 @@ public class ConsensusCommitWithCassandraIntegrationTest {
 
   @Test
   public void
-      commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException()
+      commit_WriteSkewOnExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException()
           throws Exception {
     test
-        .commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException();
+        .commit_WriteSkewOnExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException();
   }
 
   @Test
@@ -380,9 +380,10 @@ public class ConsensusCommitWithCassandraIntegrationTest {
 
   @Test
   public void
-      commit_WriteSkewWithScanOnNonExistingRecordsWithSerializable_ShouldThrowCommitException()
+      commit_WriteSkewWithScanOnNonExistingRecordsWithSerializableWithExtraWrite_ShouldThrowCommitException()
           throws Exception {
-    test.commit_WriteSkewWithScanOnNonExistingRecordsWithSerializable_ShouldThrowCommitException();
+    test
+        .commit_WriteSkewWithScanOnNonExistingRecordsWithSerializableWithExtraWrite_ShouldThrowCommitException();
   }
 
   @Test

--- a/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -273,7 +273,7 @@ public class SnapshotTest {
   public void to_PrepareMutationComposerGivenAndSnapshotIsolationSet_ShouldCallComposerProperly()
       throws CommitConflictException {
     // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT, SerializableStrategy.EXTRA_WRITE);
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Delete delete = prepareDelete();
     snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
@@ -291,7 +291,7 @@ public class SnapshotTest {
 
   @Test
   public void
-      to_PrepareMutationComposerGivenAndSerializableIsolationSet_ShouldCallComposerProperly()
+      to_PrepareMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
           throws CommitConflictException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
@@ -334,8 +334,9 @@ public class SnapshotTest {
   }
 
   @Test
-  public void to_CommitMutationComposerGivenSerializableIsolationSet_ShouldCallComposerProperly()
-      throws CommitConflictException {
+  public void
+      to_CommitMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
+          throws CommitConflictException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();
@@ -376,8 +377,9 @@ public class SnapshotTest {
   }
 
   @Test
-  public void to_RollbackMutationComposerGivenSerializableIsolationSet_ShouldCallComposerProperly()
-      throws CommitConflictException {
+  public void
+      to_RollbackMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
+          throws CommitConflictException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6038 (internal)
As the title says, EXTRA_WRITE is specified in tests explicitly if not specified. Test names are changed accordingly.