### PR TITLE
Fix scan related tests in Scalar DB

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
+++ b/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
@@ -993,7 +993,7 @@ public abstract class IntegrationTestBase {
           .isEqualTo(Optional.of(new IntValue(COL_NAME1, expectedPartitionKeyValue)));
 
       int actualClusteringKeyValue = ((IntValue) result.getValue(checkedColumn).get()).get();
-      assertThat(expectedValuesSet.contains(actualClusteringKeyValue)).isTrue();
+      assertThat(expectedValuesSet).contains(actualClusteringKeyValue);
       expectedValuesSet.remove(actualClusteringKeyValue);
     }
 

--- a/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
+++ b/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
@@ -27,8 +27,10 @@ import com.scalar.db.io.TextValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.Test;
 
@@ -130,19 +132,7 @@ public abstract class IntegrationTestBase {
     scanAll(scan).forEach(actual::add); // use iterator
 
     // Assert
-    assertThat(actual.size()).isEqualTo(3);
-    assertThat(actual.get(0).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
-    assertThat(actual.get(1).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
-    assertThat(actual.get(2).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(2).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+    assertScanResultWithoutOrdering(actual, pKey, COL_NAME4, Arrays.asList(0, 1, 2));
   }
 
   @Test
@@ -157,23 +147,25 @@ public abstract class IntegrationTestBase {
     Scanner scanner = storage.scan(scan);
 
     // Assert
+    List<Result> results = new ArrayList<>();
+
     Optional<Result> result = scanner.one();
     assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(result.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    results.add(result.get());
+
     result = scanner.one();
     assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(result.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    results.add(result.get());
+
     result = scanner.one();
     assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(result.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+    results.add(result.get());
+
     result = scanner.one();
     assertThat(result.isPresent()).isFalse();
+
+    assertScanResultWithoutOrdering(results, pKey, COL_NAME4, Arrays.asList(0, 1, 2));
+
     scanner.close();
   }
 
@@ -221,15 +213,7 @@ public abstract class IntegrationTestBase {
     List<Result> actual = scanAll(scan);
 
     // verify
-    assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
-    assertThat(actual.get(1).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    assertScanResultWithoutOrdering(actual, pKey, COL_NAME4, Arrays.asList(0, 1));
   }
 
   @Test
@@ -247,15 +231,7 @@ public abstract class IntegrationTestBase {
     List<Result> actual = scanAll(scan);
 
     // verify
-    assertThat(actual.size()).isEqualTo(2);
-    assertThat(actual.get(0).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
-    assertThat(actual.get(1).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, pKey)));
-    assertThat(actual.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
+    assertScanResultWithoutOrdering(actual, pKey, COL_NAME4, Arrays.asList(1, 2));
   }
 
   @Test
@@ -395,13 +371,8 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> results = scanAll(scan);
-    assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
-    assertThat(results.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 1)));
-    assertThat(results.get(2).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 2)));
+    assertScanResultWithoutOrdering(
+        results, pKey, COL_NAME4, Arrays.asList(pKey + cKey, pKey + cKey + 1, pKey + cKey + 2));
   }
 
   @Test
@@ -421,13 +392,8 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> results = scanAll(scan);
-    assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
-    assertThat(results.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 1)));
-    assertThat(results.get(2).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 2)));
+    assertScanResultWithoutOrdering(
+        results, pKey, COL_NAME4, Arrays.asList(pKey + cKey, pKey + cKey + 1, pKey + cKey + 2));
   }
 
   @Test
@@ -516,11 +482,7 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> results = scanAll(new Scan(new Key(new IntValue(COL_NAME1, 0))));
-    assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
-    assertThat(results.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
+    assertScanResultWithoutOrdering(results, 0, COL_NAME4, Arrays.asList(0, 1));
   }
 
   @Test
@@ -625,24 +587,6 @@ public abstract class IntegrationTestBase {
   }
 
   @Test
