### PR TITLE
Fix pip install failure in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           # We need to edit DEFAULT_CQLVER defined in the cqlsh script
           # to connect to the server without --cqlversion command line option
           command: |
-            curl -O https://bootstrap.pypa.io/get-pip.py
+            curl -O https://bootstrap.pypa.io/2.7/get-pip.py
             sudo python get-pip.py
             sudo pip install cqlsh
             sudo sed -i "s/^DEFAULT_CQLVER = .*/DEFAULT_CQLVER = '3.4.4'/" /usr/local/bin/cqlsh


### PR DESCRIPTION
It came to fail suddenly. By explicitly specifying the version of `get-pip`, it seems working fine.