### PR TITLE
Fix the bug where the error occurs when executing a Put operation wit…

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
+++ b/src/integration-test/java/com/scalar/db/storage/IntegrationTestBase.java
@@ -397,6 +397,38 @@ public abstract class IntegrationTestBase {
   }
 
   @Test
+  public void put_PutWithoutValuesGiven_ShouldStoreProperly() throws Exception {
+    // Arrange
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 0));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 0));
+
+    // Act
+    assertThatCode(() -> storage.put(new Put(partitionKey, clusteringKey)))
+        .doesNotThrowAnyException();
+
+    // Assert
+    Optional<Result> result = storage.get(new Get(partitionKey, clusteringKey));
+    assertThat(result).isPresent();
+  }
+
+  @Test
+  public void put_PutWithoutValuesGivenTwice_ShouldStoreProperly() throws Exception {
+    // Arrange
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 0));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 0));
+
+    // Act
+    assertThatCode(() -> storage.put(new Put(partitionKey, clusteringKey)))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> storage.put(new Put(partitionKey, clusteringKey)))
+        .doesNotThrowAnyException();
+
+    // Assert
+    Optional<Result> result = storage.get(new Get(partitionKey, clusteringKey));
+    assertThat(result).isPresent();
+  }
+
+  @Test
   public void put_MultiplePutWithIfNotExistsGivenWhenOneExists_ShouldThrowNoMutationException()
       throws Exception {
     // Arrange

--- a/src/main/java/com/scalar/db/storage/jdbc/query/InsertOnDuplicateKeyUpdateQuery.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/query/InsertOnDuplicateKeyUpdateQuery.java
@@ -1,9 +1,11 @@
 package com.scalar.db.storage.jdbc.query;
 
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
+
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.jdbc.RdbEngine;
-
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -11,9 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
 
 public class InsertOnDuplicateKeyUpdateQuery extends AbstractQuery implements UpsertQuery {
 
@@ -34,12 +33,19 @@ public class InsertOnDuplicateKeyUpdateQuery extends AbstractQuery implements Up
   }
 
   protected String sql() {
-    return "INSERT INTO "
-        + enclosedFullTableName(schema, table, rdbEngine)
-        + " "
-        + makeValuesSqlString()
-        + " "
-        + makeOnDuplicateKeyUpdateSqlString();
+    StringBuilder sql;
+    if (!values.isEmpty()) {
+      sql = new StringBuilder("INSERT INTO ");
+    } else {
+      sql = new StringBuilder("INSERT IGNORE INTO ");
+    }
+    sql.append(enclosedFullTableName(schema, table, rdbEngine))
+        .append(" ")
+        .append(makeValuesSqlString());
+    if (!values.isEmpty()) {
+      sql.append(" ").append(makeOnDuplicateKeyUpdateSqlString());
+    }
+    return sql.toString();
   }
 
   private String makeValuesSqlString() {

--- a/src/main/java/com/scalar/db/storage/jdbc/query/MergeQuery.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/query/MergeQuery.java
@@ -1,9 +1,11 @@
 package com.scalar.db.storage.jdbc.query;
 
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
+
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.storage.jdbc.RdbEngine;
-
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -11,9 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
-import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
 
 public class MergeQuery extends AbstractQuery implements UpsertQuery {
 
@@ -43,17 +42,22 @@ public class MergeQuery extends AbstractQuery implements UpsertQuery {
     List<String> enclosedValueNames =
         values.keySet().stream().map(n -> enclose(n, rdbEngine)).collect(Collectors.toList());
 
-    return "MERGE "
-        + enclosedFullTableName(schema, table, rdbEngine)
-        + " t1 USING (SELECT "
-        + makeUsingSelectSqlString(enclosedKeyNames)
-        + ") t2 ON ("
-        + makePrimaryKeyConditionsSqlString(enclosedKeyNames)
-        + ") WHEN MATCHED THEN UPDATE SET "
-        + makeUpdateSetSqlString(enclosedValueNames)
-        + " WHEN NOT MATCHED THEN INSERT "
-        + makeInsertSqlString(enclosedKeyNames, enclosedValueNames)
-        + ";";
+    StringBuilder sql = new StringBuilder();
+    sql.append("MERGE ")
+        .append(enclosedFullTableName(schema, table, rdbEngine))
+        .append(" t1 USING (SELECT ")
+        .append(makeUsingSelectSqlString(enclosedKeyNames))
+        .append(") t2 ON (")
+        .append(makePrimaryKeyConditionsSqlString(enclosedKeyNames))
+        .append(")");
+    if (!values.isEmpty()) {
+      sql.append(" WHEN MATCHED THEN UPDATE SET ")
+          .append(makeUpdateSetSqlString(enclosedValueNames));
+    }
+    sql.append(" WHEN NOT MATCHED THEN INSERT ")
+        .append(makeInsertSqlString(enclosedKeyNames, enclosedValueNames))
+        .append(";");
+    return sql.toString();
   }
 
   private String makeUsingSelectSqlString(List<String> enclosedKeyNames) {


### PR DESCRIPTION
…hout values in the JDBC adapter

https://scalar-labs.atlassian.net/browse/DLT-8772

When executing Put operation without values with the JDBC adapter of Scalar DB in MySQL, I faced the following error:
```
com.scalar.db.exception.storage.ExecutionException: put operation failed
	at com.scalar.db.storage.jdbc.JdbcDatabase.put(JdbcDatabase.java:123)
	at com.scalar.db.storage.IntegrationTestBase.lambda$put_PutWithoutValuesGiven_ShouldStoreProperly$5(IntegrationTestBase.java:406)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:763)
	at org.assertj.core.api.AssertionsForClassTypes.assertThatCode(AssertionsForClassTypes.java:734)
	at org.assertj.core.api.Assertions.assertThatCode(Assertions.java:1169)
	at com.scalar.db.storage.IntegrationTestBase.put_PutWithoutValuesGiven_ShouldStoreProperly(IntegrationTestBase.java:406)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:412)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1092)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1040)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeLargeUpdate(ClientPreparedStatement.java:1347)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdate(ClientPreparedStatement.java:1025)
	at org.apache.commons.dbcp2.DelegatingPreparedStatement.executeUpdate(DelegatingPreparedStatement.java:136)
	at org.apache.commons.dbcp2.DelegatingPreparedStatement.executeUpdate(DelegatingPreparedStatement.java:136)
	at com.scalar.db.storage.jdbc.JdbcService.put(JdbcService.java:131)
	at com.scalar.db.storage.jdbc.JdbcDatabase.put(JdbcDatabase.java:119)
	... 57 more
```

This PR will fix the issue.