### PR TITLE
Unify the behavior with -D (deleting all tables) in Schema Tool

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/cassandra.clj
+++ b/tools/scalar-schema/src/scalar_schema/cassandra.clj
@@ -72,12 +72,12 @@
     (doseq [index (:secondary-index schema)]
       (alia/execute session
                     (->raw (statement/create-index
-                             table
-                             index
-                             (clause/index-name (str (name table) \_
-                                                     common/INDEX_NAME_PREFIX
-                                                     \_ index))
-                             (clause/if-exists false)))))))
+                            table
+                            index
+                            (clause/index-name (str (name table) \_
+                                                    common/INDEX_NAME_PREFIX
+                                                    \_ index))
+                            (clause/if-exists false)))))))
 
 (defn- delete-table
   [session schema]

--- a/tools/scalar-schema/src/scalar_schema/cassandra.clj
+++ b/tools/scalar-schema/src/scalar_schema/cassandra.clj
@@ -72,12 +72,12 @@
     (doseq [index (:secondary-index schema)]
       (alia/execute session
                     (->raw (statement/create-index
-                            table
-                            index
-                            (clause/index-name (str (name table) \_
-                                                    common/INDEX_NAME_PREFIX
-                                                    \_ index))
-                            (clause/if-exists false)))))))
+                             table
+                             index
+                             (clause/index-name (str (name table) \_
+                                                     common/INDEX_NAME_PREFIX
+                                                     \_ index))
+                             (clause/if-exists false)))))))
 
 (defn- delete-table
   [session schema]

--- a/tools/scalar-schema/src/scalar_schema/jdbc.clj
+++ b/tools/scalar-schema/src/scalar_schema/jdbc.clj
@@ -59,12 +59,12 @@
     (get-table-name (if prefix (str prefix \_ database) database) table opts)))
 
 (defn- get-metadata-schema
-  [{:keys [text-type boolean-type]}]
-  {"full_table_name" (text-type 128)
-   "column_name"     (text-type 128)
-   "data_type" (str (text-type 20) \  "NOT NULL")
-   "key_type" (text-type 20)
-   "clustering_order" (text-type 10)
+  [{:keys [text-type-fn boolean-type]}]
+  {"full_table_name" (text-type-fn 128)
+   "column_name"     (text-type-fn 128)
+   "data_type" (str (text-type-fn 20) \  "NOT NULL")
+   "key_type" (text-type-fn 20)
+   "clustering_order" (text-type-fn 10)
    "indexed" (str boolean-type \  "NOT NULL")
    "ordinal_position" "INTEGER NOT NULL"})
 
@@ -188,20 +188,17 @@
   [{:keys [database table]} opts]
   (str "DROP TABLE " (get-table-name database table opts)))
 
+(defn- make-drop-database-statement
+  [{:keys [database]} {:keys [enclosure-fn]}]
+  (str "DROP SCHEMA " (enclosure-fn database)))
+
 (defn- drop-table
-  [schema {:keys [execution-fn] :as opts}]
-  (execution-fn (make-drop-table-statement schema opts)))
-
-(defn- make-delete-metadata-statement
-  [{:keys [database table]} {:keys [enclosure-fn] :as opts}]
-  (str "DELETE FROM "
-       (get-metadata-table-name opts)
-       " WHERE " (enclosure-fn "full_table_name") " = "
-       "'" (get-table-name database table) "'"))
-
-(defn- delete-metadata
-  [schema {:keys [execution-fn] :as opts}]
-  (execution-fn (make-delete-metadata-statement schema opts)))
+  [{:keys [database] :as schema}
+   {:keys [execution-fn rdb-engine has-tables-fn] :as opts}]
+  (execution-fn (make-drop-table-statement schema opts))
+  (when-not (= rdb-engine :oracle)
+    (when-not (has-tables-fn database)
+      (execution-fn (make-drop-database-statement schema opts)))))
 
 (defn- reorder-columns
   [{:keys [columns partition-key clustering-key]}]
@@ -216,6 +213,19 @@
     (log/debug "Executing" statement)
     (-> {:connection-uri jdbc-url :user user :password password}
         (jdbc/execute! [statement]))))
+
+(defn- get-has-tables-fn
+  [{:keys [jdbc-url user password]} rdb-engine]
+  (fn [database]
+    (println database)
+    (jdbc/with-db-metadata [meta
+                            {:connection-uri jdbc-url
+                             :user user
+                             :password password}]
+      (-> (jdbc/metadata-query (if (= rdb-engine :mysql)
+                                 (.getTables meta database nil nil nil)
+                                 (.getTables meta nil database nil nil)))
+          empty? not))))
 
 (defn- get-rdb-engine
   [{:keys [jdbc-url]}]
@@ -233,7 +243,7 @@
      (= rdb-engine :sql-server) (str "[" % "]")
      :else (str "\"" % "\"")))
 
