### PR TITLE
Integrate DynamoDB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,15 @@ configurations {
     integrationTestRuntime.extendsFrom testRuntime
 }
 
+def awssdkVersion = "2.14.24"
+
 dependencies {
     compile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.6.0'
     compile group: 'com.azure', name: 'azure-cosmos', version: '4.1.0'
     compile group: 'org.jooq', name: 'jooq', version: '3.13.2'
+    compile group: 'software.amazon.awssdk', name: 'dynamodb', version: "${awssdkVersion}"
+    compile group: 'software.amazon.awssdk', name:'core', version: "${awssdkVersion}"
+
     compile group: 'com.google.guava', name: 'guava', version: '24.1-jre'
     compile group: 'com.google.inject', name: 'guice', version: '4.2.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'

--- a/conf/database.properties
+++ b/conf/database.properties
@@ -1,12 +1,12 @@
-# Comma separated contact points
+# Comma separated contact points. For DynamoDB, the region is specified by this parameter.
 scalar.db.contact_points=localhost
 
 # Port number for all the contact points. Default port number for each database is used if empty.
 #scalar.db.contact_port=
 
-# Credential information to access the database
+# Credential information to access the database. For Cosmos DB, username isn't used. For DynamoDB, AWS_ACCESS_KEY_ID is specified by the username and AWS_ACCESS_SECRET_KEY is specified by the password.
 scalar.db.username=cassandra
 scalar.db.password=cassandra
 
-# Storage implementation. Either cassandra or cosmos can be set. Default storage is cassandra.
+# Storage implementation. cassandra, cosmos or dynamo can be set. Default storage is cassandra.
 #scalar.db.storage=cassandra

--- a/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
@@ -1190,7 +1190,7 @@ public class DynamoIntegrationTest {
         KeySchemaElement.builder().attributeName(COL_NAME4).keyType(KeyType.RANGE).build());
     LocalSecondaryIndex index =
         LocalSecondaryIndex.builder()
-            .indexName("index." + COL_NAME4)
+            .indexName(KEYSPACE + "." + TABLE + ".index." + COL_NAME4)
             .keySchema(indexKeys)
             .projection(
                 Projection.builder()
@@ -1229,7 +1229,6 @@ public class DynamoIntegrationTest {
     values.put("table", AttributeValue.builder().s(KEYSPACE + "." + TABLE).build());
     values.put("partitionKey", AttributeValue.builder().ss(Arrays.asList(COL_NAME1)).build());
     values.put("clusteringKey", AttributeValue.builder().ss(Arrays.asList(COL_NAME4)).build());
-    values.put("sortKey", AttributeValue.builder().s(COL_NAME4).build());
     Map<String, AttributeValue> columns = new HashMap<>();
     columns.put(COL_NAME1, AttributeValue.builder().s("int").build());
     columns.put(COL_NAME2, AttributeValue.builder().s("text").build());

--- a/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
@@ -1,0 +1,1208 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.scalar.db.api.ConditionalExpression.Operator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.MultiPartitionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.storage.RetriableExecutionException;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.IntStream;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+
+public class DynamoIntegrationTest {
+  private static final String METADATA_KEYSPACE = "scalardb";
+  private static final String METADATA_TABLE = "metadata";
+  private static final String KEYSPACE = "integration_testing";
+  private static final String TABLE = "test_table";
+  private static final String PARTITION_KEY = "concatenatedPartitionKey";
+  private static final String COL_NAME1 = "c1";
+  private static final String COL_NAME2 = "c2";
+  private static final String COL_NAME3 = "c3";
+  private static final String COL_NAME4 = "c4";
+  private static final String COL_NAME5 = "c5";
+  private static DynamoDbClient client;
+  private static DistributedStorage storage;
+  private List<Put> puts;
+  private List<Delete> deletes;
+
+  @Before
+  public void setUp() throws Exception {
+    storage.with(KEYSPACE, TABLE);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // truncate the TABLE
+    ScanRequest request =
+        ScanRequest.builder().tableName(KEYSPACE + "." + TABLE).consistentRead(true).build();
+    client
+        .scan(request)
+        .items()
+        .forEach(
+            i -> {
+              Map<String, AttributeValue> key = new HashMap<>();
+              key.put(PARTITION_KEY, i.get(PARTITION_KEY));
+              key.put(COL_NAME4, i.get(COL_NAME4));
+              DeleteItemRequest delRequest =
+                  DeleteItemRequest.builder().tableName(KEYSPACE + "." + TABLE).key(key).build();
+              client.deleteItem(delRequest);
+            });
+  }
+
+  @Test
+  public void operation_NoTargetGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    storage.with(null, TABLE);
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 0));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 0));
+    Get get = new Get(partitionKey, clusteringKey);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              storage.get(get);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void get_GetWithPartitionKeyAndClusteringKeyGiven_ShouldRetrieveSingleResult()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Get get = prepareGet(pKey, 0);
+    Optional<Result> actual = storage.get(get);
+
+    // Assert
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+  }
+
+  @Test
+  public void get_GetWithProjectionsGiven_ShouldRetrieveSpecifiedValues()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+    int cKey = 0;
+
+    // Act
+    Get get = prepareGet(pKey, cKey);
+    get.withProjection(COL_NAME1).withProjection(COL_NAME2).withProjection(COL_NAME3);
+    Optional<Result> actual = storage.get(get);
+
+    // Assert
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get().getValue(COL_NAME2))
+        .isEqualTo(Optional.of(new TextValue(COL_NAME2, Integer.toString(pKey + cKey))));
+    assertThat(actual.get().getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
+    assertThat(actual.get().getValue(COL_NAME4).isPresent()).isTrue(); // since it's clustering key
+    assertThat(actual.get().getValue(COL_NAME5).isPresent()).isFalse();
+  }
+
+  @Test
+  public void scan_ScanWithPartitionKeyGiven_ShouldRetrieveMultipleResults()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+    List<Result> actual = new ArrayList<>();
+    storage.scan(scan).forEach(r -> actual.add(r)); // use iterator
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(3);
+    assertThat(actual.get(0).getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    assertThat(actual.get(1).getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    assertThat(actual.get(2).getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get(2).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+  }
+
+  @Test
+  public void scan_ScanWithPartitionKeyGivenAndResultsIteratedWithOne_ShouldReturnWhatsPut()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+    Scanner scanner = storage.scan(scan);
+
+    // Assert
+    Optional<Result> result = scanner.one();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(result.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    result = scanner.one();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(result.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    result = scanner.one();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(result.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+    result = scanner.one();
+    assertThat(result.isPresent()).isFalse();
+  }
+
+  @Test
+  public void scan_ScanWithPartitionGivenThreeTimes_ShouldRetrieveResultsProperlyEveryTime()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+    double t1 = System.currentTimeMillis();
+    List<Result> actual = storage.scan(scan).all();
+    double t2 = System.currentTimeMillis();
+    storage.scan(scan);
+    double t3 = System.currentTimeMillis();
+    storage.scan(scan);
+    double t4 = System.currentTimeMillis();
+
+    // Assert
+    assertThat(actual.get(0).getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    System.err.println("first: " + (t2 - t1) + " (ms)");
+    System.err.println("second: " + (t3 - t2) + " (ms)");
+    System.err.println("third: " + (t4 - t3) + " (ms)");
+  }
+
+  @Test
+  public void scan_ScanWithStartInclusiveRangeGiven_ShouldRetrieveResultsOfGivenRange()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Scan scan =
+        new Scan(new Key(new IntValue(COL_NAME1, pKey)))
+            .withStart(new Key(new IntValue(COL_NAME4, 0)), true)
+            .withEnd(new Key(new IntValue(COL_NAME4, 1)), true);
+    List<Result> actual = storage.scan(scan).all();
+
+    // verify
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual.get(0).getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    assertThat(actual.get(1).getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+  }
+
+  @Test
+  public void scan_ScanWithStartExclusiveRangeGiven_ShouldThrowIllegalArgumentException()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Scan scan =
+        new Scan(new Key(new IntValue(COL_NAME1, pKey)))
+            .withStart(new Key(new IntValue(COL_NAME4, 0)), false)
+            .withEnd(new Key(new IntValue(COL_NAME4, 2)), true);
+
+    assertThatThrownBy(
+            () -> {
+              storage.scan(scan).all();
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_ScanWithOrderAscGiven_ShouldReturnAscendingOrderedResults()
+      throws ExecutionException {
+    // Arrange
+    puts = preparePuts();
+    storage.mutate(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+    Scan scan =
+        new Scan(new Key(new IntValue(COL_NAME1, 0)))
+            .withOrdering(new Scan.Ordering(COL_NAME4, Scan.Ordering.Order.ASC));
+
+    // Act
+    List<Result> actual = storage.scan(scan).all();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(3);
+    assertThat(actual.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    assertThat(actual.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    assertThat(actual.get(2).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+  }
+
+  @Test
+  public void scan_ScanWithOrderDescGiven_ShouldReturnDescendingOrderedResults()
+      throws ExecutionException {
+    // Arrange
+    puts = preparePuts();
+    storage.mutate(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+    Scan scan =
+        new Scan(new Key(new IntValue(COL_NAME1, 0)))
+            .withOrdering(new Scan.Ordering(COL_NAME4, Scan.Ordering.Order.DESC));
+
+    // Act
+    List<Result> actual = storage.scan(scan).all();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(3);
+    assertThat(actual.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+    assertThat(actual.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    assertThat(actual.get(2).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+  }
+
+  @Test
+  public void scan_ScanWithLimitGiven_ShouldReturnGivenNumberOfResults() throws ExecutionException {
+    // setup
+    puts = preparePuts();
+    storage.mutate(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+
+    Scan scan =
+        new Scan(new Key(new IntValue(COL_NAME1, 0)))
+            .withOrdering(new Scan.Ordering(COL_NAME4, Scan.Ordering.Order.DESC))
+            .withLimit(1);
+
+    // exercise
+    List<Result> actual = storage.scan(scan).all();
+
+    // verify
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+  }
+
+  @Test
+  public void put_SinglePutGiven_ShouldStoreProperly() throws ExecutionException {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    Get get = new Get(partitionKey, clusteringKey);
+
+    // Act
+    storage.put(puts.get(pKey * 2 + cKey));
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get().getValue(COL_NAME2))
+        .isEqualTo(Optional.of(new TextValue(COL_NAME2, Integer.toString(pKey + cKey))));
+    assertThat(actual.get().getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
+    assertThat(actual.get().getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
+    assertThat(actual.get().getValue(COL_NAME5))
+        .isEqualTo(Optional.of(new BooleanValue(COL_NAME5, (cKey % 2 == 0) ? true : false)));
+  }
+
+  @Test
+  public void put_SinglePutWithIfNotExistsGiven_ShouldStoreProperly() throws ExecutionException {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    puts.get(0).withCondition(new PutIfNotExists());
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    Get get = new Get(partitionKey, clusteringKey);
+
+    // Act
+    storage.put(puts.get(0));
+    puts.get(0).withValue(new IntValue(COL_NAME3, Integer.MAX_VALUE));
+    assertThatThrownBy(
+            () -> {
+              storage.put(puts.get(0));
+            })
+        .isInstanceOf(NoMutationException.class);
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get().getValue(COL_NAME2))
+        .isEqualTo(Optional.of(new TextValue(COL_NAME2, Integer.toString(pKey + cKey))));
+    assertThat(actual.get().getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
+    assertThat(actual.get().getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
+    assertThat(actual.get().getValue(COL_NAME5))
+        .isEqualTo(Optional.of(new BooleanValue(COL_NAME5, (cKey % 2 == 0) ? true : false)));
+  }
+
+  @Test
+  public void put_MultiplePutGiven_ShouldStoreProperly() throws Exception {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.put(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(scan).all();
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
+    assertThat(results.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 1)));
+    assertThat(results.get(2).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 2)));
+  }
+
+  @Test
+  public void put_MultiplePutWithIfNotExistsGiven_ShouldStoreProperly() throws Exception {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    puts.get(0).withCondition(new PutIfNotExists());
+    puts.get(1).withCondition(new PutIfNotExists());
+    puts.get(2).withCondition(new PutIfNotExists());
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.put(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(scan).all();
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
+    assertThat(results.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 1)));
+    assertThat(results.get(2).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 2)));
+  }
+
+  @Test
+  public void put_MultiplePutWithIfNotExistsGivenWhenOneExists_ShouldThrowNoMutationException()
+      throws Exception {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    assertThatCode(
+            () -> {
+              storage.put(puts.get(0));
+            })
+        .doesNotThrowAnyException();
+    puts.get(0).withCondition(new PutIfNotExists());
+    puts.get(1).withCondition(new PutIfNotExists());
+    puts.get(2).withCondition(new PutIfNotExists());
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+
+    // Act
+    assertThatThrownBy(
+            () -> {
+              storage.put(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+            })
+        .isInstanceOf(NoMutationException.class);
+
+    // Assert
+    List<Result> results = storage.scan(scan).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
+  }
+
+  @Test
+  public void put_MultiplePutWithDifferentPartitionsWithIfNotExistsGiven_ShouldStoreProperly()
+      throws ExecutionException {
+    // Arrange
+    puts = preparePuts();
+    puts.get(0).withCondition(new PutIfNotExists());
+    puts.get(3).withCondition(new PutIfNotExists());
+    puts.get(6).withCondition(new PutIfNotExists());
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.put(Arrays.asList(puts.get(0), puts.get(3), puts.get(6)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results;
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 0)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 1)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 2)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+  }
+
+  @Test
+  public void put_MultiplePutWithDifferentPartitionsGiven_ShouldStoreProperly()
+      throws ExecutionException {
+    // Arrange
+    puts = preparePuts();
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.put(Arrays.asList(puts.get(0), puts.get(3), puts.get(6)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results;
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 0)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 1)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 2)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+  }
+
+  @Test
+  public void put_MultiplePutWithDifferentConditionsGiven_ShouldStoreProperly()
+      throws ExecutionException {
+    // Arrange
+    puts = preparePuts();
+    storage.put(puts.get(1));
+    puts.get(0).withCondition(new PutIfNotExists());
+    puts.get(1)
+        .withCondition(
+            new PutIf(new ConditionalExpression(COL_NAME2, new TextValue("1"), Operator.EQ)));
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.put(Arrays.asList(puts.get(0), puts.get(1)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 0)))).all();
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    assertThat(results.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+  }
+
+  @Test
+  public void put_PutWithIfExistsGivenWhenNoSuchRecord_ShouldThrowNoMutationException()
+      throws ExecutionException {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    puts.get(0).withCondition(new PutIfExists());
+    Get get = prepareGet(pKey, cKey);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              storage.put(puts.get(0));
+            })
+        .isInstanceOf(NoMutationException.class);
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isFalse();
+  }
+
+  @Test
+  public void put_PutWithIfExistsGivenWhenSuchRecordExists_ShouldUpdateRecord()
+      throws ExecutionException {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Get get = prepareGet(pKey, cKey);
+
+    // Act Assert
+    storage.put(puts.get(0));
+    puts.get(0).withCondition(new PutIfExists());
+    puts.get(0).withValue(new IntValue(COL_NAME3, Integer.MAX_VALUE));
+    assertThatCode(
+            () -> {
+              storage.put(puts.get(0));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    Result result = actual.get();
+    assertThat(result.getValue(COL_NAME1)).isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(result.getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
+    assertThat(result.getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, Integer.MAX_VALUE)));
+  }
+
+  @Test
+  public void put_PutWithIfGivenWhenSuchRecordExists_ShouldUpdateRecord()
+      throws ExecutionException {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Get get = prepareGet(pKey, cKey);
+
+    // Act Assert
+    storage.put(puts.get(0));
+    puts.get(0)
+        .withCondition(
+            new PutIf(
+                new ConditionalExpression(COL_NAME3, new IntValue(pKey + cKey), Operator.EQ)));
+    puts.get(0).withValue(new IntValue(COL_NAME3, Integer.MAX_VALUE));
+    assertThatCode(
+            () -> {
+              storage.put(puts.get(0));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    Result result = actual.get();
+    assertThat(result.getValue(COL_NAME1)).isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(result.getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
+    assertThat(result.getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, Integer.MAX_VALUE)));
+  }
+
+  @Test
+  public void put_PutWithIfGivenWhenNoSuchRecord_ShouldThrowNoMutationException()
+      throws ExecutionException {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Get get = prepareGet(pKey, cKey);
+
+    // Act Assert
+    storage.put(puts.get(0));
+    puts.get(0)
+        .withCondition(
+            new PutIf(
+                new ConditionalExpression(COL_NAME3, new IntValue(pKey + cKey + 1), Operator.EQ)));
+    puts.get(0).withValue(new IntValue(COL_NAME3, Integer.MAX_VALUE));
+    assertThatThrownBy(
+            () -> {
+              storage.put(puts.get(0));
+            })
+        .isInstanceOf(NoMutationException.class);
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    Result result = actual.get();
+    assertThat(result.getValue(COL_NAME1)).isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(result.getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
+    assertThat(result.getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
+  }
+
+  @Test
+  public void delete_DeleteWithPartitionKeyGiven_ShouldThrowIllegalArgumentException()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Delete delete = new Delete(partitionKey);
+    assertThatThrownBy(
+            () -> {
+              storage.delete(delete);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void delete_DeleteWithPartitionKeyAndClusteringKeyGiven_ShouldDeleteSingleRecordProperly()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+    int cKey = 0;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+
+    // Act
+    Delete delete = prepareDelete(pKey, cKey);
+    assertThatCode(
+            () -> {
+              storage.delete(delete);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(new Scan(partitionKey)).all();
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey + 1)));
+    assertThat(results.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey + 2)));
+  }
+
+  @Test
+  public void delete_DeleteWithIfExistsGivenWhenNoSuchRecord_ShouldThrowNoMutationException()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act Assert
+    Delete delete = prepareDelete(pKey, Integer.MAX_VALUE);
+    delete.withCondition(new DeleteIfExists());
+    assertThatThrownBy(
+            () -> {
+              storage.delete(delete);
+            })
+        .isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void delete_DeleteWithIfExistsGivenWhenSuchRecordExists_ShouldDeleteProperly()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+    int cKey = 0;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+
+    // Act
+    Delete delete = prepareDelete(pKey, cKey);
+    delete.withCondition(new DeleteIfExists());
+    assertThatCode(
+            () -> {
+              storage.delete(delete);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    Optional<Result> actual = storage.get(new Get(partitionKey, clusteringKey));
+    assertThat(actual.isPresent()).isFalse();
+  }
+
+  @Test
+  public void delete_DeleteWithIfGivenWhenNoSuchRecord_ShouldThrowNoMutationException()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+    int cKey = 0;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+
+    // Act
+    Delete delete = prepareDelete(pKey, cKey);
+    delete.withCondition(
+        new DeleteIf(
+            new ConditionalExpression(
+                COL_NAME2, new TextValue(Integer.toString(Integer.MAX_VALUE)), Operator.EQ)));
+    assertThatThrownBy(
+            () -> {
+              storage.delete(delete);
+            })
+        .isInstanceOf(NoMutationException.class);
+
+    // Assert
+    Optional<Result> actual = storage.get(new Get(partitionKey, clusteringKey));
+    assertThat(actual.isPresent()).isTrue();
+  }
+
+  @Test
+  public void delete_DeleteWithIfGivenWhenSuchRecordExists_ShouldDeleteProperly()
+      throws ExecutionException {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+    int cKey = 0;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+
+    // Act
+    Delete delete = prepareDelete(pKey, cKey);
+    delete.withCondition(
+        new DeleteIf(
+            new ConditionalExpression(
+                COL_NAME2, new TextValue(Integer.toString(pKey)), Operator.EQ)));
+    assertThatCode(
+            () -> {
+              storage.delete(delete);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    Optional<Result> actual = storage.get(new Get(partitionKey, clusteringKey));
+    assertThat(actual.isPresent()).isFalse();
+  }
+
+  @Test
+  public void delete_MultipleDeleteWithDifferentConditionsGiven_ShouldDeleteProperly()
+      throws ExecutionException {
+    // Arrange
+    puts = preparePuts();
+    deletes = prepareDeletes();
+    storage.mutate(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+    deletes.get(0).withCondition(new DeleteIfExists());
+    deletes
+        .get(1)
+        .withCondition(
+            new DeleteIf(new ConditionalExpression(COL_NAME2, new TextValue("1"), Operator.EQ)));
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.delete(Arrays.asList(deletes.get(0), deletes.get(1), deletes.get(2)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 0)))).all();
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void mutate_MultiplePutGiven_ShouldStoreProperly() throws Exception {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.mutate(Arrays.asList(puts.get(0), puts.get(1), puts.get(2)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(scan).all();
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
+    assertThat(results.get(1).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 1)));
+    assertThat(results.get(2).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 2)));
+  }
+
+  @Test
+  public void mutate_MultiplePutWithDifferentPartitionsGiven_ShouldStoreProperly()
+      throws Exception {
+    // Arrange
+    puts = preparePuts();
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.mutate(Arrays.asList(puts.get(0), puts.get(3), puts.get(6)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results;
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 0)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 1)))).all();
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    assertThat(results.size()).isEqualTo(1);
+    results = storage.scan(new Scan(new Key(new IntValue(COL_NAME1, 2)))).all();
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+  }
+
+  @Test
+  public void mutate_PutAndDeleteGiven_ShouldUpdateAndDeleteRecordsProperly() throws Exception {
+    // Arrange
+    populateRecords();
+    puts = preparePuts();
+    puts.get(1).withValue(new IntValue(COL_NAME3, Integer.MAX_VALUE));
+    puts.get(2).withValue(new IntValue(COL_NAME3, Integer.MIN_VALUE));
+
+    int pKey = 0;
+    int cKey = 0;
+    Delete delete = prepareDelete(pKey, cKey);
+
+    Scan scan = new Scan(new Key(new IntValue(COL_NAME1, pKey)));
+
+    // Act
+    assertThatCode(
+            () -> {
+              storage.mutate(Arrays.asList(delete, puts.get(1), puts.get(2)));
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    List<Result> results = storage.scan(scan).all();
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.get(0).getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, Integer.MAX_VALUE)));
+    assertThat(results.get(1).getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, Integer.MIN_VALUE)));
+  }
+
+  @Test
+  public void mutate_SinglePutGiven_ShouldStoreProperly() throws Exception {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    puts = preparePuts();
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    Get get = new Get(partitionKey, clusteringKey);
+
+    // Act
+    storage.mutate(Arrays.asList(puts.get(pKey * 2 + cKey)));
+
+    // Assert
+    Optional<Result> actual = storage.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
+    assertThat(actual.get().getValue(COL_NAME2))
+        .isEqualTo(Optional.of(new TextValue(COL_NAME2, Integer.toString(pKey + cKey))));
+    assertThat(actual.get().getValue(COL_NAME3))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
+    assertThat(actual.get().getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
+    assertThat(actual.get().getValue(COL_NAME5))
+        .isEqualTo(Optional.of(new BooleanValue(COL_NAME5, (cKey % 2 == 0) ? true : false)));
+  }
+
+  @Test
+  public void mutate_SingleDeleteGiven_ShouldThrowIllegalArgumentException() throws Exception {
+    // Arrange
+    populateRecords();
+    int pKey = 0;
+
+    // Act
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Delete delete = new Delete(partitionKey);
+    assertThatThrownBy(
+            () -> {
+              storage.mutate(Arrays.asList(delete));
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void mutate_EmptyListGiven_ShouldThrowIllegalArgumentException() throws Exception {
+    // Act
+    assertThatCode(
+            () -> {
+              storage.mutate(new ArrayList<>());
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void put_PutWithoutClusteringKeyGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    int pKey = 0;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Put put = new Put(partitionKey);
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              storage.put(put);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void put_IncorrectPutGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    int pKey = 0;
+    int cKey = 0;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Put put = new Put(partitionKey).withValue(new IntValue(COL_NAME4, cKey));
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              storage.put(put);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private void populateRecords() {
+    puts = preparePuts();
+    puts.forEach(
+        p -> {
+          assertThatCode(
+                  () -> {
+                    storage.put(p);
+                  })
+              .doesNotThrowAnyException();
+        });
+  }
+
+  private Get prepareGet(int pKey, int cKey) {
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    return new Get(partitionKey, clusteringKey);
+  }
+
+  private List<Put> preparePuts() {
+    List<Put> puts = new ArrayList<>();
+
+    IntStream.range(0, 5)
+        .forEach(
+            i -> {
+              IntStream.range(0, 3)
+                  .forEach(
+                      j -> {
+                        Key partitionKey = new Key(new IntValue(COL_NAME1, i));
+                        Key clusteringKey = new Key(new IntValue(COL_NAME4, j));
+                        Put put =
+                            new Put(partitionKey, clusteringKey)
+                                .withValue(new TextValue(COL_NAME2, Integer.toString(i + j)))
+                                .withValue(new IntValue(COL_NAME3, i + j))
+                                .withValue(
+                                    new BooleanValue(COL_NAME5, (j % 2 == 0) ? true : false));
+                        puts.add(put);
+                      });
+            });
+
+    return puts;
+  }
+
+  private Delete prepareDelete(int pKey, int cKey) {
+    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    return new Delete(partitionKey, clusteringKey);
+  }
+
+  private List<Delete> prepareDeletes() {
+    List<Delete> deletes = new ArrayList<>();
+
+    IntStream.range(0, 5)
+        .forEach(
+            i -> {
+              IntStream.range(0, 3)
+                  .forEach(
+                      j -> {
+                        Key partitionKey = new Key(new IntValue(COL_NAME1, i));
+                        Key clusteringKey = new Key(new IntValue(COL_NAME4, j));
+                        Delete delete = new Delete(partitionKey, clusteringKey);
+                        deletes.add(delete);
+                      });
+            });
+
+    return deletes;
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    client = DynamoDbClient.builder().build();
+    createMetadataTable();
+    createUserTable();
+
+    // wait for the creation
+    try {
+      Thread.sleep(10000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    insertMetadata();
+
+    // reuse this storage instance through the tests
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, "dummy");
+    props.setProperty(DatabaseConfig.USERNAME, "dummy");
+    props.setProperty(DatabaseConfig.PASSWORD, "dummy");
+    storage = new Dynamo(new DatabaseConfig(props));
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    DeleteTableRequest request =
+        DeleteTableRequest.builder().tableName(KEYSPACE + "." + TABLE).build();
+    client.deleteTable(request);
+
+    request =
+        DeleteTableRequest.builder().tableName(METADATA_KEYSPACE + "." + METADATA_TABLE).build();
+    client.deleteTable(request);
+
+    client.close();
+  }
+
+  private static void createUserTable() {
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .attributeDefinitions(
+                AttributeDefinition.builder()
+                    .attributeName(PARTITION_KEY)
+                    .attributeType(ScalarAttributeType.S)
+                    .build(),
+                AttributeDefinition.builder()
+                    .attributeName(COL_NAME4)
+                    .attributeType(ScalarAttributeType.N)
+                    .build())
+            .keySchema(
+                KeySchemaElement.builder()
+                    .attributeName(PARTITION_KEY)
+                    .keyType(KeyType.HASH)
+                    .build(),
+                KeySchemaElement.builder().attributeName(COL_NAME4).keyType(KeyType.RANGE).build())
+            .provisionedThroughput(
+                ProvisionedThroughput.builder()
+                    .readCapacityUnits(10L)
+                    .writeCapacityUnits(10L)
+                    .build())
+            .tableName(KEYSPACE + "." + TABLE)
+            .build();
+    client.createTable(request);
+  }
+
+  private static void createMetadataTable() {
+    CreateTableRequest request =
+        CreateTableRequest.builder()
+            .attributeDefinitions(
+                AttributeDefinition.builder()
+                    .attributeName("table")
+                    .attributeType(ScalarAttributeType.S)
+                    .build())
+            .keySchema(
+                KeySchemaElement.builder().attributeName("table").keyType(KeyType.HASH).build())
+            .provisionedThroughput(
+                ProvisionedThroughput.builder()
+                    .readCapacityUnits(10L)
+                    .writeCapacityUnits(10L)
+                    .build())
+            .tableName(METADATA_KEYSPACE + "." + METADATA_TABLE)
+            .build();
+
+    client.createTable(request);
+  }
+
+  private static void insertMetadata() {
+    Map<String, AttributeValue> values = new HashMap<>();
+    values.put("table", AttributeValue.builder().s(KEYSPACE + "." + TABLE).build());
+    values.put("partitionKey", AttributeValue.builder().ss(Arrays.asList(COL_NAME1)).build());
+    values.put("clusteringKey", AttributeValue.builder().ss(Arrays.asList(COL_NAME4)).build());
+    values.put("sortKey", AttributeValue.builder().s(COL_NAME4).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(COL_NAME1, AttributeValue.builder().s("int").build());
+    columns.put(COL_NAME2, AttributeValue.builder().s("text").build());
+    columns.put(COL_NAME3, AttributeValue.builder().s("int").build());
+    columns.put(COL_NAME4, AttributeValue.builder().s("int").build());
+    columns.put(COL_NAME5, AttributeValue.builder().s("boolean").build());
+    values.put("columns", AttributeValue.builder().m(columns).build());
+
+    String table = METADATA_KEYSPACE + "." + METADATA_TABLE;
+    PutItemRequest request = PutItemRequest.builder().tableName(table).item(values).build();
+
+    client.putItem(request);
+  }
+}

--- a/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
@@ -20,9 +20,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.storage.MultiPartitionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.BooleanValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
@@ -1118,9 +1116,9 @@ public class DynamoIntegrationTest {
 
     // reuse this storage instance through the tests
     Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, "dummy");
-    props.setProperty(DatabaseConfig.USERNAME, "dummy");
-    props.setProperty(DatabaseConfig.PASSWORD, "dummy");
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, System.getenv("AWS_REGION"));
+    props.setProperty(DatabaseConfig.USERNAME, System.getenv("AWS_ACCESS_KEY_ID"));
+    props.setProperty(DatabaseConfig.PASSWORD, System.getenv("AWS_SECRET_ACCESS_KEY"));
     storage = new Dynamo(new DatabaseConfig(props));
   }
 

--- a/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.cosmos.Cosmos;
+import com.scalar.db.storage.dynamo.Dynamo;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -69,6 +70,9 @@ public class DatabaseConfig {
           break;
         case "cosmos":
           storageClass = Cosmos.class;
+          break;
+        case "dynamo":
+          storageClass = Dynamo.class;
           break;
         default:
           throw new IllegalArgumentException(props.getProperty(STORAGE) + " isn't supported");

--- a/src/main/java/com/scalar/db/service/StorageModule.java
+++ b/src/main/java/com/scalar/db/service/StorageModule.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.cosmos.Cosmos;
+import com.scalar.db.storage.dynamo.Dynamo;
 
 public class StorageModule extends AbstractModule {
   private final DatabaseConfig config;
@@ -28,5 +29,10 @@ public class StorageModule extends AbstractModule {
   @Provides
   Cosmos provideCosmos() {
     return new Cosmos(config);
+  }
+
+  @Provides
+  Dynamo provideDynamo() {
+    return new Dynamo(config);
   }
 }

--- a/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -8,6 +8,7 @@ import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.cosmos.Cosmos;
+import com.scalar.db.storage.dynamo.Dynamo;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
 
 public class TransactionModule extends AbstractModule {
@@ -31,5 +32,10 @@ public class TransactionModule extends AbstractModule {
   @Provides
   Cosmos provideCosmos() {
     return new Cosmos(config);
+  }
+
+  @Provides
+  Dynamo provideDynamo() {
+    return new Dynamo(config);
   }
 }

--- a/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -1,0 +1,166 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.MutationCondition;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.MultiPartitionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CancellationReason;
+import software.amazon.awssdk.services.dynamodb.model.Delete;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.Put;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
+import software.amazon.awssdk.services.dynamodb.model.Update;
+
+/**
+ * A handler for a batch
+ *
+ * @author Yuji Ito
+ */
+@ThreadSafe
+public class BatchHandler {
+  static final Logger LOGGER = LoggerFactory.getLogger(BatchHandler.class);
+  private final DynamoDbClient client;
+  private final TableMetadataManager metadataManager;
+
+  /**
+   * Constructs a {@code BatchHandler} with the specified {@link DynamoDbClient} and {@link
+   * TableMetadataManager}
+   *
+   * @param client {@code DynamoDbClient} to create a statement with
+   * @param metadataManager {@code TableMetadataManager}
+   */
+  public BatchHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+    this.client = client;
+    this.metadataManager = metadataManager;
+  }
+
+  /**
+   * Execute the specified list of {@link Mutation}s in batch. All the {@link Mutation}s in the list
+   * must be for the same partition. Otherwise, it throws an {@link MultiPartitionException}.
+   *
+   * @param mutations a list of {@code Mutation}s to execute
+   * @throws NoMutationException if at least one of conditional {@code Mutation}s failed because it
+   *     didn't meet the condition
+   */
+  public void handle(List<? extends Mutation> mutations) throws ExecutionException {
+    checkNotNull(mutations);
+    if (mutations.size() < 1) {
+      throw new IllegalArgumentException("please specify at least one mutation.");
+    } else if (mutations.size() > 25) {
+      throw new IllegalArgumentException("DynamoDB cannot batch more than 25 mutations at once.");
+    }
+
+    TransactWriteItemsRequest.Builder builder = TransactWriteItemsRequest.builder();
+    List<TransactWriteItem> transactItems = new ArrayList<>();
+    mutations.forEach(m -> transactItems.add(makeWriteItem(m)));
+    builder.transactItems(transactItems);
+
+    try {
+      client.transactWriteItems(builder.build());
+    } catch (TransactionCanceledException e) {
+      for (CancellationReason reason : e.cancellationReasons()) {
+        if (reason.code().equals("ConditionalCheckFailed")) {
+          throw new NoMutationException("no mutation was applied.", e);
+        }
+      }
+      throw new ExecutionException(e.getMessage(), e);
+    } catch (DynamoDbException e) {
+      throw new ExecutionException(e.getMessage(), e);
+    }
+  }
+
+  private TransactWriteItem makeWriteItem(Mutation mutation) {
+    TransactWriteItem.Builder itemBuilder = TransactWriteItem.builder();
+
+    if (mutation instanceof com.scalar.db.api.Put) {
+      MutationCondition condition = mutation.getCondition().orElse(null);
+      if (condition != null && (condition instanceof PutIf || condition instanceof PutIfExists)) {
+        itemBuilder.update(makeUpdate((com.scalar.db.api.Put) mutation));
+      } else {
+        itemBuilder.put(makePut((com.scalar.db.api.Put) mutation));
+      }
+    } else {
+      itemBuilder.delete(makeDelete((com.scalar.db.api.Delete) mutation));
+    }
+
+    return itemBuilder.build();
+  }
+
+  private Put makePut(com.scalar.db.api.Put put) {
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    Put.Builder putBuilder = Put.builder();
+
+    putBuilder.tableName(dynamoMutation.getTableName()).item(dynamoMutation.getValueMapWithKey());
+    if (put.getCondition().isPresent() && put.getCondition().get() instanceof PutIfNotExists) {
+      putBuilder.conditionExpression(dynamoMutation.getIfNotExistsCondition());
+    }
+
+    return putBuilder.build();
+  }
+
+  private Update makeUpdate(com.scalar.db.api.Put put) {
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    Update.Builder updateBuilder = Update.builder();
+    String condition;
+    Map<String, AttributeValue> bindMap;
+
+    if (put.getCondition().get() instanceof PutIfExists) {
+      condition = dynamoMutation.getIfExistsCondition();
+      bindMap = dynamoMutation.getValueBindMap();
+    } else {
+      condition = dynamoMutation.getCondition();
+      bindMap = dynamoMutation.getConditionBindMap();
+      bindMap.putAll(dynamoMutation.getValueBindMap());
+    }
+
+    updateBuilder
+        .tableName(dynamoMutation.getTableName())
+        .key(dynamoMutation.getKeyMap())
+        .updateExpression(dynamoMutation.getUpdateExpression())
+        .conditionExpression(condition)
+        .expressionAttributeValues(bindMap)
+        .build();
+
+    return updateBuilder.build();
+  }
+
+  private Delete makeDelete(com.scalar.db.api.Delete delete) {
+    DynamoMutation dynamoMutation = new DynamoMutation(delete, metadataManager);
+    Delete.Builder deleteBuilder =
+        Delete.builder().tableName(dynamoMutation.getTableName()).key(dynamoMutation.getKeyMap());
+
+    if (delete.getCondition().isPresent()) {
+      String condition;
+
+      if (delete.getCondition().get() instanceof DeleteIfExists) {
+        condition = dynamoMutation.getIfExistsCondition();
+      } else {
+        condition = dynamoMutation.getCondition();
+        Map<String, AttributeValue> bindMap = dynamoMutation.getConditionBindMap();
+
+        deleteBuilder.expressionAttributeValues(bindMap);
+      }
+
+      deleteBuilder.conditionExpression(condition);
+    }
+
+    return deleteBuilder.build();
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -100,22 +100,27 @@ public class BatchHandler {
     Update.Builder updateBuilder = Update.builder();
     String expression;
     String condition = null;
+    Map<String, String> columnMap;
     Map<String, AttributeValue> bindMap;
 
     if (!put.getCondition().isPresent()) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
     } else if (put.getCondition().get() instanceof PutIfNotExists) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
       condition = dynamoMutation.getIfNotExistsCondition();
     } else if (put.getCondition().get() instanceof PutIfExists) {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getValueBindMap();
     } else {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition() + " AND " + dynamoMutation.getCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getConditionBindMap();
       bindMap.putAll(dynamoMutation.getValueBindMap());
     }
@@ -125,6 +130,7 @@ public class BatchHandler {
         .key(dynamoMutation.getKeyMap())
         .updateExpression(expression)
         .conditionExpression(condition)
+        .expressionAttributeNames(columnMap)
         .expressionAttributeValues(bindMap)
         .build();
 

--- a/src/main/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilder.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilder.java
@@ -1,0 +1,127 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.MutationConditionVisitor;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A builder to make a query statement for a stored procedure of Cosmos DB from conditions
+ *
+ * @author Yuji Ito
+ */
+@NotThreadSafe
+public class ConditionExpressionBuilder implements MutationConditionVisitor {
+  private final List<String> expressions;
+  private final String alias;
+  private int index;
+
+  public ConditionExpressionBuilder(String alias) {
+    this.expressions = new ArrayList<>();
+    this.alias = alias;
+    this.index = 0;
+  }
+
+  @Nonnull
+  public String build() {
+    return String.join(" AND ", expressions);
+  }
+
+  /**
+   * Adds {@code PutIf}-specific conditions to the query
+   *
+   * @param condition {@code PutIf} condition
+   */
+  @Override
+  public void visit(PutIf condition) {
+    condition
+        .getExpressions()
+        .forEach(
+            e -> {
+              expressions.add(createConditionWith(e));
+            });
+  }
+
+  /**
+   * Adds {@code PutIfExists}-specific conditions to the query
+   *
+   * @param condition {@code PutIfExists} condition
+   */
+  @Override
+  public void visit(PutIfExists condition) {
+    // nothing to do
+  }
+
+  /**
+   * Adds {@code PutIfNotExists}-specific conditions to the query
+   *
+   * @param condition {@code PutIfNotExists} condition
+   */
+  @Override
+  public void visit(PutIfNotExists condition) {
+    // nothing to do
+  }
+
+  /**
+   * Adds {@code DeleteIf}-specific conditions to the query
+   *
+   * @param condition {@code DeleteIf} condition
+   */
+  @Override
+  public void visit(DeleteIf condition) {
+    condition
+        .getExpressions()
+        .forEach(
+            e -> {
+              expressions.add(createConditionWith(e));
+            });
+  }
+
+  /**
+   * Adds {@code DeleteIfExists}-specific conditions to the query
+   *
+   * @param condition {@code DeleteIfExists} condition
+   */
+  @Override
+  public void visit(DeleteIfExists condition) {
+    // nothing to do
+  }
+
+  private String createConditionWith(ConditionalExpression e) {
+    List<String> elements;
+    switch (e.getOperator()) {
+      case EQ:
+        elements = Arrays.asList(e.getName(), "=", alias + index);
+        break;
+      case NE:
+        elements = Arrays.asList("NOT", e.getName(), "=", alias + index);
+        break;
+      case GT:
+        elements = Arrays.asList(e.getName(), ">", alias + index);
+        break;
+      case GTE:
+        elements = Arrays.asList(e.getName(), ">=", alias + index);
+        break;
+      case LT:
+        elements = Arrays.asList(e.getName(), "<", alias + index);
+        break;
+      case LTE:
+        elements = Arrays.asList(e.getName(), "<=", alias + index);
+        break;
+      default:
+        // never comes here because ConditionalExpression accepts only above operators
+        throw new IllegalArgumentException(e.getOperator() + " is not supported");
+    }
+    index++;
+
+    return String.join(" ", elements);
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/DeleteStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DeleteStatementHandler.java
@@ -1,0 +1,71 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.Operation;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+
+/**
+ * A handler class for delete statements
+ *
+ * @author Yuji Ito
+ */
+@ThreadSafe
+public class DeleteStatementHandler extends StatementHandler {
+
+  public DeleteStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+    super(client, metadataManager);
+  }
+
+  @Override
+  public List<Map<String, AttributeValue>> handle(Operation operation) throws ExecutionException {
+    checkArgument(operation, Delete.class);
+    Delete delete = (Delete) operation;
+
+    try {
+      delete(delete);
+    } catch (ConditionalCheckFailedException e) {
+      throw new NoMutationException("no mutation was applied.", e);
+    } catch (DynamoDbException e) {
+      throw new ExecutionException(e.getMessage(), e);
+    }
+
+    return Collections.emptyList();
+  }
+
+  private void delete(Delete delete) {
+    DynamoMutation dynamoMutation = new DynamoMutation(delete, metadataManager);
+
+    DeleteItemRequest.Builder builder =
+        DeleteItemRequest.builder()
+            .tableName(dynamoMutation.getTableName())
+            .key(dynamoMutation.getKeyMap());
+
+    if (delete.getCondition().isPresent()) {
+      String condition;
+
+      if (delete.getCondition().get() instanceof DeleteIfExists) {
+        condition = dynamoMutation.getIfExistsCondition();
+      } else {
+        condition = dynamoMutation.getCondition();
+        Map<String, AttributeValue> bindMap = dynamoMutation.getConditionBindMap();
+
+        builder.expressionAttributeValues(bindMap);
+      }
+
+      builder.conditionExpression(condition);
+    }
+
+    client.deleteItem(builder.build());
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -1,0 +1,182 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.inject.Inject;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Key;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A storage implementation with DynamoDB for {@link DistributedStorage}
+ *
+ * @author Yuji Ito
+ */
+@ThreadSafe
+public class Dynamo implements DistributedStorage {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Dynamo.class);
+  private final String METADATA_DATABASE = "scalardb";
+  private final String METADATA_CONTAINER = "metadata";
+
+  private final DynamoDbClient client;
+  private final TableMetadataManager metadataManager;
+  private final SelectStatementHandler selectStatementHandler;
+  private final PutStatementHandler putStatementHandler;
+  private final DeleteStatementHandler deleteStatementHandler;
+  private final BatchHandler batchHandler;
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  @Inject
+  public Dynamo(DatabaseConfig config) {
+    this.client = DynamoDbClient.builder().build();
+
+    this.metadataManager = new TableMetadataManager(client);
+
+    this.selectStatementHandler = new SelectStatementHandler(client, metadataManager);
+    this.putStatementHandler = new PutStatementHandler(client, metadataManager);
+    this.deleteStatementHandler = new DeleteStatementHandler(client, metadataManager);
+    this.batchHandler = new BatchHandler(client, metadataManager);
+
+    LOGGER.info("DynamoDB object is created properly.");
+
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  @Nonnull
+  public Optional<Result> get(Get get) throws ExecutionException {
+    setTargetToIfNot(get);
+
+    List<Map<String, AttributeValue>> items = selectStatementHandler.handle(get);
+
+    if (items.isEmpty() || items.get(0) == null) {
+      return Optional.empty();
+    }
+
+    TableMetadata metadata = metadataManager.getTableMetadata(get);
+    return Optional.of(new ResultImpl(items.get(0), get, metadata));
+  }
+
+  @Override
+  public Scanner scan(Scan scan) throws ExecutionException {
+    setTargetToIfNot(scan);
+
+    List<Map<String, AttributeValue>> items = selectStatementHandler.handle(scan);
+
+    TableMetadata metadata = metadataManager.getTableMetadata(scan);
+    return new ScannerImpl(items, scan, metadata);
+  }
+
+  @Override
+  public void put(Put put) throws ExecutionException {
+    setTargetToIfNot(put);
+    checkIfPrimaryKeyExists(put);
+
+    putStatementHandler.handle(put);
+  }
+
+  @Override
+  public void put(List<Put> puts) throws ExecutionException {
+    mutate(puts);
+  }
+
+  @Override
+  public void delete(Delete delete) throws ExecutionException {
+    setTargetToIfNot(delete);
+    checkIfPrimaryKeyExists(delete);
+
+    deleteStatementHandler.handle(delete);
+  }
+
+  @Override
+  public void delete(List<Delete> deletes) throws ExecutionException {
+    mutate(deletes);
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws ExecutionException {
+    checkArgument(mutations.size() != 0);
+    if (mutations.size() > 1) {
+      setTargetToIfNot(mutations);
+      batchHandler.handle(mutations);
+    } else if (mutations.size() == 1) {
+      Mutation mutation = mutations.get(0);
+      if (mutation instanceof Put) {
+        put((Put) mutation);
+      } else if (mutation instanceof Delete) {
+        delete((Delete) mutation);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  private void setTargetToIfNot(List<? extends Operation> operations) {
+    operations.forEach(o -> setTargetToIfNot(o));
+  }
+
+  private void setTargetToIfNot(Operation operation) {
+    if (!operation.forNamespace().isPresent()) {
+      operation.forNamespace(namespace.orElse(null));
+    }
+    if (!operation.forTable().isPresent()) {
+      operation.forTable(tableName.orElse(null));
+    }
+    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
+      throw new IllegalArgumentException("operation has no target namespace and table name");
+    }
+  }
+
+  private void checkIfPrimaryKeyExists(Mutation mutation) {
+    TableMetadata metadata = metadataManager.getTableMetadata(mutation);
+
+    throwIfNotMatched(Optional.of(mutation.getPartitionKey()), metadata.getPartitionKeyNames());
+    throwIfNotMatched(mutation.getClusteringKey(), metadata.getClusteringKeyNames());
+  }
+
+  private void throwIfNotMatched(Optional<Key> key, Set<String> names) {
+    String message = "The primary key is not properly specified.";
+    if ((!key.isPresent() && names.size() > 0)
+        || (key.isPresent() && (key.get().size() != names.size()))) {
+      throw new IllegalArgumentException(message);
+    }
+    key.ifPresent(
+        k ->
+            k.forEach(
+                v -> {
+                  if (!names.contains(v.getName())) {
+                    throw new IllegalArgumentException(message);
+                  }
+                }));
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -37,7 +37,6 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 @ThreadSafe
 public class Dynamo implements DistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(Dynamo.class);
-
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
   private final SelectStatementHandler selectStatementHandler;
@@ -74,6 +73,26 @@ public class Dynamo implements DistributedStorage {
   public void with(String namespace, String tableName) {
     this.namespace = Optional.ofNullable(namespace);
     this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
   }
 
   @Override

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.io.Value;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -84,23 +85,59 @@ public class DynamoMutation extends DynamoOperation {
 
     if (withKey) {
       for (Value key : put.getPartitionKey().get()) {
-        expressions.add(key.getName() + " = " + VALUE_ALIAS + i);
+        expressions.add(COLUMN_NAME_ALIAS + i + " = " + VALUE_ALIAS + i);
         i++;
       }
       if (put.getClusteringKey().isPresent()) {
         for (Value key : put.getClusteringKey().get().get()) {
-          expressions.add(key.getName() + " = " + VALUE_ALIAS + i);
+          expressions.add(COLUMN_NAME_ALIAS + i + " = " + VALUE_ALIAS + i);
           i++;
         }
       }
     }
 
     for (String name : put.getValues().keySet()) {
-      expressions.add(name + " = " + VALUE_ALIAS + i);
+      expressions.add(COLUMN_NAME_ALIAS + i + " = " + VALUE_ALIAS + i);
       i++;
     }
 
     return "SET " + String.join(", ", expressions);
+  }
+
+  @Nonnull
+  public Map<String, String> getColumnMap() {
+    return getColumnMap(false);
+  }
+
+  @Nonnull
+  public Map<String, String> getColumnMapWithKey() {
+    return getColumnMap(true);
+  }
+
+  private Map<String, String> getColumnMap(boolean withKey) {
+    Put put = (Put) getOperation();
+    Map<String, String> columnMap = new HashMap<>();
+    int i = 0;
+
+    if (withKey) {
+      for (Value key : put.getPartitionKey().get()) {
+        columnMap.put(COLUMN_NAME_ALIAS + i, key.getName());
+        i++;
+      }
+      if (put.getClusteringKey().isPresent()) {
+        for (Value key : put.getClusteringKey().get().get()) {
+          columnMap.put(COLUMN_NAME_ALIAS + i, key.getName());
+          i++;
+        }
+      }
+    }
+
+    for (String name : put.getValues().keySet()) {
+      columnMap.put(COLUMN_NAME_ALIAS + i, name);
+      i++;
+    }
+
+    return columnMap;
   }
 
   @Nonnull

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-/** A class to treating utilities for a mutation */
+/** A utility class for a mutation */
 public class DynamoMutation extends DynamoOperation {
 
   DynamoMutation(Mutation mutation, TableMetadataManager metadataManager) {

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -1,0 +1,120 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/** A class to treating utilities for a mutation */
+public class DynamoMutation extends DynamoOperation {
+
+  DynamoMutation(Mutation mutation, TableMetadataManager metadataManager) {
+    super(mutation, metadataManager);
+  }
+
+  @Nonnull
+  public Map<String, AttributeValue> getValueMapWithKey() {
+    Put put = (Put) getOperation();
+    Map<String, AttributeValue> values = getKeyMap();
+    values.putAll(toMap(put.getPartitionKey().get()));
+    put.getClusteringKey()
+        .ifPresent(
+            k -> {
+              values.putAll(toMap(k.get()));
+            });
+    values.putAll(toMap(put.getValues().values()));
+
+    return values;
+  }
+
+  @Nonnull
+  public String getIfNotExistsCondition() {
+    List<String> expressions = new ArrayList<>();
+    expressions.add("attribute_not_exists(" + PARTITION_KEY + ")");
+    getOperation()
+        .getClusteringKey()
+        .ifPresent(
+            k -> {
+              k.get()
+                  .forEach(
+                      c -> {
+                        expressions.add("attribute_not_exists(" + c.getName() + ")");
+                      });
+            });
+
+    return String.join(" AND ", expressions);
+  }
+
+  @Nonnull
+  public String getIfExistsCondition() {
+    List<String> expressions = new ArrayList<>();
+    expressions.add("attribute_exists(" + PARTITION_KEY + ")");
+    getOperation()
+        .getClusteringKey()
+        .ifPresent(
+            k -> {
+              k.get()
+                  .forEach(
+                      c -> {
+                        expressions.add("attribute_exists(" + c.getName() + ")");
+                      });
+            });
+
+    return String.join(" AND ", expressions);
+  }
+
+  @Nonnull
+  public String getCondition() {
+    ConditionExpressionBuilder builder = new ConditionExpressionBuilder(CONDITION_VALUE_ALIAS);
+    Mutation mutation = (Mutation) getOperation();
+    mutation
+        .getCondition()
+        .ifPresent(
+            c -> {
+              c.accept(builder);
+            });
+
+    return builder.build();
+  }
+
+  @Nonnull
+  public String getUpdateExpression() {
+    Put put = (Put) getOperation();
+    List<String> expressions = new ArrayList<>();
+    int i = 0;
+
+    for (String name : put.getValues().keySet()) {
+      expressions.add(name + " = " + VALUE_ALIAS + i);
+      i++;
+    }
+
+    return "SET " + String.join(", ", expressions);
+  }
+
+  @Nonnull
+  public Map<String, AttributeValue> getConditionBindMap() {
+    ValueBinder binder = new ValueBinder(CONDITION_VALUE_ALIAS);
+    Mutation mutation = (Mutation) getOperation();
+    mutation
+        .getCondition()
+        .ifPresent(
+            c -> {
+              c.getExpressions().forEach(e -> e.getValue().accept(binder));
+            });
+
+    return binder.build();
+  }
+
+  @Nonnull
+  public Map<String, AttributeValue> getValueBindMap() {
+    ValueBinder binder = new ValueBinder(VALUE_ALIAS);
+    Put put = (Put) getOperation();
+    put.getValues().forEach((a, v) -> v.accept(binder));
+
+    return binder.build();
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -35,16 +35,9 @@ public class DynamoMutation extends DynamoOperation {
   public String getIfNotExistsCondition() {
     List<String> expressions = new ArrayList<>();
     expressions.add("attribute_not_exists(" + PARTITION_KEY + ")");
-    getOperation()
-        .getClusteringKey()
-        .ifPresent(
-            k -> {
-              k.get()
-                  .forEach(
-                      c -> {
-                        expressions.add("attribute_not_exists(" + c.getName() + ")");
-                      });
-            });
+    if (getOperation().getClusteringKey().isPresent()) {
+      expressions.add("attribute_not_exists(" + CLUSTERING_KEY + ")");
+    }
 
     return String.join(" AND ", expressions);
   }
@@ -53,16 +46,9 @@ public class DynamoMutation extends DynamoOperation {
   public String getIfExistsCondition() {
     List<String> expressions = new ArrayList<>();
     expressions.add("attribute_exists(" + PARTITION_KEY + ")");
-    getOperation()
-        .getClusteringKey()
-        .ifPresent(
-            k -> {
-              k.get()
-                  .forEach(
-                      c -> {
-                        expressions.add("attribute_exists(" + c.getName() + ")");
-                      });
-            });
+    if (getOperation().getClusteringKey().isPresent()) {
+      expressions.add("attribute_exists(" + CLUSTERING_KEY + ")");
+    }
 
     return String.join(" AND ", expressions);
   }

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -1,0 +1,102 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.Operation;
+import com.scalar.db.io.Value;
+import com.scalar.db.storage.cosmos.ConcatenationVisitor;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/** A class to treating utilities for a operation */
+public class DynamoOperation {
+  static final String PARTITION_KEY = "concatenatedPartitionKey";
+  static final String PARTITION_KEY_ALIAS = ":pk";
+  static final String CLUSTERING_KEY_ALIAS = ":ck";
+  static final String START_CLUSTERING_KEY_ALIAS = ":sck";
+  static final String END_CLUSTERING_KEY_ALIAS = ":eck";
+  static final String CONDITION_VALUE_ALIAS = ":cval";
+  static final String VALUE_ALIAS = ":val";
+  static final String RANGE_KEY_ALIAS = ":sk";
+  static final String RANGE_CONDITION = " BETWEEN :sk0 AND :sk1";
+
+  private final Operation operation;
+  private final TableMetadata metadata;
+
+  public DynamoOperation(Operation operation, TableMetadataManager metadataManager) {
+    this.operation = operation;
+    this.metadata = metadataManager.getTableMetadata(operation);
+  }
+
+  @Nonnull
+  public Operation getOperation() {
+    return operation;
+  }
+
+  @Nonnull
+  public TableMetadata getMetadata() {
+    return metadata;
+  }
+
+  @Nonnull
+  public String getTableName() {
+    return operation.forNamespace().get() + "." + operation.forTable().get();
+  }
+
+  @Nonnull
+  public Map<String, AttributeValue> getKeyMap() {
+    Map<String, AttributeValue> keyMap = new HashMap<>();
+    String partitionKey = getConcatenatedPartitionKey();
+    keyMap.put(PARTITION_KEY, AttributeValue.builder().s(partitionKey).build());
+
+    operation
+        .getClusteringKey()
+        .ifPresent(
+            k -> {
+              keyMap.putAll(toMap(k.get()));
+            });
+
+    return keyMap;
+  }
+
+  String getConcatenatedPartitionKey() {
+    Map<String, Value> keyMap = new HashMap<>();
+    operation
+        .getPartitionKey()
+        .get()
+        .forEach(
+            v -> {
+              keyMap.put(v.getName(), v);
+            });
+
+    ConcatenationVisitor visitor = new ConcatenationVisitor();
+    metadata
+        .getPartitionKeyNames()
+        .forEach(
+            name -> {
+              if (keyMap.containsKey(name)) {
+                keyMap.get(name).accept(visitor);
+              } else {
+                throw new IllegalArgumentException("The partition key is not properly specified.");
+              }
+            });
+
+    return visitor.build();
+  }
+
+  Map<String, AttributeValue> toMap(Collection<Value> values) {
+    MapVisitor visitor = new MapVisitor();
+    values.forEach(v -> v.accept(visitor));
+
+    return visitor.get();
+  }
+
+  boolean isSortKey(String key) {
+    if(!metadata.getSortKeyName().isPresent()) {
+      return false;
+    }
+
+    return metadata.getSortKeyName().get().equals(key);
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -20,6 +20,7 @@ public class DynamoOperation {
   static final String END_CLUSTERING_KEY_ALIAS = ":eck";
   static final String CONDITION_VALUE_ALIAS = ":cval";
   static final String VALUE_ALIAS = ":val";
+  static final String COLUMN_NAME_ALIAS = "#col";
   static final String RANGE_KEY_ALIAS = ":sk";
   static final String RANGE_CONDITION = " BETWEEN :sk0 AND :sk1";
   static final String INDEX_NAME_PREFIX = "index";

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -49,7 +49,7 @@ public class DynamoOperation {
 
   @Nonnull
   public String getIndexName(String clusteringKey) {
-    return INDEX_NAME_PREFIX + "." + clusteringKey;
+    return getTableName() + "." + INDEX_NAME_PREFIX + "." + clusteringKey;
   }
 
   @Nonnull

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -32,6 +32,11 @@ public class DynamoOperation {
     this.metadata = metadataManager.getTableMetadata(operation);
   }
 
+  public DynamoOperation(Operation operation, TableMetadata metadata) {
+    this.operation = operation;
+    this.metadata = metadata;
+  }
+
   @Nonnull
   public Operation getOperation() {
     return operation;

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-/** A class to treating utilities for a operation */
+/** A utility class for an operation */
 public class DynamoOperation {
   static final String PARTITION_KEY = "concatenatedPartitionKey";
   static final String CLUSTERING_KEY = "concatenatedClusteringKey";

--- a/src/main/java/com/scalar/db/storage/dynamo/ItemSorter.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ItemSorter.java
@@ -1,0 +1,93 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.UnsupportedTypeException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A sorter for items retrieved from DynamoDB
+ *
+ * @author Yuji Ito
+ */
+@NotThreadSafe
+public class ItemSorter {
+  private final Scan scan;
+  private final Comparator<Map<String, AttributeValue>> comparator;
+
+  public ItemSorter(Scan scan, TableMetadata metadata) {
+    checkNotNull(metadata);
+    this.scan = checkNotNull(scan);
+    this.comparator = getComparator(scan, metadata);
+  }
+
+  public List<Map<String, AttributeValue>> sort(List<Map<String, AttributeValue>> items) {
+    checkNotNull(items);
+
+    if (!scan.getOrderings().isEmpty()) {
+      Collections.sort(items, comparator);
+    }
+
+    int limit = scan.getLimit();
+    if (limit > 0 && limit < items.size()) {
+      items = items.subList(0, limit);
+    }
+
+    return items;
+  }
+
+  private Comparator<Map<String, AttributeValue>> getComparator(Scan scan, TableMetadata metadata) {
+    return new Comparator<Map<String, AttributeValue>>() {
+      public int compare(Map<String, AttributeValue> o1, Map<String, AttributeValue> o2) {
+        int compareResult = 0;
+        for (Scan.Ordering ordering : scan.getOrderings()) {
+          String name = ordering.getName();
+          compareResult =
+              compareAttributeValues(metadata.getColumns().get(name), o1.get(name), o2.get(name));
+          compareResult *= ordering.getOrder() == Scan.Ordering.Order.ASC ? 1 : -1;
+          if (compareResult != 0) {
+            break;
+          }
+        }
+
+        return compareResult;
+      }
+    };
+  }
+
+  private int compareAttributeValues(String type, AttributeValue a1, AttributeValue a2)
+      throws UnsupportedTypeException {
+    if (a1 == null && a2 == null) {
+      return 0;
+    } else if (a1 == null) {
+      return -1;
+    } else if (a2 == null) {
+      return 1;
+    }
+
+    switch (type) {
+      case "boolean":
+        return a1.bool().compareTo(a2.bool());
+      case "int":
+        return Integer.valueOf(a1.n()).compareTo(Integer.valueOf(a2.n()));
+      case "bigint":
+        return Long.valueOf(a1.n()).compareTo(Long.valueOf(a2.n()));
+      case "float":
+        return Float.valueOf(a1.n()).compareTo(Float.valueOf(a2.n()));
+      case "double":
+        return Double.valueOf(a1.n()).compareTo(Double.valueOf(a2.n()));
+      case "text":
+        return a1.s().compareTo(a2.s());
+      case "blob":
+        return a1.b().asByteBuffer().compareTo(a2.b().asByteBuffer());
+      default:
+        throw new UnsupportedTypeException(type);
+    }
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/MapVisitor.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/MapVisitor.java
@@ -1,0 +1,117 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.BlobValue;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.DoubleValue;
+import com.scalar.db.io.FloatValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.TextValue;
+import com.scalar.db.io.ValueVisitor;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A visitor to make a map to be used to create {@link Record}
+ *
+ * @author Yuji Ito
+ */
+@NotThreadSafe
+public class MapVisitor implements ValueVisitor {
+  private final Map<String, AttributeValue> values;
+
+  public MapVisitor() {
+    values = new HashMap<>();
+  }
+
+  @Nonnull
+  public Map<String, AttributeValue> get() {
+    return values;
+  }
+
+  /**
+   * Sets the specified {@code BooleanValue} to the map
+   *
+   * @param value a {@code BooleanValue} to be set
+   */
+  @Override
+  public void visit(BooleanValue value) {
+    values.put(value.getName(), AttributeValue.builder().bool(value.get()).build());
+  }
+
+  /**
+   * Sets the specified {@code IntValue} to the map
+   *
+   * @param value a {@code IntValue} to be set
+   */
+  @Override
+  public void visit(IntValue value) {
+    String v = String.valueOf(value.get());
+    values.put(value.getName(), AttributeValue.builder().n(v).build());
+  }
+
+  /**
+   * Sets the specified {@code BigIntValue} to the map
+   *
+   * @param value a {@code BigIntValue} to be set
+   */
+  @Override
+  public void visit(BigIntValue value) {
+    String v = String.valueOf(value.get());
+    values.put(value.getName(), AttributeValue.builder().n(v).build());
+  }
+
+  /**
+   * Sets the specified {@code FloatValue} to the map
+   *
+   * @param value a {@code FloatValue} to be set
+   */
+  @Override
+  public void visit(FloatValue value) {
+    String v = String.valueOf(value.get());
+    values.put(value.getName(), AttributeValue.builder().n(v).build());
+  }
+
+  /**
+   * Sets the specified {@code DoubleValue} to the map
+   *
+   * @param value a {@code DoubleValue} to be set
+   */
+  @Override
+  public void visit(DoubleValue value) {
+    String v = String.valueOf(value.get());
+    values.put(value.getName(), AttributeValue.builder().n(v).build());
+  }
+
+  /**
+   * Sets the specified {@code TextValue} to the map
+   *
+   * @param value a {@code TextValue} to be set
+   */
+  @Override
+  public void visit(TextValue value) {
+    value
+        .getString()
+        .ifPresent(s -> values.put(value.getName(), AttributeValue.builder().s(s).build()));
+  }
+
+  /**
+   * Sets the specified {@code BlobValue} to the map
+   *
+   * @param value a {@code BlobValue} to be set
+   */
+  @Override
+  public void visit(BlobValue value) {
+    value
+        .get()
+        .ifPresent(
+            b -> {
+              values.put(
+                  value.getName(), AttributeValue.builder().b(SdkBytes.fromByteArray(b)).build());
+            });
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
@@ -48,22 +48,27 @@ public class PutStatementHandler extends StatementHandler {
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
     String expression;
     String condition = null;
+    Map<String, String> columnMap;
     Map<String, AttributeValue> bindMap;
 
     if (!put.getCondition().isPresent()) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
     } else if (put.getCondition().get() instanceof PutIfNotExists) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
       condition = dynamoMutation.getIfNotExistsCondition();
     } else if (put.getCondition().get() instanceof PutIfExists) {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getValueBindMap();
     } else {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition() + " AND " + dynamoMutation.getCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getConditionBindMap();
       bindMap.putAll(dynamoMutation.getValueBindMap());
     }
@@ -74,6 +79,7 @@ public class PutStatementHandler extends StatementHandler {
             .key(dynamoMutation.getKeyMap())
             .updateExpression(expression)
             .conditionExpression(condition)
+            .expressionAttributeNames(columnMap)
             .expressionAttributeValues(bindMap)
             .build();
 

--- a/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
@@ -1,0 +1,95 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.MutationCondition;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * A handler class for put statements
+ *
+ * @author Yuji Ito
+ */
+@ThreadSafe
+public class PutStatementHandler extends StatementHandler {
+
+  public PutStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+    super(client, metadataManager);
+  }
+
+  @Override
+  public List<Map<String, AttributeValue>> handle(Operation operation) throws ExecutionException {
+    checkArgument(operation, Put.class);
+    Put put = (Put) operation;
+    MutationCondition condition = put.getCondition().orElse(null);
+
+    try {
+      if (condition != null && (condition instanceof PutIf || condition instanceof PutIfExists)) {
+        update(put);
+      } else {
+        insert(put);
+      }
+    } catch (ConditionalCheckFailedException e) {
+      throw new NoMutationException("no mutation was applied.", e);
+    } catch (DynamoDbException e) {
+      throw new ExecutionException(e.getMessage(), e);
+    }
+
+    return Collections.emptyList();
+  }
+
+  private void insert(Put put) {
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    PutItemRequest.Builder builder =
+        PutItemRequest.builder()
+            .tableName(dynamoMutation.getTableName())
+            .item(dynamoMutation.getValueMapWithKey());
+
+    if (put.getCondition().isPresent() && put.getCondition().get() instanceof PutIfNotExists) {
+      String condition = dynamoMutation.getIfNotExistsCondition();
+      builder.conditionExpression(condition);
+    }
+
+    client.putItem(builder.build());
+  }
+
+  private void update(Put put) {
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    String condition;
+    Map<String, AttributeValue> bindMap;
+    if (put.getCondition().get() instanceof PutIfExists) {
+      condition = dynamoMutation.getIfExistsCondition();
+      bindMap = dynamoMutation.getValueBindMap();
+    } else {
+      condition = dynamoMutation.getCondition();
+      bindMap = dynamoMutation.getConditionBindMap();
+      bindMap.putAll(dynamoMutation.getValueBindMap());
+    }
+
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName(dynamoMutation.getTableName())
+            .key(dynamoMutation.getKeyMap())
+            .updateExpression(dynamoMutation.getUpdateExpression())
+            .conditionExpression(condition)
+            .expressionAttributeValues(bindMap)
+            .build();
+
+    client.updateItem(request);
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
@@ -17,7 +17,6 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -131,22 +130,23 @@ public class ResultImpl implements Result {
       throws UnsupportedTypeException {
     // When itemValue is NULL, the value will be the default value.
     // It is the same behavior as the datastax C* driver
+    boolean isNull = itemValue == null || (itemValue.nul() != null && itemValue.nul());
     switch (type) {
       case "boolean":
-        return new BooleanValue(name, itemValue == null ? false : itemValue.bool());
+        return new BooleanValue(name, isNull ? false : itemValue.bool());
       case "int":
-        return new IntValue(name, itemValue == null ? 0 : Integer.valueOf(itemValue.n()));
+        return new IntValue(name, isNull ? 0 : Integer.valueOf(itemValue.n()));
       case "bigint":
-        return new BigIntValue(name, itemValue == null ? 0L : Long.valueOf(itemValue.n()));
+        return new BigIntValue(name, isNull ? 0L : Long.valueOf(itemValue.n()));
       case "float":
-        return new FloatValue(name, itemValue == null ? 0.0f : Float.valueOf(itemValue.n()));
+        return new FloatValue(name, isNull ? 0.0f : Float.valueOf(itemValue.n()));
       case "double":
-        return new DoubleValue(name, itemValue == null ? 0.0 : Double.valueOf(itemValue.n()));
+        return new DoubleValue(name, isNull ? 0.0 : Double.valueOf(itemValue.n()));
       case "text": // for backwards compatibility
       case "varchar":
-        return new TextValue(name, itemValue == null ? null : itemValue.s());
+        return new TextValue(name, isNull ? (String) null : itemValue.s());
       case "blob":
-        return new BlobValue(name, itemValue == null ? null : itemValue.b().asByteArray());
+        return new BlobValue(name, isNull ? null : itemValue.b().asByteArray());
       default:
         throw new UnsupportedTypeException(type);
     }

--- a/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
@@ -1,0 +1,154 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Selection;
+import com.scalar.db.exception.storage.UnsupportedTypeException;
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.BlobValue;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.DoubleValue;
+import com.scalar.db.io.FloatValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@Immutable
+public class ResultImpl implements Result {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResultImpl.class);
+  private final Selection selection;
+  private final TableMetadata metadata;
+  private final Map<String, Value> values;
+
+  public ResultImpl(Map<String, AttributeValue> item, Selection selection, TableMetadata metadata) {
+    checkNotNull(item);
+    this.selection = selection;
+    this.metadata = checkNotNull(metadata);
+    values = new HashMap<>();
+    interpret(item, metadata);
+  }
+
+  @Override
+  public Optional<Key> getPartitionKey() {
+    return getKey(metadata.getPartitionKeyNames());
+  }
+
+  @Override
+  public Optional<Key> getClusteringKey() {
+    return getKey(metadata.getClusteringKeyNames());
+  }
+
+  @Override
+  public Optional<Value> getValue(String name) {
+    return Optional.ofNullable(values.get(name));
+  }
+
+  @Override
+  @Nonnull
+  public Map<String, Value> getValues() {
+    return ImmutableMap.copyOf(values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(values);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ResultImpl)) {
+      return false;
+    }
+    ResultImpl other = (ResultImpl) o;
+    if (this.values.equals(other.values)) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("values", values).toString();
+  }
+
+  @VisibleForTesting
+  void interpret(Map<String, AttributeValue> item, TableMetadata metadata) {
+    if (selection.getProjections().isEmpty()) {
+      metadata
+          .getColumns()
+          .forEach(
+              (name, type) -> {
+                add(name, item.get(name));
+              });
+    } else {
+      selection
+          .getProjections()
+          .forEach(
+              name -> {
+                add(name, item.get(name));
+              });
+    }
+
+    metadata.getPartitionKeyNames().forEach(name -> add(name, item.get(name)));
+    metadata.getClusteringKeyNames().forEach(name -> add(name, item.get(name)));
+  }
+
+  private void add(String name, AttributeValue itemValue) {
+    values.put(name, convert(itemValue, name, metadata.getColumns().get(name)));
+  }
+
+  private Optional<Key> getKey(Set<String> names) {
+    List<Value> list = new ArrayList<>();
+    for (String name : names) {
+      Value value = values.get(name);
+      list.add(value);
+    }
+    return Optional.of(new Key(list));
+  }
+
+  private Value convert(AttributeValue itemValue, String name, String type)
+      throws UnsupportedTypeException {
+    // When itemValue is NULL, the value will be the default value.
+    // It is the same behavior as the datastax C* driver
+    switch (type) {
+      case "boolean":
+        return new BooleanValue(name, itemValue == null ? false : itemValue.bool());
+      case "int":
+        return new IntValue(name, itemValue == null ? 0 : Integer.valueOf(itemValue.n()));
+      case "bigint":
+        return new BigIntValue(name, itemValue == null ? 0L : Long.valueOf(itemValue.n()));
+      case "float":
+        return new FloatValue(name, itemValue == null ? 0.0f : Float.valueOf(itemValue.n()));
+      case "double":
+        return new DoubleValue(name, itemValue == null ? 0.0 : Double.valueOf(itemValue.n()));
+      case "text": // for backwards compatibility
+      case "varchar":
+        return new TextValue(name, itemValue == null ? null : itemValue.s());
+      case "blob":
+        return new BlobValue(name, itemValue == null ? null : itemValue.b().asByteArray());
+      default:
+        throw new UnsupportedTypeException(type);
+    }
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
@@ -3,9 +3,13 @@ package com.scalar.db.storage.dynamo;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.Selection;
+import com.scalar.db.exception.storage.UnsupportedTypeException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -16,15 +20,16 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 @NotThreadSafe
 public final class ScannerImpl implements Scanner {
-  private final List<Map<String, AttributeValue>> items;
   private final Selection selection;
   private final TableMetadata metadata;
+  private List<Map<String, AttributeValue>> items;
 
   public ScannerImpl(
       List<Map<String, AttributeValue>> items, Selection selection, TableMetadata metadata) {
     this.items = checkNotNull(items);
     this.selection = selection;
     this.metadata = checkNotNull(metadata);
+    sort();
   }
 
   @Override
@@ -53,4 +58,70 @@ public final class ScannerImpl implements Scanner {
 
   @Override
   public void close() {}
+
+  private void sort() {
+    Scan scan = (Scan) selection;
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadata);
+    if (dynamoOperation.isSingleClusteringKey()) {
+      // the ordering and the limitation already are applied in DynamoDB
+      return;
+    }
+
+    if (!scan.getOrderings().isEmpty()) {
+      Collections.sort(
+          items,
+          new Comparator<Map<String, AttributeValue>>() {
+            public int compare(Map<String, AttributeValue> o1, Map<String, AttributeValue> o2) {
+              int compareResult = 0;
+              for (Scan.Ordering ordering : scan.getOrderings()) {
+                String name = ordering.getName();
+                compareResult =
+                    compareAttributeValues(
+                        metadata.getColumns().get(name), o1.get(name), o2.get(name));
+                compareResult *= ordering.getOrder() == Scan.Ordering.Order.ASC ? 1 : -1;
+                if (compareResult != 0) {
+                  break;
+                }
+              }
+
+              return compareResult;
+            }
+          });
+    }
+
+    int limit = scan.getLimit();
+    if (limit > 0 && limit < items.size()) {
+      items = items.subList(0, limit);
+    }
+  }
+
+  private int compareAttributeValues(String type, AttributeValue a1, AttributeValue a2)
+      throws UnsupportedTypeException {
+    if (a1 == null && a2 == null) {
+      return 0;
+    } else if (a1 == null) {
+      return -1;
+    } else if (a2 == null) {
+      return 1;
+    }
+
+    switch (type) {
+      case "boolean":
+        return a1.bool().compareTo(a2.bool());
+      case "int":
+        return Integer.valueOf(a1.n()).compareTo(Integer.valueOf(a2.n()));
+      case "bigint":
+        return Long.valueOf(a1.n()).compareTo(Long.valueOf(a2.n()));
+      case "float":
+        return Float.valueOf(a1.n()).compareTo(Float.valueOf(a2.n()));
+      case "double":
+        return Double.valueOf(a1.n()).compareTo(Double.valueOf(a2.n()));
+      case "text":
+        return a1.s().compareTo(a2.s());
+      case "blob":
+        return a1.b().asByteBuffer().compareTo(a2.b().asByteBuffer());
+      default:
+        throw new UnsupportedTypeException(type);
+    }
+  }
 }

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
@@ -1,0 +1,56 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.api.Selection;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@NotThreadSafe
+public final class ScannerImpl implements Scanner {
+  private final List<Map<String, AttributeValue>> items;
+  private final Selection selection;
+  private final TableMetadata metadata;
+
+  public ScannerImpl(
+      List<Map<String, AttributeValue>> items, Selection selection, TableMetadata metadata) {
+    this.items = checkNotNull(items);
+    this.selection = selection;
+    this.metadata = checkNotNull(metadata);
+  }
+
+  @Override
+  @Nonnull
+  public Optional<Result> one() {
+    if (items.isEmpty()) {
+      return Optional.empty();
+    }
+    Map<String, AttributeValue> item = items.remove(0);
+
+    return Optional.of(new ResultImpl(item, selection, metadata));
+  }
+
+  @Override
+  @Nonnull
+  public List<Result> all() {
+    List<Result> results = new ArrayList<>();
+    items.forEach(i -> results.add(new ResultImpl(i, selection, metadata)));
+    return results;
+  }
+
+  @Override
+  public Iterator<Result> iterator() {
+    return new ScannerIterator(items.iterator(), selection, metadata);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
@@ -6,10 +6,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.Selection;
-import com.scalar.db.exception.storage.UnsupportedTypeException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -26,10 +23,16 @@ public final class ScannerImpl implements Scanner {
 
   public ScannerImpl(
       List<Map<String, AttributeValue>> items, Selection selection, TableMetadata metadata) {
-    this.items = checkNotNull(items);
+    DynamoOperation dynamoOperation = new DynamoOperation(selection, metadata);
+    if (dynamoOperation.isSingleClusteringKey()) {
+      // the ordering and the limitation already are applied in DynamoDB if there is only a single
+      // clustering key
+      this.items = items;
+    } else {
+      this.items = new ItemSorter((Scan) selection, metadata).sort(items);
+    }
     this.selection = selection;
     this.metadata = checkNotNull(metadata);
-    sort();
   }
 
   @Override
@@ -58,70 +61,4 @@ public final class ScannerImpl implements Scanner {
 
   @Override
   public void close() {}
-
-  private void sort() {
-    Scan scan = (Scan) selection;
-    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadata);
-    if (dynamoOperation.isSingleClusteringKey()) {
-      // the ordering and the limitation already are applied in DynamoDB
-      return;
-    }
-
-    if (!scan.getOrderings().isEmpty()) {
-      Collections.sort(
-          items,
-          new Comparator<Map<String, AttributeValue>>() {
-            public int compare(Map<String, AttributeValue> o1, Map<String, AttributeValue> o2) {
-              int compareResult = 0;
-              for (Scan.Ordering ordering : scan.getOrderings()) {
-                String name = ordering.getName();
-                compareResult =
-                    compareAttributeValues(
-                        metadata.getColumns().get(name), o1.get(name), o2.get(name));
-                compareResult *= ordering.getOrder() == Scan.Ordering.Order.ASC ? 1 : -1;
-                if (compareResult != 0) {
-                  break;
-                }
-              }
-
-              return compareResult;
-            }
-          });
-    }
-
-    int limit = scan.getLimit();
-    if (limit > 0 && limit < items.size()) {
-      items = items.subList(0, limit);
-    }
-  }
-
-  private int compareAttributeValues(String type, AttributeValue a1, AttributeValue a2)
-      throws UnsupportedTypeException {
-    if (a1 == null && a2 == null) {
-      return 0;
-    } else if (a1 == null) {
-      return -1;
-    } else if (a2 == null) {
-      return 1;
-    }
-
-    switch (type) {
-      case "boolean":
-        return a1.bool().compareTo(a2.bool());
-      case "int":
-        return Integer.valueOf(a1.n()).compareTo(Integer.valueOf(a2.n()));
-      case "bigint":
-        return Long.valueOf(a1.n()).compareTo(Long.valueOf(a2.n()));
-      case "float":
-        return Float.valueOf(a1.n()).compareTo(Float.valueOf(a2.n()));
-      case "double":
-        return Double.valueOf(a1.n()).compareTo(Double.valueOf(a2.n()));
-      case "text":
-        return a1.s().compareTo(a2.s());
-      case "blob":
-        return a1.b().asByteBuffer().compareTo(a2.b().asByteBuffer());
-      default:
-        throw new UnsupportedTypeException(type);
-    }
-  }
 }

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerIterator.java
@@ -1,0 +1,39 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Selection;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@NotThreadSafe
+public final class ScannerIterator implements Iterator<Result> {
+  private final Iterator<Map<String, AttributeValue>> iterator;
+  private final Selection selection;
+  private final TableMetadata metadata;
+
+  public ScannerIterator(
+      Iterator<Map<String, AttributeValue>> iterator, Selection selection, TableMetadata metadata) {
+    this.iterator = iterator;
+    this.selection = selection;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  @Override
+  @Nullable
+  public Result next() {
+    Map<String, AttributeValue> item = iterator.next();
+    if (item == null) {
+      return null;
+    }
+
+    return new ResultImpl(item, selection, metadata);
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -98,22 +98,20 @@ public class SelectStatementHandler extends StatementHandler {
 
     setConditions(builder, scan);
 
-    if (dynamoOperation.isSingleClusteringKey()) {
-      // When multiple clustering keys exist, the ordering and the limitation will be applied later
-      if (!scan.getOrderings().isEmpty()) {
-        scan.getOrderings()
-            .forEach(
-                o -> {
-                  if (dynamoOperation.getMetadata().getClusteringKeyNames().contains(o.getName())
-                      && o.getOrder() == Scan.Ordering.Order.DESC) {
-                    builder.scanIndexForward(false);
-                  }
-                });
-      }
+    // When multiple clustering keys exist, the ordering and the limitation will be applied later
+    if (dynamoOperation.isSingleClusteringKey() && !scan.getOrderings().isEmpty()) {
+      scan.getOrderings()
+          .forEach(
+              o -> {
+                if (dynamoOperation.getMetadata().getClusteringKeyNames().contains(o.getName())
+                    && o.getOrder() == Scan.Ordering.Order.DESC) {
+                  builder.scanIndexForward(false);
+                }
+              });
+    }
 
-      if (scan.getLimit() > 0) {
-        builder.limit(scan.getLimit());
-      }
+    if (dynamoOperation.isSingleClusteringKey() && scan.getLimit() > 0) {
+      builder.limit(scan.getLimit());
     }
 
     if (!scan.getProjections().isEmpty()) {

--- a/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -61,7 +61,7 @@ public class SelectStatementHandler extends StatementHandler {
         return new ArrayList<>(executeQuery((Scan) operation).items());
       }
     } catch (DynamoDbException e) {
-      throw e;
+      throw new ExecutionException(e.getMessage(), e);
     }
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -1,0 +1,267 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Value;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+/**
+ * A handler class for select statement
+ *
+ * @author Yuji Ito
+ */
+@ThreadSafe
+public class SelectStatementHandler extends StatementHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SelectStatementHandler.class);
+
+  /**
+   * Constructs a {@code SelectStatementHandler} with the specified {@link DynamoDbClient} and a new
+   * {@link TableMetadataManager}
+   *
+   * @param client {@code DynamoDbClient}
+   * @param metadataManager {@code TableMetadataManager}
+   */
+  public SelectStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+    super(client, metadataManager);
+  }
+
+  @Override
+  public List<Map<String, AttributeValue>> handle(Operation operation) throws ExecutionException {
+    checkArgument(operation, Get.class, Scan.class);
+
+    try {
+      if (operation instanceof Get) {
+        GetItemResponse response = executeGet((Get) operation);
+        if (response.hasItem()) {
+          return Arrays.asList(response.item());
+        } else {
+          return Collections.emptyList();
+        }
+      } else {
+        // convert to a mutable list for the Scanner
+        return new ArrayList<>(executeQuery((Scan) operation).items());
+      }
+    } catch (DynamoDbException e) {
+      throw e;
+    }
+  }
+
+  private GetItemResponse executeGet(Get get) {
+    DynamoOperation dynamoOperation = new DynamoOperation(get, metadataManager);
+
+    GetItemRequest.Builder builder =
+        GetItemRequest.builder()
+            .tableName(dynamoOperation.getTableName())
+            .key(dynamoOperation.getKeyMap());
+
+    if (!get.getProjections().isEmpty()) {
+      builder.projectionExpression(String.join(",", get.getProjections()));
+    }
+
+    if (get.getConsistency() != Consistency.EVENTUAL) {
+      builder.consistentRead(true);
+    }
+
+    return client.getItem(builder.build());
+  }
+
+  private QueryResponse executeQuery(Scan scan) {
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    QueryRequest.Builder builder = QueryRequest.builder().tableName(dynamoOperation.getTableName());
+
+    setConditions(builder, scan);
+
+    if (!scan.getOrderings().isEmpty()) {
+      scan.getOrderings()
+          .forEach(
+              o -> {
+                if (dynamoOperation.isSortKey(o.getName())
+                    && o.getOrder() == Scan.Ordering.Order.DESC) {
+                  builder.scanIndexForward(false);
+                }
+              });
+    }
+
+    if (scan.getLimit() > 0) {
+      builder.limit(scan.getLimit());
+    }
+
+    if (!scan.getProjections().isEmpty()) {
+      builder.projectionExpression(String.join(",", scan.getProjections()));
+    }
+
+    if (scan.getConsistency() != Consistency.EVENTUAL) {
+      builder.consistentRead(true);
+    }
+
+    return client.query(builder.build());
+  }
+
+  private void setConditions(QueryRequest.Builder builder, Scan scan) {
+    List<String> conditions = new ArrayList<>();
+
+    conditions.add(getPartitionKeyCondition());
+
+    boolean isRangeEnabled = setRangeCondition(scan, conditions);
+    if (!isRangeEnabled) {
+      setStartCondition(scan, conditions);
+      setEndCondition(scan, conditions);
+    }
+    String keyConditions = String.join(" AND ", conditions);
+
+    Map<String, AttributeValue> bindMap = getPartitionKeyBindMap(scan);
+    if (isRangeEnabled) {
+      bindMap.putAll(getRangeBindMap(scan));
+    }
+    bindMap.putAll(getStartBindMap(scan, isRangeEnabled));
+    bindMap.putAll(getEndBindMap(scan, isRangeEnabled));
+
+    builder.keyConditionExpression(keyConditions).expressionAttributeValues(bindMap);
+  }
+
+  private String getPartitionKeyCondition() {
+    return DynamoOperation.PARTITION_KEY + " = " + DynamoOperation.PARTITION_KEY_ALIAS;
+  }
+
+  private Map<String, AttributeValue> getPartitionKeyBindMap(Scan scan) {
+    Map<String, AttributeValue> bindMap = new HashMap<>();
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    String partitionKey = dynamoOperation.getConcatenatedPartitionKey();
+
+    bindMap.put(
+        DynamoOperation.PARTITION_KEY_ALIAS, AttributeValue.builder().s(partitionKey).build());
+
+    return bindMap;
+  }
+
+  private boolean setRangeCondition(Scan scan, List<String> conditions) {
+    if (!scan.getStartClusteringKey().isPresent() || !scan.getEndClusteringKey().isPresent()) {
+      return false;
+    }
+
+    List<Value> start = scan.getStartClusteringKey().get().get();
+    List<Value> end = scan.getEndClusteringKey().get().get();
+    String startKeyName = start.get(start.size() - 1).getName();
+    String endKeyName = end.get(end.size() - 1).getName();
+
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+
+    if (startKeyName.equals(endKeyName)) {
+      conditions.add(startKeyName + DynamoOperation.RANGE_CONDITION);
+      if (!scan.getStartInclusive() || !scan.getEndInclusive()) {
+        throw new IllegalArgumentException(
+            "DynamoDB does NOT support the range scan with the exclusiving option");
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private void setStartCondition(Scan scan, List<String> conditions) {
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    scan.getStartClusteringKey()
+        .ifPresent(
+            k -> {
+              if (k.get().size() > 1) {
+                throw new IllegalArgumentException(
+                    "DynamoDB doesn't suuport multiple clustering keys.");
+              }
+              Value value = k.get().get(0);
+              List<String> elements = new ArrayList<>();
+              elements.add(value.getName());
+              if (scan.getStartInclusive()) {
+                elements.add(">=");
+              } else {
+                elements.add(">");
+              }
+              elements.add(DynamoOperation.START_CLUSTERING_KEY_ALIAS + "0");
+              conditions.add(String.join(" ", elements));
+            });
+  }
+
+  private void setEndCondition(Scan scan, List<String> conditions) {
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    scan.getEndClusteringKey()
+        .ifPresent(
+            k -> {
+              if (k.get().size() > 1) {
+                throw new IllegalArgumentException(
+                    "DynamoDB doesn't suuport multiple clustering keys.");
+              }
+              Value value = k.get().get(0);
+              List<String> elements = new ArrayList<>();
+              elements.add(value.getName());
+              if (scan.getStartInclusive()) {
+                elements.add("<=");
+              } else {
+                elements.add("<");
+              }
+              elements.add(DynamoOperation.START_CLUSTERING_KEY_ALIAS + "0");
+              conditions.add(String.join(" ", elements));
+            });
+  }
+
+  private Map<String, AttributeValue> getRangeBindMap(Scan scan) {
+    ValueBinder binder = new ValueBinder(DynamoOperation.RANGE_KEY_ALIAS);
+    List<Value> start = scan.getStartClusteringKey().get().get();
+    List<Value> end = scan.getEndClusteringKey().get().get();
+    start.get(start.size() - 1).accept(binder);
+    end.get(end.size() - 1).accept(binder);
+
+    return binder.build();
+  }
+
+  private Map<String, AttributeValue> getStartBindMap(Scan scan, boolean isRangeEnabled) {
+    ValueBinder binder = new ValueBinder(DynamoOperation.START_CLUSTERING_KEY_ALIAS);
+    scan.getStartClusteringKey()
+        .ifPresent(
+            k -> {
+              List<Value> start = k.get();
+              int size = isRangeEnabled ? start.size() - 1 : start.size();
+              IntStream.range(0, size)
+                  .forEach(
+                      i -> {
+                        start.get(i).accept(binder);
+                      });
+            });
+
+    return binder.build();
+  }
+
+  private Map<String, AttributeValue> getEndBindMap(Scan scan, boolean isRangeEnabled) {
+    ValueBinder binder = new ValueBinder(DynamoOperation.END_CLUSTERING_KEY_ALIAS);
+    scan.getEndClusteringKey()
+        .ifPresent(
+            k -> {
+              List<Value> end = k.get();
+              int size = isRangeEnabled ? end.size() - 1 : end.size();
+              IntStream.range(0, size)
+                  .forEach(
+                      i -> {
+                        end.get(i).accept(binder);
+                      });
+            });
+
+    return binder.build();
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/StatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/StatementHandler.java
@@ -1,0 +1,58 @@
+package com.scalar.db.storage.dynamo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Joiner;
+import com.scalar.db.api.Operation;
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/** A handler class for statements */
+@ThreadSafe
+public abstract class StatementHandler {
+  protected final DynamoDbClient client;
+  protected final TableMetadataManager metadataManager;
+
+  /**
+   * Constructs a {@code StatementHandler} with the specified {@link DynamoDbClient} and a new
+   * {@link TableMetadataManager}
+   *
+   * @param client {@code DynamoDbClient}
+   * @param metadataManager {@code TableMetadataManager}
+   */
+  public StatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+    this.client = checkNotNull(client);
+    this.metadataManager = checkNotNull(metadataManager);
+  }
+
+  /**
+   * Executes the specified {@code Operation}
+   *
+   * @param operation an {@code Operation} to execute
+   * @return a list of results
+   * @throws ExecutionException if the execution failed
+   */
+  @Nonnull
+  public abstract List<Map<String, AttributeValue>> handle(Operation operation)
+      throws ExecutionException;
+
+  protected void checkArgument(Operation actual, Class<? extends Operation>... expected) {
+    for (Class<? extends Operation> e : expected) {
+      if (e.isInstance(actual)) {
+        return;
+      }
+    }
+    throw new IllegalArgumentException(
+        Joiner.on(" ")
+            .join(
+                new String[] {
+                  actual.getClass().toString(), "is passed where something like",
+                  expected[0].toString(), "is expected."
+                }));
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
@@ -43,22 +43,21 @@ public class TableMetadata {
   }
 
   public List<String> getKeyNames() {
-    if (keyNames != null) {
-      return keyNames;
-    }
-
-    keyNames =
-        new ImmutableList.Builder<String>()
-            .addAll(partitionKeyNames)
-            .addAll(clusteringKeyNames)
-            .build();
-
     return keyNames;
   }
 
   private void convert(Map<String, AttributeValue> metadata) {
     this.partitionKeyNames = ImmutableSortedSet.copyOf(metadata.get(PARTITION_KEY).ss());
-    this.clusteringKeyNames = ImmutableSortedSet.copyOf(metadata.get(CLUSTERING_KEY).ss());
+    if (metadata.containsKey(CLUSTERING_KEY)) {
+      this.clusteringKeyNames = ImmutableSortedSet.copyOf(metadata.get(CLUSTERING_KEY).ss());
+    } else {
+      this.clusteringKeyNames = ImmutableSortedSet.of();
+    }
+    this.keyNames =
+        new ImmutableList.Builder<String>()
+            .addAll(partitionKeyNames)
+            .addAll(clusteringKeyNames)
+            .build();
 
     SortedMap<String, String> cs =
         metadata.get(COLUMNS).m().entrySet().stream()

--- a/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
@@ -1,0 +1,78 @@
+package com.scalar.db.storage.dynamo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A metadata class for a table of Scalar DB to know the type of each column
+ *
+ * @author Yuji Ito
+ */
+public class TableMetadata {
+  private static final String PARTITION_KEY = "partitionKey";
+  private static final String CLUSTERING_KEY = "clusteringKey";
+  private static final String SORT_KEY = "sortKey";
+  private static final String COLUMNS = "columns";
+  private SortedSet<String> partitionKeyNames;
+  private SortedSet<String> clusteringKeyNames;
+  private Optional<String> sortKeyName;
+  private SortedMap<String, String> columns;
+  private List<String> keyNames;
+
+  public TableMetadata(Map<String, AttributeValue> metadata) {
+    convert(metadata);
+  }
+
+  public Set<String> getPartitionKeyNames() {
+    return partitionKeyNames;
+  }
+
+  public Set<String> getClusteringKeyNames() {
+    return clusteringKeyNames;
+  }
+
+  public Optional<String> getSortKeyName() {
+    return sortKeyName;
+  }
+
+  public Map<String, String> getColumns() {
+    return columns;
+  }
+
+  public List<String> getKeyNames() {
+    if (keyNames != null) {
+      return keyNames;
+    }
+
+    keyNames =
+        new ImmutableList.Builder<String>()
+            .addAll(partitionKeyNames)
+            .addAll(clusteringKeyNames)
+            .build();
+
+    return keyNames;
+  }
+
+  private void convert(Map<String, AttributeValue> metadata) {
+    this.partitionKeyNames = ImmutableSortedSet.copyOf(metadata.get(PARTITION_KEY).ss());
+    this.clusteringKeyNames = ImmutableSortedSet.copyOf(metadata.get(CLUSTERING_KEY).ss());
+    this.sortKeyName = Optional.ofNullable(metadata.get(SORT_KEY).s());
+
+    SortedMap<String, String> cs =
+        metadata.get(COLUMNS).m().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey, e -> e.getValue().s(), (u, v) -> v, TreeMap::new));
+    this.columns = Collections.unmodifiableSortedMap(cs);
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -21,11 +20,9 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 public class TableMetadata {
   private static final String PARTITION_KEY = "partitionKey";
   private static final String CLUSTERING_KEY = "clusteringKey";
-  private static final String SORT_KEY = "sortKey";
   private static final String COLUMNS = "columns";
   private SortedSet<String> partitionKeyNames;
   private SortedSet<String> clusteringKeyNames;
-  private Optional<String> sortKeyName;
   private SortedMap<String, String> columns;
   private List<String> keyNames;
 
@@ -39,10 +36,6 @@ public class TableMetadata {
 
   public Set<String> getClusteringKeyNames() {
     return clusteringKeyNames;
-  }
-
-  public Optional<String> getSortKeyName() {
-    return sortKeyName;
   }
 
   public Map<String, String> getColumns() {
@@ -66,7 +59,6 @@ public class TableMetadata {
   private void convert(Map<String, AttributeValue> metadata) {
     this.partitionKeyNames = ImmutableSortedSet.copyOf(metadata.get(PARTITION_KEY).ss());
     this.clusteringKeyNames = ImmutableSortedSet.copyOf(metadata.get(CLUSTERING_KEY).ss());
-    this.sortKeyName = Optional.ofNullable(metadata.get(SORT_KEY).s());
 
     SortedMap<String, String> cs =
         metadata.get(COLUMNS).m().entrySet().stream()

--- a/src/main/java/com/scalar/db/storage/dynamo/TableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/TableMetadataManager.java
@@ -1,0 +1,58 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.Operation;
+import com.scalar.db.exception.storage.StorageRuntimeException;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.concurrent.ThreadSafe;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+
+/**
+ * A manager to read and cache {@link TableMetadata} to know the type of each column
+ *
+ * @author Yuji Ito
+ */
+@ThreadSafe
+public class TableMetadataManager {
+  private final String METADATA_TABLE = "scalardb.metadata";
+  private final DynamoDbClient client;
+  private final Map<String, TableMetadata> tableMetadataMap;
+
+  public TableMetadataManager(DynamoDbClient client) {
+    this.client = client;
+    this.tableMetadataMap = new ConcurrentHashMap<>();
+  }
+
+  public TableMetadata getTableMetadata(Operation operation) {
+    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
+      throw new IllegalArgumentException("operation has no target namespace and table name");
+    }
+
+    return getTableMetadata(operation.forNamespace().get(), operation.forTable().get());
+  }
+
+  private TableMetadata getTableMetadata(String namespace, String tableName) {
+    String fullName = namespace + "." + tableName;
+    if (!tableMetadataMap.containsKey(fullName)) {
+      tableMetadataMap.put(fullName, readMetadata(fullName));
+    }
+    return tableMetadataMap.get(fullName);
+  }
+
+  private TableMetadata readMetadata(String fullName) {
+    Map<String, AttributeValue> key = new HashMap<>();
+    key.put("table", AttributeValue.builder().s(fullName).build());
+
+    GetItemRequest request =
+        GetItemRequest.builder().tableName(METADATA_TABLE).key(key).consistentRead(true).build();
+    try {
+      return new TableMetadata(client.getItem(request).item());
+    } catch (DynamoDbException e) {
+      throw new StorageRuntimeException("Failed to read the table metadata", e);
+    }
+  }
+}

--- a/src/main/java/com/scalar/db/storage/dynamo/ValueBinder.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ValueBinder.java
@@ -100,7 +100,13 @@ public final class ValueBinder implements ValueVisitor {
    */
   @Override
   public void visit(TextValue value) {
-    value.getString().ifPresent(s -> values.put(alias + i, AttributeValue.builder().s(s).build()));
+    AttributeValue.Builder builder = AttributeValue.builder();
+    if (value.getString().isPresent()) {
+      builder.s(value.getString().get());
+    } else {
+      builder.nul(true);
+    }
+    values.put(alias + i, builder.build());
     i++;
   }
 
@@ -111,12 +117,13 @@ public final class ValueBinder implements ValueVisitor {
    */
   @Override
   public void visit(BlobValue value) {
-    value
-        .get()
-        .ifPresent(
-            b ->
-                values.put(
-                    alias + i, AttributeValue.builder().b(SdkBytes.fromByteArray(b)).build()));
+    AttributeValue.Builder builder = AttributeValue.builder();
+    if (value.get().isPresent()) {
+      builder.b(SdkBytes.fromByteArray(value.get().get()));
+    } else {
+      builder.nul(true);
+    }
+    values.put(alias + i, builder.build());
     i++;
   }
 }

--- a/src/main/java/com/scalar/db/storage/dynamo/ValueBinder.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ValueBinder.java
@@ -1,0 +1,122 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.BlobValue;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.DoubleValue;
+import com.scalar.db.io.FloatValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.TextValue;
+import com.scalar.db.io.ValueVisitor;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A visitor class to bind {@code Value}s to a condition expression
+ *
+ * @author Yuji Ito
+ */
+@NotThreadSafe
+public final class ValueBinder implements ValueVisitor {
+  private final Map<String, AttributeValue> values;
+  private final String alias;
+  private int i;
+
+  /** Constructs {@code ValueBinder} with the specified {@code BoundStatement} */
+  public ValueBinder(String alias) {
+    this.values = new HashMap<>();
+    this.alias = alias;
+    this.i = 0;
+  }
+
+  @Nonnull
+  public Map<String, AttributeValue> build() {
+    return values;
+  }
+
+  /**
+   * Sets the specified {@code BooleanValue} to the expression
+   *
+   * @param value a {@code BooleanValue} to be set
+   */
+  @Override
+  public void visit(BooleanValue value) {
+    values.put(alias + i, AttributeValue.builder().bool(value.get()).build());
+    i++;
+  }
+
+  /**
+   * Sets the specified {@code IntValue} to the expression
+   *
+   * @param value a {@code IntValue} to be set
+   */
+  @Override
+  public void visit(IntValue value) {
+    values.put(alias + i, AttributeValue.builder().n(String.valueOf(value.get())).build());
+    i++;
+  }
+
+  /**
+   * Sets the specified {@code BigIntValue} to the expression
+   *
+   * @param value a {@code BigIntValue} to be set
+   */
+  @Override
+  public void visit(BigIntValue value) {
+    values.put(alias + i, AttributeValue.builder().n(String.valueOf(value.get())).build());
+    i++;
+  }
+
+  /**
+   * Sets the specified {@code FloatValue} to the expression
+   *
+   * @param value a {@code FloatValue} to be set
+   */
+  @Override
+  public void visit(FloatValue value) {
+    values.put(alias + i, AttributeValue.builder().n(String.valueOf(value.get())).build());
+    i++;
+  }
+
+  /**
+   * Sets the specified {@code DoubleValue} to the expression
+   *
+   * @param value a {@code DoubleValue} to be set
+   */
+  @Override
+  public void visit(DoubleValue value) {
+    values.put(alias + i, AttributeValue.builder().n(String.valueOf(value.get())).build());
+    i++;
+  }
+
+  /**
+   * Sets the specified {@code TextValue} to the expression
+   *
+   * @param value a {@code TextValue} to be set
+   */
+  @Override
+  public void visit(TextValue value) {
+    value.getString().ifPresent(s -> values.put(alias + i, AttributeValue.builder().s(s).build()));
+    i++;
+  }
+
+  /**
+   * Sets the specified {@code BlobValue} to the bound statement
+   *
+   * @param value a {@code BlobValue} to be set
+   */
+  @Override
+  public void visit(BlobValue value) {
+    value
+        .get()
+        .ifPresent(
+            b ->
+                values.put(
+                    alias + i, AttributeValue.builder().b(SdkBytes.fromByteArray(b)).build()));
+    i++;
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
@@ -149,10 +149,14 @@ public class BatchHandlerTest {
     List<TransactWriteItem> items = captor.getValue().transactItems();
     assertThat(items.size()).isEqualTo(4);
     assertThat(items.get(0).update().key()).isEqualTo(dynamoMutation1.getKeyMap());
+    assertThat(items.get(0).update().expressionAttributeNames())
+        .isEqualTo(dynamoMutation1.getColumnMapWithKey());
     assertThat(items.get(0).update().expressionAttributeValues())
         .isEqualTo(dynamoMutation1.getValueBindMapWithKey());
     assertThat(items.get(0).update().conditionExpression()).isNull();
     assertThat(items.get(1).update().key()).isEqualTo(dynamoMutation2.getKeyMap());
+    assertThat(items.get(1).update().expressionAttributeNames())
+        .isEqualTo(dynamoMutation2.getColumnMapWithKey());
     assertThat(items.get(1).update().expressionAttributeValues())
         .isEqualTo(dynamoMutation2.getValueBindMapWithKey());
     assertThat(items.get(1).update().conditionExpression())

--- a/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
@@ -121,7 +121,7 @@ public class BatchHandlerTest {
   }
 
   @Test
-  public void handle_MultipleMutationsGiven_ShouldCallStoredProcedure() {
+  public void handle_MultipleMutationsGiven_ShouldCallTransactWriteItems() {
     // Arrange
     when(client.transactWriteItems(any(TransactWriteItemsRequest.class)))
         .thenReturn(transactWriteResponse);
@@ -148,10 +148,14 @@ public class BatchHandlerTest {
     verify(client).transactWriteItems(captor.capture());
     List<TransactWriteItem> items = captor.getValue().transactItems();
     assertThat(items.size()).isEqualTo(4);
-    assertThat(items.get(0).put().item()).isEqualTo(dynamoMutation1.getValueMapWithKey());
-    assertThat(items.get(0).put().conditionExpression()).isNull();
-    assertThat(items.get(1).put().item()).isEqualTo(dynamoMutation2.getValueMapWithKey());
-    assertThat(items.get(1).put().conditionExpression())
+    assertThat(items.get(0).update().key()).isEqualTo(dynamoMutation1.getKeyMap());
+    assertThat(items.get(0).update().expressionAttributeValues())
+        .isEqualTo(dynamoMutation1.getValueBindMapWithKey());
+    assertThat(items.get(0).update().conditionExpression()).isNull();
+    assertThat(items.get(1).update().key()).isEqualTo(dynamoMutation2.getKeyMap());
+    assertThat(items.get(1).update().expressionAttributeValues())
+        .isEqualTo(dynamoMutation2.getValueBindMapWithKey());
+    assertThat(items.get(1).update().conditionExpression())
         .isEqualTo(dynamoMutation2.getIfNotExistsCondition());
     assertThat(items.get(2).delete().key()).isEqualTo(dynamoMutation3.getKeyMap());
     assertThat(items.get(2).delete().conditionExpression()).isNull();
@@ -161,7 +165,7 @@ public class BatchHandlerTest {
   }
 
   @Test
-  public void handle_MultiPartitionOperationsGiven_ShouldExecuteTransactWriteItems() {
+  public void handle_MultiPartitionOperationsGiven_ShouldCallTransactWriteItems() {
     // Arrange
     when(client.transactWriteItems(any(TransactWriteItemsRequest.class)))
         .thenReturn(transactWriteResponse);

--- a/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
@@ -1,0 +1,105 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.ConditionalExpression.Operator;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.io.IntValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+public class ConditionExpressionBuilderTest {
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final int ANY_INT = 1;
+  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void build_NoConditionsGiven_ShouldReturnEmpty() {
+    // Arrange
+    ConditionExpressionBuilder builder =
+        new ConditionExpressionBuilder(DynamoOperation.CONDITION_VALUE_ALIAS);
+
+    // Act
+    String actual = builder.build();
+
+    // Assert
+    assertThat(actual).isEqualTo("");
+  }
+
+  @Test
+  public void build_PutIfAcceptCalled_ShouldReturnCondition() {
+    // Arrange
+    PutIf condition =
+        new PutIf(
+            new ConditionalExpression(ANY_NAME_1, ANY_INT_VALUE, Operator.EQ),
+            new ConditionalExpression(ANY_NAME_2, ANY_INT_VALUE, Operator.GT));
+    ConditionExpressionBuilder builder =
+        new ConditionExpressionBuilder(DynamoOperation.CONDITION_VALUE_ALIAS);
+
+    // Act
+    condition.accept(builder);
+    String actual = builder.build();
+
+    // Assert
+    assertThat(actual).isEqualTo(ANY_NAME_1 + " = :cval0 AND " + ANY_NAME_2 + " > :cval1");
+  }
+
+  @Test
+  public void visit_PutIfExistsAcceptCalled_ShouldReturnEmpty() {
+    // Arrange
+    PutIfExists condition = new PutIfExists();
+    ConditionExpressionBuilder builder =
+        new ConditionExpressionBuilder(DynamoOperation.CONDITION_VALUE_ALIAS);
+
+    // Act
+    condition.accept(builder);
+    String actual = builder.build();
+
+    // Assert
+    assertThat(actual).isEqualTo("");
+  }
+
+  @Test
+  public void visit_PutIfNotExistsAcceptCalled_ShouldReturnEmpty() {
+    // Arrange
+    PutIfNotExists condition = new PutIfNotExists();
+    ConditionExpressionBuilder builder =
+        new ConditionExpressionBuilder(DynamoOperation.CONDITION_VALUE_ALIAS);
+
+    // Act
+    condition.accept(builder);
+    String actual = builder.build();
+
+    // Assert
+    assertThat(actual).isEqualTo("");
+  }
+
+  @Test
+  public void visit_DeleteIfAcceptCalled_ShouldCallWhere() {
+    // Arrange
+    DeleteIf condition =
+        new DeleteIf(
+            new ConditionalExpression(ANY_NAME_1, ANY_INT_VALUE, Operator.EQ),
+            new ConditionalExpression(ANY_NAME_2, ANY_INT_VALUE, Operator.GT));
+    ConditionExpressionBuilder builder =
+        new ConditionExpressionBuilder(DynamoOperation.CONDITION_VALUE_ALIAS);
+
+    // Act
+    condition.accept(builder);
+    String actual = builder.build();
+
+    // Assert
+    assertThat(actual).isEqualTo(ANY_NAME_1 + " = :cval0 AND " + ANY_NAME_2 + " > :cval1");
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
@@ -1,0 +1,203 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.Operation;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+
+public class DeleteStatementHandlerTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+
+  private DeleteStatementHandler handler;
+  private String concatenatedPartitionKey;
+  @Mock private DynamoDbClient client;
+  @Mock private TableMetadataManager metadataManager;
+  @Mock private TableMetadata metadata;
+  @Mock private DeleteItemResponse response;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    handler = new DeleteStatementHandler(client, metadataManager);
+
+    when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
+    when(metadata.getPartitionKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_1)));
+    when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+  }
+
+  private Delete prepareDelete() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    concatenatedPartitionKey = ANY_TEXT_1 + ":" + ANY_TEXT_2;
+    Delete del =
+        new Delete(partitionKey, clusteringKey)
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    return del;
+  }
+
+  @Test
+  public void handle_DeleteWithoutConditionsGiven_ShouldCallDeleteItem() {
+    // Arrange
+    when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
+    Delete delete = prepareDelete();
+    DynamoMutation dynamoMutation = new DynamoMutation(delete, metadataManager);
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(delete);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<DeleteItemRequest> captor = ArgumentCaptor.forClass(DeleteItemRequest.class);
+    verify(client).deleteItem(captor.capture());
+    DeleteItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.key()).isEqualTo(dynamoMutation.getKeyMap());
+    assertThat(actualRequest.conditionExpression()).isNull();
+  }
+
+  @Test
+  public void
+      handle_DeleteWithoutConditionsDynamoDbExceptionThrown_ShouldThrowExecutionException() {
+    // Arrange
+    DynamoDbException toThrow = mock(DynamoDbException.class);
+    doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
+
+    Delete delete = prepareDelete();
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(delete);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_DeleteWithoutClusteringKeyGiven_ShouldCallDeleteItem() {
+    // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_2)));
+    when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
+
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Delete delete =
+        new Delete(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+
+    DynamoMutation dynamoMutation = new DynamoMutation(delete, metadataManager);
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(delete);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<DeleteItemRequest> captor = ArgumentCaptor.forClass(DeleteItemRequest.class);
+    verify(client).deleteItem(captor.capture());
+    DeleteItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.key()).isEqualTo(dynamoMutation.getKeyMap());
+    assertThat(actualRequest.conditionExpression()).isNull();
+  }
+
+  @Test
+  public void handle_DeleteWithConditionsGiven_ShouldCallDeleteItem() {
+    // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_2)));
+    when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
+
+    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+
+    DynamoMutation dynamoMutation = new DynamoMutation(delete, metadataManager);
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(delete);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<DeleteItemRequest> captor = ArgumentCaptor.forClass(DeleteItemRequest.class);
+    verify(client).deleteItem(captor.capture());
+    DeleteItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.key()).isEqualTo(dynamoMutation.getKeyMap());
+    assertThat(actualRequest.conditionExpression())
+        .isEqualTo(dynamoMutation.getIfExistsCondition());
+  }
+
+  @Test
+  public void handle_DynamoDbExceptionWithConditionalCheckFailed_ShouldThrowNoMutationException() {
+    // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_2)));
+    when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
+    ConditionalCheckFailedException toThrow = mock(ConditionalCheckFailedException.class);
+    doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
+
+    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(delete);
+            })
+        .isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void handle_DeleteWithConditionDynamoDbExceptionThrown_ShouldThrowExecutionException() {
+    // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_2)));
+    when(client.deleteItem(any(DeleteItemRequest.class))).thenReturn(response);
+    DynamoDbException toThrow = mock(DynamoDbException.class);
+    doThrow(toThrow).when(client).deleteItem(any(DeleteItemRequest.class));
+
+    Delete delete = prepareDelete().withCondition(new DeleteIfExists());
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(delete);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(toThrow);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -94,7 +94,7 @@ public class DynamoMutationTest {
             "attribute_not_exists("
                 + DynamoOperation.PARTITION_KEY
                 + ") AND attribute_not_exists("
-                + ANY_NAME_2
+                + DynamoOperation.CLUSTERING_KEY
                 + ")");
   }
 
@@ -113,7 +113,7 @@ public class DynamoMutationTest {
             "attribute_exists("
                 + DynamoOperation.PARTITION_KEY
                 + ") AND attribute_exists("
-                + ANY_NAME_2
+                + DynamoOperation.CLUSTERING_KEY
                 + ")");
   }
 

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -1,0 +1,215 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.ConditionalExpression.Operator;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class DynamoMutationTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_4 = "name4";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final int ANY_INT_1 = 1;
+  private static final int ANY_INT_2 = 2;
+  private static final int ANY_INT_3 = 3;
+  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT_3);
+
+  @Mock private TableMetadataManager metadataManager;
+  @Mock private TableMetadata metadata;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
+    when(metadata.getPartitionKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_1)));
+    when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+  }
+
+  private Put preparePut() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME)
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_1))
+            .withValue(new IntValue(ANY_NAME_4, ANY_INT_2));
+
+    return put;
+  }
+
+  @Test
+  public void getValueMapWithKey_PutGiven_ShouldReturnValueMap() {
+    // Arrange
+    Put put = preparePut();
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    Map<String, AttributeValue> actual = dynamoMutation.getValueMapWithKey();
+
+    // Assert
+    assertThat(actual.get(ANY_NAME_1).s()).isEqualTo(ANY_TEXT_1);
+    assertThat(actual.get(ANY_NAME_2).s()).isEqualTo(ANY_TEXT_2);
+    assertThat(Integer.valueOf(actual.get(ANY_NAME_3).n())).isEqualTo(ANY_INT_1);
+    assertThat(Integer.valueOf(actual.get(ANY_NAME_4).n())).isEqualTo(ANY_INT_2);
+  }
+
+  @Test
+  public void getIfNotExistsCondition_PutGiven_ShouldReturnCondition() {
+    // Arrange
+    Put put = preparePut();
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    String actual = dynamoMutation.getIfNotExistsCondition();
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            "attribute_not_exists("
+                + DynamoOperation.PARTITION_KEY
+                + ") AND attribute_not_exists("
+                + ANY_NAME_2
+                + ")");
+  }
+
+  @Test
+  public void getIfExistsCondition_PutGiven_ShouldReturnCondition() {
+    // Arrange
+    Put put = preparePut();
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    String actual = dynamoMutation.getIfExistsCondition();
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            "attribute_exists("
+                + DynamoOperation.PARTITION_KEY
+                + ") AND attribute_exists("
+                + ANY_NAME_2
+                + ")");
+  }
+
+  @Test
+  public void getCondition_PutGiven_ShouldReturnCondition() {
+    // Arrange
+    PutIf conditions =
+        new PutIf(
+            new ConditionalExpression(ANY_NAME_3, ANY_INT_VALUE, Operator.EQ),
+            new ConditionalExpression(ANY_NAME_4, ANY_INT_VALUE, Operator.GT));
+    Put put = preparePut().withCondition(conditions);
+
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    String actual = dynamoMutation.getCondition();
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            ANY_NAME_3
+                + " = "
+                + DynamoOperation.CONDITION_VALUE_ALIAS
+                + "0 AND "
+                + ANY_NAME_4
+                + " > "
+                + DynamoOperation.CONDITION_VALUE_ALIAS
+                + "1");
+  }
+
+  @Test
+  public void getUpdateExpression_PutWithIfExistsGiven_ShouldReturnExpression() {
+    // Arrange
+    Put put = preparePut().withCondition(new PutIfExists());
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    String actual = dynamoMutation.getUpdateExpression();
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            "SET "
+                + ANY_NAME_3
+                + " = "
+                + DynamoOperation.VALUE_ALIAS
+                + "0, "
+                + ANY_NAME_4
+                + " = "
+                + DynamoOperation.VALUE_ALIAS
+                + "1");
+  }
+
+  @Test
+  public void getConditionBindMap_PutWithPutIfGiven_ShouldReturnBindMap() {
+    // Arrange
+    PutIf conditions =
+        new PutIf(
+            new ConditionalExpression(ANY_NAME_3, ANY_INT_VALUE, Operator.EQ),
+            new ConditionalExpression(ANY_NAME_4, ANY_INT_VALUE, Operator.GT));
+    Put put = preparePut().withCondition(conditions);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    expected.put(
+        DynamoOperation.CONDITION_VALUE_ALIAS + "0",
+        AttributeValue.builder().n(String.valueOf(ANY_INT_3)).build());
+    expected.put(
+        DynamoOperation.CONDITION_VALUE_ALIAS + "1",
+        AttributeValue.builder().n(String.valueOf(ANY_INT_3)).build());
+
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    Map<String, AttributeValue> actual = dynamoMutation.getConditionBindMap();
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void getValueBindMap_PutWithPutIfExistsGiven_ShouldReturnBindMap() {
+    // Arrange
+    Put put = preparePut().withCondition(new PutIfExists());
+    Map<String, AttributeValue> expected = new HashMap<>();
+    expected.put(
+        DynamoOperation.VALUE_ALIAS + "0",
+        AttributeValue.builder().n(String.valueOf(ANY_INT_1)).build());
+    expected.put(
+        DynamoOperation.VALUE_ALIAS + "1",
+        AttributeValue.builder().n(String.valueOf(ANY_INT_2)).build());
+
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+
+    // Act
+    Map<String, AttributeValue> actual = dynamoMutation.getValueBindMap();
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -157,12 +157,12 @@ public class DynamoMutationTest {
     assertThat(actual)
         .isEqualTo(
             "SET "
-                + ANY_NAME_3
-                + " = "
+                + DynamoOperation.COLUMN_NAME_ALIAS
+                + "0 = "
                 + DynamoOperation.VALUE_ALIAS
                 + "0, "
-                + ANY_NAME_4
-                + " = "
+                + DynamoOperation.COLUMN_NAME_ALIAS
+                + "1 = "
                 + DynamoOperation.VALUE_ALIAS
                 + "1");
   }

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -1,0 +1,81 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Operation;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class DynamoOperationTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+
+  @Mock private TableMetadataManager metadataManager;
+  @Mock private TableMetadata metadata;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
+    when(metadata.getPartitionKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_1)));
+    when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+  }
+
+  private Get prepareGet() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+
+    return get;
+  }
+
+  @Test
+  public void getTableName_GetGiven_ShouldReturnTableName() {
+    // Arrange
+    Get get = prepareGet();
+    DynamoOperation dynamoOperation = new DynamoOperation(get, metadataManager);
+
+    // Act
+    String actual = dynamoOperation.getTableName();
+
+    // Assert
+    assertThat(actual).isEqualTo(ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME);
+  }
+
+  @Test
+  public void getKeyMap_GetGiven_ShouldReturnMap() {
+    // Arrange
+    Get get = prepareGet();
+    DynamoOperation dynamoOperation = new DynamoOperation(get, metadataManager);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    expected.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    expected.put(ANY_NAME_2, AttributeValue.builder().s(ANY_TEXT_2).build());
+
+    // Act
+    Map<String, AttributeValue> actual = dynamoOperation.getKeyMap();
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -36,6 +36,8 @@ public class DynamoOperationTest {
     when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
     when(metadata.getPartitionKeyNames())
         .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_1)));
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_2)));
     when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
   }
 
@@ -70,7 +72,7 @@ public class DynamoOperationTest {
     DynamoOperation dynamoOperation = new DynamoOperation(get, metadataManager);
     Map<String, AttributeValue> expected = new HashMap<>();
     expected.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
-    expected.put(ANY_NAME_2, AttributeValue.builder().s(ANY_TEXT_2).build());
+    expected.put(DynamoOperation.CLUSTERING_KEY, AttributeValue.builder().s(ANY_TEXT_2).build());
 
     // Act
     Map<String, AttributeValue> actual = dynamoOperation.getKeyMap();

--- a/src/test/java/com/scalar/db/storage/dynamo/ItemSorterTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ItemSorterTest.java
@@ -1,0 +1,336 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class ItemSorterTest {
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_4 = "name4";
+  private static final String ANY_NAME_5 = "name5";
+  private static final String ANY_NAME_6 = "name6";
+  private static final String ANY_NAME_7 = "name7";
+  private static final String ANY_NAME_8 = "name8";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final boolean LARGE_BOOLEAN = true;
+  private static final boolean SMALL_BOOLEAN = false;
+  private static final int ANY_LARGE_INT = 100;
+  private static final int ANY_SMALL_INT = 1;
+  private static final long ANY_LARGE_BIGINT = 1000L;
+  private static final long ANY_SMALL_BIGINT = -1L;
+  private static final float ANY_LARGE_FLOAT = 1.111f;
+  private static final float ANY_SMALL_FLOAT = -1.0f;
+  private static final double ANY_LARGE_DOUBLE = 1.11111;
+  private static final double ANY_SMALL_DOUBLE = -10.0;
+  private static final String ANY_LARGE_TEXT = "sssssss";
+  private static final String ANY_SMALL_TEXT = "aa";
+  private static final byte[] ANY_LARGE_BLOB = "scalar".getBytes();
+  private static final byte[] ANY_SMALL_BLOB = "a".getBytes();
+  private static final String ANY_COLUMN_NAME_1 = "val1";
+
+  private TableMetadata metadata;
+
+  @Before
+  public void setUp() throws Exception {
+    Map<String, AttributeValue> metadataMap = new HashMap<>();
+    metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
+    metadataMap.put(
+        "clusteringKey",
+        AttributeValue.builder()
+            .ss(ANY_NAME_2, ANY_NAME_3, ANY_NAME_4, ANY_NAME_5, ANY_NAME_6, ANY_NAME_7, ANY_NAME_8)
+            .build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_NAME_3, AttributeValue.builder().s("boolean").build());
+    columns.put(ANY_NAME_4, AttributeValue.builder().s("bigint").build());
+    columns.put(ANY_NAME_5, AttributeValue.builder().s("float").build());
+    columns.put(ANY_NAME_6, AttributeValue.builder().s("double").build());
+    columns.put(ANY_NAME_7, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_8, AttributeValue.builder().s("blob").build());
+    columns.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s("text").build());
+    metadataMap.put("columns", AttributeValue.builder().m(columns).build());
+    metadata = new TableMetadata(metadataMap);
+  }
+
+  private Map<String, AttributeValue> prepareItemWithSmallValues() {
+    Map<String, AttributeValue> item = new HashMap<>();
+
+    item.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_SMALL_INT)).build());
+    item.put(ANY_NAME_3, AttributeValue.builder().bool(SMALL_BOOLEAN).build());
+    item.put(ANY_NAME_4, AttributeValue.builder().n(String.valueOf(ANY_SMALL_BIGINT)).build());
+    item.put(ANY_NAME_5, AttributeValue.builder().n(String.valueOf(ANY_SMALL_FLOAT)).build());
+    item.put(ANY_NAME_6, AttributeValue.builder().n(String.valueOf(ANY_SMALL_DOUBLE)).build());
+    item.put(ANY_NAME_7, AttributeValue.builder().s(ANY_SMALL_TEXT).build());
+    item.put(
+        ANY_NAME_8, AttributeValue.builder().b(SdkBytes.fromByteArray(ANY_SMALL_BLOB)).build());
+    item.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s(ANY_TEXT_2).build());
+
+    return item;
+  }
+
+  @Test
+  public void sort_ItemsGivenWithoutOrderingAndLimit_ShouldNotSort() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    item1.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_LARGE_INT));
+    assertThat(actual.get(1).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_SMALL_INT));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithAscOrderingInt_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    item1.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.ASC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_SMALL_INT));
+    assertThat(actual.get(1).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_LARGE_INT));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingInt_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_LARGE_INT));
+    assertThat(actual.get(1).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_SMALL_INT));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingBoolean_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_3, AttributeValue.builder().bool(LARGE_BOOLEAN).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_3, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_3).bool()).isEqualTo(LARGE_BOOLEAN);
+    assertThat(actual.get(1).get(ANY_NAME_3).bool()).isEqualTo(SMALL_BOOLEAN);
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingBigint_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_4, AttributeValue.builder().n(String.valueOf(ANY_LARGE_BIGINT)).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_4, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_4).n()).isEqualTo(String.valueOf(ANY_LARGE_BIGINT));
+    assertThat(actual.get(1).get(ANY_NAME_4).n()).isEqualTo(String.valueOf(ANY_SMALL_BIGINT));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingFloat_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_5, AttributeValue.builder().n(String.valueOf(ANY_LARGE_FLOAT)).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_5, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_5).n()).isEqualTo(String.valueOf(ANY_LARGE_FLOAT));
+    assertThat(actual.get(1).get(ANY_NAME_5).n()).isEqualTo(String.valueOf(ANY_SMALL_FLOAT));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingDouble_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_6, AttributeValue.builder().n(String.valueOf(ANY_LARGE_DOUBLE)).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_6, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_6).n()).isEqualTo(String.valueOf(ANY_LARGE_DOUBLE));
+    assertThat(actual.get(1).get(ANY_NAME_6).n()).isEqualTo(String.valueOf(ANY_SMALL_DOUBLE));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingText_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_7, AttributeValue.builder().s(ANY_LARGE_TEXT).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_7, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_7).s()).isEqualTo(ANY_LARGE_TEXT);
+    assertThat(actual.get(1).get(ANY_NAME_7).s()).isEqualTo(ANY_SMALL_TEXT);
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingBlob_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(
+        ANY_NAME_8, AttributeValue.builder().b(SdkBytes.fromByteArray(ANY_LARGE_BLOB)).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_8, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_8).b().asByteArray()).isEqualTo(ANY_LARGE_BLOB);
+    assertThat(actual.get(1).get(ANY_NAME_8).b().asByteArray()).isEqualTo(ANY_SMALL_BLOB);
+  }
+
+  @Test
+  public void sort_ItemsGivenWithDescOrderingIntAndLimit_ShouldResultLargerOne() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC))
+            .withLimit(1);
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_LARGE_INT));
+  }
+
+  @Test
+  public void sort_ItemsGivenWithMultipleOrderingIntAndText_ShouldSortProperly() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItemWithSmallValues();
+    Map<String, AttributeValue> item2 = prepareItemWithSmallValues();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    Map<String, AttributeValue> item3 = prepareItemWithSmallValues();
+    item3.put(ANY_NAME_7, AttributeValue.builder().s(ANY_LARGE_TEXT).build());
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC))
+            .withOrdering(new Scan.Ordering(ANY_NAME_7, Scan.Ordering.Order.DESC));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    items.add(item3);
+    ItemSorter sorter = new ItemSorter(scan, metadata);
+
+    // Act
+    List<Map<String, AttributeValue>> actual = sorter.sort(items);
+
+    // Assert
+    assertThat(actual.get(0).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_LARGE_INT));
+    assertThat(actual.get(0).get(ANY_NAME_7).s()).isEqualTo(ANY_SMALL_TEXT);
+    assertThat(actual.get(1).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_SMALL_INT));
+    assertThat(actual.get(1).get(ANY_NAME_7).s()).isEqualTo(ANY_LARGE_TEXT);
+    assertThat(actual.get(2).get(ANY_NAME_2).n()).isEqualTo(String.valueOf(ANY_SMALL_INT));
+    assertThat(actual.get(2).get(ANY_NAME_7).s()).isEqualTo(ANY_SMALL_TEXT);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/MapVisitorTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/MapVisitorTest.java
@@ -1,0 +1,107 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.BlobValue;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.DoubleValue;
+import com.scalar.db.io.FloatValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.TextValue;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MapVisitorTest {
+  private static final boolean ANY_BOOLEAN = false;
+  private static final BooleanValue ANY_BOOLEAN_VALUE =
+      new BooleanValue("any_boolean", ANY_BOOLEAN);
+  private static final int ANY_INT = Integer.MIN_VALUE;
+  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
+  private static final long ANY_BIGINT = Long.MAX_VALUE;
+  private static final BigIntValue ANY_BIGINT_VALUE = new BigIntValue("any_bigint", ANY_BIGINT);
+  private static final float ANY_FLOAT = Float.MIN_NORMAL;
+  private static final FloatValue ANY_FLOAT_VALUE = new FloatValue("any_float", ANY_FLOAT);
+  private static final double ANY_DOUBLE = Double.MIN_NORMAL;
+  private static final DoubleValue ANY_DOUBLE_VALUE = new DoubleValue("any_double", ANY_DOUBLE);
+  private static final String ANY_TEXT = "test";
+  private static final TextValue ANY_TEXT_VALUE = new TextValue("any_text", ANY_TEXT);
+  private static final byte[] ANY_BLOB = ANY_TEXT.getBytes(StandardCharsets.UTF_8);
+  private static final BlobValue ANY_BLOB_VALUE = new BlobValue("any_blob", ANY_BLOB);
+  private MapVisitor visitor;
+
+  @Before
+  public void setUp() {
+    visitor = new MapVisitor();
+  }
+
+  @Test
+  public void visit_BooleanValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_BOOLEAN_VALUE.accept(visitor);
+
+    // Assert
+    assertThat(visitor.get().get(ANY_BOOLEAN_VALUE.getName()).bool()).isEqualTo(ANY_BOOLEAN);
+  }
+
+  @Test
+  public void visit_IntValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_INT_VALUE.accept(visitor);
+
+    // Assert
+    assertThat(Integer.valueOf(visitor.get().get(ANY_INT_VALUE.getName()).n())).isEqualTo(ANY_INT);
+  }
+
+  @Test
+  public void visit_BigIntValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_BIGINT_VALUE.accept(visitor);
+
+    // Assert
+    assertThat(Long.valueOf(visitor.get().get(ANY_BIGINT_VALUE.getName()).n()))
+        .isEqualTo(ANY_BIGINT);
+  }
+
+  @Test
+  public void visit_FloatValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_FLOAT_VALUE.accept(visitor);
+
+    // Assert
+    assertThat(Float.valueOf(visitor.get().get(ANY_FLOAT_VALUE.getName()).n()))
+        .isEqualTo(ANY_FLOAT);
+  }
+
+  @Test
+  public void visit_DoubleValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_DOUBLE_VALUE.accept(visitor);
+
+    // Assert
+    assertThat(Double.valueOf(visitor.get().get(ANY_DOUBLE_VALUE.getName()).n()))
+        .isEqualTo(ANY_DOUBLE);
+  }
+
+  @Test
+  public void visit_TextValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_TEXT_VALUE.accept(visitor);
+
+    // Assert
+    assertThat(visitor.get().get(ANY_TEXT_VALUE.getName()).s()).isEqualTo(ANY_TEXT);
+  }
+
+  @Test
+  public void visit_BlobValueAcceptCalled_ShouldGetMap() {
+    // Act
+    ANY_BLOB_VALUE.accept(visitor);
+
+    // Assert
+    ByteBuffer expected =
+        (ByteBuffer) ByteBuffer.allocate(ANY_TEXT.length()).put(ANY_TEXT.getBytes()).flip();
+    assertThat(visitor.get().get(ANY_BLOB_VALUE.getName()).b().asByteBuffer()).isEqualTo(expected);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
@@ -1,0 +1,220 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+
+public class PutStatementHandlerTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_4 = "name4";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final int ANY_INT_1 = 1;
+  private static final int ANY_INT_2 = 2;
+
+  private PutStatementHandler handler;
+  @Mock private DynamoDbClient client;
+  @Mock private TableMetadataManager metadataManager;
+  @Mock private TableMetadata metadata;
+  @Mock private PutItemResponse putResponse;
+  @Mock private UpdateItemResponse updateResponse;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    handler = new PutStatementHandler(client, metadataManager);
+
+    when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
+    when(metadata.getPartitionKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_1)));
+    when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+  }
+
+  private Put preparePut() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME)
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_1))
+            .withValue(new IntValue(ANY_NAME_4, ANY_INT_2));
+
+    return put;
+  }
+
+  @Test
+  public void handle_PutWithoutConditionsGiven_ShouldCallPutItem() {
+    // Arrange
+    when(client.putItem(any(PutItemRequest.class))).thenReturn(putResponse);
+    Put put = preparePut();
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    Map<String, AttributeValue> expectedItem = dynamoMutation.getValueMapWithKey();
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(put);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<PutItemRequest> captor = ArgumentCaptor.forClass(PutItemRequest.class);
+    verify(client).putItem(captor.capture());
+    PutItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.item()).isEqualTo(expectedItem);
+    assertThat(actualRequest.conditionExpression()).isNull();
+  }
+
+  @Test
+  public void handle_PutWithoutClusteringKeyGiven_ShouldCallUpsertItem() {
+    // Arrange
+    when(client.putItem(any(PutItemRequest.class))).thenReturn(putResponse);
+    when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1));
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Put put =
+        new Put(partitionKey)
+            .forNamespace(ANY_KEYSPACE_NAME)
+            .forTable(ANY_TABLE_NAME)
+            .withValue(new IntValue(ANY_NAME_3, ANY_INT_1))
+            .withValue(new IntValue(ANY_NAME_4, ANY_INT_2));
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    Map<String, AttributeValue> expectedItem = dynamoMutation.getValueMapWithKey();
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(put);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<PutItemRequest> captor = ArgumentCaptor.forClass(PutItemRequest.class);
+    verify(client).putItem(captor.capture());
+    PutItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.item()).isEqualTo(expectedItem);
+    assertThat(actualRequest.conditionExpression()).isNull();
+  }
+
+  @Test
+  public void handle_PutWithoutConditionsDynamoDbExceptionThrown_ShouldThrowExecutionException() {
+    // Arrange
+    Put put = preparePut();
+
+    DynamoDbException toThrow = mock(DynamoDbException.class);
+    doThrow(toThrow).when(client).putItem(any(PutItemRequest.class));
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(put);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_PutIfNotExistsGiven_ShouldCallPutItemWithCondition() {
+    // Arrange
+    when(client.putItem(any(PutItemRequest.class))).thenReturn(putResponse);
+    Put put = preparePut().withCondition(new PutIfNotExists());
+
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    Map<String, AttributeValue> expectedItem = dynamoMutation.getValueMapWithKey();
+    String expectedCondition = dynamoMutation.getIfNotExistsCondition();
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(put);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<PutItemRequest> captor = ArgumentCaptor.forClass(PutItemRequest.class);
+    verify(client).putItem(captor.capture());
+    PutItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.item()).isEqualTo(expectedItem);
+    assertThat(actualRequest.conditionExpression()).isEqualTo(expectedCondition);
+  }
+
+  @Test
+  public void handle_PutIfExistsGiven_ShouldCallUpdateItemWithCondition() {
+    // Arrange
+    when(client.putItem(any(PutItemRequest.class))).thenReturn(putResponse);
+    Put put = preparePut().withCondition(new PutIfExists());
+    DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
+    Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
+    String updateExpression = dynamoMutation.getUpdateExpression();
+    String expectedCondition = dynamoMutation.getIfExistsCondition();
+    Map<String, AttributeValue> expectedBindMap = dynamoMutation.getValueBindMap();
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(put);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+    verify(client).updateItem(captor.capture());
+    UpdateItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.key()).isEqualTo(expectedKeys);
+    assertThat(actualRequest.updateExpression()).isEqualTo(updateExpression);
+    assertThat(actualRequest.conditionExpression()).isEqualTo(expectedCondition);
+    assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+  }
+
+  @Test
+  public void handle_DynamoDbExceptionWithConditionalCheckFailed_ShouldThrowNoMutationException() {
+    // Arrange
+    ConditionalCheckFailedException toThrow = mock(ConditionalCheckFailedException.class);
+    doThrow(toThrow).when(client).updateItem(any(UpdateItemRequest.class));
+
+    Put put = preparePut().withCondition(new PutIfExists());
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(put);
+            })
+        .isInstanceOf(NoMutationException.class);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
@@ -27,8 +27,6 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class ResultImplTest {
-  private static final String ANY_ID_1 = "id1";
-  private static final String ANY_ID_2 = "id2";
   private static final String ANY_NAME_1 = "name1";
   private static final String ANY_NAME_2 = "name2";
   private static final String ANY_TEXT_1 = "text1";
@@ -51,7 +49,6 @@ public class ResultImplTest {
     Map<String, AttributeValue> metadataMap = new HashMap<>();
     metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
     metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2).build());
