### PR TITLE
Enable dynamo backup

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -24,6 +24,7 @@
    [nil "--region REGION" "Region where the tool creates tables for DynamoDB"]
    [nil "--prefix NAMESPACE_PREFIX" "Namespace prefix. The prefix is added to all the namespaces."]
    [nil "--no-scaling" "Disable auto-scaling"]
+   [nil "--no-backup" "Disable continuous backup"]
    [nil "--help"]])
 
 (defn -main [& args]

--- a/tools/scalar-schema/src/scalar_schema/dynamo/continuous_backup.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/continuous_backup.clj
@@ -1,0 +1,22 @@
+(ns scalar-schema.dynamo.continuous-backup
+  (:require [scalar-schema.dynamo.common :as dynamo])
+  (:import (software.amazon.awssdk.services.dynamodb.model UpdateContinuousBackupsRequest
+                                                                                 PointInTimeRecoverySpecification)))
+
+(defn- get-pitr-spec
+  []
+  (-> (PointInTimeRecoverySpecification/builder)
+      (.pointInTimeRecoveryEnabled true)
+      .build))
+
+(defn- get-update-backup-request
+  [schema]
+  (-> (UpdateContinuousBackupsRequest/builder)
+      (.tableName (dynamo/get-table-name schema))
+      (.pointInTimeRecoverySpecification (get-pitr-spec))
+      .build))
+
+(defn enable-continuous-backup
+  [client schema]
+  (->> (get-update-backup-request schema)
+       (.updateContinuousBackups client)))

--- a/tools/scalar-schema/src/scalar_schema/dynamo/continuous_backup.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/continuous_backup.clj
@@ -1,7 +1,7 @@
 (ns scalar-schema.dynamo.continuous-backup
   (:require [scalar-schema.dynamo.common :as dynamo])
   (:import (software.amazon.awssdk.services.dynamodb.model UpdateContinuousBackupsRequest
-                                                                                 PointInTimeRecoverySpecification)))
+                                                           PointInTimeRecoverySpecification)))
 
 (defn- get-pitr-spec
   []


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8207

Enabled the continuous backup (for Point Time In Recovery)

Note:
This doesn't enable the backup of the `scalardb.metadata` table.
The restored metadata would be useless because the user table name should be changed.
(DynamoDB cannot restore data to the existing table.)
So, we have to remake the metadata table with this tool with the new prefix after restoring other tables.