### PR TITLE
unify the common methods for DistributedStorage

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -535,7 +535,7 @@ public class CosmosIntegrationTest {
     CosmosContainerProperties containerProperties =
         new CosmosContainerProperties(METADATA_TABLE, "/id");
     client.getDatabase(METADATA_KEYSPACE).createContainerIfNotExists(containerProperties);
-    TableMetadata metadata = new TableMetadata();
+    CosmosTableMetadata metadata = new CosmosTableMetadata();
     metadata.setId(KEYSPACE + "." + TABLE);
     metadata.setPartitionKeyNames(new HashSet<>(Arrays.asList(COL_NAME1)));
     metadata.setClusteringKeyNames(new HashSet<>(Arrays.asList(COL_NAME4)));

--- a/src/main/java/com/scalar/db/storage/StorageUtility.java
+++ b/src/main/java/com/scalar/db/storage/StorageUtility.java
@@ -1,0 +1,57 @@
+package com.scalar.db.storage;
+
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
+import com.scalar.db.io.Key;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Utilities for {@link DistributedStorage}
+ *
+ * @author Yuji Ito
+ */
+public final class StorageUtility {
+
+  public static void setTargetToIfNot(
+      List<? extends Operation> operations,
+      Optional<String> namespace,
+      Optional<String> tableName) {
+    operations.forEach(o -> setTargetToIfNot(o, namespace, tableName));
+  }
+
+  public static void setTargetToIfNot(
+      Operation operation, Optional<String> namespace, Optional<String> tableName) {
+    if (!operation.forNamespace().isPresent()) {
+      operation.forNamespace(namespace.orElse(null));
+    }
+    if (!operation.forTable().isPresent()) {
+      operation.forTable(tableName.orElse(null));
+    }
+    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
+      throw new IllegalArgumentException("operation has no target namespace and table name");
+    }
+  }
+
+  public static void checkIfPrimaryKeyExists(Mutation mutation, TableMetadata metadata) {
+    throwIfNotMatched(Optional.of(mutation.getPartitionKey()), metadata.getPartitionKeyNames());
+    throwIfNotMatched(mutation.getClusteringKey(), metadata.getClusteringKeyNames());
+  }
+
+  private static void throwIfNotMatched(Optional<Key> key, Set<String> names) {
+    String message = "The primary key is not properly specified.";
+    if ((!key.isPresent() && names.size() > 0)
+        || (key.isPresent() && (key.get().size() != names.size()))) {
+      throw new IllegalArgumentException(message);
+    }
+    key.ifPresent(
+        k ->
+            k.forEach(
+                v -> {
+                  if (!names.contains(v.getName())) {
+                    throw new IllegalArgumentException(message);
+                  }
+                }));
+  }
+}

--- a/src/main/java/com/scalar/db/storage/TableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/TableMetadata.java
@@ -1,0 +1,24 @@
+package com.scalar.db.storage;
+
+import java.util.Set;
+
+/**
+ * An interface for the table metadata
+ *
+ * @author Yuji Ito
+ */
+public interface TableMetadata {
+  /**
+   * Returns the partition key names
+   *
+   * @return an {@code Set} of partition key names
+   */
+  public Set<String> getPartitionKeyNames();
+
+  /**
+   * Returns the clustering key names
+   *
+   * @return an {@code Set} of clustering key names
+   */
+  public Set<String> getClusteringKeyNames();
+}

--- a/src/main/java/com/scalar/db/storage/Utility.java
+++ b/src/main/java/com/scalar/db/storage/Utility.java
@@ -8,11 +8,11 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Utilities for {@link DistributedStorage}
+ * Utilities for {@link com.scalar.db.api.DistributedStorage}
  *
  * @author Yuji Ito
  */
