### PR TITLE
Allow username and password to be null in DatabaseConfig

### DIFF
--- a/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -27,8 +27,8 @@ public class DatabaseConfig {
   private final Properties props;
   private List<String> contactPoints;
   private int contactPort;
-  private String username;
-  private String password;
+  private Optional<String> username;
+  private Optional<String> password;
   private Class<? extends DistributedStorage> storageClass;
   private Optional<String> namespacePrefix;
   private Isolation isolation = Isolation.SNAPSHOT;
@@ -91,8 +91,6 @@ public class DatabaseConfig {
 
     if (storageClass != MultiStorage.class) {
       checkNotNull(props.getProperty(CONTACT_POINTS));
-      checkNotNull(props.getProperty(USERNAME));
-      checkNotNull(props.getProperty(PASSWORD));
 
       contactPoints = Arrays.asList(props.getProperty(CONTACT_POINTS).split(","));
       if (props.getProperty(CONTACT_PORT) == null) {
@@ -101,8 +99,8 @@ public class DatabaseConfig {
         contactPort = Integer.parseInt(props.getProperty(CONTACT_PORT));
         checkArgument(contactPort > 0);
       }
-      username = props.getProperty(USERNAME);
-      password = props.getProperty(PASSWORD);
+      username = Optional.ofNullable(props.getProperty(USERNAME));
+      password = Optional.ofNullable(props.getProperty(PASSWORD));
 
       if (Strings.isNullOrEmpty(props.getProperty(NAMESPACE_PREFIX))) {
         namespacePrefix = Optional.empty();
@@ -129,11 +127,11 @@ public class DatabaseConfig {
     return contactPort;
   }
 
-  public String getUsername() {
+  public Optional<String> getUsername() {
     return username;
   }
 
-  public String getPassword() {
+  public Optional<String> getPassword() {
     return password;
   }
 

--- a/src/main/java/com/scalar/db/storage/cassandra/ClusterManager.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/ClusterManager.java
@@ -108,8 +108,8 @@ public class ClusterManager {
 
   @VisibleForTesting
   Cluster getCluster(DatabaseConfig config) {
-    if (config.getUsername() != null && config.getPassword() != null) {
-      builder.withCredentials(config.getUsername(), config.getPassword());
+    if (config.getUsername().isPresent() && config.getPassword().isPresent()) {
+      builder.withCredentials(config.getUsername().get(), config.getPassword().get());
     }
     return builder.build();
   }

--- a/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -53,7 +53,7 @@ public class Cosmos implements DistributedStorage {
     this.client =
         new CosmosClientBuilder()
             .endpoint(config.getContactPoints().get(0))
-            .key(config.getPassword())
+            .key(config.getPassword().orElse(null))
             .directMode()
             .consistencyLevel(ConsistencyLevel.STRONG)
             .buildClient();

--- a/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -54,7 +54,8 @@ public class Dynamo implements DistributedStorage {
         DynamoDbClient.builder()
             .credentialsProvider(
                 StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(config.getUsername(), config.getPassword())))
+                    AwsBasicCredentials.create(
+                        config.getUsername().orElse(null), config.getPassword().orElse(null))))
             .region(Region.of(config.getContactPoints().get(0)))
             .build();
 

--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -1,12 +1,11 @@
 package com.scalar.db.storage.jdbc;
 
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
-import oracle.jdbc.OracleDriver;
-import org.apache.commons.dbcp2.BasicDataSource;
-
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import oracle.jdbc.OracleDriver;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
   private JdbcUtils() {}
@@ -41,8 +40,9 @@ public final class JdbcUtils {
     dataSource.setDriver(getDriverClass(jdbcUrl));
 
     dataSource.setUrl(jdbcUrl);
-    dataSource.setUsername(config.getUsername());
-    dataSource.setPassword(config.getPassword());
+
+    config.getUsername().ifPresent(dataSource::setUsername);
+    config.getPassword().ifPresent(dataSource::setPassword);
 
     if (transactional) {
       dataSource.setDefaultAutoCommit(false);

--- a/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -7,7 +7,7 @@ import com.scalar.db.api.Isolation;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.cosmos.Cosmos;
 import com.scalar.db.transaction.consensuscommit.SerializableStrategy;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -29,10 +29,52 @@ public class DatabaseConfigTest {
     DatabaseConfig config = new DatabaseConfig(props);
 
     // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Arrays.asList(ANY_HOST));
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
+  }
+
+  @Test
+  public void constructor_PropertiesWithoutUsernameGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(DatabaseConfig.CONTACT_PORT, Integer.toString(ANY_PORT));
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+
+    // Act
+    DatabaseConfig config = new DatabaseConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.getContactPort()).isEqualTo(ANY_PORT);
+    assertThat(config.getUsername().isPresent()).isFalse();
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
+  }
+
+  @Test
+  public void constructor_PropertiesWithoutPasswordGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(DatabaseConfig.CONTACT_PORT, Integer.toString(ANY_PORT));
+    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
+
+    // Act
+    DatabaseConfig config = new DatabaseConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.getContactPort()).isEqualTo(ANY_PORT);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isFalse();
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
   }
 
@@ -49,10 +91,12 @@ public class DatabaseConfigTest {
     DatabaseConfig config = new DatabaseConfig(props);
 
     // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Arrays.asList(ANY_HOST));
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.getContactPort()).isEqualTo(ANY_PORT);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
   }
 
   @Test
@@ -98,10 +142,12 @@ public class DatabaseConfigTest {
     DatabaseConfig config = new DatabaseConfig(props);
 
     // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Arrays.asList(ANY_HOST));
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
   }
 
@@ -135,10 +181,12 @@ public class DatabaseConfigTest {
     DatabaseConfig config = new DatabaseConfig(props);
 
     // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Arrays.asList(ANY_HOST));
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getIsolation()).isEqualTo(Isolation.SERIALIZABLE);
   }
 
@@ -173,10 +221,12 @@ public class DatabaseConfigTest {
     DatabaseConfig config = new DatabaseConfig(props);
 
     // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Arrays.asList(ANY_HOST));
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_WRITE);
   }
 

--- a/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConfigTest.java
+++ b/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConfigTest.java
@@ -1,13 +1,12 @@
 package com.scalar.db.storage.jdbc;
 
-import com.scalar.db.config.DatabaseConfig;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.Properties;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Collections;
+import java.util.Properties;
+import org.junit.Test;
 
 public class JdbcDatabaseConfigTest {
 
@@ -41,8 +40,10 @@ public class JdbcDatabaseConfigTest {
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_JDBC_URL));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getNamespacePrefix().isPresent()).isTrue();
     assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
@@ -72,8 +73,10 @@ public class JdbcDatabaseConfigTest {
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_JDBC_URL));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getNamespacePrefix().isPresent()).isTrue();
     assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
