### PR TITLE
fix the default type for auto-scaling

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
@@ -89,7 +89,7 @@
         .build)))
 
 (defn enable-auto-scaling
-  [scaling-client schema {:keys [ru] :or {ru 10}}]
+  [scaling-client schema {:keys [ru] :or {ru (int 10)}}]
   (mapv (fn [type]
           (doto scaling-client
             (.registerScalableTarget (make-scaling-request schema ru type))


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7716

### Issue
- Failed to create tables without `-r` option
```
Exception in thread "main" java.lang.ClassCastException: Cannot cast java.lang.Long to java.lang.Integer
	at java.lang.Class.cast(Class.java:3369)
	at clojure.lang.Reflector.boxArg(Reflector.java:552)
	at clojure.lang.Reflector.boxArgs(Reflector.java:585)
	at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:132)
	at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:102)
	at scalar_schema.dynamo.auto_scaling$make_scaling_request.invokeStatic(auto_scaling.clj:42)
	at scalar_schema.dynamo.auto_scaling$enable_auto_scaling$fn__3265.invoke(auto_scaling.clj:93)
	at clojure.core$mapv$fn__8445.invoke(core.clj:6912)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:343)
	at clojure.core$reduce.invokeStatic(core.clj:6827)
	at clojure.core$mapv.invokeStatic(core.clj:6903)
	at scalar_schema.dynamo.auto_scaling$enable_auto_scaling.invokeStatic(auto_scaling.clj:91)
	at scalar_schema.dynamo$make_dynamo_operator$reify__3314.create_table(dynamo.clj:191)
	at scalar_schema.operations$create_tables$fn__3323.invoke(operations.clj:21)
	at clojure.core$map$fn__5866.invoke(core.clj:2755)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.RT.seq(RT.java:535)
	at clojure.core$seq__5402.invokeStatic(core.clj:137)
	at clojure.core$dorun.invokeStatic(core.clj:3133)
	at clojure.core$doall.invokeStatic(core.clj:3148)
	at scalar_schema.operations$create_tables.invokeStatic(operations.clj:20)
	at scalar_schema.core$_main.invokeStatic(core.clj:31)
	at scalar_schema.core$_main.doInvoke(core.clj:28)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at scalar_schema.core.main(Unknown Source)
```

### Cause
- The default type of RU was Long for auto-scaling

### Fix
- Change the default type to `int`