-    metadataMap.put("sortKey", AttributeValue.builder().s(ANY_NAME_2).build());
     Map<String, AttributeValue> columns = new HashMap<>();
     columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
     columns.put(ANY_NAME_2, AttributeValue.builder().s("text").build());

--- a/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
@@ -128,6 +128,37 @@ public class ResultImplTest {
   }
 
   @Test
+  public void getValues_NullValuesGivenInConstructor_ShouldReturnDefaultValueSet() {
+    // Arrange
+    Map<String, AttributeValue> nullItem = new HashMap<>();
+    nullItem.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    nullItem.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());
+    nullItem.put(ANY_NAME_2, AttributeValue.builder().s(ANY_TEXT_2).build());
+    nullItem.put(ANY_COLUMN_NAME_1, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_2, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_3, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_4, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_5, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_6, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_7, AttributeValue.builder().nul(true).build());
+
+    ResultImpl result = new ResultImpl(nullItem, get, metadata);
+
+    // Act
+    Map<String, Value> actual = result.getValues();
+
+    // Assert
+    assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, false));
+    assertThat(actual.get(ANY_COLUMN_NAME_2)).isEqualTo(new IntValue(ANY_COLUMN_NAME_2, 0));
+    assertThat(actual.get(ANY_COLUMN_NAME_3)).isEqualTo(new BigIntValue(ANY_COLUMN_NAME_3, 0L));
+    assertThat(actual.get(ANY_COLUMN_NAME_4)).isEqualTo(new FloatValue(ANY_COLUMN_NAME_4, 0.0f));
+    assertThat(actual.get(ANY_COLUMN_NAME_5)).isEqualTo(new DoubleValue(ANY_COLUMN_NAME_5, 0.0));
+    assertThat(actual.get(ANY_COLUMN_NAME_6))
+        .isEqualTo(new TextValue(ANY_COLUMN_NAME_6, (String) null));
+    assertThat(actual.get(ANY_COLUMN_NAME_7)).isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, null));
+  }
+
+  @Test
   public void getValue_GetValueCalledBefore_ShouldNotLoadAgain() {
     // Arrange
     ResultImpl spy = spy(new ResultImpl(item, get, metadata));

--- a/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
@@ -1,0 +1,240 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.BlobValue;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.DoubleValue;
+import com.scalar.db.io.FloatValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class ResultImplTest {
+  private static final String ANY_ID_1 = "id1";
+  private static final String ANY_ID_2 = "id2";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final byte[] ANY_BLOB = "ブロブ".getBytes(StandardCharsets.UTF_8);
+  private static final String ANY_COLUMN_NAME_1 = "val1";
+  private static final String ANY_COLUMN_NAME_2 = "val2";
+  private static final String ANY_COLUMN_NAME_3 = "val3";
+  private static final String ANY_COLUMN_NAME_4 = "val4";
+  private static final String ANY_COLUMN_NAME_5 = "val5";
+  private static final String ANY_COLUMN_NAME_6 = "val6";
+  private static final String ANY_COLUMN_NAME_7 = "val7";
+
+  private Get get;
+  private TableMetadata metadata;
+  private Map<String, AttributeValue> item = new HashMap<>();
+
+  @Before
+  public void setUp() throws Exception {
+    Map<String, AttributeValue> metadataMap = new HashMap<>();
+    metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
+    metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2).build());
+    metadataMap.put("sortKey", AttributeValue.builder().s(ANY_NAME_2).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("text").build());
+    columns.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s("boolean").build());
+    columns.put(ANY_COLUMN_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_COLUMN_NAME_3, AttributeValue.builder().s("bigint").build());
+    columns.put(ANY_COLUMN_NAME_4, AttributeValue.builder().s("float").build());
+    columns.put(ANY_COLUMN_NAME_5, AttributeValue.builder().s("double").build());
+    columns.put(ANY_COLUMN_NAME_6, AttributeValue.builder().s("text").build());
+    columns.put(ANY_COLUMN_NAME_7, AttributeValue.builder().s("blob").build());
+    metadataMap.put("columns", AttributeValue.builder().m(columns).build());
+    metadata = new TableMetadata(metadataMap);
+
+    item.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item.put(ANY_NAME_2, AttributeValue.builder().s(ANY_TEXT_2).build());
+    item.put(ANY_COLUMN_NAME_1, AttributeValue.builder().bool(true).build());
+    item.put(
+        ANY_COLUMN_NAME_2, AttributeValue.builder().n(String.valueOf(Integer.MAX_VALUE)).build());
+    item.put(ANY_COLUMN_NAME_3, AttributeValue.builder().n(String.valueOf(Long.MAX_VALUE)).build());
+    item.put(
+        ANY_COLUMN_NAME_4, AttributeValue.builder().n(String.valueOf(Float.MAX_VALUE)).build());
+    item.put(
+        ANY_COLUMN_NAME_5, AttributeValue.builder().n(String.valueOf(Double.MAX_VALUE)).build());
+    item.put(ANY_COLUMN_NAME_6, AttributeValue.builder().s("string").build());
+    item.put(
+        ANY_COLUMN_NAME_7, AttributeValue.builder().b(SdkBytes.fromByteArray(ANY_BLOB)).build());
+
+    get = new Get(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
+  }
+
+  @Test
+  public void getValue_ProperValuesGivenInConstructor_ShouldReturnWhatsSet() {
+    // Arrange
+    ResultImpl result = new ResultImpl(item, get, metadata);
+
+    // Act
+    Optional<Value> actual = result.getValue(ANY_NAME_1);
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
+  }
+
+  @Test
+  public void getValues_ProperValuesGivenInConstructor_ShouldReturnWhatsSet() {
+    // Arrange
+    ResultImpl result = new ResultImpl(item, get, metadata);
+
+    // Act
+    Map<String, Value> actual = result.getValues();
+
+    // Assert
+    assertThat(actual.get(ANY_NAME_1)).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    assertThat(actual.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, true));
+    assertThat(actual.get(ANY_COLUMN_NAME_7)).isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, ANY_BLOB));
+  }
+
+  @Test
+  public void getValues_NoValuesGivenInConstructor_ShouldReturnDefaultValueSet() {
+    // Arrange
+    Map<String, AttributeValue> emptyItem = new HashMap<>();
+    ResultImpl result = new ResultImpl(emptyItem, get, metadata);
+
+    // Act
+    Map<String, Value> actual = result.getValues();
+
+    // Assert
+    assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, false));
+    assertThat(actual.get(ANY_COLUMN_NAME_2)).isEqualTo(new IntValue(ANY_COLUMN_NAME_2, 0));
+    assertThat(actual.get(ANY_COLUMN_NAME_3)).isEqualTo(new BigIntValue(ANY_COLUMN_NAME_3, 0L));
+    assertThat(actual.get(ANY_COLUMN_NAME_4)).isEqualTo(new FloatValue(ANY_COLUMN_NAME_4, 0.0f));
+    assertThat(actual.get(ANY_COLUMN_NAME_5)).isEqualTo(new DoubleValue(ANY_COLUMN_NAME_5, 0.0));
+    assertThat(actual.get(ANY_COLUMN_NAME_6))
+        .isEqualTo(new TextValue(ANY_COLUMN_NAME_6, (String) null));
+    assertThat(actual.get(ANY_COLUMN_NAME_7)).isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, null));
+  }
+
+  @Test
+  public void getValue_GetValueCalledBefore_ShouldNotLoadAgain() {
+    // Arrange
+    ResultImpl spy = spy(new ResultImpl(item, get, metadata));
+    spy.interpret(item, metadata);
+    spy.getValue(ANY_COLUMN_NAME_1);
+
+    // Act
+    spy.getValue(ANY_COLUMN_NAME_1);
+
+    // Assert
+    verify(spy, times(1)).interpret(item, metadata);
+  }
+
+  @Test
+  public void getValues_TryToModifyReturned_ShouldThrowException() {
+    // Arrange
+    ResultImpl result = new ResultImpl(item, get, metadata);
+    Map<String, Value> values = result.getValues();
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              values.put("new", new TextValue(ANY_NAME_1, ANY_TEXT_1));
+            })
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void getValues_GetWithProjectionsGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Get getWithProjections =
+        get.withProjections(Arrays.asList(ANY_COLUMN_NAME_1, ANY_COLUMN_NAME_4));
+    ResultImpl result = new ResultImpl(item, getWithProjections, metadata);
+
+    // Act
+    Map<String, Value> actual = result.getValues();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(4);
+    assertThat(actual.get(ANY_NAME_1)).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    assertThat(actual.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, true));
+    assertThat(actual.get(ANY_COLUMN_NAME_4))
+        .isEqualTo(new FloatValue(ANY_COLUMN_NAME_4, Float.MAX_VALUE));
+  }
+
+  @Test
+  public void equals_DifferentObjectsSameValuesGiven_ShouldReturnTrue() {
+    // Arrange
+    ResultImpl r1 = new ResultImpl(item, get, metadata);
+    ResultImpl r2 = new ResultImpl(item, get, metadata);
+
+    // Act Assert
+    assertThat(r1.equals(r2)).isTrue();
+  }
+
+  @Test
+  public void equals_DifferentObjectsDifferentValuesGiven_ShouldReturnFalse() {
+    // Arrange
+    ResultImpl r1 = new ResultImpl(item, get, metadata);
+    Map<String, AttributeValue> item2 = new HashMap<>();
+    item2.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item2.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item2.put(ANY_NAME_2, AttributeValue.builder().s(ANY_TEXT_2).build());
+    item2.put(ANY_COLUMN_NAME_1, AttributeValue.builder().bool(true).build());
+    ResultImpl r2 = new ResultImpl(item2, get, metadata);
+
+    // Act Assert
+    assertThat(r1.equals(r2)).isFalse();
+  }
+
+  @Test
+  public void constructor_NullGiven_ShouldThrowNullPointerException() {
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              new ResultImpl(null, null, null);
+            })
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void getPartitionKey_RequiredValuesGiven_ShouldReturnPartitionKey() {
+    // Arrange
+    ResultImpl result = new ResultImpl(item, get, metadata);
+
+    // Act
+    Optional<Key> key = result.getPartitionKey();
+
+    // Assert
+    assertThat(key.get().get().size()).isEqualTo(1);
+    assertThat(key.get().get().get(0)).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+  }
+
+  @Test
+  public void getClusteringKey_RequiredValuesGiven_ShouldReturnClusteringKey() {
+    // Arrange
+    ResultImpl result = new ResultImpl(item, get, metadata);
+
+    // Act
+    Optional<Key> key = result.getClusteringKey();
+
+    // Assert
+    assertThat(key.get().get().size()).isEqualTo(1);
+    assertThat(key.get().get().get(0)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/ScannerImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ScannerImplTest.java
@@ -1,0 +1,166 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class ScannerImplTest {
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final int ANY_LARGE_INT = 1000;
+  private static final int ANY_SMALL_INT = 1;
+  private static final String ANY_LARGE_TEXT = "sssssss";
+  private static final String ANY_SMALL_TEXT = "aa";
+  private static final String ANY_COLUMN_NAME_1 = "val1";
+
+  private TableMetadata metadata;
+
+  @Before
+  public void setUp() throws Exception {
+    Map<String, AttributeValue> metadataMap = new HashMap<>();
+    metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
+    metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2, ANY_NAME_3).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_NAME_3, AttributeValue.builder().s("text").build());
+    columns.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s("text").build());
+    metadataMap.put("columns", AttributeValue.builder().m(columns).build());
+    metadata = new TableMetadata(metadataMap);
+  }
+
+  private Map<String, AttributeValue> prepareItem() {
+    Map<String, AttributeValue> item = new HashMap<>();
+
+    item.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());
+    item.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_SMALL_INT)).build());
+    item.put(ANY_NAME_3, AttributeValue.builder().s(ANY_SMALL_TEXT).build());
+    item.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s(ANY_TEXT_2).build());
+
+    return item;
+  }
+
+  @Test
+  public void one_MultipleItemsGivenWithoutOrderingAndLimit_ShouldReturnSmallResult() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItem();
+    Map<String, AttributeValue> item2 = prepareItem();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
+
+    // Act
+    Optional<Result> actual = scanner.one();
+
+    // Assert
+    assertThat(actual.get().getValue(ANY_NAME_2).get())
+        .isEqualTo(new IntValue(ANY_NAME_2, ANY_SMALL_INT));
+  }
+
+  @Test
+  public void one_MultipleItemsGivenWithDescOrdering_ShouldReturnLargeResult() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItem();
+    Map<String, AttributeValue> item2 = prepareItem();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC));
+
+    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
+
+    // Act
+    Optional<Result> actual = scanner.one();
+
+    // Assert
+    assertThat(actual.get().getValue(ANY_NAME_2).get())
+        .isEqualTo(new IntValue(ANY_NAME_2, ANY_LARGE_INT));
+  }
+
+  @Test
+  public void all_MultipleItemsGivenWithoutOrderingAndLimit_ShouldReturnAllResults() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItem();
+    Map<String, AttributeValue> item2 = prepareItem();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
+
+    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
+
+    // Act
+    List<Result> actual = scanner.all();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void all_MultipleItemsGivenWithMultipleOrdering_ShouldReturnLargeResult() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItem();
+    Map<String, AttributeValue> item2 = prepareItem();
+    item2.put(ANY_NAME_3, AttributeValue.builder().s(String.valueOf(ANY_LARGE_TEXT)).build());
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    Scan scan =
+        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC))
+            .withOrdering(new Scan.Ordering(ANY_NAME_3, Scan.Ordering.Order.DESC));
+
+    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
+
+    // Act
+    List<Result> actual = scanner.all();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual.get(0).getValue(ANY_NAME_3).get())
+        .isEqualTo(new TextValue(ANY_NAME_3, ANY_LARGE_TEXT));
+  }
+
+  @Test
+  public void all_MultipleItemsGivenWithLimit_ShouldReturnLargeResult() {
+    // Arrange
+    Map<String, AttributeValue> item1 = prepareItem();
+    Map<String, AttributeValue> item2 = prepareItem();
+    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(item1);
+    items.add(item2);
+    Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1))).withLimit(1);
+
+    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
+
+    // Act
+    List<Result> actual = scanner.all();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(1);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/ScannerImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ScannerImplTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.dynamo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
@@ -11,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -24,24 +22,38 @@ public class ScannerImplTest {
   private static final String ANY_TEXT_2 = "text2";
   private static final int ANY_LARGE_INT = 1000;
   private static final int ANY_SMALL_INT = 1;
-  private static final String ANY_LARGE_TEXT = "sssssss";
   private static final String ANY_SMALL_TEXT = "aa";
   private static final String ANY_COLUMN_NAME_1 = "val1";
 
-  private TableMetadata metadata;
-
   @Before
-  public void setUp() throws Exception {
+  public void setUp() throws Exception {}
+
+  private TableMetadata prepareMetadataForSingleClusteringKey() {
+    Map<String, AttributeValue> metadataMap = new HashMap<>();
+    metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
+    metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2).build());
+    metadataMap.put("columns", AttributeValue.builder().m(prepareColumns()).build());
+
+    return new TableMetadata(metadataMap);
+  }
+
+  private TableMetadata prepareMetadataForMultipleClusteringKeys() {
     Map<String, AttributeValue> metadataMap = new HashMap<>();
     metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
     metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2, ANY_NAME_3).build());
