### PR TITLE
Specify a driver class corresponding to the JDBC URL to the dataSource

### DIFF
--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -34,7 +34,7 @@ public final class JdbcUtils {
     BasicDataSource dataSource = new BasicDataSource();
 
     /*
-     * We need to specify a driver class corresponding to the JDBC URL to the dataSource in order
+     * We need to set the driver class of an underlining database to the dataSource in order
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
      * work (e.g., when we dynamically load a driver class from a fatJar).
      */

--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -36,7 +36,7 @@ public final class JdbcUtils {
     /*
      * We need to specify a driver class corresponding to the JDBC URL to the dataSource in order
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
-     * work (ex. we dynamically load a driver class from a fatJar).
+     * work (e.g., when we dynamically load a driver class from a fatJar).
      */
     dataSource.setDriver(getDriverClass(jdbcUrl));
 


### PR DESCRIPTION
We need to specify a driver class corresponding to the specified JDBC URL to the dataSource in order to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't work (ex. we dynamically load a driver class from a fatJar).

I'm not sure this is the best solution, but I think it's a reasonable one. If you have any better idea for it, please let me know.