### PR TITLE
Fix not to return unexpected results

### DIFF
--- a/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -227,10 +227,10 @@ public class SelectStatementHandler extends StatementHandler {
     String endKeyName = end.get(end.size() - 1).getName();
 
     if (startKeyName.equals(endKeyName)) {
-      conditions.add(startKeyName + DynamoOperation.RANGE_CONDITION);
       if (!scan.getStartInclusive() || !scan.getEndInclusive()) {
-        LOGGER.warn("DynamoDB does NOT support the range scan with the exclusiving option");
+        throw new IllegalArgumentException("DynamoDB does NOT support scan with exclusive range.");
       }
+      conditions.add(startKeyName + DynamoOperation.RANGE_CONDITION);
       return true;
     } else {
       return false;


### PR DESCRIPTION
Since DynamoDB seems not able to scan with an exclusive range like `a < x < b`,  I updated it to throw an exception instead of giving the warning message.