### PR TITLE
fix for a null value

### DIFF
--- a/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
@@ -17,7 +17,6 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -131,22 +130,23 @@ public class ResultImpl implements Result {
       throws UnsupportedTypeException {
     // When itemValue is NULL, the value will be the default value.
     // It is the same behavior as the datastax C* driver
+    boolean isNull = itemValue == null || (itemValue.nul() != null && itemValue.nul());
     switch (type) {
       case "boolean":
-        return new BooleanValue(name, itemValue == null ? false : itemValue.bool());
+        return new BooleanValue(name, isNull ? false : itemValue.bool());
       case "int":
-        return new IntValue(name, itemValue == null ? 0 : Integer.valueOf(itemValue.n()));
+        return new IntValue(name, isNull ? 0 : Integer.valueOf(itemValue.n()));
       case "bigint":
-        return new BigIntValue(name, itemValue == null ? 0L : Long.valueOf(itemValue.n()));
+        return new BigIntValue(name, isNull ? 0L : Long.valueOf(itemValue.n()));
       case "float":
-        return new FloatValue(name, itemValue == null ? 0.0f : Float.valueOf(itemValue.n()));
+        return new FloatValue(name, isNull ? 0.0f : Float.valueOf(itemValue.n()));
       case "double":
-        return new DoubleValue(name, itemValue == null ? 0.0 : Double.valueOf(itemValue.n()));
+        return new DoubleValue(name, isNull ? 0.0 : Double.valueOf(itemValue.n()));
       case "text": // for backwards compatibility
       case "varchar":
-        return new TextValue(name, itemValue == null ? null : itemValue.s());
+        return new TextValue(name, isNull ? (String) null : itemValue.s());
       case "blob":
-        return new BlobValue(name, itemValue == null ? null : itemValue.b().asByteArray());
+        return new BlobValue(name, isNull ? null : itemValue.b().asByteArray());
       default:
         throw new UnsupportedTypeException(type);
     }

--- a/src/main/java/com/scalar/db/storage/dynamo/ValueBinder.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ValueBinder.java
@@ -100,7 +100,13 @@ public final class ValueBinder implements ValueVisitor {
    */
   @Override
   public void visit(TextValue value) {
-    value.getString().ifPresent(s -> values.put(alias + i, AttributeValue.builder().s(s).build()));
+    AttributeValue.Builder builder = AttributeValue.builder();
+    if (value.getString().isPresent()) {
+      builder.s(value.getString().get());
+    } else {
+      builder.nul(true);
+    }
+    values.put(alias + i, builder.build());
     i++;
   }
 
@@ -111,12 +117,13 @@ public final class ValueBinder implements ValueVisitor {
    */
   @Override
   public void visit(BlobValue value) {
-    value
-        .get()
-        .ifPresent(
-            b ->
-                values.put(
-                    alias + i, AttributeValue.builder().b(SdkBytes.fromByteArray(b)).build()));
+    AttributeValue.Builder builder = AttributeValue.builder();
+    if (value.get().isPresent()) {
+      builder.b(SdkBytes.fromByteArray(value.get().get()));
+    } else {
+      builder.nul(true);
+    }
+    values.put(alias + i, builder.build());
     i++;
   }
 }

--- a/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
@@ -128,6 +128,37 @@ public class ResultImplTest {
   }
 
   @Test
+  public void getValues_NullValuesGivenInConstructor_ShouldReturnDefaultValueSet() {
+    // Arrange
+    Map<String, AttributeValue> nullItem = new HashMap<>();
+    nullItem.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
+    nullItem.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());
+    nullItem.put(ANY_NAME_2, AttributeValue.builder().s(ANY_TEXT_2).build());
+    nullItem.put(ANY_COLUMN_NAME_1, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_2, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_3, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_4, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_5, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_6, AttributeValue.builder().nul(true).build());
+    nullItem.put(ANY_COLUMN_NAME_7, AttributeValue.builder().nul(true).build());
+
+    ResultImpl result = new ResultImpl(nullItem, get, metadata);
+
+    // Act
+    Map<String, Value> actual = result.getValues();
+
+    // Assert
+    assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, false));
+    assertThat(actual.get(ANY_COLUMN_NAME_2)).isEqualTo(new IntValue(ANY_COLUMN_NAME_2, 0));
+    assertThat(actual.get(ANY_COLUMN_NAME_3)).isEqualTo(new BigIntValue(ANY_COLUMN_NAME_3, 0L));
+    assertThat(actual.get(ANY_COLUMN_NAME_4)).isEqualTo(new FloatValue(ANY_COLUMN_NAME_4, 0.0f));
+    assertThat(actual.get(ANY_COLUMN_NAME_5)).isEqualTo(new DoubleValue(ANY_COLUMN_NAME_5, 0.0));
+    assertThat(actual.get(ANY_COLUMN_NAME_6))
+        .isEqualTo(new TextValue(ANY_COLUMN_NAME_6, (String) null));
+    assertThat(actual.get(ANY_COLUMN_NAME_7)).isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, null));
+  }
+
+  @Test
   public void getValue_GetValueCalledBefore_ShouldNotLoadAgain() {
     // Arrange
     ResultImpl spy = spy(new ResultImpl(item, get, metadata));


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7534

### Issue
- Put with a null value failed
```
Caused by: com.scalar.db.exception.storage.ExecutionException: Invalid UpdateExpression: An expression attribute value used in expression is not defined; ...
```

### Cause
- A null string(bytes) could not be defined as an AttributeValue
```
# non null string
:val0=AttributeValue(S=foo, SS=[], NS=[], BS=[], M={}, L=[])
# null string
:val4=AttributeValue(SS=[], NS=[], BS=[], M={}, L=[])
```

### Fix
- A null string(bytes) is set as a null type value
```
:val4=AttributeValue(SS=[], NS=[], BS=[], M={}, L=[], NUL=true)
```