### PR TITLE
Update ByteBuffer compatibility for java 11

### DIFF
--- a/src/main/java/com/scalar/db/io/BlobValue.java
+++ b/src/main/java/com/scalar/db/io/BlobValue.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
@@ -36,7 +38,7 @@ public final class BlobValue implements Value<BlobValue> {
       bytes.ifPresent(
           b -> {
             b.put(value);
-            b.flip();
+            ((Buffer)b).flip();
           });
     }
   }

--- a/src/main/java/com/scalar/db/io/TextValue.java
+++ b/src/main/java/com/scalar/db/io/TextValue.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -83,7 +85,7 @@ public final class TextValue implements Value<TextValue> {
     bytes.ifPresent(
         b -> {
           b.put(value);
-          b.flip();
+          ((Buffer)b).flip();
         });
   }
 


### PR DESCRIPTION
ScalarDB compatibility issue fix with Java 11
```
> Task :run
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Exception in thread "main" java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
        at com.scalar.db.io.TextValue.lambda$set$0(TextValue.java:86)
        at java.util.Optional.ifPresent(Optional.java:159)
        at com.scalar.db.io.TextValue.set(TextValue.java:83)
        at com.scalar.db.io.TextValue.<init>(TextValue.java:64)
        at sample.ElectronicMoneyWithStorage.charge(ElectronicMoneyWithStorage.java:30)
        at sample.ElectronicMoneyMain.main(ElectronicMoneyMain.java:38)
<=========----> 75% EXECUTING [16s]
```

Ref:- https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip