### PR TITLE
Some scanners in CrudHandler and Snapshot are not closed

### DIFF
--- a/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -15,6 +15,7 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.CrudRuntimeException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.io.Key;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -66,23 +67,35 @@ public class CrudHandler {
     }
 
     List<Snapshot.Key> keys = new ArrayList<>();
-    for (Result r : getFromStorage(scan)) {
-      TransactionResult result = new TransactionResult(r);
-      if (!result.isCommitted()) {
-        throw new UncommittedRecordException(result, "the record needs recovery");
+    Scanner scanner = null;
+    try {
+      scanner = getFromStorage(scan);
+      for (Result r : scanner) {
+        TransactionResult result = new TransactionResult(r);
+        if (!result.isCommitted()) {
+          throw new UncommittedRecordException(result, "the record needs recovery");
+        }
+
+        Snapshot.Key key =
+            getSnapshotKey(r, scan)
+                .orElseThrow(() -> new CrudRuntimeException("can't get a snapshot key"));
+
+        if (snapshot.get(key).isPresent()) {
+          result = snapshot.get(key).get();
+        }
+
+        snapshot.put(key, Optional.of(result));
+        keys.add(key);
+        results.add(result);
       }
-
-      Snapshot.Key key =
-          getSnapshotKey(r, scan)
-              .orElseThrow(() -> new CrudRuntimeException("can't get a snapshot key"));
-
-      if (snapshot.get(key).isPresent()) {
-        result = snapshot.get(key).get();
+    } finally {
+      if (scanner != null) {
+        try {
+          scanner.close();
+        } catch (IOException e) {
+          LOGGER.warn("failed to close the scanner", e);
+        }
       }
-
-      snapshot.put(key, Optional.of(result));
-      keys.add(key);
-      results.add(result);
     }
     snapshot.put(scan, Optional.of(keys));
 


### PR DESCRIPTION
While adding the JDBC adapter, I found some scanners in CrudHandler and Snapshot are not closed. We should close them.