### PR TITLE
use aliases of columns for batch

### DIFF
--- a/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -100,22 +100,27 @@ public class BatchHandler {
     Update.Builder updateBuilder = Update.builder();
     String expression;
     String condition = null;
+    Map<String, String> columnMap;
     Map<String, AttributeValue> bindMap;
 
     if (!put.getCondition().isPresent()) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
     } else if (put.getCondition().get() instanceof PutIfNotExists) {
       expression = dynamoMutation.getUpdateExpressionWithKey();
+      columnMap = dynamoMutation.getColumnMapWithKey();
       bindMap = dynamoMutation.getValueBindMapWithKey();
       condition = dynamoMutation.getIfNotExistsCondition();
     } else if (put.getCondition().get() instanceof PutIfExists) {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getValueBindMap();
     } else {
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition() + " AND " + dynamoMutation.getCondition();
+      columnMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getConditionBindMap();
       bindMap.putAll(dynamoMutation.getValueBindMap());
     }
@@ -125,6 +130,7 @@ public class BatchHandler {
         .key(dynamoMutation.getKeyMap())
         .updateExpression(expression)
         .conditionExpression(condition)
+        .expressionAttributeNames(columnMap)
         .expressionAttributeValues(bindMap)
         .build();
 

--- a/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
@@ -149,10 +149,14 @@ public class BatchHandlerTest {
     List<TransactWriteItem> items = captor.getValue().transactItems();
     assertThat(items.size()).isEqualTo(4);
     assertThat(items.get(0).update().key()).isEqualTo(dynamoMutation1.getKeyMap());
+    assertThat(items.get(0).update().expressionAttributeNames())
+        .isEqualTo(dynamoMutation1.getColumnMapWithKey());
     assertThat(items.get(0).update().expressionAttributeValues())
         .isEqualTo(dynamoMutation1.getValueBindMapWithKey());
     assertThat(items.get(0).update().conditionExpression()).isNull();
     assertThat(items.get(1).update().key()).isEqualTo(dynamoMutation2.getKeyMap());
+    assertThat(items.get(1).update().expressionAttributeNames())
+        .isEqualTo(dynamoMutation2.getColumnMapWithKey());
     assertThat(items.get(1).update().expressionAttributeValues())
         .isEqualTo(dynamoMutation2.getValueBindMapWithKey());
     assertThat(items.get(1).update().conditionExpression())


### PR DESCRIPTION
Similar to #106
Sorry, I forgot to add the aliases of columns for a bach operation.

https://scalar-labs.atlassian.net/browse/DLT-7500
To use column names reserved by DynamoDB like `date`, `user`.

Set aliases of columns and the name map to the update request for a batch operation.