### PR TITLE
upgrade guice version to 5.0.1 for java 11 compatibility 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     compile group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '8.4.1.jre8'
 
     compile group: 'com.google.guava', name: 'guava', version: '24.1-jre'
-    compile group: 'com.google.inject', name: 'guice', version: '5.0.1'
+    compile group: 'com.google.inject', name: 'guice', version: '4.2.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.1'

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     compile group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '8.4.1.jre8'
 
     compile group: 'com.google.guava', name: 'guava', version: '24.1-jre'
-    compile group: 'com.google.inject', name: 'guice', version: '4.2.0'
+    compile group: 'com.google.inject', name: 'guice', version: '5.0.1'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.1'


### PR DESCRIPTION
Upgrade the guice version to avoid some warnings with java 11
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/Users/boney/Documents/scalar-labs/15-mar-2021/scalar/client/build/install/client/lib/guice-4.2.0.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```