### PR TITLE
Support auto-scaling for DynamoDB

### DIFF
--- a/tools/scalar-schema/README.md
+++ b/tools/scalar-schema/README.md
@@ -38,21 +38,20 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --cassandra -h <CASSAN
   - If `-p <CASSANDRA_PASSWORD>` is not supplied, it defaults to `cassandra`.
   - `<NETWORK_STRATEGY>` should be `SimpleStrategy` or `NetworkTopologyStrategy`
 
-### Delete all tables
+### Delete tables
 ```console
 # For Cosmos DB
-$ java -jar target/scalar-schema-standalone-<version>.jar --cosmos -h <YOUR_ACCOUNT_URI> -p <YOUR_ACCOUNT_PASSWORD> -D
+$ java -jar target/scalar-schema-standalone-<version>.jar --cosmos -h <YOUR_ACCOUNT_URI> -p <YOUR_ACCOUNT_PASSWORD> -f schema.json -D
 ```
 
 ```console
 # For DynamoDB
 $ java -jar target/scalar-schema.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> -f schema.json -D
 ```
-  - For DynamoDB, only the tables which are included in the schema file will be deleted.
 
 ```console
 # For Cassandra
-$ java -jar target/scalar-schema-standalone-<version>.jar --cassandra -h <CASSANDRA_IP> [-P <CASSANDRA_PORT>] [-u <CASSNDRA_USER>] [-p <CASSANDRA_PASSWORD>] -D
+$ java -jar target/scalar-schema-standalone-<version>.jar --cassandra -h <CASSANDRA_IP> [-P <CASSANDRA_PORT>] [-u <CASSNDRA_USER>] [-p <CASSANDRA_PASSWORD>] -f schema.json -D
 ```
 
 ### Show help

--- a/tools/scalar-schema/README.md
+++ b/tools/scalar-schema/README.md
@@ -103,13 +103,13 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --help
 - `compaction-strategy` should be `STCS`, `LCS` or `TWCS`. This is ignored in Cosmos DB and DynamoDB.
 - This `ru` value is set for all tables on this database even if `-r BASE_RESOURCE_UNIT` is set when Cosmos DB and DynamoDB. `ru` is ignored in Cassandra.
 
-## Performance tuning
-We can tune the throughput of Cosmos DB and DynamoDB by `-r` option or `ru` parameter for each table. For Cassandra, the tool cannot tune it since the performance depends on the resources of the node.
+## Scaling Performance
 
 ### RU
