### PR TITLE
Divide the integration test into Cassandra and JDBC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           name: Save Gradle integration test reports
           command: |
             mkdir -p /tmp/gradle_integration_test_reports
-            cp -a build/reports/tests/integrationTest /tmp/gradle_integration_test_reports/
+            cp -a build/reports/tests/integrationTestCassandra /tmp/gradle_integration_test_reports/
           when: always
 
       - store_artifacts:
@@ -147,7 +147,7 @@ jobs:
           name: Save Gradle integration test reports
           command: |
             mkdir -p /tmp/gradle_integration_test_reports
-            cp -a build/reports/tests/integrationTest /tmp/gradle_integration_test_reports/
+            cp -a build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/
           when: always
 
       - store_artifacts:
@@ -202,7 +202,7 @@ jobs:
           name: Save Gradle integration test reports
           command: |
             mkdir -p /tmp/gradle_integration_test_reports
-            cp -a build/reports/tests/integrationTest /tmp/gradle_integration_test_reports/
+            cp -a build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/
           when: always
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
 
       # run tests!
       - run: gradle test
-      - run: gradle integrationTest --tests "com.scalar.db.storage.cassandra.CassandraIntegrationTest" --tests "com.scalar.db.transaction.consensuscommit.ConsensusCommitWithCassandraIntegrationTest"
+      - run: gradle integrationTestCassandra
 
       - run:
           name: Run short verification
@@ -138,10 +138,10 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
       # run tests!
-      - run: gradle integrationTest --tests "com.scalar.db.storage.jdbc.JdbcMetadataIntegrationTest" --tests "com.scalar.db.storage.jdbc.JdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.consensuscommit.ConsensusCommitWithJdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.jdbc.JdbcTransactionIntegrationTest" -Dscalardb.jdbc.url="jdbc:mysql://localhost:3306/" -Dscalardb.jdbc.username=root -Dscalardb.jdbc.password=mysql
+      - run: gradle integrationTestJdbc -Dscalardb.jdbc.url="jdbc:mysql://localhost:3306/" -Dscalardb.jdbc.username=root -Dscalardb.jdbc.password=mysql
 
       # run tests with the namespace prefix!
-      - run: gradle integrationTest --tests "com.scalar.db.storage.jdbc.JdbcMetadataIntegrationTest" --tests "com.scalar.db.storage.jdbc.JdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.consensuscommit.ConsensusCommitWithJdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.jdbc.JdbcTransactionIntegrationTest" -Dscalardb.jdbc.url="jdbc:mysql://localhost:3306/" -Dscalardb.jdbc.username=root -Dscalardb.jdbc.password=mysql -Dscalardb.namespace_prefix=ns_prefix
+      - run: gradle integrationTestJdbc -Dscalardb.jdbc.url="jdbc:mysql://localhost:3306/" -Dscalardb.jdbc.username=root -Dscalardb.jdbc.password=mysql -Dscalardb.namespace_prefix=ns_prefix
 
       - run:
           name: Save Gradle integration test reports
@@ -193,10 +193,10 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
       # run tests!
-      - run: gradle integrationTest --tests "com.scalar.db.storage.jdbc.JdbcMetadataIntegrationTest" --tests "com.scalar.db.storage.jdbc.JdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.consensuscommit.ConsensusCommitWithJdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.jdbc.JdbcTransactionIntegrationTest" -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+      - run: gradle integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
 
       # run tests with the namespace prefix!
