### PR TITLE
Simplify the condition

### DIFF
--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -35,16 +35,9 @@ public class DynamoMutation extends DynamoOperation {
   public String getIfNotExistsCondition() {
     List<String> expressions = new ArrayList<>();
     expressions.add("attribute_not_exists(" + PARTITION_KEY + ")");
-    getOperation()
-        .getClusteringKey()
-        .ifPresent(
-            k -> {
-              k.get()
-                  .forEach(
-                      c -> {
-                        expressions.add("attribute_not_exists(" + c.getName() + ")");
-                      });
-            });
+    if (getOperation().getClusteringKey().isPresent()) {
+      expressions.add("attribute_not_exists(" + CLUSTERING_KEY + ")");
+    }
 
     return String.join(" AND ", expressions);
   }
@@ -53,16 +46,9 @@ public class DynamoMutation extends DynamoOperation {
   public String getIfExistsCondition() {
     List<String> expressions = new ArrayList<>();
     expressions.add("attribute_exists(" + PARTITION_KEY + ")");
-    getOperation()
-        .getClusteringKey()
-        .ifPresent(
-            k -> {
-              k.get()
-                  .forEach(
-                      c -> {
-                        expressions.add("attribute_exists(" + c.getName() + ")");
-                      });
-            });
+    if (getOperation().getClusteringKey().isPresent()) {
+      expressions.add("attribute_exists(" + CLUSTERING_KEY + ")");
+    }
 
     return String.join(" AND ", expressions);
   }

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -94,7 +94,7 @@ public class DynamoMutationTest {
             "attribute_not_exists("
                 + DynamoOperation.PARTITION_KEY
                 + ") AND attribute_not_exists("
-                + ANY_NAME_2
+                + DynamoOperation.CLUSTERING_KEY
                 + ")");
   }
 
@@ -113,7 +113,7 @@ public class DynamoMutationTest {
             "attribute_exists("
                 + DynamoOperation.PARTITION_KEY
                 + ") AND attribute_exists("
-                + ANY_NAME_2
+                + DynamoOperation.CLUSTERING_KEY
                 + ")");
   }
 


### PR DESCRIPTION
We can simplify the condition for IfNotExists and IfExists because we have `concatenatedClusteringKey` attribute after supporting multiple clustering keys.