+    metadataMap.put("columns", AttributeValue.builder().m(prepareColumns()).build());
+
+    return new TableMetadata(metadataMap);
+  }
+
+  private Map<String, AttributeValue> prepareColumns() {
     Map<String, AttributeValue> columns = new HashMap<>();
     columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
     columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
     columns.put(ANY_NAME_3, AttributeValue.builder().s("text").build());
     columns.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s("text").build());
-    metadataMap.put("columns", AttributeValue.builder().m(columns).build());
-    metadata = new TableMetadata(metadataMap);
+
+    return columns;
   }
 
   private Map<String, AttributeValue> prepareItem() {
@@ -57,110 +69,44 @@ public class ScannerImplTest {
   }
 
   @Test
-  public void one_MultipleItemsGivenWithoutOrderingAndLimit_ShouldReturnSmallResult() {
+  public void constructor_ItemsWithSingleClusteringKeyGiven_ShouldNotSortItems() {
     // Arrange
+    TableMetadata metadata = prepareMetadataForSingleClusteringKey();
     Map<String, AttributeValue> item1 = prepareItem();
+    item1.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
     Map<String, AttributeValue> item2 = prepareItem();
-    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
     Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
     List<Map<String, AttributeValue>> items = new ArrayList<>();
     items.add(item1);
     items.add(item2);
-    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
 
     // Act
-    Optional<Result> actual = scanner.one();
+    ScannerImpl actual = new ScannerImpl(items, scan, metadata);
 
     // Assert
-    assertThat(actual.get().getValue(ANY_NAME_2).get())
-        .isEqualTo(new IntValue(ANY_NAME_2, ANY_SMALL_INT));
-  }
-
-  @Test
-  public void one_MultipleItemsGivenWithDescOrdering_ShouldReturnLargeResult() {
-    // Arrange
-    Map<String, AttributeValue> item1 = prepareItem();
-    Map<String, AttributeValue> item2 = prepareItem();
-    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
-    List<Map<String, AttributeValue>> items = new ArrayList<>();
-    items.add(item1);
-    items.add(item2);
-    Scan scan =
-        new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC));
-
-    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
-
-    // Act
-    Optional<Result> actual = scanner.one();
-
-    // Assert
-    assertThat(actual.get().getValue(ANY_NAME_2).get())
+    assertThat(actual.one().get().getValue(ANY_NAME_2).get())
         .isEqualTo(new IntValue(ANY_NAME_2, ANY_LARGE_INT));
   }
 
   @Test