-  public void delete_DeleteWithPartitionKeyGiven_ShouldDeleteRecordProperly() throws Exception {
-    // Arrange
-    populateRecords();
-    int pKey = 0;
-    int cKey = 0;
-
-    // Act
-    Key partitionKey = new Key(new IntValue(COL_NAME1, pKey));
-    Key clusteringKey = new Key(new IntValue(COL_NAME4, cKey));
-    Delete delete = new Delete(partitionKey, clusteringKey);
-    assertThatCode(() -> storage.delete(delete)).doesNotThrowAnyException();
-
-    // Assert
-    List<Result> actual = scanAll(new Scan(partitionKey));
-    assertThat(actual.size()).isEqualTo(2);
-  }
-
-  @Test
   public void delete_DeleteWithPartitionKeyAndClusteringKeyGiven_ShouldDeleteSingleRecordProperly()
       throws Exception {
     // Arrange
@@ -657,11 +601,7 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> results = scanAll(new Scan(partitionKey));
-    assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey + 1)));
-    assertThat(results.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, cKey + 2)));
+    assertScanResultWithoutOrdering(results, pKey, COL_NAME4, Arrays.asList(cKey + 1, cKey + 2));
   }
 
   @Test
@@ -785,13 +725,8 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> results = scanAll(scan);
-    assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey)));
-    assertThat(results.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 1)));
-    assertThat(results.get(2).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, pKey + cKey + 2)));
+    assertScanResultWithoutOrdering(
+        results, pKey, COL_NAME4, Arrays.asList(pKey + cKey, pKey + cKey + 1, pKey + cKey + 2));
   }
 
   @Test
@@ -834,11 +769,8 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> results = scanAll(scan);
-    assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getValue(COL_NAME3))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME3, Integer.MAX_VALUE)));
-    assertThat(results.get(1).getValue(COL_NAME3))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME3, Integer.MIN_VALUE)));
+    assertScanResultWithoutOrdering(
+        results, pKey, COL_NAME3, Arrays.asList(Integer.MAX_VALUE, Integer.MIN_VALUE));
   }
 
   @Test
@@ -870,7 +802,9 @@ public abstract class IntegrationTestBase {
   }
 
   @Test
-  public void mutate_SingleDeleteGiven_ShouldDeleteRecordProperly() throws Exception {
+  public void
+      mutate_SingleDeleteWithPartitionKeyAndClusteringKeyGiven_ShouldDeleteSingleRecordProperly()
+          throws Exception {
     // Arrange
     populateRecords();
     int pKey = 0;
@@ -885,7 +819,7 @@ public abstract class IntegrationTestBase {
 
     // Assert
     List<Result> actual = scanAll(new Scan(partitionKey));
-    assertThat(actual.size()).isEqualTo(2);
+    assertScanResultWithoutOrdering(actual, pKey, COL_NAME4, Arrays.asList(cKey + 1, cKey + 2));
   }
 
   @Test
@@ -958,18 +892,18 @@ public abstract class IntegrationTestBase {
 
     // Assert
     assertThat(actual.size()).isEqualTo(3); // (1,2), (2,1), (3,0)
-    assertThat(actual.get(0).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, 1)));
-    assertThat(actual.get(0).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 2)));
-    assertThat(actual.get(1).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, 2)));
-    assertThat(actual.get(1).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 1)));
-    assertThat(actual.get(2).getValue(COL_NAME1))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME1, 3)));
-    assertThat(actual.get(2).getValue(COL_NAME4))
-        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    List<List<Integer>> expectedValues =
+        new ArrayList<>(
+            Arrays.asList(Arrays.asList(1, 2), Arrays.asList(2, 1), Arrays.asList(3, 0)));
+    for (Result result : actual) {
+      int col1Val = ((IntValue) result.getValue(COL_NAME1).get()).get();
+      int col4Val = ((IntValue) result.getValue(COL_NAME4).get()).get();
+      List<Integer> col1AndCol4 = Arrays.asList(col1Val, col4Val);
+      assertThat(expectedValues.contains(col1AndCol4)).isTrue();
+      expectedValues.remove(col1AndCol4);
+    }
+
+    assertThat(expectedValues.isEmpty()).isTrue();
   }
 
   @Test
@@ -1044,5 +978,25 @@ public abstract class IntegrationTestBase {
     try (Scanner scanner = storage.scan(scan)) {
       return scanner.all();
     }
+  }
+
+  private void assertScanResultWithoutOrdering(
+      List<Result> actual,
+      int expectedPartitionKeyValue,
+      String checkedColumn,
+      List<Integer> expectedValues) {
+    Set<Integer> expectedValuesSet = new HashSet<>(expectedValues);
+    assertThat(actual.size()).isEqualTo(expectedValues.size());
+
+    for (Result result : actual) {
+      assertThat(result.getValue(COL_NAME1))
+          .isEqualTo(Optional.of(new IntValue(COL_NAME1, expectedPartitionKeyValue)));
+
+      int actualClusteringKeyValue = ((IntValue) result.getValue(checkedColumn).get()).get();
+      assertThat(expectedValuesSet.contains(actualClusteringKeyValue)).isTrue();
+      expectedValuesSet.remove(actualClusteringKeyValue);
+    }
+
+    assertThat(expectedValuesSet.isEmpty()).isTrue();
   }
 }

