### PR TITLE
Include transaction/consensuscommit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,9 @@ sourceSets {
         java {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
-            srcDir file('src/integration-test/java/com/scalar/db/storage/cassandra')
+            srcDir file('src/integration-test/java')
+            exclude '**/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java'
+            exclude '**/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java'
         }
         resources.srcDir file('src/integration-test/resources')
     }


### PR DESCRIPTION
Make it include the integration tests of `transaction/consensuscommit, which was excluded by a previous commit.

Somehow,
`srcDir file('src/integration-test/java/com/scalar/db/transaction/consensuscommit')`
or 
`exclude 'src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java'`
doesn't work.
So, I came to the current solution. But I'm not sure if it's the best way.
Please suggest if you know a better way.

I'll fix the broken test in another PR.