-public final class StorageUtility {
+public final class Utility {
 
   public static void setTargetToIfNot(
       List<? extends Operation> operations,

--- a/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -16,12 +16,10 @@ import com.scalar.db.api.Selection;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.InvalidUsageException;
-import com.scalar.db.io.Key;
-import com.scalar.db.storage.StorageUtility;
+import com.scalar.db.storage.Utility;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -94,7 +92,7 @@ public class Cassandra implements DistributedStorage {
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
     LOGGER.debug("executing get operation with " + get);
-    StorageUtility.setTargetToIfNot(get, namespace, tableName);
+    Utility.setTargetToIfNot(get, namespace, tableName);
     addProjectionsForKeys(get);
     CassandraTableMetadata metadata =
         getTableMetadata(get.forNamespace().get(), get.forTable().get());
@@ -113,7 +111,7 @@ public class Cassandra implements DistributedStorage {
   @Nonnull
   public Scanner scan(Scan scan) throws ExecutionException {
     LOGGER.debug("executing scan operation with " + scan);
-    StorageUtility.setTargetToIfNot(scan, namespace, tableName);
+    Utility.setTargetToIfNot(scan, namespace, tableName);
     addProjectionsForKeys(scan);
     CassandraTableMetadata metadata =
         getTableMetadata(scan.forNamespace().get(), scan.forTable().get());
@@ -125,7 +123,7 @@ public class Cassandra implements DistributedStorage {
   @Override
   public void put(Put put) throws ExecutionException {
     LOGGER.debug("executing put operation with " + put);
-    StorageUtility.setTargetToIfNot(put, namespace, tableName);
+    Utility.setTargetToIfNot(put, namespace, tableName);
     checkIfPrimaryKeyExists(put);
     handlers.get(put).handle(put);
   }
@@ -139,7 +137,7 @@ public class Cassandra implements DistributedStorage {
   @Override
   public void delete(Delete delete) throws ExecutionException {
     LOGGER.debug("executing delete operation with " + delete);
-    StorageUtility.setTargetToIfNot(delete, namespace, tableName);
+    Utility.setTargetToIfNot(delete, namespace, tableName);
     handlers.delete().handle(delete);
   }
 
@@ -154,7 +152,7 @@ public class Cassandra implements DistributedStorage {
     checkArgument(mutations.size() != 0);
     LOGGER.debug("executing batch-mutate operation with " + mutations);
     if (mutations.size() > 1) {
-      StorageUtility.setTargetToIfNot(mutations, namespace, tableName);
+      Utility.setTargetToIfNot(mutations, namespace, tableName);
       batch.handle(mutations);
     } else if (mutations.size() == 1) {
       Mutation mutation = mutations.get(0);
@@ -197,6 +195,6 @@ public class Cassandra implements DistributedStorage {
     CassandraTableMetadata metadata =
         getTableMetadata(put.forNamespace().get(), put.forTable().get());
 
-    StorageUtility.checkIfPrimaryKeyExists(put, metadata);
+    Utility.checkIfPrimaryKeyExists(put, metadata);
   }
 }

--- a/src/main/java/com/scalar/db/storage/cassandra/CassandraTableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/CassandraTableMetadata.java
@@ -2,37 +2,36 @@ package com.scalar.db.storage.cassandra;
 
 import com.datastax.driver.core.ColumnMetadata;
 import com.google.common.collect.ImmutableSet;
+import com.scalar.db.storage.TableMetadata;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-public class TableMetadata {
+public class CassandraTableMetadata implements TableMetadata {
   private final Set<String> partitionKeyNames;
   private final Set<String> clusteringColumnNames;
 
-  public TableMetadata(com.datastax.driver.core.TableMetadata tableMetadata) {
+  public CassandraTableMetadata(com.datastax.driver.core.TableMetadata tableMetadata) {
     this.partitionKeyNames =
         ImmutableSet.copyOf(
-            tableMetadata
-                .getPartitionKey()
-                .stream()
+            tableMetadata.getPartitionKey().stream()
                 .map(ColumnMetadata::getName)
                 .collect(Collectors.toSet()));
     this.clusteringColumnNames =
         ImmutableSet.copyOf(
-            tableMetadata
-                .getClusteringColumns()
-                .stream()
+            tableMetadata.getClusteringColumns().stream()
                 .map(ColumnMetadata::getName)
                 .collect(Collectors.toSet()));
   }
 
+  @Override
   public Set<String> getPartitionKeyNames() {
     return partitionKeyNames;
   }
 
-  public Set<String> getClusteringColumnNames() {
+  @Override
+  public Set<String> getClusteringKeyNames() {
     return clusteringColumnNames;
   }
 }

--- a/src/main/java/com/scalar/db/storage/cassandra/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/ResultImpl.java
@@ -37,10 +37,10 @@ import org.slf4j.LoggerFactory;
 @Immutable
 public class ResultImpl implements Result {
   private static final Logger LOGGER = LoggerFactory.getLogger(ResultImpl.class);
-  private final TableMetadata metadata;
+  private final CassandraTableMetadata metadata;
   private Map<String, Value> values;
 
-  public ResultImpl(Row row, TableMetadata metadata) {
+  public ResultImpl(Row row, CassandraTableMetadata metadata) {
     checkNotNull(row);
     this.metadata = checkNotNull(metadata);
     interpret(row);
@@ -52,7 +52,7 @@ public class ResultImpl implements Result {
    * @param values
    */
   @VisibleForTesting
-  ResultImpl(Collection<Value> values, TableMetadata metadata) {
+  ResultImpl(Collection<Value> values, CassandraTableMetadata metadata) {
     this.metadata = metadata;
     this.values = new HashMap<>();
     values.forEach(v -> this.values.put(v.getName(), v));
@@ -65,7 +65,7 @@ public class ResultImpl implements Result {
 
   @Override
   public Optional<Key> getClusteringKey() {
-    return getKey(metadata.getClusteringColumnNames());
+    return getKey(metadata.getClusteringKeyNames());
   }
 
   @Override
@@ -117,9 +117,7 @@ public class ResultImpl implements Result {
 
   @VisibleForTesting
   Map<String, DataType> getColumnDefinitions(Row row) {
-    return row.getColumnDefinitions()
-        .asList()
-        .stream()
+    return row.getColumnDefinitions().asList().stream()
         .collect(
             Collectors.toMap(
                 Definition::getName,

--- a/src/main/java/com/scalar/db/storage/cassandra/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/ScannerImpl.java
@@ -16,9 +16,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public final class ScannerImpl implements Scanner {
   private final ResultSet resultSet;
-  private final TableMetadata metadata;
+  private final CassandraTableMetadata metadata;
 
-  public ScannerImpl(ResultSet resultSet, TableMetadata metadata) {
+  public ScannerImpl(ResultSet resultSet, CassandraTableMetadata metadata) {
     this.resultSet = checkNotNull(resultSet);
     this.metadata = checkNotNull(metadata);
   }
@@ -47,6 +47,5 @@ public final class ScannerImpl implements Scanner {
   }
 
   @Override
-  public void close() {
-  }
+  public void close() {}
 }

--- a/src/main/java/com/scalar/db/storage/cassandra/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/ScannerIterator.java
@@ -10,9 +10,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public final class ScannerIterator implements Iterator<Result> {
   private final Iterator<Row> iterator;
-  private final TableMetadata metadata;
+  private final CassandraTableMetadata metadata;
 
-  public ScannerIterator(ResultSet resultSet, TableMetadata metadata) {
+  public ScannerIterator(ResultSet resultSet, CassandraTableMetadata metadata) {
     iterator = resultSet.iterator();
     this.metadata = metadata;
   }

--- a/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -11,17 +11,15 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
-import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.io.Key;
+import com.scalar.db.storage.StorageUtility;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
@@ -101,7 +99,7 @@ public class Cosmos implements DistributedStorage {
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
-    setTargetToIfNot(get);
+    StorageUtility.setTargetToIfNot(get, namespace, tableName);
 
     List<Record> records = selectStatementHandler.handle(get);
 
@@ -109,23 +107,23 @@ public class Cosmos implements DistributedStorage {
       return Optional.empty();
     }
 
-    TableMetadata metadata = metadataManager.getTableMetadata(get);
+    CosmosTableMetadata metadata = metadataManager.getTableMetadata(get);
     return Optional.of(new ResultImpl(records.get(0), get, metadata));
   }
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    setTargetToIfNot(scan);
+    StorageUtility.setTargetToIfNot(scan, namespace, tableName);
 
     List<Record> records = selectStatementHandler.handle(scan);
 
-    TableMetadata metadata = metadataManager.getTableMetadata(scan);
+    CosmosTableMetadata metadata = metadataManager.getTableMetadata(scan);
     return new ScannerImpl(records, scan, metadata);
   }
 
   @Override
   public void put(Put put) throws ExecutionException {
-    setTargetToIfNot(put);
+    StorageUtility.setTargetToIfNot(put, namespace, tableName);
     checkIfPrimaryKeyExists(put);
 
     putStatementHandler.handle(put);
@@ -138,7 +136,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
-    setTargetToIfNot(delete);
+    StorageUtility.setTargetToIfNot(delete, namespace, tableName);
     deleteStatementHandler.handle(delete);
   }
 
@@ -151,7 +149,7 @@ public class Cosmos implements DistributedStorage {
   public void mutate(List<? extends Mutation> mutations) throws ExecutionException {
     checkArgument(mutations.size() != 0);
     if (mutations.size() > 1) {
-      setTargetToIfNot(mutations);
+      StorageUtility.setTargetToIfNot(mutations, namespace, tableName);
       batchHandler.handle(mutations);
     } else if (mutations.size() == 1) {
       Mutation mutation = mutations.get(0);
@@ -168,42 +166,9 @@ public class Cosmos implements DistributedStorage {
     client.close();
   }
 
-  private void setTargetToIfNot(List<? extends Operation> operations) {
-    operations.forEach(o -> setTargetToIfNot(o));
-  }
-
-  private void setTargetToIfNot(Operation operation) {
-    if (!operation.forNamespace().isPresent()) {
-      operation.forNamespace(namespace.orElse(null));
-    }
-    if (!operation.forTable().isPresent()) {
-      operation.forTable(tableName.orElse(null));
-    }
-    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
-      throw new IllegalArgumentException("operation has no target namespace and table name");
-    }
-  }
-
   private void checkIfPrimaryKeyExists(Put put) {
-    TableMetadata metadata = metadataManager.getTableMetadata(put);
+    CosmosTableMetadata metadata = metadataManager.getTableMetadata(put);
 
-    throwIfNotMatched(Optional.of(put.getPartitionKey()), metadata.getPartitionKeyNames());
-    throwIfNotMatched(put.getClusteringKey(), metadata.getClusteringKeyNames());
-  }
-
-  private void throwIfNotMatched(Optional<Key> key, Set<String> names) {
-    String message = "The primary key is not properly specified.";
-    if ((!key.isPresent() && names.size() > 0)
-        || (key.isPresent() && (key.get().size() != names.size()))) {
-      throw new IllegalArgumentException(message);
-    }
-    key.ifPresent(
-        k ->
-            k.forEach(
-                v -> {
-                  if (!names.contains(v.getName())) {
-                    throw new IllegalArgumentException(message);
-                  }
-                }));
+    StorageUtility.checkIfPrimaryKeyExists(put, metadata);
   }
 }

--- a/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -17,7 +17,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.storage.StorageUtility;
+import com.scalar.db.storage.Utility;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -99,7 +99,7 @@ public class Cosmos implements DistributedStorage {
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(get, namespace, tableName);
+    Utility.setTargetToIfNot(get, namespace, tableName);
 
     List<Record> records = selectStatementHandler.handle(get);
 
@@ -113,7 +113,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(scan, namespace, tableName);
+    Utility.setTargetToIfNot(scan, namespace, tableName);
 
     List<Record> records = selectStatementHandler.handle(scan);
 
@@ -123,7 +123,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(put, namespace, tableName);
+    Utility.setTargetToIfNot(put, namespace, tableName);
     checkIfPrimaryKeyExists(put);
 
     putStatementHandler.handle(put);
@@ -136,7 +136,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(delete, namespace, tableName);
+    Utility.setTargetToIfNot(delete, namespace, tableName);
     deleteStatementHandler.handle(delete);
   }
 
@@ -149,7 +149,7 @@ public class Cosmos implements DistributedStorage {
   public void mutate(List<? extends Mutation> mutations) throws ExecutionException {
     checkArgument(mutations.size() != 0);
     if (mutations.size() > 1) {
-      StorageUtility.setTargetToIfNot(mutations, namespace, tableName);
+      Utility.setTargetToIfNot(mutations, namespace, tableName);
       batchHandler.handle(mutations);
     } else if (mutations.size() == 1) {
       Mutation mutation = mutations.get(0);
@@ -169,6 +169,6 @@ public class Cosmos implements DistributedStorage {
   private void checkIfPrimaryKeyExists(Put put) {
     CosmosTableMetadata metadata = metadataManager.getTableMetadata(put);
 
-    StorageUtility.checkIfPrimaryKeyExists(put, metadata);
+    Utility.checkIfPrimaryKeyExists(put, metadata);
   }
 }

--- a/src/main/java/com/scalar/db/storage/cosmos/CosmosOperation.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/CosmosOperation.java
@@ -13,7 +13,7 @@ import javax.annotation.Nonnull;
 /** A class to treating utilities for a operation */
 public class CosmosOperation {
   private final Operation operation;
-  private final TableMetadata metadata;
+  private final CosmosTableMetadata metadata;
 
   public CosmosOperation(Operation operation, TableMetadataManager metadataManager) {
     this.operation = operation;

--- a/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cosmos;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.scalar.db.storage.TableMetadata;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -15,14 +16,14 @@ import java.util.SortedSet;
  *
  * @author Yuji Ito
  */
-public class TableMetadata {
+public class CosmosTableMetadata implements TableMetadata {
   private String id;
   private SortedSet<String> partitionKeyNames;
   private SortedSet<String> clusteringKeyNames;
   private SortedMap<String, String> columns;
   private List<String> keyNames;
 
-  public TableMetadata() {}
+  public CosmosTableMetadata() {}
 
   public void setId(String id) {
     this.id = id;
@@ -48,10 +49,12 @@ public class TableMetadata {
     return id;
   }
 
+  @Override
   public Set<String> getPartitionKeyNames() {
     return ImmutableSortedSet.copyOf(partitionKeyNames);
   }
 
+  @Override
   public Set<String> getClusteringKeyNames() {
     return ImmutableSortedSet.copyOf(clusteringKeyNames);
   }

--- a/src/main/java/com/scalar/db/storage/cosmos/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ResultImpl.java
@@ -34,10 +34,10 @@ import org.slf4j.LoggerFactory;
 @Immutable
 public class ResultImpl implements Result {
   private static final Logger LOGGER = LoggerFactory.getLogger(ResultImpl.class);
-  private final TableMetadata metadata;
+  private final CosmosTableMetadata metadata;
   private final Map<String, Value> values;
 
-  public ResultImpl(Record record, Selection selection, TableMetadata metadata) {
+  public ResultImpl(Record record, Selection selection, CosmosTableMetadata metadata) {
     checkNotNull(record);
     this.metadata = checkNotNull(metadata);
     values = new HashMap<>();
@@ -91,7 +91,7 @@ public class ResultImpl implements Result {
   }
 
   @VisibleForTesting
-  void interpret(Record record, Selection selection, TableMetadata metadata) {
+  void interpret(Record record, Selection selection, CosmosTableMetadata metadata) {
     Map<String, Object> recordValues = record.getValues();
     if (selection.getProjections().isEmpty()) {
       metadata

--- a/src/main/java/com/scalar/db/storage/cosmos/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ScannerImpl.java
@@ -16,9 +16,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class ScannerImpl implements Scanner {
   private final List<Record> records;
   private final Selection selection;
-  private final TableMetadata metadata;
+  private final CosmosTableMetadata metadata;
 
-  public ScannerImpl(List<Record> records, Selection selection, TableMetadata metadata) {
+  public ScannerImpl(List<Record> records, Selection selection, CosmosTableMetadata metadata) {
     this.records = checkNotNull(records);
     this.selection = selection;
     this.metadata = checkNotNull(metadata);

--- a/src/main/java/com/scalar/db/storage/cosmos/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ScannerIterator.java
@@ -10,9 +10,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class ScannerIterator implements Iterator<Result> {
   private final Iterator<Record> iterator;
   private final Selection selection;
-  private final TableMetadata metadata;
+  private final CosmosTableMetadata metadata;
 
-  public ScannerIterator(Iterator<Record> iterator, Selection selection, TableMetadata metadata) {
+  public ScannerIterator(Iterator<Record> iterator, Selection selection, CosmosTableMetadata metadata) {
     this.iterator = iterator;
     this.selection = selection;
     this.metadata = metadata;

--- a/src/main/java/com/scalar/db/storage/cosmos/TableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/TableMetadataManager.java
@@ -10,21 +10,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A manager to read and cache {@link TableMetadata} to know the type of each column
+ * A manager to read and cache {@link CosmosTableMetadata} to know the type of each column
  *
  * @author Yuji Ito
  */
 @ThreadSafe
 public class TableMetadataManager {
   private final CosmosContainer container;
-  private final Map<String, TableMetadata> tableMetadataMap;
+  private final Map<String, CosmosTableMetadata> tableMetadataMap;
 
   public TableMetadataManager(CosmosContainer container) {
     this.container = container;
     this.tableMetadataMap = new ConcurrentHashMap<>();
   }
 
-  public TableMetadata getTableMetadata(Operation operation) {
+  public CosmosTableMetadata getTableMetadata(Operation operation) {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
       throw new IllegalArgumentException("operation has no target namespace and table name");
     }
@@ -32,7 +32,7 @@ public class TableMetadataManager {
     return getTableMetadata(operation.forNamespace().get(), operation.forTable().get());
   }
 
-  private TableMetadata getTableMetadata(String namespace, String tableName) {
+  private CosmosTableMetadata getTableMetadata(String namespace, String tableName) {
     String fullName = namespace + "." + tableName;
     if (!tableMetadataMap.containsKey(fullName)) {
       tableMetadataMap.put(fullName, readMetadata(fullName));
@@ -40,10 +40,10 @@ public class TableMetadataManager {
     return tableMetadataMap.get(fullName);
   }
 
-  private TableMetadata readMetadata(String fullName) {
+  private CosmosTableMetadata readMetadata(String fullName) {
     try {
       return container
-          .readItem(fullName, new PartitionKey(fullName), TableMetadata.class)
+          .readItem(fullName, new PartitionKey(fullName), CosmosTableMetadata.class)
           .getItem();
     } catch (CosmosException e) {
       throw new StorageRuntimeException("Failed to read the table metadata", e);

--- a/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -13,12 +13,10 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.io.Key;
-import com.scalar.db.storage.StorageUtility;
+import com.scalar.db.storage.Utility;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
@@ -98,7 +96,7 @@ public class Dynamo implements DistributedStorage {
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(get, namespace, tableName);
+    Utility.setTargetToIfNot(get, namespace, tableName);
 
     List<Map<String, AttributeValue>> items = selectStatementHandler.handle(get);
 
@@ -112,7 +110,7 @@ public class Dynamo implements DistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(scan, namespace, tableName);
+    Utility.setTargetToIfNot(scan, namespace, tableName);
 
     List<Map<String, AttributeValue>> items = selectStatementHandler.handle(scan);
 
@@ -122,7 +120,7 @@ public class Dynamo implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(put, namespace, tableName);
+    Utility.setTargetToIfNot(put, namespace, tableName);
     checkIfPrimaryKeyExists(put);
 
     putStatementHandler.handle(put);
@@ -135,7 +133,7 @@ public class Dynamo implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
-    StorageUtility.setTargetToIfNot(delete, namespace, tableName);
+    Utility.setTargetToIfNot(delete, namespace, tableName);
     checkIfPrimaryKeyExists(delete);
 
     deleteStatementHandler.handle(delete);
@@ -150,7 +148,7 @@ public class Dynamo implements DistributedStorage {
   public void mutate(List<? extends Mutation> mutations) throws ExecutionException {
     checkArgument(mutations.size() != 0);
     if (mutations.size() > 1) {
-      StorageUtility.setTargetToIfNot(mutations, namespace, tableName);
+      Utility.setTargetToIfNot(mutations, namespace, tableName);
       batchHandler.handle(mutations);
     } else if (mutations.size() == 1) {
       Mutation mutation = mutations.get(0);
@@ -170,6 +168,6 @@ public class Dynamo implements DistributedStorage {
   private void checkIfPrimaryKeyExists(Mutation mutation) {
     DynamoTableMetadata metadata = metadataManager.getTableMetadata(mutation);
 
-    StorageUtility.checkIfPrimaryKeyExists(mutation, metadata);
+    Utility.checkIfPrimaryKeyExists(mutation, metadata);
   }
 }

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -26,14 +26,14 @@ public class DynamoOperation {
   static final String INDEX_NAME_PREFIX = "index";
 
   private final Operation operation;
-  private final TableMetadata metadata;
+  private final DynamoTableMetadata metadata;
 
   public DynamoOperation(Operation operation, TableMetadataManager metadataManager) {
     this.operation = operation;
     this.metadata = metadataManager.getTableMetadata(operation);
   }
 
-  public DynamoOperation(Operation operation, TableMetadata metadata) {
+  public DynamoOperation(Operation operation, DynamoTableMetadata metadata) {
     this.operation = operation;
     this.metadata = metadata;
   }
@@ -44,7 +44,7 @@ public class DynamoOperation {
   }
 
   @Nonnull
-  public TableMetadata getMetadata() {
+  public DynamoTableMetadata getMetadata() {
     return metadata;
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoTableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoTableMetadata.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
+import com.scalar.db.storage.TableMetadata;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +18,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  *
  * @author Yuji Ito
  */
-public class TableMetadata {
+public class DynamoTableMetadata implements TableMetadata {
   private static final String PARTITION_KEY = "partitionKey";
   private static final String CLUSTERING_KEY = "clusteringKey";
   private static final String COLUMNS = "columns";
@@ -26,14 +27,16 @@ public class TableMetadata {
   private SortedMap<String, String> columns;
   private List<String> keyNames;
 
-  public TableMetadata(Map<String, AttributeValue> metadata) {
+  public DynamoTableMetadata(Map<String, AttributeValue> metadata) {
     convert(metadata);
   }
 
+  @Override
   public Set<String> getPartitionKeyNames() {
     return partitionKeyNames;
   }
 
+  @Override
   public Set<String> getClusteringKeyNames() {
     return clusteringKeyNames;
   }

--- a/src/main/java/com/scalar/db/storage/dynamo/ItemSorter.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ItemSorter.java
@@ -21,7 +21,7 @@ public class ItemSorter {
   private final Scan scan;
   private final Comparator<Map<String, AttributeValue>> comparator;
 
-  public ItemSorter(Scan scan, TableMetadata metadata) {
+  public ItemSorter(Scan scan, DynamoTableMetadata metadata) {
     checkNotNull(metadata);
     this.scan = checkNotNull(scan);
     this.comparator = getComparator(scan, metadata);
@@ -42,7 +42,8 @@ public class ItemSorter {
     return items;
   }
 
-  private Comparator<Map<String, AttributeValue>> getComparator(Scan scan, TableMetadata metadata) {
+  private Comparator<Map<String, AttributeValue>> getComparator(
+      Scan scan, DynamoTableMetadata metadata) {
     return new Comparator<Map<String, AttributeValue>>() {
       public int compare(Map<String, AttributeValue> o1, Map<String, AttributeValue> o2) {
         int compareResult = 0;

--- a/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ResultImpl.java
@@ -34,10 +34,11 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 public class ResultImpl implements Result {
   private static final Logger LOGGER = LoggerFactory.getLogger(ResultImpl.class);
   private final Selection selection;
-  private final TableMetadata metadata;
+  private final DynamoTableMetadata metadata;
   private final Map<String, Value> values;
 
-  public ResultImpl(Map<String, AttributeValue> item, Selection selection, TableMetadata metadata) {
+  public ResultImpl(
+      Map<String, AttributeValue> item, Selection selection, DynamoTableMetadata metadata) {
     checkNotNull(item);
     this.selection = selection;
     this.metadata = checkNotNull(metadata);
@@ -92,7 +93,7 @@ public class ResultImpl implements Result {
   }
 
   @VisibleForTesting
-  void interpret(Map<String, AttributeValue> item, TableMetadata metadata) {
+  void interpret(Map<String, AttributeValue> item, DynamoTableMetadata metadata) {
     if (selection.getProjections().isEmpty()) {
       metadata
           .getColumns()

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
@@ -18,11 +18,11 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 @NotThreadSafe
 public final class ScannerImpl implements Scanner {
   private final Selection selection;
-  private final TableMetadata metadata;
+  private final DynamoTableMetadata metadata;
   private List<Map<String, AttributeValue>> items;
 
   public ScannerImpl(
-      List<Map<String, AttributeValue>> items, Selection selection, TableMetadata metadata) {
+      List<Map<String, AttributeValue>> items, Selection selection, DynamoTableMetadata metadata) {
     DynamoOperation dynamoOperation = new DynamoOperation(selection, metadata);
     if (dynamoOperation.isSingleClusteringKey()) {
       // the ordering and the limitation already are applied in DynamoDB if there is only a single

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerIterator.java
@@ -12,10 +12,12 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 public final class ScannerIterator implements Iterator<Result> {
   private final Iterator<Map<String, AttributeValue>> iterator;
   private final Selection selection;
-  private final TableMetadata metadata;
+  private final DynamoTableMetadata metadata;
 
   public ScannerIterator(
-      Iterator<Map<String, AttributeValue>> iterator, Selection selection, TableMetadata metadata) {
+      Iterator<Map<String, AttributeValue>> iterator,
+      Selection selection,
+      DynamoTableMetadata metadata) {
     this.iterator = iterator;
     this.selection = selection;
     this.metadata = metadata;

--- a/src/main/java/com/scalar/db/storage/dynamo/TableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/TableMetadataManager.java
@@ -2,8 +2,8 @@ package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.api.Operation;
 import com.scalar.db.exception.storage.StorageRuntimeException;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 
 /**
- * A manager to read and cache {@link TableMetadata} to know the type of each column
+ * A manager to read and cache {@link DynamoTableMetadata} to know the type of each column
  *
  * @author Yuji Ito
  */
@@ -20,14 +20,14 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 public class TableMetadataManager {
   private final String METADATA_TABLE = "scalardb.metadata";
   private final DynamoDbClient client;
-  private final Map<String, TableMetadata> tableMetadataMap;
+  private final Map<String, DynamoTableMetadata> tableMetadataMap;
 
   public TableMetadataManager(DynamoDbClient client) {
     this.client = client;
     this.tableMetadataMap = new ConcurrentHashMap<>();
   }
 
-  public TableMetadata getTableMetadata(Operation operation) {
+  public DynamoTableMetadata getTableMetadata(Operation operation) {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
       throw new IllegalArgumentException("operation has no target namespace and table name");
     }
@@ -35,7 +35,7 @@ public class TableMetadataManager {
     return getTableMetadata(operation.forNamespace().get(), operation.forTable().get());
   }
 
-  private TableMetadata getTableMetadata(String namespace, String tableName) {
+  private DynamoTableMetadata getTableMetadata(String namespace, String tableName) {
     String fullName = namespace + "." + tableName;
     if (!tableMetadataMap.containsKey(fullName)) {
       tableMetadataMap.put(fullName, readMetadata(fullName));
@@ -43,14 +43,14 @@ public class TableMetadataManager {
     return tableMetadataMap.get(fullName);
   }
 
-  private TableMetadata readMetadata(String fullName) {
+  private DynamoTableMetadata readMetadata(String fullName) {
     Map<String, AttributeValue> key = new HashMap<>();
     key.put("table", AttributeValue.builder().s(fullName).build());
 
     GetItemRequest request =
         GetItemRequest.builder().tableName(METADATA_TABLE).key(key).consistentRead(true).build();
     try {
-      return new TableMetadata(client.getItem(request).item());
+      return new DynamoTableMetadata(client.getItem(request).item());
     } catch (DynamoDbException e) {
       throw new StorageRuntimeException("Failed to read the table metadata", e);
     }

--- a/src/test/java/com/scalar/db/storage/cassandra/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/cassandra/ResultImplTest.java
@@ -42,7 +42,7 @@ public class ResultImplTest {
   private static final int ANY_INT = 10;
   private Definitions definitions;
   @Mock private Row row;
-  @Mock private TableMetadata tableMetadata;
+  @Mock private CassandraTableMetadata CassandraTableMetadata;
   @Mock private ColumnMetadata columnMetadata;
 
   @Before
@@ -172,8 +172,9 @@ public class ResultImplTest {
   @Test
   public void getPartitionKey_RequiredValuesGiven_ShouldReturnPartitionKey() {
     // Arrange
-    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), tableMetadata));
-    when(tableMetadata.getPartitionKeyNames()).thenReturn(ImmutableSet.of(ANY_COLUMN_NAME_2));
+    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), CassandraTableMetadata));
+    when(CassandraTableMetadata.getPartitionKeyNames())
+        .thenReturn(ImmutableSet.of(ANY_COLUMN_NAME_2));
     doReturn(definitions.get()).when(spy).getColumnDefinitions(row);
     spy.interpret(row);
 
@@ -189,8 +190,8 @@ public class ResultImplTest {
   @Test
   public void getPartitionKey_RequiredValuesNotGiven_ShouldReturnEmpty() {
     // Arrange
-    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), tableMetadata));
-    when(tableMetadata.getPartitionKeyNames()).thenReturn(ImmutableSet.of("another"));
+    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), CassandraTableMetadata));
+    when(CassandraTableMetadata.getPartitionKeyNames()).thenReturn(ImmutableSet.of("another"));
     doReturn(definitions.get()).when(spy).getColumnDefinitions(row);
     spy.interpret(row);
 
@@ -204,8 +205,9 @@ public class ResultImplTest {
   @Test
   public void getClusteringKey_RequiredValuesGiven_ShouldReturnClusteringKey() {
     // Arrange
-    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), tableMetadata));
-    when(tableMetadata.getClusteringColumnNames()).thenReturn(ImmutableSet.of(ANY_COLUMN_NAME_2));
+    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), CassandraTableMetadata));
+    when(CassandraTableMetadata.getClusteringKeyNames())
+        .thenReturn(ImmutableSet.of(ANY_COLUMN_NAME_2));
     doReturn(definitions.get()).when(spy).getColumnDefinitions(row);
     spy.interpret(row);
 
@@ -221,8 +223,8 @@ public class ResultImplTest {
   @Test
   public void getClusteringKey_RequiredValuesNotGiven_ShouldReturnEmpty() {
     // Arrange
-    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), tableMetadata));
-    when(tableMetadata.getClusteringColumnNames()).thenReturn(ImmutableSet.of("another"));
+    ResultImpl spy = spy(new ResultImpl(new ArrayList<>(), CassandraTableMetadata));
+    when(CassandraTableMetadata.getClusteringKeyNames()).thenReturn(ImmutableSet.of("another"));
     doReturn(definitions.get()).when(spy).getColumnDefinitions(row);
     spy.interpret(row);
 

--- a/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
@@ -58,7 +58,7 @@ public class BatchHandlerTest {
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosScripts cosmosScripts;
   @Mock private CosmosStoredProcedure storedProcedure;
   @Mock private CosmosStoredProcedureResponse spResponse;

--- a/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -37,7 +37,7 @@ public class CosmosMutationTest {
 
   @Mock private CosmosContainer container;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private CosmosTableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
@@ -34,7 +34,7 @@ public class CosmosOperationTest {
   private static final int ANY_INT_1 = 1;
 
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private CosmosTableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -53,7 +53,7 @@ public class DeleteStatementHandlerTest {
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse response;
   @Mock private CosmosScripts cosmosScripts;
   @Mock private CosmosStoredProcedure storedProcedure;

--- a/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
@@ -56,7 +56,7 @@ public class PutStatementHandlerTest {
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse response;
   @Mock private CosmosScripts cosmosScripts;
   @Mock private CosmosStoredProcedure storedProcedure;

--- a/src/test/java/com/scalar/db/storage/cosmos/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/ResultImplTest.java
@@ -46,11 +46,11 @@ public class ResultImplTest {
 
   private Record record;
   private Get get;
-  private TableMetadata metadata;
+  private CosmosTableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {
-    metadata = new TableMetadata();
+    metadata = new CosmosTableMetadata();
     metadata.setId("ks.tbl");
     metadata.setPartitionKeyNames(ImmutableSet.of(ANY_NAME_1));
     metadata.setClusteringKeyNames(ImmutableSet.of(ANY_NAME_2));

--- a/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -54,7 +54,7 @@ public class SelectStatementHandlerTest {
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse<Record> response;
   @Mock private CosmosPagedIterable<Record> responseIterable;
 

--- a/src/test/java/com/scalar/db/storage/cosmos/TableMetadataManagerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/TableMetadataManagerTest.java
@@ -33,8 +33,8 @@ public class TableMetadataManagerTest {
 
   private TableMetadataManager manager;
   @Mock private CosmosContainer container;
-  @Mock private TableMetadata metadata;
-  @Mock private CosmosItemResponse<TableMetadata> response;
+  @Mock private CosmosTableMetadata metadata;
+  @Mock private CosmosItemResponse<CosmosTableMetadata> response;
 
   @Before
   public void setUp() throws Exception {
@@ -46,7 +46,7 @@ public class TableMetadataManagerTest {
   @Test
   public void getTableMetadata_ProperOperationGivenFirst_ShouldCallReadItem() {
     // Arrange
-    when(container.readItem(anyString(), any(PartitionKey.class), eq(TableMetadata.class)))
+    when(container.readItem(anyString(), any(PartitionKey.class), eq(CosmosTableMetadata.class)))
         .thenReturn(response);
     when(response.getItem()).thenReturn(metadata);
 
@@ -56,13 +56,13 @@ public class TableMetadataManagerTest {
     // Act
     manager.getTableMetadata(get);
 
-    verify(container).readItem(FULLNAME, new PartitionKey(FULLNAME), TableMetadata.class);
+    verify(container).readItem(FULLNAME, new PartitionKey(FULLNAME), CosmosTableMetadata.class);
   }
 
   @Test
   public void getTableMetadata_SameTableGiven_ShouldCallReadItemOnce() {
     // Arrange
-    when(container.readItem(anyString(), any(PartitionKey.class), eq(TableMetadata.class)))
+    when(container.readItem(anyString(), any(PartitionKey.class), eq(CosmosTableMetadata.class)))
         .thenReturn(response);
     when(response.getItem()).thenReturn(metadata);
 
@@ -75,13 +75,14 @@ public class TableMetadataManagerTest {
     manager.getTableMetadata(get1);
     manager.getTableMetadata(get2);
 
-    verify(container, times(1)).readItem(FULLNAME, new PartitionKey(FULLNAME), TableMetadata.class);
+    verify(container, times(1))
+        .readItem(FULLNAME, new PartitionKey(FULLNAME), CosmosTableMetadata.class);
   }
 
   @Test
   public void getTableMetadata_OperationWithoutTableGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
-    when(container.readItem(anyString(), any(PartitionKey.class), eq(TableMetadata.class)))
+    when(container.readItem(anyString(), any(PartitionKey.class), eq(CosmosTableMetadata.class)))
         .thenReturn(response);
     when(response.getItem()).thenReturn(metadata);
 
@@ -102,7 +103,7 @@ public class TableMetadataManagerTest {
     CosmosException toThrow = mock(CosmosException.class);
     doThrow(toThrow)
         .when(container)
-        .readItem(anyString(), any(PartitionKey.class), eq(TableMetadata.class));
+        .readItem(anyString(), any(PartitionKey.class), eq(CosmosTableMetadata.class));
 
     Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
     Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);

--- a/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
@@ -54,7 +54,7 @@ public class BatchHandlerTest {
   private BatchHandler handler;
   @Mock private DynamoDbClient client;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private DynamoTableMetadata metadata;
   @Mock private TransactWriteItemsResponse transactWriteResponse;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
@@ -41,7 +41,7 @@ public class DeleteStatementHandlerTest {
   private String concatenatedPartitionKey;
   @Mock private DynamoDbClient client;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private DynamoTableMetadata metadata;
   @Mock private DeleteItemResponse response;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -38,7 +38,7 @@ public class DynamoMutationTest {
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT_3);
 
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private DynamoTableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -27,7 +27,7 @@ public class DynamoOperationTest {
   private static final String ANY_TEXT_2 = "text2";
 
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private DynamoTableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoTableMetadataTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoTableMetadataTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.junit.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-public class TableMetadataTest {
+public class DynamoTableMetadataTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -30,7 +30,7 @@ public class TableMetadataTest {
     metadata.put("columns", AttributeValue.builder().m(columns).build());
 
     // Act
-    TableMetadata actual = new TableMetadata(metadata);
+    DynamoTableMetadata actual = new DynamoTableMetadata(metadata);
 
     // Assert
     assertThat(actual.getPartitionKeyNames().size()).isEqualTo(2);
@@ -60,7 +60,7 @@ public class TableMetadataTest {
     metadata.put("columns", AttributeValue.builder().m(columns).build());
 
     // Act
-    TableMetadata actual = new TableMetadata(metadata);
+    DynamoTableMetadata actual = new DynamoTableMetadata(metadata);
 
     // Assert
     assertThat(actual.getPartitionKeyNames().size()).isEqualTo(1);

--- a/src/test/java/com/scalar/db/storage/dynamo/ItemSorterTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ItemSorterTest.java
@@ -41,7 +41,7 @@ public class ItemSorterTest {
   private static final byte[] ANY_SMALL_BLOB = "a".getBytes();
   private static final String ANY_COLUMN_NAME_1 = "val1";
 
-  private TableMetadata metadata;
+  private DynamoTableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {
@@ -63,7 +63,7 @@ public class ItemSorterTest {
     columns.put(ANY_NAME_8, AttributeValue.builder().s("blob").build());
     columns.put(ANY_COLUMN_NAME_1, AttributeValue.builder().s("text").build());
     metadataMap.put("columns", AttributeValue.builder().m(columns).build());
-    metadata = new TableMetadata(metadataMap);
+    metadata = new DynamoTableMetadata(metadataMap);
   }
 
   private Map<String, AttributeValue> prepareItemWithSmallValues() {

--- a/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
@@ -48,7 +48,7 @@ public class PutStatementHandlerTest {
   private PutStatementHandler handler;
   @Mock private DynamoDbClient client;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private DynamoTableMetadata metadata;
   @Mock private UpdateItemResponse updateResponse;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ResultImplTest.java
@@ -41,7 +41,7 @@ public class ResultImplTest {
   private static final String ANY_COLUMN_NAME_7 = "val7";
 
   private Get get;
-  private TableMetadata metadata;
+  private DynamoTableMetadata metadata;
   private Map<String, AttributeValue> item = new HashMap<>();
 
   @Before
@@ -60,7 +60,7 @@ public class ResultImplTest {
     columns.put(ANY_COLUMN_NAME_6, AttributeValue.builder().s("text").build());
     columns.put(ANY_COLUMN_NAME_7, AttributeValue.builder().s("blob").build());
     metadataMap.put("columns", AttributeValue.builder().m(columns).build());
-    metadata = new TableMetadata(metadataMap);
+    metadata = new DynamoTableMetadata(metadataMap);
 
     item.put(DynamoOperation.PARTITION_KEY, AttributeValue.builder().s(ANY_TEXT_1).build());
     item.put(ANY_NAME_1, AttributeValue.builder().s(ANY_TEXT_1).build());

--- a/src/test/java/com/scalar/db/storage/dynamo/ScannerImplTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/ScannerImplTest.java
@@ -28,22 +28,22 @@ public class ScannerImplTest {
   @Before
   public void setUp() throws Exception {}
 
-  private TableMetadata prepareMetadataForSingleClusteringKey() {
+  private DynamoTableMetadata prepareMetadataForSingleClusteringKey() {
     Map<String, AttributeValue> metadataMap = new HashMap<>();
     metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
     metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2).build());
     metadataMap.put("columns", AttributeValue.builder().m(prepareColumns()).build());
 
-    return new TableMetadata(metadataMap);
+    return new DynamoTableMetadata(metadataMap);
   }
 
-  private TableMetadata prepareMetadataForMultipleClusteringKeys() {
+  private DynamoTableMetadata prepareMetadataForMultipleClusteringKeys() {
     Map<String, AttributeValue> metadataMap = new HashMap<>();
     metadataMap.put("partitionKey", AttributeValue.builder().ss(ANY_NAME_1).build());
     metadataMap.put("clusteringKey", AttributeValue.builder().ss(ANY_NAME_2, ANY_NAME_3).build());
     metadataMap.put("columns", AttributeValue.builder().m(prepareColumns()).build());
 
-    return new TableMetadata(metadataMap);
+    return new DynamoTableMetadata(metadataMap);
   }
 
   private Map<String, AttributeValue> prepareColumns() {
@@ -71,7 +71,7 @@ public class ScannerImplTest {
   @Test
   public void constructor_ItemsWithSingleClusteringKeyGiven_ShouldNotSortItems() {
     // Arrange
-    TableMetadata metadata = prepareMetadataForSingleClusteringKey();
+    DynamoTableMetadata metadata = prepareMetadataForSingleClusteringKey();
     Map<String, AttributeValue> item1 = prepareItem();
     item1.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());
     Map<String, AttributeValue> item2 = prepareItem();
@@ -91,7 +91,7 @@ public class ScannerImplTest {
   @Test
   public void constructor_ItemsWithMultipleClusteringKeysGiven_ShouldSortItems() {
     // Arrange
-    TableMetadata metadata = prepareMetadataForMultipleClusteringKeys();
+    DynamoTableMetadata metadata = prepareMetadataForMultipleClusteringKeys();
     Map<String, AttributeValue> item1 = prepareItem();
     Map<String, AttributeValue> item2 = prepareItem();
     item2.put(ANY_NAME_2, AttributeValue.builder().n(String.valueOf(ANY_LARGE_INT)).build());

--- a/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -50,7 +50,7 @@ public class SelectStatementHandlerTest {
   private SelectStatementHandler handler;
   @Mock private DynamoDbClient client;
   @Mock private TableMetadataManager metadataManager;
-  @Mock private TableMetadata metadata;
+  @Mock private DynamoTableMetadata metadata;
   @Mock private GetItemResponse getResponse;
   @Mock private QueryResponse queryResponse;
 

--- a/tools/scalar-schema/java/src/CosmosTableMetadata.java
+++ b/tools/scalar-schema/java/src/CosmosTableMetadata.java
@@ -10,17 +10,17 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
-/* Copied from Scalar DB
- * https://github.com/scalar-labs/scalardb/blob/master/src/main/java/com/scalar/db/storage/cosmos/TableMetadata.java
+/* Based on Scalar DB
+ * https://github.com/scalar-labs/scalardb/blob/master/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
  */
-public class TableMetadata {
+public class CosmosTableMetadata {
   private String id;
   private SortedSet<String> partitionKeyNames;
   private SortedSet<String> clusteringKeyNames;
   private SortedMap<String, String> columns;
   private List<String> keyNames;
 
-  public TableMetadata() {}
+  public CosmosTableMetadata() {}
 
   public void setId(String id) {
     this.id = id;

--- a/tools/scalar-schema/src/scalar_schema/cosmos.clj
+++ b/tools/scalar-schema/src/scalar_schema/cosmos.clj
@@ -13,7 +13,7 @@
                                     IncludedPath
                                     IndexingPolicy
                                     ThroughputProperties)
-           (com.scalar.db.storage.cosmos TableMetadata)))
+           (com.scalar.db.storage.cosmos CosmosTableMetadata)))
 
 (def ^:const ^:private ^String METADATA_PARTITION_KEY "/id")
 (def ^:const ^:private ^String
@@ -88,7 +88,7 @@
     (create-database client common/METADATA_DATABASE 400 true))
   (when-not (container-exists? client common/METADATA_DATABASE common/METADATA_TABLE)
     (create-container client common/METADATA_DATABASE common/METADATA_TABLE))
-  (let [metadata (doto (TableMetadata.)
+  (let [metadata (doto (CosmosTableMetadata.)
                    (.setId (common/get-fullname (:database schema)
                                                 (:table schema)))
                    (.setPartitionKeyNames (set (:partition-key schema)))


### PR DESCRIPTION
Before adding a prefix to each namespace, I'd like to unify the common methods for `DistributedStorage`.

- `setTargetToIfNot()` and `checkIfPrimaryKeyExists()` in each storage are unified in `StorageUtility`
- Add `TableMetadata` interface and rename each `TableMetadata`