### PR TITLE
Fix reading blob from Cosmos DB

### DIFF
--- a/src/main/java/com/scalar/db/storage/cosmos/MapVisitor.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/MapVisitor.java
@@ -8,7 +8,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.ValueVisitor;
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -91,8 +91,7 @@ public class MapVisitor implements ValueVisitor {
   }
 
   /**
-   * Sets the specified {@code BlobValue} to the map. Scalar DB converts the blob as a string
-   * because Cosmos DB doesn't receive a byte array.
+   * Sets the specified {@code BlobValue} to the map
    *
    * @param value a {@code BlobValue} to be set
    */
@@ -102,7 +101,7 @@ public class MapVisitor implements ValueVisitor {
         .get()
         .ifPresent(
             b -> {
-              values.put(value.getName(), new String(value.get().get(), StandardCharsets.UTF_8));
+              values.put(value.getName(), (ByteBuffer) ByteBuffer.allocate(b.length).put(b).flip());
             });
   }
 }

--- a/src/main/java/com/scalar/db/storage/cosmos/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ResultImpl.java
@@ -20,6 +20,7 @@ import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,7 +153,9 @@ public class ResultImpl implements Result {
             new String(
                 ((String) recordValue).getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
       case "blob":
-        return new BlobValue(name, ((String) recordValue).getBytes(StandardCharsets.UTF_8));
+        return new BlobValue(
+            name,
+            Base64.getDecoder().decode(((String) recordValue).getBytes(StandardCharsets.UTF_8)));
       default:
         throw new UnsupportedTypeException(type);
     }

--- a/src/test/java/com/scalar/db/storage/cosmos/MapVisitorTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/MapVisitorTest.java
@@ -9,6 +9,7 @@ import com.scalar.db.io.DoubleValue;
 import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +28,7 @@ public class MapVisitorTest {
   private static final DoubleValue ANY_DOUBLE_VALUE = new DoubleValue("any_double", ANY_DOUBLE);
   private static final String ANY_TEXT = "test";
   private static final TextValue ANY_TEXT_VALUE = new TextValue("any_text", ANY_TEXT);
-  private static final byte[] ANY_BLOB = "scalar".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] ANY_BLOB = ANY_TEXT.getBytes(StandardCharsets.UTF_8);
   private static final BlobValue ANY_BLOB_VALUE = new BlobValue("any_blob", ANY_BLOB);
   private MapVisitor visitor;
 
@@ -96,7 +97,8 @@ public class MapVisitorTest {
     ANY_BLOB_VALUE.accept(visitor);
 
     // Assert
-    String expected = new String(ANY_BLOB);
+    ByteBuffer expected =
+        (ByteBuffer) ByteBuffer.allocate(ANY_TEXT.length()).put(ANY_TEXT.getBytes()).flip();
     assertThat(visitor.get().get(ANY_BLOB_VALUE.getName())).isEqualTo(expected);
   }
 }

--- a/src/test/java/com/scalar/db/storage/cosmos/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/ResultImplTest.java
@@ -10,12 +10,15 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Get;
+import com.scalar.db.io.BlobValue;
 import com.scalar.db.io.BooleanValue;
 import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.Before;
@@ -28,6 +31,8 @@ public class ResultImplTest {
   private static final String ANY_NAME_2 = "name2";
   private static final String ANY_TEXT_1 = "text1";
   private static final String ANY_TEXT_2 = "text2";
+  private static final byte[] ANY_BLOB = "ブロブ".getBytes(StandardCharsets.UTF_8);
+  private static final String ANY_BLOB_STRING = Base64.getEncoder().encodeToString(ANY_BLOB);
   private static final String ANY_COLUMN_NAME_1 = "val1";
   private static final String ANY_COLUMN_NAME_2 = "val2";
   private static final String ANY_COLUMN_NAME_3 = "val3";
@@ -74,8 +79,8 @@ public class ResultImplTest {
             .put(ANY_COLUMN_NAME_4, Float.MAX_VALUE)
             .put(ANY_COLUMN_NAME_5, Double.MAX_VALUE)
             .put(ANY_COLUMN_NAME_6, "string")
-            // Cosmos DB converts byte[] to a string
-            .put(ANY_COLUMN_NAME_7, "ブロブ")
+            // Cosmos DB converts byte[] to a base64 string
+            .put(ANY_COLUMN_NAME_7, ANY_BLOB_STRING)
             .build();
     record.setValues(values);
 
@@ -106,6 +111,7 @@ public class ResultImplTest {
     assertThat(actual.get(ANY_NAME_1)).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
     assertThat(actual.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
     assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, true));
+    assertThat(actual.get(ANY_COLUMN_NAME_7)).isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, ANY_BLOB));
   }
 
   @Test


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7035

I found a bug about reading blob value from Cosmos DB.
In this modification, Scalar DB requests a write of blob value, does not convert it to `String`, and Cosmos DB will convert to String by Base64 encoding.
When reading the blob value, Scalar DB decodes the value because Cosmos DB returns it as String.

I tested the blob conversion to String in Scalar DB before. It worked well when the blob was short.
This PR supports long blob values.