-  public void all_MultipleItemsGivenWithoutOrderingAndLimit_ShouldReturnAllResults() {
+  public void constructor_ItemsWithMultipleClusteringKeysGiven_ShouldSortItems() {
     // Arrange
+    TableMetadata metadata = prepareMetadataForMultipleClusteringKeys();
     Map<String, AttributeValue> item1 = prepareItem();
     Map<String, AttributeValue> item2 = prepareItem();
     item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
-    List<Map<String, AttributeValue>> items = new ArrayList<>();
-    items.add(item1);
-    items.add(item2);
-    Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)));
-
-    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
-
-    // Act
-    List<Result> actual = scanner.all();
-
-    // Assert
-    assertThat(actual.size()).isEqualTo(2);
-  }
-
-  @Test
-  public void all_MultipleItemsGivenWithMultipleOrdering_ShouldReturnLargeResult() {
-    // Arrange
-    Map<String, AttributeValue> item1 = prepareItem();
-    Map<String, AttributeValue> item2 = prepareItem();
-    item2.put(ANY_NAME_3, AttributeValue.builder().s(String.valueOf(ANY_LARGE_TEXT)).build());
-    List<Map<String, AttributeValue>> items = new ArrayList<>();
-    items.add(item1);
-    items.add(item2);
     Scan scan =
         new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1)))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(ANY_NAME_3, Scan.Ordering.Order.DESC));
