### PR TITLE
fix RU type for DynamoDB

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
@@ -114,8 +114,8 @@
 (defn- make-throughput
   [ru]
   (-> (ProvisionedThroughput/builder)
-      (.readCapacityUnits ru)
-      (.writeCapacityUnits ru)
+      (.readCapacityUnits (long ru))
+      (.writeCapacityUnits (long ru))
       .build))
 
 (defn- insert-metadata


### PR DESCRIPTION
To specify the RU for DynamoDB.

### Issue
- RU couldn't set for DynamoDB
```
Exception in thread "main" java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
```

### Cause
- The given type wasn't correct for `readCapacityUnits()` and `writeCapacityUnits()`

### Fix
- Cast to Long