### PR TITLE
Unify the behavior between the adapters when a specified table in a o…

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
+++ b/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
@@ -66,6 +66,30 @@ public abstract class IntegrationTestBase {
   }
 
   @Test
+  public void operation_WrongNamespaceGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    storage.with("wrong_" + NAMESPACE, TABLE); // a wrong namespace
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 0));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 0));
+    Get get = new Get(partitionKey, clusteringKey);
+
+    // Act Assert
+    assertThatThrownBy(() -> storage.get(get)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void operation_WrongTableGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    storage.with(NAMESPACE, "wrong_" + TABLE); // a wrong table
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 0));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 0));
+    Get get = new Get(partitionKey, clusteringKey);
+
+    // Act Assert
+    assertThatThrownBy(() -> storage.get(get)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void get_GetWithPartitionKeyAndClusteringKeyGiven_ShouldRetrieveSingleResult()
       throws ExecutionException {
     // Arrange

--- a/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraMetadataIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraMetadataIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.scalar.db.storage.cassandra;
 
+import com.scalar.db.api.Get;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.Key;
 import com.scalar.db.storage.MetadataIntegrationTestBase;
 import java.util.Properties;
 import org.junit.AfterClass;
@@ -81,7 +83,11 @@ public class CassandraMetadataIntegrationTest extends MetadataIntegrationTestBas
     props.setProperty(DatabaseConfig.PASSWORD, PASSWORD);
     ClusterManager clusterManager = new ClusterManager(new DatabaseConfig(props));
     clusterManager.getSession();
-    tableMetadata = new CassandraTableMetadata(clusterManager.getMetadata(NAMESPACE, TABLE));
+    CassandraTableMetadataManager tableMetadataManager =
+        new CassandraTableMetadataManager(clusterManager);
+
+    Get dummyOperation = new Get(new Key()).forNamespace(NAMESPACE).forTable(TABLE);
+    tableMetadata = tableMetadataManager.getTableMetadata(dummyOperation);
     clusterManager.close();
   }
 

--- a/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMetadataIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMetadataIntegrationTest.java
@@ -100,7 +100,7 @@ public class CosmosMetadataIntegrationTest extends MetadataIntegrationTestBase {
 
     CosmosContainer container =
         client.getDatabase(database(METADATA_DATABASE)).getContainer(METADATA_CONTAINER);
-    TableMetadataManager tableMetadataManager = new TableMetadataManager(container);
+    CosmosTableMetadataManager tableMetadataManager = new CosmosTableMetadataManager(container);
 
     Get dummyOperation = new Get(new Key()).forNamespace(NAMESPACE).forTable(TABLE);
     namespacePrefix.ifPresent(n -> dummyOperation.forNamespacePrefix(namespacePrefix()));

--- a/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMetadataIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMetadataIntegrationTest.java
@@ -155,7 +155,7 @@ public class DynamoMetadataIntegrationTest extends MetadataIntegrationTestBase {
 
     client.putItem(putItemRequest);
 
-    TableMetadataManager tableMetadataManager = new TableMetadataManager(client, namespacePrefix());
+    DynamoTableMetadataManager tableMetadataManager = new DynamoTableMetadataManager(client, namespacePrefix());
 
     Get dummyOperation = new Get(new Key()).forNamespace(NAMESPACE).forTable(TABLE);
     namespacePrefix.ifPresent(n -> dummyOperation.forNamespacePrefix(namespacePrefix().get()));

--- a/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMetadataIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMetadataIntegrationTest.java
@@ -6,7 +6,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.storage.MetadataIntegrationTestBase;
 import com.scalar.db.storage.common.metadata.DataType;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
-import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
+import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadataManager;
 import com.scalar.db.storage.jdbc.test.TestEnv;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -70,8 +70,8 @@ public class JdbcMetadataIntegrationTest extends MetadataIntegrationTestBase {
     testEnv.insertMetadata();
 
     Optional<String> namespacePrefix = testEnv.getJdbcDatabaseConfig().getNamespacePrefix();
-    TableMetadataManager tableMetadataManager =
-        new TableMetadataManager(testEnv.getDataSource(), namespacePrefix, testEnv.getRdbEngine());
+    JdbcTableMetadataManager tableMetadataManager =
+        new JdbcTableMetadataManager(testEnv.getDataSource(), namespacePrefix, testEnv.getRdbEngine());
     String fullTableName = namespacePrefix.orElse("") + NAMESPACE + "." + TABLE;
     tableMetadata = tableMetadataManager.getTableMetadata(fullTableName);
   }

--- a/src/integration-test/java/com/scalar/db/storage/jdbc/test/TestEnv.java
+++ b/src/integration-test/java/com/scalar/db/storage/jdbc/test/TestEnv.java
@@ -7,7 +7,7 @@ import com.scalar.db.storage.jdbc.JdbcDatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
-import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
+import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadataManager;
 import com.scalar.db.storage.jdbc.query.QueryUtils;
 import java.io.Closeable;
 import java.io.IOException;
@@ -214,11 +214,11 @@ public class TestEnv implements Closeable {
   }
 
   private String getMetadataSchema() {
-    return namespacePrefix() + TableMetadataManager.SCHEMA;
+    return namespacePrefix() + JdbcTableMetadataManager.SCHEMA;
   }
 
   private String enclosedMetadataTableName() {
-    return enclosedFullTableName(getMetadataSchema(), TableMetadataManager.TABLE);
+    return enclosedFullTableName(getMetadataSchema(), JdbcTableMetadataManager.TABLE);
   }
 
   private void createSchema(String schema) throws SQLException {

--- a/src/main/java/com/scalar/db/storage/cassandra/CassandraTableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/CassandraTableMetadataManager.java
@@ -1,0 +1,41 @@
+package com.scalar.db.storage.cassandra;
+
+import com.datastax.driver.core.TableMetadata;
+import com.scalar.db.api.Operation;
+import com.scalar.db.exception.storage.StorageRuntimeException;
+import com.scalar.db.storage.common.metadata.TableMetadataManager;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CassandraTableMetadataManager implements TableMetadataManager {
+
+  private final Map<String, CassandraTableMetadata> tableMetadataMap;
+  private final ClusterManager clusterManager;
+
+  public CassandraTableMetadataManager(ClusterManager clusterManager) {
+    this.clusterManager = clusterManager;
+    tableMetadataMap = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public CassandraTableMetadata getTableMetadata(Operation operation) {
+    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
+      throw new IllegalArgumentException("operation has no target namespace and table name");
+    }
+
+    String fullName = operation.forFullTableName().get();
+    if (!tableMetadataMap.containsKey(fullName)) {
+      try {
+        TableMetadata metadata =
+            clusterManager.getMetadata(
+                operation.forFullNamespace().get(), operation.forTable().get());
+        tableMetadataMap.put(fullName, new CassandraTableMetadata(metadata));
+      } catch (StorageRuntimeException e) {
+        // The specified table is not found
+        return null;
+      }
+    }
+
+    return tableMetadataMap.get(fullName);
+  }
+}

--- a/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
+++ b/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
@@ -11,8 +11,8 @@ import com.scalar.db.exception.storage.MultiPartitionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.common.metadata.TableMetadata;
+import com.scalar.db.storage.common.metadata.TableMetadataManager;
 import com.scalar.db.storage.common.util.Utility;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -22,14 +22,16 @@ import java.util.function.Supplier;
 
 public class OperationChecker {
 
-  private final TableMetadata metadata;
+  private final TableMetadataManager metadataManager;
 
-  public OperationChecker(TableMetadata metadata) {
-    this.metadata = metadata;
+  public OperationChecker(TableMetadataManager metadataManager) {
+    this.metadataManager = metadataManager;
   }
 
   public void check(Get get) {
-    checkProjections(get);
+    TableMetadata metadata = getMetadata(get);
+
+    checkProjections(get, metadata);
 
     if (Utility.isSecondaryIndexSpecified(get, metadata)) {
       if (!new ColumnChecker(metadata).check(get.getPartitionKey().get().get(0))) {
@@ -44,11 +46,13 @@ public class OperationChecker {
       return;
     }
 
-    checkPrimaryKey(get);
+    checkPrimaryKey(get, metadata);
   }
 
   public void check(Scan scan) {
-    checkProjections(scan);
+    TableMetadata metadata = getMetadata(scan);
+
+    checkProjections(scan, metadata);
 
     if (Utility.isSecondaryIndexSpecified(scan, metadata)) {
       if (!new ColumnChecker(metadata).check(scan.getPartitionKey().get().get(0))) {
@@ -67,18 +71,18 @@ public class OperationChecker {
       return;
     }
 
-    checkPartitionKey(scan);
+    checkPartitionKey(scan, metadata);
 
-    checkClusteringKeys(scan);
+    checkClusteringKeys(scan, metadata);
 
     if (scan.getLimit() < 0) {
       throw new IllegalArgumentException("The limit cannot be negative Operation: " + scan);
     }
 
-    checkOrderings(scan);
+    checkOrderings(scan, metadata);
   }
 
-  private void checkProjections(Selection selection) {
+  private void checkProjections(Selection selection, TableMetadata metadata) {
     for (String projection : selection.getProjections()) {
       if (!metadata.getColumnNames().contains(projection)) {
         throw new IllegalArgumentException(
@@ -87,10 +91,11 @@ public class OperationChecker {
     }
   }
 
-  private void checkClusteringKeys(Scan scan) {
-    scan.getStartClusteringKey().ifPresent(startClusteringKey -> checkStartClusteringKey(scan));
+  private void checkClusteringKeys(Scan scan, TableMetadata metadata) {
+    scan.getStartClusteringKey()
+        .ifPresent(startClusteringKey -> checkStartClusteringKey(scan, metadata));
 
-    scan.getEndClusteringKey().ifPresent(endClusteringKey -> checkEndClusteringKey(scan));
+    scan.getEndClusteringKey().ifPresent(endClusteringKey -> checkEndClusteringKey(scan, metadata));
 
     if (scan.getStartClusteringKey().isPresent() && scan.getEndClusteringKey().isPresent()) {
       Key startClusteringKey = scan.getStartClusteringKey().get();
@@ -112,29 +117,29 @@ public class OperationChecker {
     }
   }
 
-  private void checkStartClusteringKey(Scan scan) {
+  private void checkStartClusteringKey(Scan scan, TableMetadata metadata) {
     scan.getStartClusteringKey()
         .ifPresent(
             ckey -> {
-              if (!checkKey(ckey, metadata.getClusteringKeyNames(), true)) {
+              if (!checkKey(ckey, metadata.getClusteringKeyNames(), true, metadata)) {
                 throw new IllegalArgumentException(
                     "The start clustering key is not properly specified. Operation: " + scan);
               }
             });
   }
 
-  private void checkEndClusteringKey(Scan scan) {
+  private void checkEndClusteringKey(Scan scan, TableMetadata metadata) {
     scan.getEndClusteringKey()
         .ifPresent(
             ckey -> {
-              if (!checkKey(ckey, metadata.getClusteringKeyNames(), true)) {
+              if (!checkKey(ckey, metadata.getClusteringKeyNames(), true, metadata)) {
                 throw new IllegalArgumentException(
                     "The end clustering key is not properly specified. Operation: " + scan);
               }
             });
   }
 
-  private void checkOrderings(Scan scan) {
+  private void checkOrderings(Scan scan, TableMetadata metadata) {
     List<Scan.Ordering> orderings = scan.getOrderings();
     if (orderings.isEmpty()) {
       return;
@@ -174,17 +179,28 @@ public class OperationChecker {
   }
 
   public void check(Put put) {
-    checkPrimaryKey(put);
-    checkValues(put);
-    checkCondition(put);
+    TableMetadata metadata = getMetadata(put);
+    checkPrimaryKey(put, metadata);
+    checkValues(put, metadata);
+    checkCondition(put, metadata);
   }
 
   public void check(Delete delete) {
-    checkPrimaryKey(delete);
-    checkCondition(delete);
+    TableMetadata metadata = getMetadata(delete);
+    checkPrimaryKey(delete, metadata);
+    checkCondition(delete, metadata);
   }
 
-  private void checkValues(Put put) {
+  private TableMetadata getMetadata(Operation operation) {
+    TableMetadata metadata = metadataManager.getTableMetadata(operation);
+    if (metadata == null) {
+      throw new IllegalArgumentException(
+          "The specified table is not found: " + operation.forFullTableName().get());
+    }
+    return metadata;
+  }
+
+  private void checkValues(Put put, TableMetadata metadata) {
     for (Map.Entry<String, Value> entry : put.getValues().entrySet()) {
       if (!new ColumnChecker(metadata).check(entry.getValue())) {
         throw new IllegalArgumentException(
@@ -193,7 +209,7 @@ public class OperationChecker {
     }
   }
 
-  private void checkCondition(Mutation mutation) {
+  private void checkCondition(Mutation mutation, TableMetadata metadata) {
     boolean isPut = mutation instanceof Put;
     mutation
         .getCondition()
@@ -221,19 +237,19 @@ public class OperationChecker {
     }
   }
 
-  private void checkPrimaryKey(Operation operation) {
-    checkPartitionKey(operation);
-    checkClusteringKey(operation);
+  private void checkPrimaryKey(Operation operation, TableMetadata metadata) {
+    checkPartitionKey(operation, metadata);
+    checkClusteringKey(operation, metadata);
   }
 
-  private void checkPartitionKey(Operation operation) {
-    if (!checkKey(operation.getPartitionKey(), metadata.getPartitionKeyNames(), false)) {
+  private void checkPartitionKey(Operation operation, TableMetadata metadata) {
+    if (!checkKey(operation.getPartitionKey(), metadata.getPartitionKeyNames(), false, metadata)) {
       throw new IllegalArgumentException(
           "The partition key is not properly specified. Operation: " + operation);
     }
   }
 
-  private void checkClusteringKey(Operation operation) {
+  private void checkClusteringKey(Operation operation, TableMetadata metadata) {
     Supplier<String> message =
         () -> "The clustering key is not properly specified. Operation: " + operation;
 
@@ -245,13 +261,14 @@ public class OperationChecker {
         .getClusteringKey()
         .ifPresent(
             ckey -> {
-              if (!checkKey(ckey, metadata.getClusteringKeyNames(), false)) {
+              if (!checkKey(ckey, metadata.getClusteringKeyNames(), false, metadata)) {
                 throw new IllegalArgumentException(message.get());
               }
             });
   }
 
-  private boolean checkKey(Key key, LinkedHashSet<String> keyNames, boolean allowPartial) {
+  private boolean checkKey(
+      Key key, LinkedHashSet<String> keyNames, boolean allowPartial, TableMetadata metadata) {
     List<Value> values = new ArrayList<>(key.get());
 
     if (!allowPartial) {

--- a/src/main/java/com/scalar/db/storage/common/metadata/TableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/common/metadata/TableMetadataManager.java
@@ -1,0 +1,14 @@
+package com.scalar.db.storage.common.metadata;
+
+import com.scalar.db.api.Operation;
+
+public interface TableMetadataManager {
+
+  /**
+   * Returns a table metadata corresponding to the specified operation.
+   *
+   * @param operation an operation
+   * @return a table metadata. null if the table is not found.
+   */
+  TableMetadata getTableMetadata(Operation operation);
+}

--- a/src/main/java/com/scalar/db/storage/cosmos/BatchHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/BatchHandler.java
@@ -6,12 +6,11 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A handler for a batch
@@ -22,17 +21,17 @@ import java.util.List;
 public class BatchHandler {
   static final Logger LOGGER = LoggerFactory.getLogger(BatchHandler.class);
   private final CosmosClient client;
-  private final TableMetadataManager metadataManager;
+  private final CosmosTableMetadataManager metadataManager;
   private final String MUTATION_STORED_PROCEDURE = "mutate.js";
 
   /**
    * Constructs a {@code BatchHandler} with the specified {@link CosmosClient} and {@link
-   * TableMetadataManager}
+   * CosmosTableMetadataManager}
    *
    * @param client {@code CosmosClient} to create a statement with
    * @param metadataManager {@code TableMetadataManager}
    */
-  public BatchHandler(CosmosClient client, TableMetadataManager metadataManager) {
+  public BatchHandler(CosmosClient client, CosmosTableMetadataManager metadataManager) {
     this.client = client;
     this.metadataManager = metadataManager;
   }

--- a/src/main/java/com/scalar/db/storage/cosmos/CosmosMutation.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/CosmosMutation.java
@@ -20,7 +20,7 @@ import org.jooq.impl.DSL;
 
 /** A class to treating utilities for a mutation */
 public class CosmosMutation extends CosmosOperation {
-  CosmosMutation(Mutation mutation, TableMetadataManager metadataManager) {
+  CosmosMutation(Mutation mutation, CosmosTableMetadataManager metadataManager) {
     super(mutation, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/cosmos/CosmosOperation.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/CosmosOperation.java
@@ -4,19 +4,18 @@ import com.azure.cosmos.models.PartitionKey;
 import com.google.common.base.Joiner;
 import com.scalar.db.api.Operation;
 import com.scalar.db.io.Value;
-
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 /** A class to treating utilities for a operation */
 public class CosmosOperation {
   private final Operation operation;
   private final CosmosTableMetadata metadata;
 
-  public CosmosOperation(Operation operation, TableMetadataManager metadataManager) {
+  public CosmosOperation(Operation operation, CosmosTableMetadataManager metadataManager) {
     this.operation = operation;
     this.metadata = metadataManager.getTableMetadata(operation);
   }

--- a/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadataManager.java
@@ -2,9 +2,11 @@ package com.scalar.db.storage.cosmos;
 
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.PartitionKey;
 import com.scalar.db.api.Operation;
 import com.scalar.db.exception.storage.StorageRuntimeException;
+import com.scalar.db.storage.common.metadata.TableMetadataManager;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
@@ -15,15 +17,16 @@ import javax.annotation.concurrent.ThreadSafe;
  * @author Yuji Ito
  */
 @ThreadSafe
-public class TableMetadataManager {
+public class CosmosTableMetadataManager implements TableMetadataManager {
   private final CosmosContainer container;
   private final Map<String, CosmosTableMetadata> tableMetadataMap;
 
-  public TableMetadataManager(CosmosContainer container) {
+  public CosmosTableMetadataManager(CosmosContainer container) {
     this.container = container;
     this.tableMetadataMap = new ConcurrentHashMap<>();
   }
 
+  @Override
   public CosmosTableMetadata getTableMetadata(Operation operation) {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
       throw new IllegalArgumentException("operation has no target namespace and table name");
@@ -31,7 +34,11 @@ public class TableMetadataManager {
 
     String fullName = operation.forFullTableName().get();
     if (!tableMetadataMap.containsKey(fullName)) {
-      tableMetadataMap.put(fullName, readMetadata(fullName));
+      CosmosTableMetadata cosmosTableMetadata = readMetadata(fullName);
+      if (cosmosTableMetadata == null) {
+        return null;
+      }
+      tableMetadataMap.put(fullName, cosmosTableMetadata);
     }
 
     return tableMetadataMap.get(fullName);
@@ -42,6 +49,9 @@ public class TableMetadataManager {
       return container
           .readItem(fullName, new PartitionKey(fullName), CosmosTableMetadata.class)
           .getItem();
+    } catch (NotFoundException e) {
+      // The specified table is not found
+      return null;
     } catch (CosmosException e) {
       throw new StorageRuntimeException("Failed to read the table metadata", e);
     }

--- a/src/main/java/com/scalar/db/storage/cosmos/DeleteStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/DeleteStatementHandler.java
@@ -19,7 +19,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class DeleteStatementHandler extends MutateStatementHandler {
 
-  public DeleteStatementHandler(CosmosClient client, TableMetadataManager metadataManager) {
+  public DeleteStatementHandler(CosmosClient client, CosmosTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/cosmos/MutateStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/MutateStatementHandler.java
@@ -21,7 +21,7 @@ public abstract class MutateStatementHandler extends StatementHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(MutateStatementHandler.class);
   private final String MUTATION_STORED_PROCEDURE = "mutate.js";
 
-  public MutateStatementHandler(CosmosClient client, TableMetadataManager metadataManager) {
+  public MutateStatementHandler(CosmosClient client, CosmosTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/cosmos/PutStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/PutStatementHandler.java
@@ -2,10 +2,8 @@ package com.scalar.db.storage.cosmos;
 
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosException;
-import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
-import com.scalar.db.api.Put;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
@@ -18,7 +16,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class PutStatementHandler extends MutateStatementHandler {
 
-  public PutStatementHandler(CosmosClient client, TableMetadataManager metadataManager) {
+  public PutStatementHandler(CosmosClient client, CosmosTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
@@ -11,6 +11,11 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Scan;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.common.util.Utility;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 import org.jooq.Field;
 import org.jooq.OrderField;
 import org.jooq.SQLDialect;
@@ -19,19 +24,13 @@ import org.jooq.SelectWhereStep;
 import org.jooq.conf.ParamType;
 import org.jooq.impl.DSL;
 
-import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.IntStream;
-
 /**
  * A handler class for select statements
  *
  * @author Yuji Ito
  */
 public class SelectStatementHandler extends StatementHandler {
-  public SelectStatementHandler(CosmosClient client, TableMetadataManager metadataManager) {
+  public SelectStatementHandler(CosmosClient client, CosmosTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/cosmos/StatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/StatementHandler.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 public abstract class StatementHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(StatementHandler.class);
   protected final CosmosClient client;
-  protected final TableMetadataManager metadataManager;
+  protected final CosmosTableMetadataManager metadataManager;
 
   /**
    * Constructs a {@code StatementHandler} with the specified {@link CosmosClient}
@@ -26,7 +26,7 @@ public abstract class StatementHandler {
    * @param client {@code CosmosClient}
    * @param metadataManager {@code TableMetadataManager}
    */
-  protected StatementHandler(CosmosClient client, TableMetadataManager metadataManager) {
+  protected StatementHandler(CosmosClient client, CosmosTableMetadataManager metadataManager) {
     this.client = checkNotNull(client);
     this.metadataManager = checkNotNull(metadataManager);
   }

--- a/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -6,6 +6,10 @@ import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -18,11 +22,6 @@ import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
 import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
 import software.amazon.awssdk.services.dynamodb.model.Update;
 
-import javax.annotation.concurrent.ThreadSafe;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 /**
  * A handler for a batch
  *
@@ -32,16 +31,16 @@ import java.util.Map;
 public class BatchHandler {
   static final Logger LOGGER = LoggerFactory.getLogger(BatchHandler.class);
   private final DynamoDbClient client;
-  private final TableMetadataManager metadataManager;
+  private final DynamoTableMetadataManager metadataManager;
 
   /**
    * Constructs a {@code BatchHandler} with the specified {@link DynamoDbClient} and {@link
-   * TableMetadataManager}
+   * DynamoTableMetadataManager}
    *
    * @param client {@code DynamoDbClient} to create a statement with
    * @param metadataManager {@code TableMetadataManager}
    */
-  public BatchHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public BatchHandler(DynamoDbClient client, DynamoTableMetadataManager metadataManager) {
     this.client = client;
     this.metadataManager = metadataManager;
   }

--- a/src/main/java/com/scalar/db/storage/dynamo/DeleteStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DeleteStatementHandler.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 @ThreadSafe
 public class DeleteStatementHandler extends StatementHandler {
 
-  public DeleteStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public DeleteStatementHandler(DynamoDbClient client, DynamoTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 /** A utility class for a mutation */
 public class DynamoMutation extends DynamoOperation {
 
-  DynamoMutation(Mutation mutation, TableMetadataManager metadataManager) {
+  DynamoMutation(Mutation mutation, DynamoTableMetadataManager metadataManager) {
     super(mutation, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoOperation.java
@@ -3,13 +3,12 @@ package com.scalar.db.storage.dynamo;
 import com.scalar.db.api.Operation;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.cosmos.ConcatenationVisitor;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /** A utility class for an operation */
 public class DynamoOperation {
@@ -30,7 +29,7 @@ public class DynamoOperation {
   private final Operation operation;
   private final DynamoTableMetadata metadata;
 
-  public DynamoOperation(Operation operation, TableMetadataManager metadataManager) {
+  public DynamoOperation(Operation operation, DynamoTableMetadataManager metadataManager) {
     this.operation = operation;
     this.metadata = metadataManager.getTableMetadata(operation);
   }

--- a/src/main/java/com/scalar/db/storage/dynamo/DynamoTableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/DynamoTableMetadataManager.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.api.Operation;
 import com.scalar.db.exception.storage.StorageRuntimeException;
+import com.scalar.db.storage.common.metadata.TableMetadataManager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -18,18 +19,19 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
  * @author Yuji Ito
  */
 @ThreadSafe
-public class TableMetadataManager {
+public class DynamoTableMetadataManager implements TableMetadataManager {
   private final String METADATA_TABLE = "scalardb.metadata";
   private final DynamoDbClient client;
   private final Optional<String> namespacePrefix;
   private final Map<String, DynamoTableMetadata> tableMetadataMap;
 
-  public TableMetadataManager(DynamoDbClient client, Optional<String> namespacePrefix) {
+  public DynamoTableMetadataManager(DynamoDbClient client, Optional<String> namespacePrefix) {
     this.client = client;
     this.namespacePrefix = namespacePrefix;
     this.tableMetadataMap = new ConcurrentHashMap<>();
   }
 
+  @Override
   public DynamoTableMetadata getTableMetadata(Operation operation) {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
       throw new IllegalArgumentException("operation has no target namespace and table name");
@@ -37,7 +39,11 @@ public class TableMetadataManager {
 
     String fullName = operation.forFullTableName().get();
     if (!tableMetadataMap.containsKey(fullName)) {
-      tableMetadataMap.put(fullName, readMetadata(fullName));
+      DynamoTableMetadata dynamoTableMetadata = readMetadata(fullName);
+      if (dynamoTableMetadata == null) {
+        return null;
+      }
+      tableMetadataMap.put(fullName, dynamoTableMetadata);
     }
 
     return tableMetadataMap.get(fullName);
@@ -46,13 +52,17 @@ public class TableMetadataManager {
   private DynamoTableMetadata readMetadata(String fullName) {
     Map<String, AttributeValue> key = new HashMap<>();
     key.put("table", AttributeValue.builder().s(fullName).build());
-    String metadataTable =
-        namespacePrefix.isPresent() ? namespacePrefix.get() + METADATA_TABLE : METADATA_TABLE;
+    String metadataTable = namespacePrefix.map(s -> s + METADATA_TABLE).orElse(METADATA_TABLE);
 
     GetItemRequest request =
         GetItemRequest.builder().tableName(metadataTable).key(key).consistentRead(true).build();
     try {
-      return new DynamoTableMetadata(client.getItem(request).item());
+      Map<String, AttributeValue> metadata = client.getItem(request).item();
+      if (metadata.isEmpty()) {
+        // The specified table is not found
+        return null;
+      }
+      return new DynamoTableMetadata(metadata);
     } catch (DynamoDbException e) {
       throw new StorageRuntimeException("Failed to read the table metadata", e);
     }

--- a/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 @ThreadSafe
 public class PutStatementHandler extends StatementHandler {
 
-  public PutStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public PutStatementHandler(DynamoDbClient client, DynamoTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -8,6 +8,15 @@ import com.scalar.db.api.Selection;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.common.util.Utility;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -17,16 +26,6 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
-
-import javax.annotation.concurrent.ThreadSafe;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 
 /**
  * A handler class for select statement
@@ -39,12 +38,12 @@ public class SelectStatementHandler extends StatementHandler {
 
   /**
    * Constructs a {@code SelectStatementHandler} with the specified {@link DynamoDbClient} and a new
-   * {@link TableMetadataManager}
+   * {@link DynamoTableMetadataManager}
    *
    * @param client {@code DynamoDbClient}
    * @param metadataManager {@code TableMetadataManager}
    */
-  public SelectStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public SelectStatementHandler(DynamoDbClient client, DynamoTableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
 

--- a/src/main/java/com/scalar/db/storage/dynamo/StatementHandler.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/StatementHandler.java
@@ -16,16 +16,16 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 @ThreadSafe
 public abstract class StatementHandler {
   protected final DynamoDbClient client;
-  protected final TableMetadataManager metadataManager;
+  protected final DynamoTableMetadataManager metadataManager;
 
   /**
    * Constructs a {@code StatementHandler} with the specified {@link DynamoDbClient} and a new
-   * {@link TableMetadataManager}
+   * {@link DynamoTableMetadataManager}
    *
    * @param client {@code DynamoDbClient}
    * @param metadataManager {@code TableMetadataManager}
    */
-  public StatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public StatementHandler(DynamoDbClient client, DynamoTableMetadataManager metadataManager) {
     this.client = checkNotNull(client);
     this.metadataManager = checkNotNull(metadataManager);
   }

--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -11,18 +11,18 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
+import com.scalar.db.storage.common.checker.OperationChecker;
+import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadataManager;
 import com.scalar.db.storage.jdbc.query.QueryBuilder;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Inject;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A storage implementation with JDBC for {@link DistributedStorage}.
@@ -46,10 +46,12 @@ public class JdbcDatabase implements DistributedStorage {
     dataSource = JdbcUtils.initDataSource(config);
     Optional<String> namespacePrefix = config.getNamespacePrefix();
     RdbEngine rdbEngine = JdbcUtils.getRdbEngine(config.getContactPoints().get(0));
-    TableMetadataManager tableMetadataManager =
-        new TableMetadataManager(dataSource, namespacePrefix, rdbEngine);
+    JdbcTableMetadataManager tableMetadataManager =
+        new JdbcTableMetadataManager(dataSource, namespacePrefix, rdbEngine);
+    OperationChecker operationChecker = new OperationChecker(tableMetadataManager);
     QueryBuilder queryBuilder = new QueryBuilder(tableMetadataManager, rdbEngine);
-    jdbcService = new JdbcService(tableMetadataManager, queryBuilder, namespacePrefix);
+    jdbcService =
+        new JdbcService(tableMetadataManager, operationChecker, queryBuilder, namespacePrefix);
     namespace = Optional.empty();
     tableName = Optional.empty();
   }

--- a/src/main/java/com/scalar/db/storage/jdbc/metadata/JdbcTableMetadataManager.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/metadata/JdbcTableMetadataManager.java
@@ -6,8 +6,11 @@ import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.scalar.db.api.Operation;
 import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.StorageRuntimeException;
 import com.scalar.db.storage.common.metadata.DataType;
+import com.scalar.db.storage.common.metadata.TableMetadataManager;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -29,27 +32,29 @@ import javax.sql.DataSource;
  * @author Toshihiro Suzuki
  */
 @ThreadSafe
-public class TableMetadataManager {
+public class JdbcTableMetadataManager implements TableMetadataManager {
   public static final String SCHEMA = "scalardb";
   public static final String TABLE = "metadata";
-  private final LoadingCache<String, JdbcTableMetadata> tableMetadataCache;
 
-  public TableMetadataManager(
+  private final LoadingCache<String, Optional<JdbcTableMetadata>> tableMetadataCache;
+
+  public JdbcTableMetadataManager(
       DataSource dataSource, Optional<String> schemaPrefix, RdbEngine rdbEngine) {
     // TODO Need to add an expiration to handle the case of altering table
     tableMetadataCache =
         CacheBuilder.newBuilder()
             .build(
-                new CacheLoader<String, JdbcTableMetadata>() {
+                new CacheLoader<String, Optional<JdbcTableMetadata>>() {
                   @Override
-                  public JdbcTableMetadata load(@Nonnull String fullTableName) throws SQLException {
-                    return TableMetadataManager.this.load(
+                  public Optional<JdbcTableMetadata> load(@Nonnull String fullTableName)
+                      throws SQLException {
+                    return JdbcTableMetadataManager.this.load(
                         dataSource, fullTableName, schemaPrefix, rdbEngine);
                   }
                 });
   }
 
-  private JdbcTableMetadata load(
+  private Optional<JdbcTableMetadata> load(
       DataSource dataSource,
       String fullTableName,
       Optional<String> schemaPrefix,
@@ -99,13 +104,19 @@ public class TableMetadataManager {
       }
     }
 
-    return new JdbcTableMetadata(
-        fullTableName,
-        partitionKeyNames,
-        clusteringKeyNames,
-        clusteringOrders,
-        columnDataTypes,
-        secondaryIndexNames);
+    if (partitionKeyNames.isEmpty()) {
+      // The specified table is not found
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new JdbcTableMetadata(
+            fullTableName,
+            partitionKeyNames,
+            clusteringKeyNames,
+            clusteringOrders,
+            columnDataTypes,
+            secondaryIndexNames));
   }
 
   private String getSelectColumnsStatement(Optional<String> schemaPrefix, RdbEngine rdbEngine) {
@@ -128,15 +139,21 @@ public class TableMetadataManager {
         + " ASC";
   }
 
-  public JdbcTableMetadata getTableMetadata(String fullTableName) throws SQLException {
+  @Override
+  public JdbcTableMetadata getTableMetadata(Operation operation) {
+    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
+      throw new IllegalArgumentException("operation has no target namespace and table name");
+    }
+
+    String fullTableName = operation.forFullTableName().get();
+    return getTableMetadata(fullTableName);
+  }
+
+  public JdbcTableMetadata getTableMetadata(String fullTableName) {
     try {
-      return tableMetadataCache.get(fullTableName);
+      return tableMetadataCache.get(fullTableName).orElse(null);
     } catch (ExecutionException e) {
-      if (e.getCause() instanceof SQLException) {
-        throw (SQLException) e.getCause();
-      } else {
-        throw new SQLException(e.getCause());
-      }
+      throw new StorageRuntimeException("Failed to read the table metadata", e);
     }
   }
 }

--- a/src/main/java/com/scalar/db/storage/jdbc/query/QueryBuilder.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/query/QueryBuilder.java
@@ -1,8 +1,7 @@
 package com.scalar.db.storage.jdbc.query;
 
 import com.scalar.db.storage.jdbc.RdbEngine;
-import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
-
+import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadataManager;
 import java.util.List;
 import java.util.Objects;
 
@@ -13,10 +12,10 @@ import java.util.Objects;
  */
 public final class QueryBuilder {
 
-  private final TableMetadataManager tableMetadataManager;
+  private final JdbcTableMetadataManager tableMetadataManager;
   private final RdbEngine rdbEngine;
 
-  public QueryBuilder(TableMetadataManager tableMetadataManager, RdbEngine rdbEngine) {
+  public QueryBuilder(JdbcTableMetadataManager tableMetadataManager, RdbEngine rdbEngine) {
     this.tableMetadataManager = Objects.requireNonNull(tableMetadataManager);
     this.rdbEngine = Objects.requireNonNull(rdbEngine);
   }

--- a/src/main/java/com/scalar/db/storage/jdbc/query/SelectQuery.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/query/SelectQuery.java
@@ -6,7 +6,7 @@ import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
-import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
+import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadataManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -18,7 +18,7 @@ public interface SelectQuery extends Query {
   Result getResult(ResultSet resultSet) throws SQLException;
 
   class Builder {
-    private final TableMetadataManager tableMetadataManager;
+    private final JdbcTableMetadataManager tableMetadataManager;
     final RdbEngine rdbEngine;
     final List<String> projections;
     String schema;
@@ -37,7 +37,9 @@ public interface SelectQuery extends Query {
     Optional<String> indexedColumn = Optional.empty();
 
     Builder(
-        TableMetadataManager tableMetadataManager, RdbEngine rdbEngine, List<String> projections) {
+        JdbcTableMetadataManager tableMetadataManager,
+        RdbEngine rdbEngine,
+        List<String> projections) {
       this.tableMetadataManager = tableMetadataManager;
       this.rdbEngine = rdbEngine;
       this.projections = projections;
@@ -48,11 +50,7 @@ public interface SelectQuery extends Query {
       this.table = table;
 
       String fullTableName = schema + "." + table;
-      try {
-        this.tableMetadata = tableMetadataManager.getTableMetadata(fullTableName);
-      } catch (SQLException e) {
-        throw new RuntimeException("failed to get the metadata of " + fullTableName, e);
-      }
+      tableMetadata = tableMetadataManager.getTableMetadata(fullTableName);
       return this;
     }
 

--- a/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
@@ -1,5 +1,15 @@
 package com.scalar.db.storage.cosmos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -18,26 +28,15 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BatchHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -58,7 +57,7 @@ public class BatchHandlerTest {
   @Mock private CosmosClient client;
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
   @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosScripts cosmosScripts;
   @Mock private CosmosStoredProcedure storedProcedure;

--- a/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -1,5 +1,9 @@
 package com.scalar.db.storage.cosmos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
 import com.azure.cosmos.CosmosContainer;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.ConditionalExpression.Operator;
@@ -10,18 +14,13 @@ import com.scalar.db.api.PutIf;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
 
 public class CosmosMutationTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -38,7 +37,7 @@ public class CosmosMutationTest {
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT_3);
 
   @Mock private CosmosContainer container;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
   @Mock private CosmosTableMetadata metadata;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
@@ -1,5 +1,11 @@
 package com.scalar.db.storage.cosmos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.azure.cosmos.models.PartitionKey;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.api.Delete;
@@ -9,20 +15,13 @@ import com.scalar.db.api.Put;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CosmosOperationTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -35,7 +34,7 @@ public class CosmosOperationTest {
   private static final String ANY_TEXT_2 = "text2";
   private static final int ANY_INT_1 = 1;
 
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
   @Mock private CosmosTableMetadata metadata;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/cosmos/CosmosTableMetadataManagerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/CosmosTableMetadataManagerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class TableMetadataManagerTest {
+public class CosmosTableMetadataManagerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -31,7 +31,7 @@ public class TableMetadataManagerTest {
   private static final String ANY_TEXT_2 = "text2";
   private static final String FULLNAME = ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME;
 
-  private TableMetadataManager manager;
+  private CosmosTableMetadataManager manager;
   @Mock private CosmosContainer container;
   @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse<CosmosTableMetadata> response;
@@ -40,7 +40,7 @@ public class TableMetadataManagerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    manager = new TableMetadataManager(container);
+    manager = new CosmosTableMetadataManager(container);
   }
 
   @Test

--- a/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -1,5 +1,16 @@
 package com.scalar.db.storage.cosmos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -18,27 +29,15 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class DeleteStatementHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -54,7 +53,7 @@ public class DeleteStatementHandlerTest {
   @Mock private CosmosClient client;
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
   @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse response;
   @Mock private CosmosScripts cosmosScripts;

--- a/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
@@ -1,5 +1,15 @@
 package com.scalar.db.storage.cosmos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -18,26 +28,15 @@ import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class PutStatementHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -55,7 +54,7 @@ public class PutStatementHandlerTest {
   @Mock private CosmosClient client;
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
   @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse response;
   @Mock private CosmosScripts cosmosScripts;

--- a/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -1,5 +1,16 @@
 package com.scalar.db.storage.cosmos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -14,26 +25,14 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class SelectStatementHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -55,7 +54,7 @@ public class SelectStatementHandlerTest {
   @Mock private CosmosClient client;
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
   @Mock private CosmosTableMetadata metadata;
   @Mock private CosmosItemResponse<Record> response;
   @Mock private CosmosPagedIterable<Record> responseIterable;

--- a/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class StatementHandlerTest {
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private CosmosTableMetadataManager metadataManager;
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
@@ -1,5 +1,14 @@
 package com.scalar.db.storage.dynamo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
@@ -10,6 +19,12 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,22 +37,6 @@ import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsResponse;
 import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BatchHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -55,7 +54,7 @@ public class BatchHandlerTest {
 
   private BatchHandler handler;
   @Mock private DynamoDbClient client;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private DynamoTableMetadata metadata;
   @Mock private TransactWriteItemsResponse transactWriteResponse;
 

--- a/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
@@ -1,5 +1,14 @@
 package com.scalar.db.storage.dynamo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Operation;
@@ -7,6 +16,9 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -17,19 +29,6 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class DeleteStatementHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -42,7 +41,7 @@ public class DeleteStatementHandlerTest {
   private DeleteStatementHandler handler;
   private String concatenatedPartitionKey;
   @Mock private DynamoDbClient client;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private DynamoTableMetadata metadata;
   @Mock private DeleteItemResponse response;
 

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -1,5 +1,9 @@
 package com.scalar.db.storage.dynamo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Operation;
@@ -9,21 +13,16 @@ import com.scalar.db.api.PutIfExists;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoMutationTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -39,7 +38,7 @@ public class DynamoMutationTest {
   private static final int ANY_INT_3 = 3;
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT_3);
 
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private DynamoTableMetadata metadata;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -1,24 +1,23 @@
 package com.scalar.db.storage.dynamo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoOperationTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -28,7 +27,7 @@ public class DynamoOperationTest {
   private static final String ANY_TEXT_1 = "text1";
   private static final String ANY_TEXT_2 = "text2";
 
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private DynamoTableMetadata metadata;
 
   @Before

--- a/src/test/java/com/scalar/db/storage/dynamo/DynamoTableMetadataManagerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/DynamoTableMetadataManagerTest.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 
-public class TableMetadataManagerTest {
+public class DynamoTableMetadataManagerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -39,7 +39,7 @@ public class TableMetadataManagerTest {
   private static final String ANY_COLUMN_NAME_2 = "val2";
   private static final String FULLNAME = ANY_KEYSPACE_NAME + "." + ANY_TABLE_NAME;
 
-  private TableMetadataManager manager;
+  private DynamoTableMetadataManager manager;
   private Map<String, AttributeValue> metadataMap;
   @Mock private DynamoDbClient client;
   @Mock private GetItemResponse response;
@@ -48,7 +48,7 @@ public class TableMetadataManagerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    manager = new TableMetadataManager(client, Optional.empty());
+    manager = new DynamoTableMetadataManager(client, Optional.empty());
     setMetadataMap();
   }
 
@@ -92,7 +92,7 @@ public class TableMetadataManagerTest {
     // Arrange
     when(client.getItem(any(GetItemRequest.class))).thenReturn(response);
     when(response.item()).thenReturn(metadataMap);
-    manager = new TableMetadataManager(client, Optional.of("prefix_"));
+    manager = new DynamoTableMetadataManager(client, Optional.of("prefix_"));
 
     Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
     Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);

--- a/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
@@ -1,5 +1,14 @@
 package com.scalar.db.storage.dynamo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIfExists;
@@ -9,6 +18,10 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,20 +33,6 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class PutStatementHandlerTest {
   private static final String ANY_KEYSPACE_NAME = "keyspace";
@@ -49,7 +48,7 @@ public class PutStatementHandlerTest {
 
   private PutStatementHandler handler;
   @Mock private DynamoDbClient client;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private DynamoTableMetadata metadata;
   @Mock private UpdateItemResponse updateResponse;
 

--- a/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -51,7 +51,7 @@ public class SelectStatementHandlerTest {
 
   private SelectStatementHandler handler;
   @Mock private DynamoDbClient client;
-  @Mock private TableMetadataManager metadataManager;
+  @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private DynamoTableMetadata metadata;
   @Mock private GetItemResponse getResponse;
   @Mock private QueryResponse queryResponse;

--- a/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -14,7 +14,7 @@ import com.scalar.db.io.Value;
 import com.scalar.db.storage.common.metadata.DataType;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadata;
-import com.scalar.db.storage.jdbc.metadata.TableMetadataManager;
+import com.scalar.db.storage.jdbc.metadata.JdbcTableMetadataManager;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,7 +35,7 @@ public class QueryBuilderTest {
   private static final String NAMESPACE = "n1";
   private static final String TABLE = "t1";
   @Parameterized.Parameter public RdbEngine rdbEngine;
-  @Mock private TableMetadataManager tableMetadataManager;
+  @Mock private JdbcTableMetadataManager tableMetadataManager;
   private QueryBuilder queryBuilder;
 
   @Parameterized.Parameters(name = "RDB={0}")


### PR DESCRIPTION
…peration is not found

https://scalar-labs.atlassian.net/browse/DLT-8742

Currently, the behavior when a specified table in an operation is not found is different between the adapters in Scalar DB. We should unify it.

This will fix the following, as well:
https://github.com/scalar-labs/scalardb/issues/86