### PR TITLE
Add a validation that checks not to use BOOLEAN type for a clustering…

### DIFF
--- a/tools/scalar-schema/src/scalar_schema/dynamo.clj
+++ b/tools/scalar-schema/src/scalar_schema/dynamo.clj
@@ -62,6 +62,10 @@
 
 (defn- make-attribute-definition
   [name type]
+  (when (= type "boolean")
+    (throw (IllegalArgumentException.
+            (str "BOOLEAN type is not supported for a clustering key"
+                 " or a secondary index in DynamoDB"))))
   (-> (AttributeDefinition/builder)
       (.attributeName name)
       (.attributeType (type-map type))


### PR DESCRIPTION
… key or a secondary index in Schema Tool for DynamoDB