### PR TITLE
Fix the schema tool to modify the secondary index table

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo_schema.clj
@@ -102,8 +102,7 @@
       (.keySchema [(make-key-schema-element PARTITION_KEY KeyType/HASH)
                    (make-key-schema-element index-key KeyType/RANGE)])
       (.projection (-> (Projection/builder)
-                       (.projectionType (ProjectionType/INCLUDE))
-                       (.nonKeyAttributes ((comp keys :columns) schema))
+                       (.projectionType (ProjectionType/ALL))
                        .build))
       .build))
 


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7404
https://scalar-labs.atlassian.net/browse/DLT-7499

### Issue
- Schema tool failed to create a secondary index which had more than 20 non-key attributes
```
'localSecondaryIndexes.1.member.projection.nonKeyAttributes' failed to satisfy constraint: Member must have length less than or equal to 20
```

### Cause
- The API `nonKeyAttributes()` couldn't receive more than 20 attributes

### Fix
- Use `ProjectionType/ALL` instead of `ProjectionType/INCLUDE` to set all attributes