### PR TITLE
Check existence before deleting

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/cassandra.clj
+++ b/tools/scalar-schema/src/scalar_schema/cassandra.clj
@@ -71,7 +71,9 @@
 
 (defn- delete-table
   [session schema]
-  (alia/execute session (->raw (statement/drop-keyspace (:database schema)))))
+  (alia/execute session
+                (->raw (statement/drop-keyspace (:database schema)
+                                                (clause/if-exists true)))))
 
 (defn make-cassandra-operator
   [{:keys [host port user password]

--- a/tools/scalar-schema/src/scalar_schema/cosmos.clj
+++ b/tools/scalar-schema/src/scalar_schema/cosmos.clj
@@ -126,8 +126,9 @@
         (register-stored-procedure client database table)))))
 
 (defn- delete-table
-  [client schema]
-  (->> (.getDatabase client (:database schema)) .delete))
+  [client {:keys [database]}]
+  (when (database-exists? client database)
+    (->> (.getDatabase client database) .delete)))
 
 (defn make-cosmos-operator
   [{:keys [host password]}]


### PR DESCRIPTION
Fixed a bug about database existence before deleting.

### Issue
- Failed to delete all tables for Cassandra and Cosmos DB
  - For DynamoDB, it worked well because each table has a unique name

### Cause
- Tried deleting non-existing databases

### Fix
- Check database existence before deleting