-
-    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
-
-    // Act
-    List<Result> actual = scanner.all();
-
-    // Assert
-    assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(ANY_NAME_3).get())
-        .isEqualTo(new TextValue(ANY_NAME_3, ANY_LARGE_TEXT));
-  }
-
-  @Test
-  public void all_MultipleItemsGivenWithLimit_ShouldReturnLargeResult() {
-    // Arrange
-    Map<String, AttributeValue> item1 = prepareItem();
-    Map<String, AttributeValue> item2 = prepareItem();
-    item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC));
     List<Map<String, AttributeValue>> items = new ArrayList<>();
     items.add(item1);
     items.add(item2);
-    Scan scan = new Scan(new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1))).withLimit(1);
-
-    ScannerImpl scanner = new ScannerImpl(items, scan, metadata);
 
     // Act
-    List<Result> actual = scanner.all();
+    ScannerImpl actual = new ScannerImpl(items, scan, metadata);
 
     // Assert
-    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.one().get().getValue(ANY_NAME_2).get())
+        .isEqualTo(new IntValue(ANY_NAME_2, ANY_LARGE_INT));
   }
 }

--- a/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -1,0 +1,367 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+public class SelectStatementHandlerTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final String ANY_TEXT_4 = "text4";
+  private static final Scan.Ordering.Order ASC_ORDER = Scan.Ordering.Order.ASC;
+  private static final Scan.Ordering.Order DESC_ORDER = Scan.Ordering.Order.DESC;
+  private static final int ANY_LIMIT = 100;
+
+  private SelectStatementHandler handler;
+  @Mock private DynamoDbClient client;
+  @Mock private TableMetadataManager metadataManager;
+  @Mock private TableMetadata metadata;
+  @Mock private GetItemResponse getResponse;
+  @Mock private QueryResponse queryResponse;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    handler = new SelectStatementHandler(client, metadataManager);
+
+    when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
+    when(metadata.getPartitionKeyNames())
+        .thenReturn(new HashSet<String>(Arrays.asList(ANY_NAME_1)));
+    when(metadata.getKeyNames()).thenReturn(Arrays.asList(ANY_NAME_1, ANY_NAME_2));
+  }
+
+  private Get prepareGet() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    return new Get(partitionKey, clusteringKey)
+        .forNamespace(ANY_KEYSPACE_NAME)
+        .forTable(ANY_TABLE_NAME);
+  }
+
+  private Scan prepareScan() {
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    return new Scan(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+  }
+
+  @Test
+  public void handle_GetOperationGiven_ShouldCallGetItem() {
+    // Arrange
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(getResponse);
+    when(getResponse.hasItem()).thenReturn(true);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    when(getResponse.item()).thenReturn(expected);
+    Get get = prepareGet();
+    DynamoOperation dynamoOperation = new DynamoOperation(get, metadataManager);
+    Map<String, AttributeValue> expectedKeys = dynamoOperation.getKeyMap();
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(get);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<GetItemRequest> captor = ArgumentCaptor.forClass(GetItemRequest.class);
+    verify(client).getItem(captor.capture());
+    GetItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.key()).isEqualTo(expectedKeys);
+    assertThat(actualRequest.projectionExpression()).isNull();
+  }
+
+  @Test
+  public void handle_GetOperationNoItemReturned_ShouldReturnEmptyList() throws Exception {
+    // Arrange
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(getResponse);
+    when(getResponse.hasItem()).thenReturn(false);
+
+    Get get = prepareGet();
+
+    // Act Assert
+    List<Map<String, AttributeValue>> actual = handler.handle(get);
+
+    // Assert
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  public void handle_GetOperationDynamoDbExceptionThrown_ShouldThrowExecutionException() {
+    // Arrange
+    DynamoDbException toThrow = mock(DynamoDbException.class);
+    doThrow(toThrow).when(client).getItem(any(GetItemRequest.class));
+
+    Get get = prepareGet();
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(get);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_ScanOperationGiven_ShouldCallQuery() {
+    // Arrange
+    when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    when(queryResponse.items()).thenReturn(Arrays.asList(expected));
+    Scan scan = prepareScan();
+    String expectedKeyCondition =
+        DynamoOperation.PARTITION_KEY + " = " + DynamoOperation.PARTITION_KEY_ALIAS;
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    String partitionKey = dynamoOperation.getConcatenatedPartitionKey();
+    Map<String, AttributeValue> expectedBindMap = new HashMap<>();
+    expectedBindMap.put(
+        DynamoOperation.PARTITION_KEY_ALIAS, AttributeValue.builder().s(partitionKey).build());
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(scan);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+    verify(client).query(captor.capture());
+    QueryRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedKeyCondition);
+    assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+  }
+
+  @Test
+  public void handle_ScanOperationCosmosExceptionThrown_ShouldThrowExecutionException() {
+    // Arrange
+    DynamoDbException toThrow = mock(DynamoDbException.class);
+    doThrow(toThrow).when(client).query(any(QueryRequest.class));
+
+    Scan scan = prepareScan();
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(scan);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_ScanOperationWithSingleClusteringKey_ShouldCallQueryItemsWithProperQuery() {
+    // Arrange
+    when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    when(queryResponse.items()).thenReturn(Arrays.asList(expected));
+
+    Scan scan =
+        prepareScan()
+            .withStart(new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2)))
+            .withEnd(new Key(new TextValue(ANY_NAME_2, ANY_TEXT_3)));
+
+    String expectedCondition =
+        DynamoOperation.PARTITION_KEY
+            + " = "
+            + DynamoOperation.PARTITION_KEY_ALIAS
+            + " AND "
+            + ANY_NAME_2
+            + DynamoOperation.RANGE_CONDITION;
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    String partitionKey = dynamoOperation.getConcatenatedPartitionKey();
+    Map<String, AttributeValue> expectedBindMap = new HashMap<>();
+    expectedBindMap.put(
+        DynamoOperation.PARTITION_KEY_ALIAS, AttributeValue.builder().s(partitionKey).build());
+    expectedBindMap.put(
+        DynamoOperation.RANGE_KEY_ALIAS + "0", AttributeValue.builder().s(ANY_TEXT_2).build());
+    expectedBindMap.put(
+        DynamoOperation.RANGE_KEY_ALIAS + "1", AttributeValue.builder().s(ANY_TEXT_3).build());
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(scan);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+    verify(client).query(captor.capture());
+    QueryRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
+    assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+  }
+
+  // TODO: multiple clustering keys
+  @Ignore
+  @Test
+  public void handle_ScanOperationWithMultipleClusteringKeys_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scan =
+        prepareScan()
+            .withStart(
+                new Key(
+                    new TextValue(ANY_NAME_2, ANY_TEXT_2), new TextValue(ANY_NAME_3, ANY_TEXT_3)))
+            .withEnd(
+                new Key(
+                    new TextValue(ANY_NAME_2, ANY_TEXT_2), new TextValue(ANY_NAME_3, ANY_TEXT_4)));
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(scan);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void handle_ScanOperationWithNeitherInclusive_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scan =
+        prepareScan()
+            .withStart(new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2)), false)
+            .withEnd(new Key(new TextValue(ANY_NAME_2, ANY_TEXT_3)), false);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              handler.handle(scan);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void handle_ScanOperationWithOrderingAndLimit_ShouldCallQueryWithProperRequest() {
+    // Arrange
+    when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    when(queryResponse.items()).thenReturn(Arrays.asList(expected));
+
+    Scan scan =
+        prepareScan()
+            .withStart(new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
+            .withLimit(ANY_LIMIT);
+
+    String expectedCondition =
+        DynamoOperation.PARTITION_KEY
+            + " = "
+            + DynamoOperation.PARTITION_KEY_ALIAS
+            + " AND "
+            + ANY_NAME_2
+            + " >= "
+            + DynamoOperation.START_CLUSTERING_KEY_ALIAS
+            + "0";
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    String partitionKey = dynamoOperation.getConcatenatedPartitionKey();
+    Map<String, AttributeValue> expectedBindMap = new HashMap<>();
+    expectedBindMap.put(
+        DynamoOperation.PARTITION_KEY_ALIAS, AttributeValue.builder().s(partitionKey).build());
+    expectedBindMap.put(
+        DynamoOperation.START_CLUSTERING_KEY_ALIAS + "0",
+        AttributeValue.builder().s(ANY_TEXT_2).build());
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(scan);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+    verify(client).query(captor.capture());
+    QueryRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
+    assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.scanIndexForward()).isNull();
+    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+  }
+
+  @Test
+  public void handle_ScanOperationWithMultipleOrdering_ShouldCallQueryWithProperRequest() {
+    // Arrange
+    when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
+    Map<String, AttributeValue> expected = new HashMap<>();
+    when(queryResponse.items()).thenReturn(Arrays.asList(expected));
+
+    Scan scan =
+        prepareScan()
+            .withStart(new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2)))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
+            .withOrdering(new Scan.Ordering(ANY_NAME_3, DESC_ORDER))
+            .withLimit(ANY_LIMIT);
+
+    String expectedCondition =
+        DynamoOperation.PARTITION_KEY
+            + " = "
+            + DynamoOperation.PARTITION_KEY_ALIAS
+            + " AND "
+            + ANY_NAME_2
+            + " >= "
+            + DynamoOperation.START_CLUSTERING_KEY_ALIAS
+            + "0";
+    DynamoOperation dynamoOperation = new DynamoOperation(scan, metadataManager);
+    String partitionKey = dynamoOperation.getConcatenatedPartitionKey();
+    Map<String, AttributeValue> expectedBindMap = new HashMap<>();
+    expectedBindMap.put(
+        DynamoOperation.PARTITION_KEY_ALIAS, AttributeValue.builder().s(partitionKey).build());
+    expectedBindMap.put(
+        DynamoOperation.START_CLUSTERING_KEY_ALIAS + "0",
+        AttributeValue.builder().s(ANY_TEXT_2).build());
+
+    // Act Assert
+    assertThatCode(
+            () -> {
+              handler.handle(scan);
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+    verify(client).query(captor.capture());
+    QueryRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
+    assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    // TODO: multiple ordering
+    assertThat(actualRequest.scanIndexForward()).isNull();
+    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/TableMetadataManagerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/TableMetadataManagerTest.java
@@ -1,0 +1,138 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.exception.storage.StorageRuntimeException;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+
+public class TableMetadataManagerTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_COLUMN_NAME_1 = "val1";
+  private static final String ANY_COLUMN_NAME_2 = "val2";
+  private static final String FULLNAME = ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME;
+
+  private TableMetadataManager manager;
+  private Map<String, AttributeValue> metadataMap;
+  @Mock private DynamoDbClient client;
+  @Mock private GetItemResponse response;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    manager = new TableMetadataManager(client);
+
+    metadataMap = new HashMap<>();
+    metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
+    metadataMap.put("clusteringKey", AttributeValue.builder().ss(new ArrayList<String>()).build());
+    metadataMap.put("sortKey", AttributeValue.builder().s(null).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("text").build());
+    columns.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s("boolean").build());
+    columns.put(ANY_COLUMN_NAME_2, AttributeValue.builder().s("int").build());
+    metadataMap.put("columns", AttributeValue.builder().m(columns).build());
+  }
+
+  @Test
+  public void getTableMetadata_ProperOperationGivenFirst_ShouldCallGetItem() {
+    // Arrange
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(response);
+    when(response.item()).thenReturn(metadataMap);
+
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+    Map<String, AttributeValue> expectedKey = new HashMap<>();
+    expectedKey.put("table", AttributeValue.builder().s(FULLNAME).build());
+
+    // Act
+    manager.getTableMetadata(get);
+
+    // Assert
+    ArgumentCaptor<GetItemRequest> captor = ArgumentCaptor.forClass(GetItemRequest.class);
+    verify(client).getItem(captor.capture());
+    GetItemRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.tableName()).isEqualTo("scalardb.metadata");
+    assertThat(actualRequest.key()).isEqualTo(expectedKey);
+  }
+
+  @Test
+  public void getTableMetadata_SameTableGiven_ShouldCallReadItemOnce() {
+    // Arrange
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(response);
+    when(response.item()).thenReturn(metadataMap);
+
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Get get1 = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+    Key partitionKey2 = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_2));
+    Get get2 = new Get(partitionKey2).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+
+    // Act
+    manager.getTableMetadata(get1);
+    manager.getTableMetadata(get2);
+
+    verify(client, times(1)).getItem(any(GetItemRequest.class));
+  }
+
+  @Test
+  public void getTableMetadata_OperationWithoutTableGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(response);
+    when(response.item()).thenReturn(metadataMap);
+
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              manager.getTableMetadata(get);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getTableMetadata_CosmosExceptionThrown_ShouldThrowStorageRuntimeException() {
+    // Arrange
+    DynamoDbException toThrow = mock(DynamoDbException.class);
+    doThrow(toThrow).when(client).getItem(any(GetItemRequest.class));
+
+    Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              manager.getTableMetadata(get);
+            })
+        .isInstanceOf(StorageRuntimeException.class)
+        .hasCause(toThrow);
+  }
+}

