### PR TITLE
Check operations if they are given with correct keys

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraIntegrationTest.java
@@ -20,7 +20,6 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.storage.InvalidUsageException;
 import com.scalar.db.exception.storage.MultiPartitionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
@@ -136,7 +135,7 @@ public class CassandraIntegrationTest {
             () -> {
               storage.get(get);
             })
-        .isInstanceOf(InvalidUsageException.class);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -712,15 +711,17 @@ public class CassandraIntegrationTest {
   }
 
   @Test
-  public void delete_DeleteWithPartitionKeyGiven_ShouldDeleteRecordsProperly()
+  public void delete_DeleteWithPartitionKeyGiven_ShouldDeleteRecordProperly()
       throws ExecutionException {
     // Arrange
     populateRecords();
     int pKey = 0;
+    int cKey = 0;
 
     // Act
     Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
-    Delete delete = new Delete(partitionKey);
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    Delete delete = new Delete(partitionKey, clusteringKey);
     assertThatCode(
             () -> {
               storage.delete(delete);
@@ -729,7 +730,7 @@ public class CassandraIntegrationTest {
 
     // Assert
     List<Result> actual = storage.scan(new Scan(partitionKey)).all();
-    assertThat(actual.size()).isEqualTo(0);
+    assertThat(actual.size()).isEqualTo(2);
   }
 
   @Test
@@ -991,10 +992,12 @@ public class CassandraIntegrationTest {
     // Arrange
     populateRecords();
     int pKey = 0;
+    int cKey = 0;
 
     // Act
     Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
-    Delete delete = new Delete(partitionKey);
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
+    Delete delete = new Delete(partitionKey, clusteringKey);
     assertThatCode(
             () -> {
               storage.mutate(Arrays.asList(delete));
@@ -1003,7 +1006,7 @@ public class CassandraIntegrationTest {
 
     // Assert
     List<Result> actual = storage.scan(new Scan(partitionKey)).all();
-    assertThat(actual.size()).isEqualTo(0);
+    assertThat(actual.size()).isEqualTo(2);
   }
 
   @Test

--- a/src/main/java/com/scalar/db/storage/Utility.java
+++ b/src/main/java/com/scalar/db/storage/Utility.java
@@ -1,6 +1,5 @@
 package com.scalar.db.storage;
 
-import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.io.Key;
 import java.util.List;
@@ -41,13 +40,17 @@ public final class Utility {
     }
   }
 
-  public static void checkIfPrimaryKeyExists(Mutation mutation, TableMetadata metadata) {
-    throwIfNotMatched(Optional.of(mutation.getPartitionKey()), metadata.getPartitionKeyNames());
-    throwIfNotMatched(mutation.getClusteringKey(), metadata.getClusteringKeyNames());
+  public static void checkIfPrimaryKeyExists(Operation operation, TableMetadata metadata) {
+    throwIfNotMatched(Optional.of(operation.getPartitionKey()), metadata.getPartitionKeyNames());
+    throwIfNotMatched(operation.getClusteringKey(), metadata.getClusteringKeyNames());
+  }
+
+  public static void checkIfPartitionKeyExists(Operation operation, TableMetadata metadata) {
+    throwIfNotMatched(Optional.of(operation.getPartitionKey()), metadata.getPartitionKeyNames());
   }
 
   private static void throwIfNotMatched(Optional<Key> key, Set<String> names) {
-    String message = "The primary key is not properly specified.";
+    String message = "The required key (primary or partition) is not properly specified.";
     if ((!key.isPresent() && names.size() > 0)
         || (key.isPresent() && (key.get().size() != names.size()))) {
       throw new IllegalArgumentException(message);


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-3333

There is no check in the current C* adapter if given operations have proper keys or not.
So, I fixed it in this PR as well since it is pretty related to the bug.