### PR TITLE
Update scalar-schema tool to exit with status 1 if errors in CLI options

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -30,11 +30,13 @@
   (let [{:keys [options summary errors]
          {:keys [cassandra cosmos dynamo help]} :options}
         (parse-opts args cli-options)]
-    (if (or help errors)
-      (do (when (not help)
-            (println (str "ERROR: " errors)))
-          (println summary))
-      (do
-        (when cassandra (cassandra-schema/operate-cassandra options))
-        (when cosmos (cosmos-schema/operate-cosmos options))
-        (when dynamo (dynamo-schema/operate-dynamo options))))))
+    (cond
+      help (println summary)
+      errors (do
+               (println (str "ERROR: " errors))
+               (println summary)
+               (System/exit 1))
+      :else (do
+              (when cassandra (cassandra-schema/operate-cassandra options))
+              (when cosmos (cosmos-schema/operate-cosmos options))
+              (when dynamo (dynamo-schema/operate-dynamo options))))))


### PR DESCRIPTION
In case of an error in the scalar-schema CLI options, it should fail with an exit status other than `0`.

It is needed to notify tools like Ansible and Terraform of the result of the scalar-schema tool.
For example, if the argument for the `--region` option is missing, it should fail with a status other than `0` to tell Terraform to abort.
The following case should not complete successfully.

```
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_schema[0] (remote-exec): ERROR: ["Missing required argument for \"--region REGION\""]
...
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_schema[0]: Creation complete after 8s [id=5751361347562494241]
```

https://scalar-labs.atlassian.net/browse/DLT-7415
