### PR TITLE
Fix the cast for numbers on Cosmos DB

### DIFF
--- a/src/main/java/com/scalar/db/storage/cosmos/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ResultImpl.java
@@ -137,13 +137,15 @@ public class ResultImpl implements Result {
       case "boolean":
         return new BooleanValue(name, recordValue == null ? false : (boolean) recordValue);
       case "int":
-        return new IntValue(name, recordValue == null ? 0 : (int) recordValue);
+        return new IntValue(name, recordValue == null ? 0 : ((Number) recordValue).intValue());
       case "bigint":
-        return new BigIntValue(name, recordValue == null ? 0L : (long) recordValue);
+        return new BigIntValue(name, recordValue == null ? 0L : ((Number) recordValue).longValue());
       case "float":
-        return new FloatValue(name, recordValue == null ? 0.0f : (float) recordValue);
+        return new FloatValue(
+            name, recordValue == null ? 0.0f : ((Number) recordValue).floatValue());
       case "double":
-        return new DoubleValue(name, recordValue == null ? 0.0 : (double) recordValue);
+        return new DoubleValue(
+            name, recordValue == null ? 0.0 : ((Number) recordValue).doubleValue());
       case "text": // for backwards compatibility
       case "varchar":
         return new TextValue(


### PR DESCRIPTION
#89

## Issue
Scalar DB failed to cast to a long value on Cosmos DB.

```
Execution error (ClassCastException) at com.scalar.db.storage.cosmos.ResultImpl/convert (ResultImpl.java:142).
java.lang.Integer cannot be cast to java.lang.Long
```

## Cause
A value read from Cosmos DB is a Number. Some values like zero were cast to Integer.

## Fix
Cast a number via Number