--- a/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
+++ b/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
@@ -899,11 +899,11 @@ public abstract class IntegrationTestBase {
       int col1Val = ((IntValue) result.getValue(COL_NAME1).get()).get();
       int col4Val = ((IntValue) result.getValue(COL_NAME4).get()).get();
       List<Integer> col1AndCol4 = Arrays.asList(col1Val, col4Val);
-      assertThat(expectedValues.contains(col1AndCol4)).isTrue();
+      assertThat(expectedValues).contains(col1AndCol4);
       expectedValues.remove(col1AndCol4);
     }
 
-    assertThat(expectedValues.isEmpty()).isTrue();
+    assertThat(expectedValues).isEmpty();
   }
 
   @Test
@@ -997,6 +997,6 @@ public abstract class IntegrationTestBase {
       expectedValuesSet.remove(actualClusteringKeyValue);
     }
 
-    assertThat(expectedValuesSet.isEmpty()).isTrue();
+    assertThat(expectedValuesSet).isEmpty();
   }
 }

--- a/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 
 public class CosmosIntegrationTest extends IntegrationTestBase {
 
@@ -62,11 +61,6 @@ public class CosmosIntegrationTest extends IntegrationTestBase {
           .deleteItem(record, new CosmosItemRequestOptions());
     }
   }
-
-  // FIXME Ignore this test for now. It seems like the order of the result is not correct
-  @Ignore
-  @Override
-  public void put_MultiplePutWithDifferentConditionsGiven_ShouldStoreProperly() {}
 
   @BeforeClass
   public static void setUpBeforeClass() throws IOException {

--- a/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
@@ -80,14 +80,6 @@ public class DynamoIntegrationTest extends IntegrationTestBase {
   @Override
   public void scan_ScanWithStartInclusiveRangeGiven_ShouldRetrieveResultsOfGivenRange() {}
 
-  /*
-   * FIXME Ignore this test for now. It seems like the order of the result is not correct when
-   *  using an index
-   */
-  @Ignore
-  @Override
-  public void scan_ScanGivenForIndexedColumn_ShouldScan() {}
-
   @BeforeClass
   public static void setUpBeforeClass() {
     String endpointOverride =

--- a/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
@@ -50,12 +50,7 @@ public class JdbcDatabaseIntegrationTest extends IntegrationTestBase {
             put(COL_NAME5, DataType.BOOLEAN);
           }
         },
-        Collections.singletonList(COL_NAME3),
-        new HashMap<String, Scan.Ordering.Order>() {
-          {
-            put(COL_NAME3, Scan.Ordering.Order.ASC);
-          }
-        });
+        Collections.singletonList(COL_NAME3));
     testEnv.createMetadataTable();
     testEnv.createTables();
     testEnv.insertMetadata();

--- a/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMetadataIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMetadataIntegrationTest.java
@@ -36,21 +36,6 @@ public class JdbcMetadataIntegrationTest extends MetadataIntegrationTestBase {
     assertThat(tableMetadata.getFullTableName()).isEqualTo(fullTableName);
   }
 
-  @Test
-  public void testSecondaryIndexOrder() {
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME1)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME2)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME3)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME4)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME5)).isEqualTo(Scan.Ordering.Order.ASC);
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME6)).isEqualTo(Scan.Ordering.Order.DESC);
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME7)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME8)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME9)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME10)).isNull();
-    assertThat(tableMetadata.getSecondaryIndexOrder(COL_NAME11)).isNull();
-  }
-
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     testEnv = new TestEnv();
@@ -80,13 +65,7 @@ public class JdbcMetadataIntegrationTest extends MetadataIntegrationTestBase {
             put(COL_NAME11, DataType.BLOB);
           }
         },
-        Arrays.asList(COL_NAME5, COL_NAME6),
-        new HashMap<String, Scan.Ordering.Order>() {
-          {
-            put(COL_NAME5, Scan.Ordering.Order.ASC);
-            put(COL_NAME6, Scan.Ordering.Order.DESC);
-          }
-        });
+        Arrays.asList(COL_NAME5, COL_NAME6));
     testEnv.createMetadataTable();
     testEnv.insertMetadata();
 

