### PR TITLE
[Scalar-Schema] Set DynamoDB secondary index

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/dynamo/common.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/common.clj
@@ -3,6 +3,9 @@
   (:import (software.amazon.awssdk.auth.credentials AwsBasicCredentials
                                                     StaticCredentialsProvider)))
 
+(def ^:const ^:private ^String INDEX_NAME_PREFIX "index")
+(def ^:const ^:private ^String GLOBAL_INDEX_NAME_PREFIX "global_index")
+
 (defn get-credentials-provider
   [user password]
   (StaticCredentialsProvider/create
@@ -11,3 +14,11 @@
 (defn get-table-name
   [{:keys [database table]}]
   (common/get-fullname database table))
+
+(defn get-index-name
+  [schema key-name]
+  (str (get-table-name schema) \. INDEX_NAME_PREFIX \. key-name))
+
+(defn get-global-index-name
+  [schema key-name]
+  (str (get-table-name schema) \. GLOBAL_INDEX_NAME_PREFIX \. key-name))


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8021

This PR is for DynamoDB.
We use global secondary indexes for the Scalar DB secondary index because the local secondary index requires the partition key.
The consistency is only **eventual consistency** in DynamoDB global secondary index.

For Cassandra: #140 
For Cosmos DB: #141 

Please merge after #140