--- a/src/test/java/com/scalar/db/storage/dynamo/TableMetadataTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/TableMetadataTest.java
@@ -1,0 +1,77 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class TableMetadataTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+
+  @Test
+  public void constructor_MetadataWithoutClusteringKeyGiven_ShouldConvertPropoerly() {
+    // Arrange
+    Map<String, AttributeValue> metadata = new HashMap<>();
+    metadata.put(
+        "table", AttributeValue.builder().s(ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME).build());
+    metadata.put(
+        "partitionKey", AttributeValue.builder().ss(Arrays.asList(ANY_NAME_1, ANY_NAME_2)).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_NAME_3, AttributeValue.builder().s("text").build());
+    metadata.put("columns", AttributeValue.builder().m(columns).build());
+
+    // Act
+    TableMetadata actual = new TableMetadata(metadata);
+
+    // Assert
+    assertThat(actual.getPartitionKeyNames().size()).isEqualTo(2);
+    assertThat(actual.getPartitionKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getPartitionKeyNames().contains(ANY_NAME_2)).isTrue();
+    assertThat(actual.getClusteringKeyNames().size()).isEqualTo(0);
+    assertThat(actual.getColumns().get(ANY_NAME_1)).isEqualTo("text");
+    assertThat(actual.getColumns().get(ANY_NAME_2)).isEqualTo("int");
+    assertThat(actual.getColumns().get(ANY_NAME_3)).isEqualTo("text");
+    assertThat(actual.getKeyNames().size()).isEqualTo(2);
+    assertThat(actual.getKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getKeyNames().contains(ANY_NAME_2)).isTrue();
+  }
+
+  @Test
+  public void constructor_MetadataWithClusteringKeyGiven_ShouldConvertPropoerly() {
+    // Arrange
+    Map<String, AttributeValue> metadata = new HashMap<>();
+    metadata.put(
+        "table", AttributeValue.builder().s(ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME).build());
+    metadata.put("partitionKey", AttributeValue.builder().ss(Arrays.asList(ANY_NAME_1)).build());
+    metadata.put("clusteringKey", AttributeValue.builder().ss(Arrays.asList(ANY_NAME_2)).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_NAME_3, AttributeValue.builder().s("text").build());
+    metadata.put("columns", AttributeValue.builder().m(columns).build());
+
+    // Act
+    TableMetadata actual = new TableMetadata(metadata);
+
+    // Assert
+    assertThat(actual.getPartitionKeyNames().size()).isEqualTo(1);
+    assertThat(actual.getPartitionKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getClusteringKeyNames().size()).isEqualTo(1);
+    assertThat(actual.getClusteringKeyNames().contains(ANY_NAME_2)).isTrue();
+    assertThat(actual.getColumns().get(ANY_NAME_1)).isEqualTo("text");
+    assertThat(actual.getColumns().get(ANY_NAME_2)).isEqualTo("int");
+    assertThat(actual.getColumns().get(ANY_NAME_3)).isEqualTo("text");
+    assertThat(actual.getKeyNames().size()).isEqualTo(2);
+    assertThat(actual.getKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getKeyNames().contains(ANY_NAME_2)).isTrue();
+  }
+}

