### PR TITLE
Add support for endpoint_override in Schema Tool for DynamoDB

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -9,24 +9,25 @@
    [nil "--dynamo" "Operate for DynamoDB"]
    [nil "--jdbc" "Operate for a JDBC database"]
    ["-h" "--host DB_HOST" "Address of Cassandra like IP or URI address of your Cosmos DB account"]
-   ["-P" "--port DB_PORT" "Port of Cassandra. This option is ignored when Cosmos DB and DynamoDB."
+   ["-P" "--port DB_PORT" "Port of Cassandra"
     :parse-fn #(Integer/parseInt %)]
-   ["-u" "--user USERNAME" "Username of the database. This option is ignored when Cosmos DB and DynamoDB."]
-   ["-p" "--password PASSWORD" "Password of Cassandra or Cosmos DB account or a JDBC database"]
+   ["-u" "--user USERNAME" "Username of Cassandra or a JDBC database"]
+   ["-p" "--password PASSWORD" "Password of the database"]
    ["-f" "--schema-file SCHEMA_JSON" "Schema file"]
-   ["-r" "--ru RESOURCE_UNIT" "Base RU for each table on Cosmos DB or DynamoDB. The RU of the coordinator for Scalar DB transaction is specified by this option. This option is ignored when Cassandra."
+   ["-r" "--ru RESOURCE_UNIT" "Base RU for each table on Cosmos DB or DynamoDB. The RU of the coordinator for Scalar DB transaction is specified by this option"
     :parse-fn #(Integer/parseInt %)]
    ["-R" "--replication-factor REPLICATION_FACTOR"
-    "The number of replicas. This options is ignored when Cosmos DB and DynamoDB."
+    "The number of replicas for Cassandra"
     :default 1 :parse-fn #(Integer/parseInt %)]
    ["-n" "--network-strategy NETWORK_STRATEGY"
-    "The network topology strategy. SimpleStrategy or NetworkTopologyStrategy. This option is ignored when Cosmos DB and DynamoDB."]
+    "The network topology strategy for Cassandra. SimpleStrategy or NetworkTopologyStrategy"]
    ["-D" "--delete-all" "All database will be deleted, if this is enabled."]
    [nil "--region REGION" "Region where the tool creates tables for DynamoDB"]
    [nil "--prefix NAMESPACE_PREFIX" "Namespace prefix. The prefix is added to all the namespaces."]
    ["-j" "--jdbc-url JDBC_URL" "JDBC URL for a JDBC database"]
-   [nil "--no-scaling" "Disable auto-scaling for Cosmos DB and DynamoDB. This option is ignored when Cassandra and JDBC databases"]
-   [nil "--no-backup" "Disable continuous backup for DynamoDB. This option is ignored when Cosmos DB and Cassandra and JDBC databases."]
+   [nil "--no-scaling" "Disable auto-scaling for Cosmos DB and DynamoDB"]
+   [nil "--no-backup" "Disable continuous backup for DynamoDB"]
+   [nil "--endpoint-override ENDPOINT_OVERRIDE" "Endpoint with which the DynamoDB SDK should communicate"]
    [nil "--help"]])
 
 (defn -main [& args]

--- a/tools/scalar-schema/src/scalar_schema/core.clj
+++ b/tools/scalar-schema/src/scalar_schema/core.clj
@@ -12,7 +12,7 @@
    ["-P" "--port DB_PORT" "Port of Cassandra"
     :parse-fn #(Integer/parseInt %)]
    ["-u" "--user USERNAME" "Username of Cassandra or a JDBC database"]
-   ["-p" "--password PASSWORD" "Password of the database"]
+   ["-p" "--password PASSWORD" "Password of a database"]
    ["-f" "--schema-file SCHEMA_JSON" "Schema file"]
    ["-r" "--ru RESOURCE_UNIT" "Base RU for each table on Cosmos DB or DynamoDB. The RU of the coordinator for Scalar DB transaction is specified by this option"
     :parse-fn #(Integer/parseInt %)]

--- a/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo/auto_scaling.clj
@@ -28,10 +28,12 @@
    :index-write ScalableDimension/DYNAMODB_INDEX_WRITE_CAPACITY_UNITS})
 
 (defn get-scaling-client
-  [user password region]
+  [user password region endpoint-override]
   (-> (ApplicationAutoScalingClient/builder)
       (.credentialsProvider (dynamo/get-credentials-provider user password))
       (.region (Region/of region))
+      (#(if endpoint-override
+          (.endpointOverride % (java.net.URI/create endpoint-override)) %))
       .build))
 
 (defn- get-resource-id


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8880

By supporting endpoint_override in Schema Tool for DynamoDB, we can use DynamoDB local that is a downloadable version of DynamoDB that enables developers to develop and test applications using a version of DynamoDB running in your own development environment:
https://hub.docker.com/r/amazon/dynamodb-local

It will be useful for test.