### PR TITLE
partial update for Cosmos DB

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -340,34 +340,6 @@ public class CosmosIntegrationTest {
   }
 
   @Test
-  public void put_SinglePutGiven_ShouldStoreProperly() throws ExecutionException {
-    // Arrange
-    int pKey = 0;
-    int cKey = 0;
-    List<Put> puts = preparePuts();
-    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
-    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
-    Get get = new Get(partitionKey, clusteringKey);
-
-    // Act
-    storage.put(puts.get(pKey * 2 + cKey));
-
-    // Assert
-    Optional<Result> actual = storage.get(get);
-    assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get().getValue(COL_NAME2))
-        .isEqualTo(Optional.of(new TextValue(COL_NAME2, Integer.toString(pKey + cKey))));
-    assertThat(actual.get().getValue(COL_NAME3))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
-    assertThat(actual.get().getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey)));
-    assertThat(actual.get().getValue(COL_NAME5))
-        .isEqualTo(Optional.of(new BooleanValue(COL_NAME5, (cKey % 2 == 0) ? true : false)));
-  }
-
-  @Test
   public void delete_DeleteWithPartitionKeyAndClusteringKeyGiven_ShouldDeleteSingleRecordProperly()
       throws ExecutionException {
     // Arrange

--- a/src/main/java/com/scalar/db/storage/cosmos/PutStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/PutStatementHandler.java
@@ -26,22 +26,8 @@ public class PutStatementHandler extends MutateStatementHandler {
   protected List<Record> execute(Operation operation) throws CosmosException {
     Mutation mutation = (Mutation) operation;
 
-    if (mutation.getCondition().isPresent()) {
-      executeStoredProcedure(mutation);
-    } else {
-      execute(mutation);
-    }
+    executeStoredProcedure(mutation);
 
     return Collections.emptyList();
-  }
-
-  private void execute(Mutation mutation) throws CosmosException {
-    CosmosMutation cosmosMutation = new CosmosMutation(mutation, metadataManager);
-    cosmosMutation.checkArgument(Put.class);
-
-    Record record = cosmosMutation.makeRecord();
-    CosmosItemRequestOptions options = new CosmosItemRequestOptions();
-
-    getContainer(mutation).upsertItem(record, options);
   }
 }


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7425

### Issue
- Non-updated columns are removed when partial updating
  - before updating

    | partition key | clustering key | c1 | c2 |
    --|--|--|--
    | 0 | 1 | "inserted" |  null |

  - after updating the only c2, c1's value is removed

    | partition key | clustering key | c1 | c2 |
    --|--|--|--
    | 0 | 1 | null |  "new" |

### Cause
- [Cosmos DB doesn't support partial update](https://feedback.azure.com/forums/263030-azure-cosmos-db/suggestions/6693091-be-able-to-do-partial-updates-on-document#%7Btoggle_previous_statuses%7D)

### Fix
- Use the stored procedure to read the existing record and update it
  - Insert a new record when the record doesn't exist