### PR TITLE
Refactor the code around ScannerIterator

### DIFF
--- a/src/main/java/com/scalar/db/storage/cassandra/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/ScannerImpl.java
@@ -18,6 +18,8 @@ public final class ScannerImpl implements Scanner {
   private final ResultSet resultSet;
   private final CassandraTableMetadata metadata;
 
+  private ScannerIterator scannerIterator;
+
   public ScannerImpl(ResultSet resultSet, CassandraTableMetadata metadata) {
     this.resultSet = checkNotNull(resultSet);
     this.metadata = checkNotNull(metadata);
@@ -43,7 +45,10 @@ public final class ScannerImpl implements Scanner {
 
   @Override
   public Iterator<Result> iterator() {
-    return new ScannerIterator(resultSet, metadata);
+    if (scannerIterator == null) {
+      scannerIterator = new ScannerIterator(resultSet, metadata);
+    }
+    return scannerIterator;
   }
 
   @Override

--- a/src/main/java/com/scalar/db/storage/cassandra/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/cassandra/ScannerIterator.java
@@ -4,7 +4,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.scalar.db.api.Result;
 import java.util.Iterator;
-import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
 import javax.annotation.concurrent.NotThreadSafe;
 
 @NotThreadSafe
@@ -23,11 +23,10 @@ public final class ScannerIterator implements Iterator<Result> {
   }
 
   @Override
-  @Nullable
   public Result next() {
     Row row = iterator.next();
     if (row == null) {
-      return null;
+      throw new NoSuchElementException();
     }
     return new ResultImpl(row, metadata);
   }

--- a/src/main/java/com/scalar/db/storage/cosmos/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ScannerImpl.java
@@ -18,6 +18,8 @@ public final class ScannerImpl implements Scanner {
   private final Selection selection;
   private final CosmosTableMetadata metadata;
 
+  private ScannerIterator scannerIterator;
+
   public ScannerImpl(List<Record> records, Selection selection, CosmosTableMetadata metadata) {
     this.records = checkNotNull(records);
     this.selection = selection;
@@ -45,7 +47,10 @@ public final class ScannerImpl implements Scanner {
 
   @Override
   public Iterator<Result> iterator() {
-    return new ScannerIterator(records.iterator(), selection, metadata);
+    if (scannerIterator == null) {
+      scannerIterator = new ScannerIterator(records.iterator(), selection, metadata);
+    }
+    return scannerIterator;
   }
 
   @Override

--- a/src/main/java/com/scalar/db/storage/cosmos/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/cosmos/ScannerIterator.java
@@ -3,7 +3,7 @@ package com.scalar.db.storage.cosmos;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Selection;
 import java.util.Iterator;
-import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
 import javax.annotation.concurrent.NotThreadSafe;
 
 @NotThreadSafe
@@ -12,7 +12,8 @@ public final class ScannerIterator implements Iterator<Result> {
   private final Selection selection;
   private final CosmosTableMetadata metadata;
 
-  public ScannerIterator(Iterator<Record> iterator, Selection selection, CosmosTableMetadata metadata) {
+  public ScannerIterator(
+      Iterator<Record> iterator, Selection selection, CosmosTableMetadata metadata) {
     this.iterator = iterator;
     this.selection = selection;
     this.metadata = metadata;
@@ -24,11 +25,10 @@ public final class ScannerIterator implements Iterator<Result> {
   }
 
   @Override
-  @Nullable
   public Result next() {
     Record record = iterator.next();
     if (record == null) {
-      return null;
+      throw new NoSuchElementException();
     }
 
     return new ResultImpl(record, selection, metadata);

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerImpl.java
@@ -21,6 +21,8 @@ public final class ScannerImpl implements Scanner {
   private final DynamoTableMetadata metadata;
   private List<Map<String, AttributeValue>> items;
 
+  private ScannerIterator scannerIterator;
+
   public ScannerImpl(
       List<Map<String, AttributeValue>> items, Selection selection, DynamoTableMetadata metadata) {
     DynamoOperation dynamoOperation = new DynamoOperation(selection, metadata);
@@ -56,7 +58,10 @@ public final class ScannerImpl implements Scanner {
 
   @Override
   public Iterator<Result> iterator() {
-    return new ScannerIterator(items.iterator(), selection, metadata);
+    if (scannerIterator == null) {
+      scannerIterator = new ScannerIterator(items.iterator(), selection, metadata);
+    }
+    return scannerIterator;
   }
 
   @Override

--- a/src/main/java/com/scalar/db/storage/dynamo/ScannerIterator.java
+++ b/src/main/java/com/scalar/db/storage/dynamo/ScannerIterator.java
@@ -4,7 +4,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Selection;
 import java.util.Iterator;
 import java.util.Map;
-import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
 import javax.annotation.concurrent.NotThreadSafe;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -29,11 +29,10 @@ public final class ScannerIterator implements Iterator<Result> {
   }
 
   @Override
-  @Nullable
   public Result next() {
     Map<String, AttributeValue> item = iterator.next();
     if (item == null) {
-      return null;
+      throw new NoSuchElementException();
     }
 
     return new ResultImpl(item, selection, metadata);

--- a/src/main/java/com/scalar/db/storage/jdbc/ScannerImpl.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/ScannerImpl.java
@@ -4,11 +4,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -19,6 +14,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @NotThreadSafe
 public class ScannerImpl implements Scanner {
@@ -28,6 +27,8 @@ public class ScannerImpl implements Scanner {
   private final Connection connection;
   private final PreparedStatement preparedStatement;
   private final ResultSet resultSet;
+
+  private ScannerIterator scannerIterator;
 
   public ScannerImpl(
       SelectQuery selectQuery,
@@ -69,7 +70,10 @@ public class ScannerImpl implements Scanner {
   @Override
   @Nonnull
   public Iterator<Result> iterator() {
-    return new ScannerIterator(this);
+    if (scannerIterator == null) {
+      scannerIterator = new ScannerIterator(this);
+    }
+    return scannerIterator;
   }
 
   @Override


### PR DESCRIPTION
What I did in this PR is as follows:
- Throw NoSuchElementException when ScannerIterator doesn't have next element in Cassandra, Cosmos DB and DynamoDB
- Cache an iterator object in Scanner