-(defn- get-text-type
+(defn- get-text-type-fn
   [rdb-engine]
   #(cond
      (= rdb-engine :oracle) (str "VARCHAR2(" % ")")
@@ -264,9 +274,10 @@
                     :execution-fn (get-execution-fn opts)
                     :rdb-engine rdb-engine
                     :enclosure-fn (get-enclosure-fn rdb-engine)
-                    :text-type (get-text-type rdb-engine)
+                    :text-type-fn (get-text-type-fn rdb-engine)
                     :boolean-type (get-boolean-type rdb-engine)
-                    :boolean-value-fn (get-boolean-value-fn rdb-engine))]
+                    :boolean-value-fn (get-boolean-value-fn rdb-engine)
+                    :has-tables-fn (get-has-tables-fn opts rdb-engine))]
     (reify proto/IOperator
       (create-table [_ {:keys [database table] :as schema} _]
         (let [schema (assoc schema :reordered-columns (reorder-columns schema))
@@ -285,9 +296,6 @@
       (delete-table [_ {:keys [database table] :as schema} _]
         (let [table-name (get-table-name database table)]
           (try
-            (create-metadata-database opts)
-            (create-metadata-table opts)
-            (delete-metadata schema opts)
             (drop-table schema opts)
             (log/info table-name "is deleted successfully.")
             (catch SQLException e (if (or (string/includes? (.getMessage e) "Unknown table")

--- a/tools/scalar-schema/src/scalar_schema/jdbc.clj
+++ b/tools/scalar-schema/src/scalar_schema/jdbc.clj
@@ -59,12 +59,12 @@
     (get-table-name (if prefix (str prefix \_ database) database) table opts)))
 
 (defn- get-metadata-schema
-  [{:keys [text-type-fn boolean-type]}]
-  {"full_table_name" (text-type-fn 128)
-   "column_name"     (text-type-fn 128)
-   "data_type" (str (text-type-fn 20) \  "NOT NULL")
-   "key_type" (text-type-fn 20)
-   "clustering_order" (text-type-fn 10)
+  [{:keys [text-type boolean-type]}]
+  {"full_table_name" (text-type 128)
+   "column_name"     (text-type 128)
+   "data_type" (str (text-type 20) \  "NOT NULL")
+   "key_type" (text-type 20)
+   "clustering_order" (text-type 10)
    "indexed" (str boolean-type \  "NOT NULL")
    "ordinal_position" "INTEGER NOT NULL"})
 
@@ -243,7 +243,7 @@
      (= rdb-engine :sql-server) (str "[" % "]")
      :else (str "\"" % "\"")))
 
-(defn- get-text-type-fn
+(defn- get-text-type
   [rdb-engine]
   #(cond
      (= rdb-engine :oracle) (str "VARCHAR2(" % ")")
@@ -274,7 +274,7 @@
                     :execution-fn (get-execution-fn opts)
                     :rdb-engine rdb-engine
                     :enclosure-fn (get-enclosure-fn rdb-engine)
-                    :text-type-fn (get-text-type-fn rdb-engine)
+                    :text-type (get-text-type rdb-engine)
                     :boolean-type (get-boolean-type rdb-engine)
                     :boolean-value-fn (get-boolean-value-fn rdb-engine)
                     :has-tables-fn (get-has-tables-fn opts rdb-engine))]

--- a/tools/scalar-schema/src/scalar_schema/operations.clj
+++ b/tools/scalar-schema/src/scalar_schema/operations.clj
@@ -24,11 +24,11 @@
     (proto/close operator opts)))
 
 (defn delete-all
-  [{:keys [cosmos dynamo prefix] :as opts}]
+  [{:keys [cosmos dynamo jdbc prefix] :as opts}]
   (log/warn "Deleting all databases and tables in the file")
   (let [operator (make-operator opts)
         parsed (common/parse-schema opts)
-        schema (if (or cosmos dynamo)
+        schema (if (or cosmos dynamo jdbc)
                  (conj parsed
                        {:database (if prefix
                                     (str prefix \_ common/METADATA_DATABASE)


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8878

Currently, Schema Tool for JDBC doesn’t drop schemas and the metadata table/schema, which is different behavior from the others. We should unify it in this PR.

