### PR TITLE
Remove prefix from indexes of DynamoDB

### DIFF
--- a/src/main/java/com/scalar/db/api/Operation.java
+++ b/src/main/java/com/scalar/db/api/Operation.java
@@ -94,13 +94,28 @@ public abstract class Operation {
    */
   @Nonnull
   public Optional<String> forFullTableName() {
+    return forFullTableName(true);
+  }
+
+  /**
+   * Returns the full table name without the prefix with the namespace for this operation
+   *
+   * @return an {@code Optional} with the returned the full table name
+   */
+  @Nonnull
+  public Optional<String> forFullTableNameWithoutPrefix() {
+    return forFullTableName(false);
+  }
+
+  @Nonnull
+  private Optional<String> forFullTableName(boolean withPrefix) {
     if (!namespace.isPresent() || !tableName.isPresent()) {
       LOGGER.warn("namespace or table name isn't specified");
       return Optional.empty();
     }
 
     StringBuilder builder = new StringBuilder();
-    if (namespacePrefix.isPresent()) {
+    if (withPrefix && namespacePrefix.isPresent()) {
       builder.append(namespacePrefix.get());
     }
     builder.append(namespace.get());

--- a/src/main/java/com/scalar/db/api/Operation.java
+++ b/src/main/java/com/scalar/db/api/Operation.java
@@ -98,12 +98,12 @@ public abstract class Operation {
   }
 
   /**
-   * Returns the full table name without the prefix with the namespace for this operation
+   * Returns the full table name with the unprefixed namespace for this operation
    *
    * @return an {@code Optional} with the returned the full table name
    */
   @Nonnull
-  public Optional<String> forFullTableNameWithoutPrefix() {
+  public Optional<String> forUnprefixedFullTableName() {
     return forFullTableName(false);
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -56,7 +56,7 @@ public class DynamoOperation {
 
   @Nonnull
   public String getIndexName(String clusteringKey) {
-    return operation.forFullTableNameWithoutPrefix().get()
+    return operation.forUnprefixedFullTableName().get()
         + "."
         + INDEX_NAME_PREFIX
         + "."
@@ -65,7 +65,7 @@ public class DynamoOperation {
 
   @Nonnull
   public String getGlobalIndexName(String column) {
-    return operation.forFullTableNameWithoutPrefix().get()
+    return operation.forUnprefixedFullTableName().get()
         + "."
         + GLOBAL_INDEX_NAME_PREFIX
         + "."

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -56,12 +56,20 @@ public class DynamoOperation {
 
   @Nonnull
   public String getIndexName(String clusteringKey) {
-    return getTableName() + "." + INDEX_NAME_PREFIX + "." + clusteringKey;
+    return operation.forFullTableNameWithoutPrefix().get()
+        + "."
+        + INDEX_NAME_PREFIX
+        + "."
+        + clusteringKey;
   }
 
   @Nonnull
   public String getGlobalIndexName(String column) {
-    return getTableName() + "." + GLOBAL_INDEX_NAME_PREFIX + "." + column;
+    return operation.forFullTableNameWithoutPrefix().get()
+        + "."
+        + GLOBAL_INDEX_NAME_PREFIX
+        + "."
+        + column;
   }
 
   @Nonnull

--- a/tools/scalar-schema/src/scalar_schema/common.clj
+++ b/tools/scalar-schema/src/scalar_schema/common.clj
@@ -76,8 +76,8 @@
   (if prefix
     (map (fn [table-schema]
            (assoc table-schema
-                  :database
-                  (str prefix \_ (:database table-schema))))
+                  :prefix prefix
+                  :database (str prefix \_ (:database table-schema))))
          schema)
     schema))
 

--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -19,12 +19,12 @@
     "The number of replicas. This options is ignored when Cosmos DB and DynamoDB."
     :default 1 :parse-fn #(Integer/parseInt %)]
    ["-n" "--network-strategy NETWORK_STRATEGY"
-    "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This options is ignored when Cosmos DB and DynamoDB."]
+    "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This option is ignored when Cosmos DB and DynamoDB."]
    ["-D" "--delete-all" "All database will be deleted, if this is enabled."]
    [nil "--region REGION" "Region where the tool creates tables for DynamoDB"]
    [nil "--prefix NAMESPACE_PREFIX" "Namespace prefix. The prefix is added to all the namespaces."]
-   [nil "--no-scaling" "Disable auto-scaling"]
-   [nil "--no-backup" "Disable continuous backup"]
+   [nil "--no-scaling" "Disable auto-scaling for Cosmos DB and DynamoDB. This option is ignored when Cassandra"]
+   [nil "--no-backup" "Disable continuous backup for DynamoDB. This option is ignored when Cosmos DB and Cassandra."]
    [nil "--help"]])
 
 (defn -main [& args]

--- a/tools/scalar-schema/src/scalar_schema/dynamo/common.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/common.clj
@@ -1,5 +1,6 @@
 (ns scalar-schema.dynamo.common
-  (:require [scalar-schema.common :as common])
+  (:require [clojure.string :as str]
+            [scalar-schema.common :as common])
   (:import (software.amazon.awssdk.auth.credentials AwsBasicCredentials
                                                     StaticCredentialsProvider)))
 
@@ -15,10 +16,17 @@
   [{:keys [database table]}]
   (common/get-fullname database table))
 
+(defn- get-table-name-without-prefix
+  [{:keys [prefix] :as schema}]
+  (str/replace-first (get-table-name schema)
+                     (java.util.regex.Pattern/compile (str prefix \_)) ""))
+
 (defn get-index-name
   [schema key-name]
-  (str (get-table-name schema) \. INDEX_NAME_PREFIX \. key-name))
+  (str (get-table-name-without-prefix schema)
+       \. INDEX_NAME_PREFIX \. key-name))
 
 (defn get-global-index-name
   [schema key-name]
-  (str (get-table-name schema) \. GLOBAL_INDEX_NAME_PREFIX \. key-name))
+  (str (get-table-name-without-prefix schema)
+       \. GLOBAL_INDEX_NAME_PREFIX \. key-name))


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8207

For DyanmoDB recovery, the prefix for index tables is removed.

Scalar DB requires the same name about index tables after restoring the table. However, the name of the restored tables should be different from that of the source table to restore data. This requirement can be satisfied by adding the prefix. Also, the name of an index table couldn't be modified after restoring the table on DyanmoDB.
That's why I don't want to add a prefix to the index.