-The RU means Request Unit for Cosmos DB, Capacity Unit for DynamoDB. This unit is different between [Cosmos DB](https://docs.microsoft.com/azure/cosmos-db/request-units) and [DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual). DynamoDB has Read Capacity Unit and Write Capacity Unit. The tool sets the same value to both.
+You can scale the throughput of Cosmos DB and DynamoDB by specifying `-r` option (which applies to all the tables) or `ru` parameter for each table. Those configurations are ignored in Cassandra. The default values are `400` for Cosmos DB and `10` for DynamoDB respectively, which are set without `-r` option.
 
-The tool set the maximum RU 400 on Cosmos DB, and 10 on DynamoDB by default. You can set the RU of all tables by `-r` option. If you want to set a different value to the specific table, you need to add `ru` parameter of the table in the schema file.
+Note that the schema tool abstracts [Request Unit](https://docs.microsoft.com/azure/cosmos-db/request-units) of Cosmos DB and [Capacity Unit](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual) of DynamoDB with `RU`.
+So, please set an appropriate value depending on the database implementations. Please also note that the schema tool sets the same value to both Read Capacity Unit and Write Capacity Unit for DynamoDB.
 
 ### Auto-scaling
-The tool enables auto-scaling of RU for all tables automatically to reduce the cost. The RU can be scaled in or out between 10% and 100% of RU depending on the workload. When you add `-r 10000` to the table the creation, the RU of each table will be scaled in or out between 1000 and 10000. The auto-scaling of Cosmos DB is enabled when you set more than 4000 RU because the minimum Request Unit of Cosmos DB is 400.
+By default, the schema tool enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload. For example, if you specify `-r 10000`, RU of each table is scaled in or out between 1000 and 10000. Note that auto-scaling of Cosmos DB is enabled only when you set more than or equal to 4000 RU.

--- a/tools/scalar-schema/README.md
+++ b/tools/scalar-schema/README.md
@@ -103,3 +103,14 @@ $ java -jar target/scalar-schema-standalone-<version>.jar --help
 ```
 - `compaction-strategy` should be `STCS`, `LCS` or `TWCS`. This is ignored in Cosmos DB and DynamoDB.
 - This `ru` value is set for all tables on this database even if `-r BASE_RESOURCE_UNIT` is set when Cosmos DB and DynamoDB. `ru` is ignored in Cassandra.
+
+## Performance tuning
+We can tune the throughput of Cosmos DB and DynamoDB by `-r` option or `ru` parameter for each table. For Cassandra, the tool cannot tune it since the performance depends on the resources of the node.
+
+### RU
+The RU means Request Unit for Cosmos DB, Capacity Unit for DynamoDB. This unit is different between [Cosmos DB](https://docs.microsoft.com/azure/cosmos-db/request-units) and [DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual). DynamoDB has Read Capacity Unit and Write Capacity Unit. The tool sets the same value to both.
+
+The tool set the maximum RU 400 on Cosmos DB, and 10 on DynamoDB by default. You can set the RU of all tables by `-r` option. If you want to set a different value to the specific table, you need to add `ru` parameter of the table in the schema file.
+
+### Auto-scaling
+The tool enables auto-scaling of RU for all tables automatically to reduce the cost. The RU can be scaled in or out between 10% and 100% of RU depending on the workload. When you add `-r 10000` to the table the creation, the RU of each table will be scaled in or out between 1000 and 10000. The auto-scaling of Cosmos DB is enabled when you set more than 4000 RU because the minimum Request Unit of Cosmos DB is 400.

--- a/tools/scalar-schema/project.clj
+++ b/tools/scalar-schema/project.clj
@@ -9,6 +9,7 @@
                  [cheshire "5.10.0"]
                  [com.azure/azure-cosmos "4.1.0"]
                  [software.amazon.awssdk/dynamodb "2.14.24"]
+                 [software.amazon.awssdk/applicationautoscaling "2.14.24"]
                  [com.google.guava/guava "24.1-jre"]
                  [cc.qbits/alia "4.3.3"]
                  [cc.qbits/hayt "4.1.0"]]

--- a/tools/scalar-schema/sample_schema/sample_schema.json
+++ b/tools/scalar-schema/sample_schema/sample_schema.json
@@ -13,7 +13,7 @@
       "c4": "INT",
       "c5": "BOOLEAN"
     },
-    "ru": 123,
+    "ru": 5000,
     "compaction-strategy": "LCS"
   },
 

--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -22,6 +22,7 @@
     "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This options is ignored when Cosmos DB and DynamoDB."]
    ["-D" "--delete-all" "All database will be deleted, if this is enabled."]
    [nil "--region REGION" "Region where the tool creates tables for DynamoDB"]
+   [nil "--no-scaling" "Disable auto-scaling"]
    [nil "--help"]])
 
 (defn -main [& args]

--- a/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
@@ -1,67 +1,111 @@
 (ns scalar-schema.dynamo.auto-scaling
   (:require [clojure.tools.logging :as log]
-            [scalar-schema.common :as common])
-  (:import (software.amazon.awssdk.auth.credentials AwsBasicCredentials
-                                                    StaticCredentialsProvider)
-           (software.amazon.awssdk.regions Region)
+            [scalar-schema.dynamo.common :as dynamo])
+  (:import (software.amazon.awssdk.regions Region)
            (software.amazon.awssdk.services.applicationautoscaling
             ApplicationAutoScalingClient)
            (software.amazon.awssdk.services.applicationautoscaling.model
+            DeleteScalingPolicyRequest
             DeregisterScalableTargetRequest
+            MetricType
             RegisterScalableTargetRequest
             ObjectNotFoundException
+            PolicyType
+            PredefinedMetricSpecification
+            PutScalingPolicyRequest
             ScalableDimension
-            ServiceNamespace)))
+            ServiceNamespace
+            TargetTrackingScalingPolicyConfiguration)))
 
-(defn- get-credentials-provider
-  [user password]
-  (StaticCredentialsProvider/create
-   (AwsBasicCredentials/create user password)))
+;; TODO: options?
+(def ^:const ^:private COOL_TIME_SEC (int 60))
+(def ^:const ^:private ^double TARGET_USAGE_RATE 70.0)
+
+(def ^:private SCALABLE_DIMENSIONS
+  {:read ScalableDimension/DYNAMODB_TABLE_READ_CAPACITY_UNITS
+   :write ScalableDimension/DYNAMODB_TABLE_WRITE_CAPACITY_UNITS})
 
 (defn get-scaling-client
   [user password region]
   (-> (ApplicationAutoScalingClient/builder)
-      (.credentialsProvider (get-credentials-provider user password))
+      (.credentialsProvider (dynamo/get-credentials-provider user password))
       (.region (Region/of region))
       .build))
 
 (defn- make-scaling-request
-  [table ru type]
+  [schema ru type]
   (-> (RegisterScalableTargetRequest/builder)
       (.serviceNamespace ServiceNamespace/DYNAMODB)
-      (.resourceId (str "table/" table))
-      (.scalableDimension (if (= type :read)
-                            ScalableDimension/DYNAMODB_TABLE_READ_CAPACITY_UNITS
-                            ScalableDimension/DYNAMODB_TABLE_WRITE_CAPACITY_UNITS))
+      (.resourceId (str "table/" (dynamo/get-table-name schema)))
+      (.scalableDimension (get SCALABLE_DIMENSIONS type))
       (.minCapacity (int (if (> ru 10) (/ ru 10) ru)))
       (.maxCapacity ru)
       .build))
 
 (defn- make-scaling-disable-request
-  [table type]
+  [schema type]
   (-> (DeregisterScalableTargetRequest/builder)
       (.serviceNamespace ServiceNamespace/DYNAMODB)
-      (.resourceId (str "table/" table))
-      (.scalableDimension (if (= type :read)
-                            ScalableDimension/DYNAMODB_TABLE_READ_CAPACITY_UNITS
-                            ScalableDimension/DYNAMODB_TABLE_WRITE_CAPACITY_UNITS))
+      (.resourceId (str "table/" (dynamo/get-table-name schema)))
+      (.scalableDimension (get SCALABLE_DIMENSIONS type))
       .build))
+
+(defn- make-scaling-policy-config
+  [type]
+  (-> (TargetTrackingScalingPolicyConfiguration/builder)
+      (.predefinedMetricSpecification
+       (-> (PredefinedMetricSpecification/builder)
+           (.predefinedMetricType
+            (if (= type :read)
+              MetricType/DYNAMO_DB_READ_CAPACITY_UTILIZATION
+              MetricType/DYNAMO_DB_WRITE_CAPACITY_UTILIZATION))
+           .build))
+      (.scaleInCooldown COOL_TIME_SEC)
+      (.scaleOutCooldown COOL_TIME_SEC)
+      (.targetValue TARGET_USAGE_RATE)
+      .build))
+
+(defn- make-scaling-policy-request
+  [schema type]
+  (let [table (dynamo/get-table-name schema)]
+    (-> (PutScalingPolicyRequest/builder)
+        (.serviceNamespace ServiceNamespace/DYNAMODB)
+        (.resourceId (str "table/" table))
+        (.scalableDimension (get SCALABLE_DIMENSIONS type))
+        (.policyName (str table \- (name type)))
+        (.policyType PolicyType/TARGET_TRACKING_SCALING)
+        (.targetTrackingScalingPolicyConfiguration
+         (make-scaling-policy-config type))
+        .build)))
+
+(defn- make-scaling-policy-delete-request
+  [schema type]
+  (let [table (dynamo/get-table-name schema)]
+    (-> (DeleteScalingPolicyRequest/builder)
+        (.serviceNamespace ServiceNamespace/DYNAMODB)
+        (.resourceId (str "table/" table))
+        (.scalableDimension (get SCALABLE_DIMENSIONS type))
+        (.policyName (str table \- (name type)))
+        .build)))
 
 (defn enable-auto-scaling
   [scaling-client schema {:keys [ru] :or {ru 10}}]
-  (let [table (common/get-fullname (:database schema) (:table schema))]
-    (mapv (fn [type]
-            (->> (make-scaling-request table ru type)
-                 (.registerScalableTarget scaling-client)))
-          [:read :write])))
+  (mapv (fn [type]
+          (doto scaling-client
+            (.registerScalableTarget (make-scaling-request schema ru type))
+            (.putScalingPolicy (make-scaling-policy-request schema type))))
+        [:read :write]))
 
 (defn disable-auto-scaling
   [scaling-client schema]
-  (let [table (common/get-fullname (:database schema) (:table schema))]
-    (mapv (fn [type]
-            (try
-              (->> (make-scaling-disable-request table type)
-                   (.deregisterScalableTarget scaling-client))
-              (catch ObjectNotFoundException _
-                (log/info "No auto-scaling configuration for " table))))
-          [:read :write])))
+  (mapv (fn [type]
+          (try
+            (doto scaling-client
+              (.deregisterScalableTarget
+               (make-scaling-disable-request schema type))
+              (.deleteScalingPolicy
+               (make-scaling-policy-delete-request schema type)))
+            (catch ObjectNotFoundException _
+              (log/info "No auto-scaling configuration for"
+                        (dynamo/get-table-name schema)))))
+        [:read :write]))

--- a/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
@@ -1,0 +1,67 @@
+(ns scalar-schema.dynamo.auto-scaling
+  (:require [clojure.tools.logging :as log]
+            [scalar-schema.common :as common])
+  (:import (software.amazon.awssdk.auth.credentials AwsBasicCredentials
+                                                    StaticCredentialsProvider)
+           (software.amazon.awssdk.regions Region)
+           (software.amazon.awssdk.services.applicationautoscaling
+            ApplicationAutoScalingClient)
+           (software.amazon.awssdk.services.applicationautoscaling.model
+            DeregisterScalableTargetRequest
+            RegisterScalableTargetRequest
+            ObjectNotFoundException
+            ScalableDimension
+            ServiceNamespace)))
+
+(defn- get-credentials-provider
+  [user password]
+  (StaticCredentialsProvider/create
+   (AwsBasicCredentials/create user password)))
+
+(defn get-scaling-client
+  [user password region]
+  (-> (ApplicationAutoScalingClient/builder)
+      (.credentialsProvider (get-credentials-provider user password))
+      (.region (Region/of region))
+      .build))
+
+(defn- make-scaling-request
+  [table ru type]
+  (-> (RegisterScalableTargetRequest/builder)
+      (.serviceNamespace ServiceNamespace/DYNAMODB)
+      (.resourceId (str "table/" table))
+      (.scalableDimension (if (= type :read)
+                            ScalableDimension/DYNAMODB_TABLE_READ_CAPACITY_UNITS
+                            ScalableDimension/DYNAMODB_TABLE_WRITE_CAPACITY_UNITS))
+      (.minCapacity (int (if (> ru 10) (/ ru 10) ru)))
+      (.maxCapacity ru)
+      .build))
+
+(defn- make-scaling-disable-request
+  [table type]
+  (-> (DeregisterScalableTargetRequest/builder)
+      (.serviceNamespace ServiceNamespace/DYNAMODB)
+      (.resourceId (str "table/" table))
+      (.scalableDimension (if (= type :read)
+                            ScalableDimension/DYNAMODB_TABLE_READ_CAPACITY_UNITS
+                            ScalableDimension/DYNAMODB_TABLE_WRITE_CAPACITY_UNITS))
+      .build))
+
+(defn enable-auto-scaling
+  [scaling-client schema {:keys [ru] :or {ru 10}}]
+  (let [table (common/get-fullname (:database schema) (:table schema))]
+    (mapv (fn [type]
+            (->> (make-scaling-request table ru type)
+                 (.registerScalableTarget scaling-client)))
+          [:read :write])))
+
+(defn disable-auto-scaling
+  [scaling-client schema]
+  (let [table (common/get-fullname (:database schema) (:table schema))]
+    (mapv (fn [type]
+            (try
+              (->> (make-scaling-disable-request table type)
+                   (.deregisterScalableTarget scaling-client))
+              (catch ObjectNotFoundException _
+                (log/info "No auto-scaling configuration for " table))))
+          [:read :write])))

--- a/tools/scalar-schema/src/scalar_schema/dynamo/common.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/common.clj
@@ -1,0 +1,13 @@
+(ns scalar-schema.dynamo.common
+  (:require [scalar-schema.common :as common])
+  (:import (software.amazon.awssdk.auth.credentials AwsBasicCredentials
+                                                    StaticCredentialsProvider)))
+
+(defn get-credentials-provider
+  [user password]
+  (StaticCredentialsProvider/create
+   (AwsBasicCredentials/create user password)))
+
+(defn get-table-name
+  [{:keys [database table]}]
+  (common/get-fullname database table))

--- a/tools/scalar-schema/test/scalar_schema/common_test.clj
+++ b/tools/scalar-schema/test/scalar_schema/common_test.clj
@@ -24,7 +24,7 @@
             "c4" "int"
             "c5" "boolean"}
            (:columns table0)))
-    (is (= 123 (:ru table0)))
+    (is (= 5000 (:ru table0)))
     (is (= "LCS" (:compaction-strategy table0)))
 
     ;; sample_db.sample_table1


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7579

To register ScalableTarget and set ScalingPocily to each table.
ScalableTarget specifies the minimum and the maximum Capacity Unit.
ScalingPolicy specifies the interval and the usage rate to scale in/out the CU.

Ref. https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AutoScaling.html