-      - run: gradle integrationTest --tests "com.scalar.db.storage.jdbc.JdbcMetadataIntegrationTest" --tests "com.scalar.db.storage.jdbc.JdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.consensuscommit.ConsensusCommitWithJdbcDatabaseIntegrationTest" --tests "com.scalar.db.transaction.jdbc.JdbcTransactionIntegrationTest" -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres -Dscalardb.namespace_prefix=ns_prefix
+      - run: gradle integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres -Dscalardb.namespace_prefix=ns_prefix
 
       - run:
           name: Save Gradle integration test reports

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ task integrationTestCassandra(type: Test) {
     testClassesDirs = sourceSets.integrationTestCassandra.output.classesDirs
     classpath = sourceSets.integrationTestCassandra.runtimeClasspath
     outputs.upToDateWhen { false }  // ensures integration tests are run every time when called
-    shouldRunAfter test
 }
 
 task integrationTestJdbc(type: Test) {
@@ -104,7 +103,6 @@ task integrationTestJdbc(type: Test) {
     testClassesDirs = sourceSets.integrationTestJdbc.output.classesDirs
     classpath = sourceSets.integrationTestJdbc.runtimeClasspath
     outputs.upToDateWhen { false }  // ensures integration tests are run every time when called
-    shouldRunAfter test
     options {
         systemProperties(System.getProperties())
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,9 @@ sourceSets {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
             srcDir file('src/integration-test/java')
-            exclude '**/com/scalar/db/storage/cosmos/*.java'
-            exclude '**/com/scalar/db/storage/dynamo/*.java'
-            exclude '**/com/scalar/db/storage/jdbc/*.java'
-            exclude '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java'
-            exclude '**/com/scalar/db/transaction/jdbc/*.java'
+            include '**/com/scalar/db/storage/cassandra/*.java'
+            include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTest.java'
+            include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java'
         }
         resources.srcDir file('src/integration-test/resources')
     }
@@ -27,10 +25,11 @@ sourceSets {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
             srcDir file('src/integration-test/java')
-            exclude '**/com/scalar/db/storage/cassandra/*.java'
-            exclude '**/com/scalar/db/storage/cosmos/*.java'
-            exclude '**/com/scalar/db/storage/dynamo/*.java'
-            exclude '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java'
+            include '**/com/scalar/db/storage/jdbc/*.java'
+            include '**/com/scalar/db/storage/jdbc/test/*.java'
+            include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTest.java'
+            include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java'
+            include '**/com/scalar/db/transaction/jdbc/*.java'
         }
         resources.srcDir file('src/integration-test/resources')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,19 +9,38 @@ repositories {
 }
 
 sourceSets {
-    integrationTest {
+    integrationTestCassandra {
         java {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
             srcDir file('src/integration-test/java')
+            exclude '**/com/scalar/db/storage/cosmos/*.java'
+            exclude '**/com/scalar/db/storage/dynamo/*.java'
+            exclude '**/com/scalar/db/storage/jdbc/*.java'
+            exclude '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java'
+            exclude '**/com/scalar/db/transaction/jdbc/*.java'
+        }
+        resources.srcDir file('src/integration-test/resources')
+    }
+    integrationTestJdbc {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integration-test/java')
+            exclude '**/com/scalar/db/storage/cassandra/*.java'
+            exclude '**/com/scalar/db/storage/cosmos/*.java'
+            exclude '**/com/scalar/db/storage/dynamo/*.java'
+            exclude '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java'
         }
         resources.srcDir file('src/integration-test/resources')
     }
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestCassandraCompile.extendsFrom testCompile
+    integrationTestCassandraRuntime.extendsFrom testRuntime
+    integrationTestJdbcCompile.extendsFrom testCompile
+    integrationTestJdbcRuntime.extendsFrom testRuntime
 }
 
 def awssdkVersion = "2.14.24"
@@ -71,21 +90,30 @@ task testJar(type: Jar) {
   from sourceSets.test.output
 }
 
-task integrationTest(type: Test) {
-    description = 'Runs the integration tests.'
+task integrationTestCassandra(type: Test) {
+    description = 'Runs the integration tests for Cassandra.'
     group = 'verification'
-    testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath = sourceSets.integrationTest.runtimeClasspath
+    testClassesDirs = sourceSets.integrationTestCassandra.output.classesDirs
+    classpath = sourceSets.integrationTestCassandra.runtimeClasspath
     outputs.upToDateWhen { false }  // ensures integration tests are run every time when called
     shouldRunAfter test
+}
 
+task integrationTestJdbc(type: Test) {
+    description = 'Runs the integration tests for a JDBC database.'
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTestJdbc.output.classesDirs
+    classpath = sourceSets.integrationTestJdbc.runtimeClasspath
+    outputs.upToDateWhen { false }  // ensures integration tests are run every time when called
+    shouldRunAfter test
     options {
         systemProperties(System.getProperties())
     }
 }
 
 // build should not depend on the integration tests
-check.dependsOn -= integrationTest
+check.dependsOn -= integrationTestCassandra
+check.dependsOn -= integrationTestJdbc
 
 task copyTestJarsToTestLib(type: Copy) {
     from configurations.testCompile


### PR DESCRIPTION
After this change, we can run the integration tests for Cassandra and JDBC as follows:

Cassandra:
```
gradle integrationTestCassandra
```

JDBC (MySQL):
```
gradle integrationTestJdbc -Dscalardb.jdbc.url=jdbc:mysql://localhost:3306/ -Dscalardb.jdbc.username=root -Dscalardb.jdbc.password=mysql
```

