### PR TITLE
Fix to set RU for DynamoDB

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
@@ -110,6 +110,7 @@
 (defn enable-auto-scaling
   [scaling-client schema {:keys [ru] :or {ru (int 10)}}]
   (let [table (dynamo/get-table-name schema)
+        ru (if (:ru schema) (:ru schema) ru)
         global-index-tables (map #(dynamo/get-global-index-name schema %)
                                  (:secondary-index schema))
         scaling-reqs (make-requests (scaling-request-fn ru)


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8333

When auto-scaling is enabled for DynamoDB, the RU of each table wasn't applied.