### PR TITLE
fix metadata

### DIFF
--- a/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/TableMetadata.java
@@ -43,22 +43,21 @@ public class TableMetadata {
   }
 
   public List<String> getKeyNames() {
-    if (keyNames != null) {
-      return keyNames;
-    }
-
-    keyNames =
-        new ImmutableList.Builder<String>()
-            .addAll(partitionKeyNames)
-            .addAll(clusteringKeyNames)
-            .build();
-
     return keyNames;
   }
 
   private void convert(Map<String, AttributeValue> metadata) {
     this.partitionKeyNames = ImmutableSortedSet.copyOf(metadata.get(PARTITION_KEY).ss());
-    this.clusteringKeyNames = ImmutableSortedSet.copyOf(metadata.get(CLUSTERING_KEY).ss());
+    if (metadata.containsKey(CLUSTERING_KEY)) {
+      this.clusteringKeyNames = ImmutableSortedSet.copyOf(metadata.get(CLUSTERING_KEY).ss());
+    } else {
+      this.clusteringKeyNames = ImmutableSortedSet.of();
+    }
+    this.keyNames =
+        new ImmutableList.Builder<String>()
+            .addAll(partitionKeyNames)
+            .addAll(clusteringKeyNames)
+            .build();
 
     SortedMap<String, String> cs =
         metadata.get(COLUMNS).m().entrySet().stream()

--- a/src/test/java/com/scalar/db/storage/dynamo/TableMetadataTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/TableMetadataTest.java
@@ -1,0 +1,77 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class TableMetadataTest {
+  private static final String ANY_KEYSPACE_NAME = "keyspace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+
+  @Test
+  public void constructor_MetadataWithoutClusteringKeyGiven_ShouldConvertPropoerly() {
+    // Arrange
+    Map<String, AttributeValue> metadata = new HashMap<>();
+    metadata.put(
+        "table", AttributeValue.builder().s(ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME).build());
+    metadata.put(
+        "partitionKey", AttributeValue.builder().ss(Arrays.asList(ANY_NAME_1, ANY_NAME_2)).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_NAME_3, AttributeValue.builder().s("text").build());
+    metadata.put("columns", AttributeValue.builder().m(columns).build());
+
+    // Act
+    TableMetadata actual = new TableMetadata(metadata);
+
+    // Assert
+    assertThat(actual.getPartitionKeyNames().size()).isEqualTo(2);
+    assertThat(actual.getPartitionKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getPartitionKeyNames().contains(ANY_NAME_2)).isTrue();
+    assertThat(actual.getClusteringKeyNames().size()).isEqualTo(0);
+    assertThat(actual.getColumns().get(ANY_NAME_1)).isEqualTo("text");
+    assertThat(actual.getColumns().get(ANY_NAME_2)).isEqualTo("int");
+    assertThat(actual.getColumns().get(ANY_NAME_3)).isEqualTo("text");
+    assertThat(actual.getKeyNames().size()).isEqualTo(2);
+    assertThat(actual.getKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getKeyNames().contains(ANY_NAME_2)).isTrue();
+  }
+
+  @Test
+  public void constructor_MetadataWithClusteringKeyGiven_ShouldConvertPropoerly() {
+    // Arrange
+    Map<String, AttributeValue> metadata = new HashMap<>();
+    metadata.put(
+        "table", AttributeValue.builder().s(ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME).build());
+    metadata.put("partitionKey", AttributeValue.builder().ss(Arrays.asList(ANY_NAME_1)).build());
+    metadata.put("clusteringKey", AttributeValue.builder().ss(Arrays.asList(ANY_NAME_2)).build());
+    Map<String, AttributeValue> columns = new HashMap<>();
+    columns.put(ANY_NAME_1, AttributeValue.builder().s("text").build());
+    columns.put(ANY_NAME_2, AttributeValue.builder().s("int").build());
+    columns.put(ANY_NAME_3, AttributeValue.builder().s("text").build());
+    metadata.put("columns", AttributeValue.builder().m(columns).build());
+
+    // Act
+    TableMetadata actual = new TableMetadata(metadata);
+
+    // Assert
+    assertThat(actual.getPartitionKeyNames().size()).isEqualTo(1);
+    assertThat(actual.getPartitionKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getClusteringKeyNames().size()).isEqualTo(1);
+    assertThat(actual.getClusteringKeyNames().contains(ANY_NAME_2)).isTrue();
+    assertThat(actual.getColumns().get(ANY_NAME_1)).isEqualTo("text");
+    assertThat(actual.getColumns().get(ANY_NAME_2)).isEqualTo("int");
+    assertThat(actual.getColumns().get(ANY_NAME_3)).isEqualTo("text");
+    assertThat(actual.getKeyNames().size()).isEqualTo(2);
+    assertThat(actual.getKeyNames().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.getKeyNames().contains(ANY_NAME_2)).isTrue();
+  }
+}


### PR DESCRIPTION
### Issue
- When no clustering key exists, NullPointerException was thrown.
```
Execution error (NullPointerException) at com.scalar.db.storage.dynamo.TableMetadata/convert (TableMetadata.java:61).
```

### Cause
- The metadata couldn't be converted from the values on the metadata table because the value was null when no clustering key

### Fix
- When no clustering key, the name set of clustering keys is set as an empty set.