### PR TITLE
Use com.google.inject.Inject instead of javax.inject.Inject

### DIFF
--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
@@ -19,7 +20,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Inject;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.inject.Guice;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -23,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Inject;
 
 /**
  * A storage implementation with multi-storage for {@link DistributedStorage}.

--- a/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -1,6 +1,7 @@
 package com.scalar.db.transaction.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Isolation;
 import com.scalar.db.api.SerializableStrategy;
@@ -16,7 +17,6 @@ import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import java.sql.SQLException;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Inject;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
I found that we are using the `javax.inject.Inject` annotations in some parts. In this change, I fixed it to use the `com.google.inject.Inject` annotations.