--- a/src/integration-test/java/com/scalar/db/storage/jdbc/test/TestEnv.java
+++ b/src/integration-test/java/com/scalar/db/storage/jdbc/test/TestEnv.java
@@ -165,8 +165,7 @@ public class TestEnv implements Closeable {
       List<String> clusteringKeyNames,
       Map<String, Scan.Ordering.Order> clusteringOrders,
       Map<String, DataType> columnDataTypes,
-      List<String> secondaryIndexNames,
-      Map<String, Scan.Ordering.Order> secondaryIndexOrders) {
+      List<String> secondaryIndexNames) {
     metadataList.add(
         new JdbcTableMetadata(
             namespacePrefix() + schema,
@@ -175,8 +174,7 @@ public class TestEnv implements Closeable {
             clusteringKeyNames,
             clusteringOrders,
             columnDataTypes,
-            secondaryIndexNames,
-            secondaryIndexOrders));
+            secondaryIndexNames));
   }
 
   public void register(
@@ -193,8 +191,7 @@ public class TestEnv implements Closeable {
         clusteringKeyNames,
         clusteringOrders,
         columnDataTypes,
-        new ArrayList<>(),
-        new HashMap<>());
+        new ArrayList<>());
   }
 
   private String namespacePrefix() {
@@ -322,10 +319,9 @@ public class TestEnv implements Closeable {
       throws SQLException {
     String keyType = getKeyType(column, metadata);
     Scan.Ordering.Order keyOrder = metadata.getClusteringOrder(column);
-    Scan.Ordering.Order indexOrder = metadata.getSecondaryIndexOrder(column);
     execute(
         String.format(
-            "INSERT INTO %s VALUES('%s','%s','%s',%s,%s,%s,%s,%d)",
+            "INSERT INTO %s VALUES('%s','%s','%s',%s,%s,%s,%d)",
             enclosedMetadataTableName(),
             metadata.getFullTableName(),
             column,
@@ -333,7 +329,6 @@ public class TestEnv implements Closeable {
             keyType != null ? "'" + keyType + "'" : "NULL",
             keyOrder != null ? "'" + keyOrder + "'" : "NULL",
             booleanValue(metadata.getSecondaryIndexNames().contains(column)),
-            indexOrder != null ? "'" + indexOrder + "'" : "NULL",
             ordinalPosition));
   }
 
@@ -382,8 +377,6 @@ public class TestEnv implements Closeable {
             + " "
             + booleanType()
             + " NOT NULL,"
-            + enclose("index_order")
-            + " VARCHAR(10),"
             + enclose("ordinal_position")
             + " INTEGER NOT NULL,"
             + "PRIMARY KEY ("

--- a/src/main/java/com/scalar/db/storage/jdbc/metadata/JdbcTableMetadata.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/metadata/JdbcTableMetadata.java
@@ -6,13 +6,12 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.storage.common.metadata.DataType;
 import com.scalar.db.storage.common.metadata.TableMetadata;
 import com.scalar.db.storage.common.util.ImmutableLinkedHashSet;
-
-import javax.annotation.concurrent.Immutable;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.concurrent.Immutable;
 
 @Immutable
 public class JdbcTableMetadata implements TableMetadata {
@@ -25,7 +24,6 @@ public class JdbcTableMetadata implements TableMetadata {
   private final ImmutableMap<String, Scan.Ordering.Order> clusteringOrders;
   private final Map<String, DataType> columnDataTypes;
   private final Set<String> secondaryIndexNames;
-  private final ImmutableMap<String, Scan.Ordering.Order> secondaryIndexOrders;
 
   public JdbcTableMetadata(
       String fullTableName,
@@ -33,8 +31,7 @@ public class JdbcTableMetadata implements TableMetadata {
       List<String> clusteringKeyNames,
       Map<String, Scan.Ordering.Order> clusteringOrders,
       Map<String, DataType> columnDataTypes,
-      List<String> secondaryIndexNames,
-      Map<String, Scan.Ordering.Order> secondaryIndexOrders) {
+      List<String> secondaryIndexNames) {
     this.fullTableName = Objects.requireNonNull(fullTableName);
     String[] schemaAndTable = fullTableName.split("\\.");
     schema = schemaAndTable[0];
@@ -46,7 +43,6 @@ public class JdbcTableMetadata implements TableMetadata {
     this.clusteringOrders = ImmutableMap.copyOf(Objects.requireNonNull(clusteringOrders));
     this.columnDataTypes = ImmutableMap.copyOf(Objects.requireNonNull(columnDataTypes));
     this.secondaryIndexNames = ImmutableSet.copyOf(Objects.requireNonNull(secondaryIndexNames));
-    this.secondaryIndexOrders = ImmutableMap.copyOf(Objects.requireNonNull(secondaryIndexOrders));
   }
 
   public JdbcTableMetadata(
@@ -56,8 +52,7 @@ public class JdbcTableMetadata implements TableMetadata {
       List<String> clusteringKeyNames,
       Map<String, Scan.Ordering.Order> clusteringOrders,
       Map<String, DataType> columnDataTypes,
-      List<String> secondaryIndexNames,
-      Map<String, Scan.Ordering.Order> secondaryIndexOrders) {
+      List<String> secondaryIndexNames) {
     this.schema = Objects.requireNonNull(schema);
     this.table = Objects.requireNonNull(table);
     this.fullTableName = schema + "." + table;
@@ -68,7 +63,6 @@ public class JdbcTableMetadata implements TableMetadata {
     this.clusteringOrders = ImmutableMap.copyOf(Objects.requireNonNull(clusteringOrders));
     this.columnDataTypes = ImmutableMap.copyOf(Objects.requireNonNull(columnDataTypes));
     this.secondaryIndexNames = ImmutableSet.copyOf(Objects.requireNonNull(secondaryIndexNames));
-    this.secondaryIndexOrders = ImmutableMap.copyOf(Objects.requireNonNull(secondaryIndexOrders));
   }
 
   public String getFullTableName() {
@@ -111,9 +105,5 @@ public class JdbcTableMetadata implements TableMetadata {
   @Override
   public Set<String> getSecondaryIndexNames() {
     return secondaryIndexNames;
-  }
-
-  public Scan.Ordering.Order getSecondaryIndexOrder(String column) {
-    return secondaryIndexOrders.get(column);
   }
 }

--- a/src/main/java/com/scalar/db/storage/jdbc/query/SelectQuery.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/query/SelectQuery.java
@@ -7,7 +7,6 @@ import com.scalar.db.io.Value;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
 import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -36,7 +35,6 @@ public interface SelectQuery extends Query {
     private int limit;
     boolean isRangeQuery;
     Optional<String> indexedColumn = Optional.empty();
-    Optional<Scan.Ordering.Order> indexedOrder = Optional.empty();
 
     Builder(
         TableMetadataManager tableMetadataManager, RdbEngine rdbEngine, List<String> projections) {
@@ -126,7 +124,6 @@ public interface SelectQuery extends Query {
       }
 
       indexedColumn = Optional.of(column);
-      indexedOrder = Optional.of(tableMetadata.getSecondaryIndexOrder(column));
     }
 
     public Builder orderBy(List<Scan.Ordering> orderings) {

--- a/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
@@ -1,5 +1,8 @@
 package com.scalar.db.storage.jdbc.query;
 
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
+
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.io.Key;
@@ -7,7 +10,6 @@ import com.scalar.db.io.Value;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.ResultImpl;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
-
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -15,9 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
 
 public class SimpleSelectQuery extends AbstractQuery implements SelectQuery {
 
@@ -36,7 +35,6 @@ public class SimpleSelectQuery extends AbstractQuery implements SelectQuery {
   private final List<Scan.Ordering> orderings;
   private final boolean isRangeQuery;
   private final Optional<String> indexedColumn;
-  private final Optional<Scan.Ordering.Order> indexedOrder;
 
   SimpleSelectQuery(Builder builder) {
     tableMetadata = builder.tableMetadata;
@@ -54,7 +52,6 @@ public class SimpleSelectQuery extends AbstractQuery implements SelectQuery {
     orderings = builder.orderings;
     isRangeQuery = builder.isRangeQuery;
     indexedColumn = builder.indexedColumn;
-    indexedOrder = builder.indexedOrder;
   }
 
   protected String sql() {
@@ -89,12 +86,8 @@ public class SimpleSelectQuery extends AbstractQuery implements SelectQuery {
   }
 
   private String orderBySqlString() {
-    if (!isRangeQuery) {
+    if (!isRangeQuery || indexedColumn.isPresent()) {
       return "";
-    }
-
-    if (indexedColumn.isPresent()) {
-      return " ORDER BY " + enclose(indexedColumn.get(), rdbEngine) + " " + indexedOrder.get();
     }
 
     List<Scan.Ordering> orderingList = new ArrayList<>(orderings);

--- a/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -1,5 +1,8 @@
 package com.scalar.db.storage.common.checker;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -19,21 +22,18 @@ import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.common.metadata.DataType;
+import com.scalar.db.storage.common.metadata.TableMetadata;
 import com.scalar.db.storage.common.util.Utility;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockitoAnnotations;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
 
 public class OperationCheckerTest {
 
@@ -49,13 +49,13 @@ public class OperationCheckerTest {
   private static final String COL2 = "v2";
   private static final String COL3 = "v3";
 
-  private JdbcTableMetadata metadata;
+  private TableMetadata metadata;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    // Dummy metadata
+    // Dummy metadata. Using JdbcTableMetadata here as an example
     metadata =
         new JdbcTableMetadata(
             TABLE_FULL_NAME,
@@ -78,12 +78,7 @@ public class OperationCheckerTest {
                 put(COL3, DataType.BOOLEAN);
               }
             },
-            Collections.singletonList(COL1),
-            new HashMap<String, Scan.Ordering.Order>() {
-              {
-                put(COL1, Scan.Ordering.Order.ASC);
-              }
-            });
+            Collections.singletonList(COL1));
   }
 
   @Test

--- a/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -1,5 +1,12 @@
 package com.scalar.db.storage.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -21,11 +28,6 @@ import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpdateQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,13 +36,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class JdbcServiceTest {
 
@@ -88,8 +87,7 @@ public class JdbcServiceTest {
                     put("v1", DataType.TEXT);
                   }
                 },
-                Collections.emptyList(),
-                new HashMap<String, Scan.Ordering.Order>() {}));
+                Collections.emptyList()));
   }
 
   @Test

--- a/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -1,5 +1,10 @@
 package com.scalar.db.storage.jdbc.query;
 
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Scan;
@@ -10,13 +15,6 @@ import com.scalar.db.storage.common.metadata.DataType;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
 import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,11 +22,12 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(Parameterized.class)
 public class QueryBuilderTest {
@@ -73,13 +72,7 @@ public class QueryBuilderTest {
                 put("v4", DataType.TEXT);
               }
             },
-            Arrays.asList("v1", "v2"),
-            new HashMap<String, Scan.Ordering.Order>() {
-              {
-                put("v1", Scan.Ordering.Order.ASC);
-                put("v2", Scan.Ordering.Order.DESC);
-              }
-            });
+            Arrays.asList("v1", "v2"));
 
     when(tableMetadataManager.getTableMetadata(any(String.class))).thenReturn(dummyTableMetadata);
 
@@ -325,7 +318,7 @@ public class QueryBuilderTest {
                     false)
                 .build()
                 .toString())
-        .isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE v1=? ORDER BY v1 ASC"));
+        .isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE v1=?"));
 
     assertThat(
             queryBuilder
@@ -348,7 +341,7 @@ public class QueryBuilderTest {
                     false)
                 .build()
                 .toString())
-        .isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE v2=? ORDER BY v2 DESC"));
+        .isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE v2=?"));
   }
 
   @Test

--- a/tools/scalar-schema/src/scalar_schema/jdbc.clj
+++ b/tools/scalar-schema/src/scalar_schema/jdbc.clj
@@ -65,7 +65,6 @@
    "key_type" "VARCHAR(20)"
    "clustering_order" "VARCHAR(10)"
    "indexed" (str boolean-type \  "NOT NULL")
-   "index_order" "VARCHAR(10)"
    "ordinal_position" "INTEGER NOT NULL"})
 
 (defn- make-create-metadata-statement
@@ -162,8 +161,7 @@
    column data-type ordinal-position]
   (let [key-type (get-key-type column partition-key clustering-key)
         key-order (if (key? column clustering-key) "'ASC'" "NULL")
-        indexed (boolean-value-fn (secondary-indexed? column secondary-index))
-        index-order (if (key? column secondary-index) "'ASC'" "NULL")]
+        indexed (boolean-value-fn (secondary-indexed? column secondary-index))]
     (str "INSERT INTO "
          (get-metadata-table-name opts)
          " VALUES ("
@@ -173,7 +171,6 @@
          (if key-type (str "'" key-type "'") "NULL") ","
          key-order ","
          indexed ","
-         index-order ","
          ordinal-position
          ")")))
 


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8642

I changed the integration tests to make them match the following requirements:
- The code doesn't assume determined sort orders for clustering keys
- No more tests that are ignored due to the scan results ordering issue
- The code doesn't assume determined sort orders for scan with secondary indexes

Also, I realized that the `index_order` column in JDBC metadata is unnecessary, so removed it in this PR.