--- a/tools/scalar-schema/README.md
+++ b/tools/scalar-schema/README.md
@@ -1,6 +1,7 @@
 # Schema Tool for Scalar DB
-This tool creates Scalar DB schemas on Cosmos DB and Cassandra.
+This tool creates Scalar DB schemas on Cosmos DB, DynamoDB and Cassandra.
   - For Cosmos DB, this tool creates databases(collections) and tables(containers), also inserts metadata which is required by Scalar DB.
+  - For DynamoDB, this tool creates tables named with the database names and table names, also inserts metadata which is required by Scalar DB.
   - For Cassandra, this tool creates databases(keyspaces) and tables. You can specify the compaction strategy, the network topology strategy, and the replication factor as well.
   - You don't have to add Scalar DB metadata for transactions. This tool automatically adds them when you set the `transaction` parameter `true` in your schema file.
 
@@ -21,6 +22,12 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --cosmos -h <YOUR_ACCO
   - `-r BASE_RESOURCE_UNIT` is an option. You can specify the RU of each database. The maximum RU in tables in the database will be set. If you don't specify RU of tables, the database RU will be set with this option. When you use transaction function, the RU of the coordinator table of Scalar DB is specified by this option. By default, it's 400.
 
 ```console
+# For DynamoDB
+$ java -jar target/scalar-schema.jar --dynamo -f schema.json [-r BASE_RESOURCE_UNIT]
+```
+  - `-r` option is almost the same as Cosmos DB option. However, the unit means DynamoDB capacity unit. The read and write capacity units are set the same value.
+
+```console
 # For Cassandra
 $ java -jar target/scalar-schema-standalone-<version>.jar --cassandra -h <CASSANDRA_IP> [-P <CASSANDRA_PORT>] [-u <CASSNDRA_USER>] [-p <CASSANDRA_PASSWORD>] -f schema.json [-n <NETWORK_STRATEGY>] [-R <REPLICATION_FACTOR>]
 ```
