### PR TITLE
Alias for update expression

### DIFF
--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.io.Value;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -84,23 +85,59 @@ public class DynamoMutation extends DynamoOperation {
 
     if (withKey) {
       for (Value key : put.getPartitionKey().get()) {
-        expressions.add(key.getName() + " = " + VALUE_ALIAS + i);
+        expressions.add(COLUMN_NAME_ALIAS + i + " = " + VALUE_ALIAS + i);
         i++;
       }
       if (put.getClusteringKey().isPresent()) {
         for (Value key : put.getClusteringKey().get().get()) {
-          expressions.add(key.getName() + " = " + VALUE_ALIAS + i);
+          expressions.add(COLUMN_NAME_ALIAS + i + " = " + VALUE_ALIAS + i);
           i++;
         }
       }
     }
 
     for (String name : put.getValues().keySet()) {
-      expressions.add(name + " = " + VALUE_ALIAS + i);
+      expressions.add(COLUMN_NAME_ALIAS + i + " = " + VALUE_ALIAS + i);
       i++;
     }
 
     return "SET " + String.join(", ", expressions);
+  }
+
+  @Nonnull
+  public Map<String, String> getColumnMap() {
+    return getColumnMap(false);
+  }
+
+  @Nonnull
+  public Map<String, String> getColumnMapWithKey() {
+    return getColumnMap(true);
+  }
+
+  private Map<String, String> getColumnMap(boolean withKey) {
+    Put put = (Put) getOperation();
+    Map<String, String> columnMap = new HashMap<>();
+    int i = 0;
+
+    if (withKey) {
+      for (Value key : put.getPartitionKey().get()) {
+        columnMap.put(COLUMN_NAME_ALIAS + i, key.getName());
+        i++;
+      }
+      if (put.getClusteringKey().isPresent()) {
+        for (Value key : put.getClusteringKey().get().get()) {
+          columnMap.put(COLUMN_NAME_ALIAS + i, key.getName());
+          i++;
+        }
+      }
+    }
+
+    for (String name : put.getValues().keySet()) {
+      columnMap.put(COLUMN_NAME_ALIAS + i, name);
+      i++;
+    }
+
+    return columnMap;
   }
 
   @Nonnull

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -20,6 +20,7 @@ public class DynamoOperation {
   static final String END_CLUSTERING_KEY_ALIAS = ":eck";
   static final String CONDITION_VALUE_ALIAS = ":cval";
   static final String VALUE_ALIAS = ":val";
+  static final String COLUMN_NAME_ALIAS = "#col";
   static final String RANGE_KEY_ALIAS = ":sk";
   static final String RANGE_CONDITION = " BETWEEN :sk0 AND :sk1";
   static final String INDEX_NAME_PREFIX = "index";

--- a/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
@@ -48,22 +48,27 @@ public class PutStatementHandler extends StatementHandler {
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
     String expression;
     String condition = null;
+    Map<String, String> columnMap;
     Map<String, AttributeValue> bindMap;
 
     if (!put.getCondition().isPresent()) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
     } else if (put.getCondition().get() instanceof PutIfNotExists) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
       condition = dynamoMutation.getIfNotExistsCondition();
     } else if (put.getCondition().get() instanceof PutIfExists) {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getValueBindMap();
     } else {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition() + " AND " + dynamoMutation.getCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getConditionBindMap();
       bindMap.putAll(dynamoMutation.getValueBindMap());
     }
@@ -74,6 +79,7 @@ public class PutStatementHandler extends StatementHandler {
             .key(dynamoMutation.getKeyMap())
             .updateExpression(expression)
             .conditionExpression(condition)
+            .expressionAttributeNames(columnMap)
             .expressionAttributeValues(bindMap)
             .build();
 

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -157,12 +157,12 @@ public class DynamoMutationTest {
     assertThat(actual)
         .isEqualTo(
             "SET "
-                + ANY_NAME_3
-                + " = "
+                + DynamoOperation.COLUMN_NAME_ALIAS
+                + "0 = "
                 + DynamoOperation.VALUE_ALIAS
                 + "0, "
-                + ANY_NAME_4
-                + " = "
+                + DynamoOperation.COLUMN_NAME_ALIAS
+                + "1 = "
                 + DynamoOperation.VALUE_ALIAS
                 + "1");
   }


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7500
To use column names reserved by DynamoDB like `date`, `user`.

Set aliases of columns and the name map to the update request.