@@ -129,8 +132,10 @@ public class JdbcDatabaseConfigTest {
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_JDBC_URL));
     assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword()).isEqualTo(ANY_PASSWORD);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getNamespacePrefix().isPresent()).isTrue();
     assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);

--- a/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
+++ b/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
@@ -47,8 +47,10 @@ public class MultiStorageConfigTest {
     assertThat(c.getStorageClass()).isEqualTo(Cassandra.class);
     assertThat(c.getContactPoints()).isEqualTo(Collections.singletonList("localhost"));
     assertThat(c.getContactPort()).isEqualTo(7000);
-    assertThat(c.getUsername()).isEqualTo("cassandra");
-    assertThat(c.getPassword()).isEqualTo("cassandra");
+    assertThat(c.getUsername().isPresent()).isTrue();
+    assertThat(c.getUsername().get()).isEqualTo("cassandra");
+    assertThat(c.getPassword().isPresent()).isTrue();
+    assertThat(c.getPassword().get()).isEqualTo("cassandra");
     assertThat(c.getNamespacePrefix().isPresent()).isTrue();
     assertThat(c.getNamespacePrefix().get()).isEqualTo("prefix_");
     assertThat(config.getDatabaseConfigMap().containsKey("mysql")).isTrue();
@@ -56,8 +58,10 @@ public class MultiStorageConfigTest {
     assertThat(c.getStorageClass()).isEqualTo(JdbcDatabase.class);
     assertThat(c.getContactPoints())
         .isEqualTo(Collections.singletonList("jdbc:mysql://localhost:3306/"));
-    assertThat(c.getUsername()).isEqualTo("root");
-    assertThat(c.getPassword()).isEqualTo("mysql");
+    assertThat(c.getUsername().isPresent()).isTrue();
+    assertThat(c.getUsername().get()).isEqualTo("root");
+    assertThat(c.getPassword().isPresent()).isTrue();
+    assertThat(c.getPassword().get()).isEqualTo("mysql");
     assertThat(c.getNamespacePrefix().isPresent()).isFalse();
 
     assertThat(config.getTableStorageMap().size()).isEqualTo(3);


### PR DESCRIPTION
Some databases might not need a username and a password, but they are currently required in `DatabaseConfig`. This PR will fix it. Please take a look at this!