@@ -35,6 +42,12 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --cassandra -h <CASSAN
 # For Cosmos DB
 $ java -jar target/scalar-schema-standalone-<version>.jar --cosmos -h <YOUR_ACCOUNT_URI> -p <YOUR_ACCOUNT_PASSWORD> -D
 ```
+
+```console
+# For DynamoDB
+$ java -jar target/scalar-schema.jar --dynamo -f schema.json -D
+```
+  - For DynamoDB, only the tables which are included in the schema file will be deleted.
 
 ```console
 # For Cassandra
@@ -87,5 +100,5 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --help
   }
 }
 ```
-- `compaction-strategy` should be `STCS`, `LCS` or `TWCS`. This is ignored in Cosmos DB.
-- This `ru` value is set for all tables on this database even if `-r BASE_RESOURCE_UNIT` is set when Cosmos DB. `ru` is ignored in Cassandra.
+- `compaction-strategy` should be `STCS`, `LCS` or `TWCS`. This is ignored in Cosmos DB and DynamoDB.
+- This `ru` value is set for all tables on this database even if `-r BASE_RESOURCE_UNIT` is set when Cosmos DB and DynamoDB. `ru` is ignored in Cassandra.

--- a/tools/scalar-schema/README.md
+++ b/tools/scalar-schema/README.md
@@ -23,8 +23,9 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --cosmos -h <YOUR_ACCO
 
 ```console
 # For DynamoDB
-$ java -jar target/scalar-schema.jar --dynamo -f schema.json [-r BASE_RESOURCE_UNIT]
+$ java -jar target/scalar-schema.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> -f schema.json [-r BASE_RESOURCE_UNIT]
 ```
+  - `<REGION>` should be a string to specify an AWS region like `ap-northeast-1`.
   - `-r` option is almost the same as Cosmos DB option. However, the unit means DynamoDB capacity unit. The read and write capacity units are set the same value.
 
 ```console
@@ -45,7 +46,7 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --cosmos -h <YOUR_ACCO
 
 ```console
 # For DynamoDB
-$ java -jar target/scalar-schema.jar --dynamo -f schema.json -D
+$ java -jar target/scalar-schema.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> -f schema.json -D
 ```
   - For DynamoDB, only the tables which are included in the schema file will be deleted.
 

--- a/tools/scalar-schema/project.clj
+++ b/tools/scalar-schema/project.clj
@@ -8,6 +8,7 @@
                  [org.slf4j/slf4j-log4j12 "1.7.30"]
                  [cheshire "5.10.0"]
                  [com.azure/azure-cosmos "4.1.0"]
+                 [software.amazon.awssdk/dynamodb "2.14.24"]
                  [com.google.guava/guava "24.1-jre"]
                  [cc.qbits/alia "4.3.3"]
                  [cc.qbits/hayt "4.1.0"]]

--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -15,7 +15,7 @@
    ["-u" "--user USERNAME" "Username of the database. This option is ignored when Cosmos DB and DynamoDB."]
    ["-p" "--password ACCOUNT_PASSWORD" "Password of Cassandra or Cosmos DB account"]
    ["-f" "--schema-file SCHEMA_JSON" "Schema file"]
-   ["-r" "--ru RESOURCE_UNIT" "Base RU for each table on Cosmos DB. The RU of the coordinator for Scalar DB transaction is specified by this option. This option is ignored when Cassandra."
+   ["-r" "--ru RESOURCE_UNIT" "Base RU for each table on Cosmos DB or DynamoDB. The RU of the coordinator for Scalar DB transaction is specified by this option. This option is ignored when Cassandra."
     :parse-fn #(Integer/parseInt %)]
    ["-R" "--replication-factor REPLICATION_FACTOR"
     "The number of replicas. This options is ignored when Cosmos DB and DynamoDB."
@@ -23,6 +23,7 @@
    ["-n" "--network-strategy NETWORK_STRATEGY"
     "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This options is ignored when Cosmos DB and DynamoDB."]
    ["-D" "--delete-all" "All database will be deleted, if this is enabled."]
+   [nil "--region REGION" "Region where the tool creates tables for DynamoDB"]
    [nil "--help"]])
 
 (defn -main [& args]

--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -1,31 +1,33 @@
 (ns scalar-schema.core
   (:require [clojure.tools.cli :refer [parse-opts]]
             [scalar-schema.cassandra-schema :as cassandra-schema]
-            [scalar-schema.cosmos-schema :as cosmos-schema])
+            [scalar-schema.cosmos-schema :as cosmos-schema]
+            [scalar-schema.dynamo-schema :as dynamo-schema])
   (:gen-class))
 
 (def cli-options
   [[nil "--cassandra" "Operate for Cassandra"]
    [nil "--cosmos" "Operate for Cosmos DB"]
+   [nil "--dynamo" "Operate for DynamoDB"]
    ["-h" "--host DB_HOST" "Address of Cassandra like IP or URI address of your Cosmos DB account"]
-   ["-P" "--port DB_PORT" "Port of Cassandra. This option is ignored when Cosmos DB."
+   ["-P" "--port DB_PORT" "Port of Cassandra. This option is ignored when Cosmos DB and DynamoDB."
     :parse-fn #(Integer/parseInt %)]
-   ["-u" "--user USERNAME" "Username of the database. This option is ignored when Cosmos DB."]
+   ["-u" "--user USERNAME" "Username of the database. This option is ignored when Cosmos DB and DynamoDB."]
    ["-p" "--password ACCOUNT_PASSWORD" "Password of Cassandra or Cosmos DB account"]
    ["-f" "--schema-file SCHEMA_JSON" "Schema file"]
    ["-r" "--ru RESOURCE_UNIT" "Base RU for each table on Cosmos DB. The RU of the coordinator for Scalar DB transaction is specified by this option. This option is ignored when Cassandra."
-    :default 400 :parse-fn #(Integer/parseInt %)]
+    :parse-fn #(Integer/parseInt %)]
    ["-R" "--replication-factor REPLICATION_FACTOR"
-    "The number of replicas. This options is ignored when Cosmos DB."
+    "The number of replicas. This options is ignored when Cosmos DB and DynamoDB."
     :default 1 :parse-fn #(Integer/parseInt %)]
    ["-n" "--network-strategy NETWORK_STRATEGY"
-    "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This options is ignored when Cosmos DB."]
+    "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This options is ignored when Cosmos DB and DynamoDB."]
    ["-D" "--delete-all" "All database will be deleted, if this is enabled."]
    [nil "--help"]])
 
 (defn -main [& args]
   (let [{:keys [options summary errors]
-         {:keys [cassandra cosmos help]} :options}
+         {:keys [cassandra cosmos dynamo help]} :options}
         (parse-opts args cli-options)]
     (if (or help errors)
       (do (when (not help)
@@ -33,6 +35,5 @@
           (println summary))
       (do
         (when cassandra (cassandra-schema/operate-cassandra options))
-        (when cosmos (cosmos-schema/operate-cosmos options))))))
-
-
+        (when cosmos (cosmos-schema/operate-cosmos options))
+        (when dynamo (dynamo-schema/operate-dynamo options))))))

--- a/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
@@ -34,7 +34,7 @@
 
 (def ^:private type-map
   {"int" ScalarAttributeType/N
-   "biging" ScalarAttributeType/N
+   "bigint" ScalarAttributeType/N
    "float" ScalarAttributeType/N
    "double" ScalarAttributeType/N
    "text" ScalarAttributeType/S

--- a/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
@@ -102,8 +102,7 @@
       (.keySchema [(make-key-schema-element PARTITION_KEY KeyType/HASH)
                    (make-key-schema-element index-key KeyType/RANGE)])
       (.projection (-> (Projection/builder)
-                       (.projectionType (ProjectionType/INCLUDE))
-                       (.nonKeyAttributes ((comp keys :columns) schema))
+                       (.projectionType (ProjectionType/ALL))
                        .build))
       .build))
 

--- a/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
@@ -1,0 +1,209 @@
+(ns scalar-schema.dynamo-schema
+  (:require [clojure.tools.logging :as log]
+            [clojure.java.io :as io]
+            [scalar-schema.common :as common])
+  (:import (software.amazon.awssdk.services.dynamodb DynamoDbClient)
+           (software.amazon.awssdk.services.dynamodb.model AttributeDefinition
+                                                           AttributeValue
+                                                           CreateTableRequest
+                                                           DeleteTableRequest
+                                                           KeySchemaElement
+                                                           KeyType
+                                                           LocalSecondaryIndex
+                                                           Projection
+                                                           ProjectionType
+                                                           ProvisionedThroughput
+                                                           PutItemRequest
+                                                           ScalarAttributeType)))
+
+(def ^:const ^:private ^String WAIT_FOR_CREATION 10000)
+(def ^:const ^:private ^String METADATA_DATABASE "scalardb")
+(def ^:const ^:private ^String METADATA_TABLE "metadata")
+(def ^:const ^:private ^String METADATA_PARTITION_KEY "table")
+(def ^:const ^:private ^String PARTITION_KEY "concatenatedPartitionKey")
+(def ^:const ^:private ^String CLUSTERING_KEY "concatenatedClusteringKey")
+(def ^:const ^:private ^String INDEX_NAME_PREFIX "index")
+(def ^:const ^:private ^String PARTITION_KEY_COLUMN "partitionKey")
+(def ^:const ^:private ^String CLUSTERING_KEY_COLUMN "clusteringKey")
+(def ^:const ^:private ^String COLUMNS_COLUMN "columns")
+(def ^:private META_TABLE (common/get-fullname METADATA_DATABASE
+                                               METADATA_TABLE))
+
+(def ^:private type-map
+  {"int" ScalarAttributeType/N
+   "biging" ScalarAttributeType/N
+   "float" ScalarAttributeType/N
+   "double" ScalarAttributeType/N
+   "text" ScalarAttributeType/S
+   "blob" ScalarAttributeType/B})
+
+(defn- get-client
+  []
+  (-> (DynamoDbClient/builder)
+      .build))
+
+(defn- table-exists?
+  [client table]
+  (let [tables (-> (.listTables client) .tableNames)]
+    (not (nil? (some #(= table %) tables)))))
+
+(defn- clustering-keys-exist?
+  [schema]
+  (not (empty? (:clustering-key schema))))
+
+(defn- make-attribute-definition
+  [name type]
+  (-> (AttributeDefinition/builder)
+      (.attributeName name)
+      (.attributeType (type-map type))
+      .build))
+
+(defn- make-attribute-definitions
+  [schema]
+  (let [clustering-keys (:clustering-key schema)
+        clustering-key-types (map #((:columns schema) %) clustering-keys)
+        base [(make-attribute-definition PARTITION_KEY "text")]]
+    (if (clustering-keys-exist? schema)
+      (-> base
+          (conj (make-attribute-definition CLUSTERING_KEY "text"))
+          (into (mapv #(make-attribute-definition %1 %2)
+                      clustering-keys clustering-key-types)))
+      base)))
+
+(defn- make-key-schema-element
+  [name key-type]
+  (-> (KeySchemaElement/builder)
+      (.attributeName name)
+      (.keyType key-type)
+      .build))
+
+(defn- make-primary-key-schema
+  [schema]
+  (if (clustering-keys-exist? schema)
+    [(make-key-schema-element PARTITION_KEY KeyType/HASH)
+     (make-key-schema-element CLUSTERING_KEY KeyType/RANGE)]
+    [(make-key-schema-element PARTITION_KEY KeyType/HASH)]))
+
+(defn- get-index-name
+  [schema key-name]
+  (str (common/get-fullname (:database schema) (:table schema))
+       "." INDEX_NAME_PREFIX "." key-name))
+
+(defn- make-local-secondary-index
+  [schema index-key]
+  (-> (LocalSecondaryIndex/builder)
+      (.indexName (get-index-name schema index-key))
+      (.keySchema [(make-key-schema-element PARTITION_KEY KeyType/HASH)
+                   (make-key-schema-element index-key KeyType/RANGE)])
+      (.projection (-> (Projection/builder)
+                       (.projectionType (ProjectionType/INCLUDE))
+                       (.nonKeyAttributes ((comp keys :columns) schema))
+                       .build))
+      .build))
+
+(defn- make-local-secondary-indexes
+  [schema]
+  (map #(make-local-secondary-index schema %) (:clustering-key schema)))
+
+(defn- make-throughput
+  [ru]
+  (-> (ProvisionedThroughput/builder)
+      (.readCapacityUnits ru)
+      (.writeCapacityUnits ru)
+      .build))
+
+(defn- insert-metadata
+  [client schema]
+  (let [table (common/get-fullname (:database schema) (:table schema))
+        columns (reduce-kv (fn [m c t]
+                             (assoc m c (-> (AttributeValue/builder)
+                                            (.s t) .build)))
+                           {} (:columns schema))
+        base-item {METADATA_PARTITION_KEY (-> (AttributeValue/builder)
+                                              (.s table) .build)
+                   PARTITION_KEY_COLUMN (-> (AttributeValue/builder)
+                                            (.ss (:partition-key schema))
+                                            .build)
+                   COLUMNS_COLUMN (-> (AttributeValue/builder)
+                                      (.m columns) .build)}
+        item (if (clustering-keys-exist? schema)
+               (assoc base-item CLUSTERING_KEY_COLUMN
+                      (-> (AttributeValue/builder)
+                          (.ss (:clustering-key schema)) .build))
+               base-item)
+        request (-> (PutItemRequest/builder)
+                    (.tableName META_TABLE)
+                    (.item item) .build)]
+    (.putItem client request)))
+
+(defn- create-metadata
+  [client schema]
+  (let [builder (-> (CreateTableRequest/builder)
+                    (.attributeDefinitions
+                     [(make-attribute-definition METADATA_PARTITION_KEY
+                                                 "text")])
+                    (.keySchema [(make-key-schema-element
+                                  METADATA_PARTITION_KEY KeyType/HASH)])
+                    (.provisionedThroughput (make-throughput 1))
+                    (.tableName META_TABLE))]
+    (when-not (table-exists? client META_TABLE)
+      (.createTable client (.build builder))
+      (Thread/sleep WAIT_FOR_CREATION))
+    (insert-metadata client schema)))
+
+(defn- create-table
+  [client schema {:keys [ru] :or {ru 10}}]
+  (let [table (common/get-fullname (:database schema) (:table schema))
+        ru (if (:ru schema) (:ru schema) ru)
+        builder (-> (CreateTableRequest/builder)
+                    (.attributeDefinitions
+                     (make-attribute-definitions schema))
+                    (.keySchema (make-primary-key-schema schema))
+                    (.provisionedThroughput (make-throughput ru))
+                    (.tableName table))]
+    (create-metadata client schema)
+    (if (table-exists? client table)
+      (log/warn table "already exists")
+      (do
+        (when (clustering-keys-exist? schema)
+          (.localSecondaryIndexes builder
+                                  (make-local-secondary-indexes schema)))
+        (.createTable client (.build builder))))))
+
+(defn- create-transaction-table
+  [client schema opts]
+  (create-table client (common/update-for-transaction schema) opts)
+  (create-table client common/COORDINATOR_SCHEMA opts))
+
+(defn- create-tables
+  [client schema-file opts]
+  (->> (common/parse-schema schema-file)
+       (map #(if (:transaction %)
+               (create-transaction-table client % opts)
+               (create-table client % opts)))
+       doall))
+
+(defn- delete-table
+  [client table]
+  (if (table-exists? client table)
+    (->> (-> (DeleteTableRequest/builder) (.tableName table) .build)
+         (.deleteTable client))
+    (log/warn table "doesn't exist")))
+
+(defn- delete-all
+  [client schema-file]
+  (log/warn "Deleting all databases and tables in the file")
+  (let [tables (map #(common/get-fullname (:database %) (:table %))
+                    (common/parse-schema schema-file))
+        coordinator (common/get-fullname (:database common/COORDINATOR_SCHEMA)
+                                         (:table common/COORDINATOR_SCHEMA))]
+    (doall (map #(delete-table client %)
+                (into tables [META_TABLE coordinator])))))
+
+(defn operate-dynamo
+  [{:keys [schema-file host password] :as options}]
+  [host password schema-file options]
+  (with-open [client (get-client)]
+    (if (:delete-all options)
+      (delete-all client schema-file)
+      (create-tables client schema-file options))))

--- a/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
@@ -114,8 +114,8 @@
 (defn- make-throughput
   [ru]
   (-> (ProvisionedThroughput/builder)
-      (.readCapacityUnits ru)
-      (.writeCapacityUnits ru)
+      (.readCapacityUnits (long ru))
+      (.writeCapacityUnits (long ru))
       .build))
 
 (defn- insert-metadata


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7137

This PR covers basic CRUD operations and conditional mutations of Scalar DB on Cosmos DB.

## TODO
- [x] Manage DynamoDB client
- [x] Data model conversion & Metadata
- [x] Put operation without conditions
- [x] ResultImpl
- [x] Get operation
- [x] Scan operation
- [x] Delete operation without conditions
- [x] Conditional mutations
- [x] Batch operation
- [x] Integration tests
- [x] Select storages

## Added TODO
- [x] Specify AWS credentials by the config file
- [x] Support multiple clustering keys
- [x] Use updateItem() for insertion
- [x] Unit tests
- [x] Update the schema tool for DynamoDB

## Others
- ~Only 1 clustering key can be used~
  - Dynamo DB cannot support multiple sort(clustering) keys
    - Scalar DB supports multiple clustering keys by local secondary indexes
  - ~I'll modify the schema tool to reject the multiple clustering keys for Dynamo DB~
- `delete` cannot multiple records at once with partition keys on DynamoDB
  - Need to specify the primary key (partition key + clustering(sort) key)
- ~Need to modify the schema tool to set up the metadata tables on DynamoDB~ [done]