### PR TITLE
Support namespace mappings in MultiStorage

### DIFF
--- a/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
+++ b/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageIntegrationTest.java
@@ -20,6 +20,7 @@ import com.scalar.db.io.TextValue;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.jdbc.JdbcDatabase;
 import com.scalar.db.storage.jdbc.test.TestEnv;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +34,8 @@ import org.junit.Test;
 
 public class MultiStorageIntegrationTest {
 
-  protected static final String NAMESPACE = "integration_testing";
+  protected static final String NAMESPACE1 = "integration_testing1";
+  protected static final String NAMESPACE2 = "integration_testing2";
   protected static final String TABLE1 = "test_table1";
   protected static final String TABLE2 = "test_table2";
   protected static final String TABLE3 = "test_table3";
@@ -63,20 +65,22 @@ public class MultiStorageIntegrationTest {
   }
 
   private void truncateCassandra() throws Exception {
-    ProcessBuilder builder;
-    Process process;
-    int ret;
-
     for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
-      String truncateTableStmt = "TRUNCATE " + NAMESPACE + "." + table;
-      builder =
-          new ProcessBuilder(
-              "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", truncateTableStmt);
-      process = builder.start();
-      ret = process.waitFor();
-      if (ret != 0) {
-        Assert.fail("TRUNCATE TABLE failed: " + table);
-      }
+      truncateTable(NAMESPACE1, table);
+    }
+    truncateTable(NAMESPACE2, TABLE1);
+  }
+
+  private static void truncateTable(String keyspace, String table)
+      throws IOException, InterruptedException {
+    String truncateTableStmt = "TRUNCATE " + keyspace + "." + table;
+    ProcessBuilder builder =
+        new ProcessBuilder(
+            "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", truncateTableStmt);
+    Process process = builder.start();
+    int ret = process.waitFor();
+    if (ret != 0) {
+      Assert.fail("TRUNCATE TABLE failed: " + keyspace + "." + table);
     }
   }
 
@@ -87,6 +91,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenPutDataIntoTable1_DataShouldBeWrittenIntoCassandra() throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE1;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
@@ -95,14 +100,14 @@ public class MultiStorageIntegrationTest {
             .withValue(new TextValue(COL_NAME2, "val2"))
             .withValue(new IntValue(COL_NAME3, 3))
             .withValue(new BooleanValue(COL_NAME5, true))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table);
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -129,6 +134,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenPutDataIntoTable2_DataShouldBeWrittenIntoMySql() throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE2;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
@@ -137,14 +143,14 @@ public class MultiStorageIntegrationTest {
             .withValue(new TextValue(COL_NAME2, "val2"))
             .withValue(new IntValue(COL_NAME3, 3))
             .withValue(new BooleanValue(COL_NAME5, true))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table);
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -169,9 +175,10 @@ public class MultiStorageIntegrationTest {
   }
 
   @Test
-  public void whenPutDataIntoTable2_DataShouldBeWrittenIntoDefaultStorage()
+  public void whenPutDataIntoTable3_DataShouldBeWrittenIntoDefaultStorage()
       throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE3;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
@@ -181,14 +188,14 @@ public class MultiStorageIntegrationTest {
             .withValue(new TextValue(COL_NAME2, "val2"))
             .withValue(new IntValue(COL_NAME3, 3))
             .withValue(new BooleanValue(COL_NAME5, true))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     // Act
     multiStorage.put(put);
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table);
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isTrue();
@@ -215,6 +222,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenScanDataFromTable1_DataShouldBeScannedFromCassandra() throws Exception {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE1;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 0));
@@ -225,19 +233,19 @@ public class MultiStorageIntegrationTest {
         Arrays.asList(
             new Put(partitionKey, clusteringKey1)
                 .withValue(new IntValue(COL_NAME3, 2))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
             new Put(partitionKey, clusteringKey2)
                 .withValue(new IntValue(COL_NAME3, 1))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
             new Put(partitionKey, clusteringKey3)
                 .withValue(new IntValue(COL_NAME3, 0))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table)));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(NAMESPACE).forTable(table));
+    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -255,6 +263,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenScanDataFromTable2_DataShouldBeScannedFromMySql() throws Exception {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE2;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 0));
@@ -265,19 +274,19 @@ public class MultiStorageIntegrationTest {
         Arrays.asList(
             new Put(partitionKey, clusteringKey1)
                 .withValue(new IntValue(COL_NAME3, 2))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
             new Put(partitionKey, clusteringKey2)
                 .withValue(new IntValue(COL_NAME3, 1))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
             new Put(partitionKey, clusteringKey3)
                 .withValue(new IntValue(COL_NAME3, 0))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table)));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(NAMESPACE).forTable(table));
+    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -295,6 +304,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenScanDataFromTable3_DataShouldBeScannedFromDefaultStorage() throws Exception {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE3;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 0));
@@ -305,19 +315,19 @@ public class MultiStorageIntegrationTest {
         Arrays.asList(
             new Put(partitionKey, clusteringKey1)
                 .withValue(new IntValue(COL_NAME3, 2))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
             new Put(partitionKey, clusteringKey2)
                 .withValue(new IntValue(COL_NAME3, 1))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
             new Put(partitionKey, clusteringKey3)
                 .withValue(new IntValue(COL_NAME3, 0))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table)));
 
     // Act
-    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(NAMESPACE).forTable(table));
+    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
@@ -342,13 +352,14 @@ public class MultiStorageIntegrationTest {
   public void whenDeleteDataFromTable1_DataShouldBeDeletedFromCassandra()
       throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE1;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(new IntValue(COL_NAME3, 3))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     cassandra.put(put);
@@ -356,10 +367,10 @@ public class MultiStorageIntegrationTest {
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table));
+        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table);
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -377,13 +388,14 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenDeleteDataFromTable2_DataShouldBeDeletedFromMySql() throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE2;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(new IntValue(COL_NAME3, 3))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     cassandra.put(put);
@@ -391,10 +403,10 @@ public class MultiStorageIntegrationTest {
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table));
+        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table);
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -413,13 +425,14 @@ public class MultiStorageIntegrationTest {
   public void whenDeleteDataFromTable3_DataShouldBeDeletedFromDefaultStorage()
       throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE3;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
     Put put =
         new Put(partitionKey, clusteringKey)
             .withValue(new IntValue(COL_NAME3, 3))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     cassandra.put(put);
@@ -427,10 +440,10 @@ public class MultiStorageIntegrationTest {
 
     // Act
     multiStorage.delete(
-        new Delete(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table));
+        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
 
     // Assert
-    Get get = new Get(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(table);
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get);
     assertThat(result.isPresent()).isFalse();
@@ -448,6 +461,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenMutateDataToTable1_ShouldExecuteForCassandra() throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE1;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 1));
@@ -455,7 +469,7 @@ public class MultiStorageIntegrationTest {
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(new IntValue(COL_NAME3, 3))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     cassandra.put(put);
@@ -466,13 +480,13 @@ public class MultiStorageIntegrationTest {
         Arrays.asList(
             new Put(partitionKey, clusteringKey2)
                 .withValue(new IntValue(COL_NAME3, 3))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(NAMESPACE).forTable(table)));
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(NAMESPACE).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(NAMESPACE).forTable(table);
+    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
+    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();
@@ -502,6 +516,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenMutateDataToTable2_ShouldExecuteForMySql() throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE2;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 1));
@@ -509,7 +524,7 @@ public class MultiStorageIntegrationTest {
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(new IntValue(COL_NAME3, 3))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     cassandra.put(put);
@@ -520,13 +535,13 @@ public class MultiStorageIntegrationTest {
         Arrays.asList(
             new Put(partitionKey, clusteringKey2)
                 .withValue(new IntValue(COL_NAME3, 3))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(NAMESPACE).forTable(table)));
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(NAMESPACE).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(NAMESPACE).forTable(table);
+    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
+    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();
@@ -556,6 +571,7 @@ public class MultiStorageIntegrationTest {
   @Test
   public void whenMutateDataToTable3_ShouldExecuteForDefaultStorage() throws ExecutionException {
     // Arrange
+    String namespace = NAMESPACE1;
     String table = TABLE3;
     Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
     Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 1));
@@ -563,7 +579,7 @@ public class MultiStorageIntegrationTest {
     Put put =
         new Put(partitionKey, clusteringKey1)
             .withValue(new IntValue(COL_NAME3, 3))
-            .forNamespace(NAMESPACE)
+            .forNamespace(namespace)
             .forTable(table);
 
     cassandra.put(put);
@@ -574,13 +590,13 @@ public class MultiStorageIntegrationTest {
         Arrays.asList(
             new Put(partitionKey, clusteringKey2)
                 .withValue(new IntValue(COL_NAME3, 3))
-                .forNamespace(NAMESPACE)
+                .forNamespace(namespace)
                 .forTable(table),
-            new Delete(partitionKey, clusteringKey1).forNamespace(NAMESPACE).forTable(table)));
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
 
     // Assert
-    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(NAMESPACE).forTable(table);
-    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(NAMESPACE).forTable(table);
+    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
+    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
 
     Optional<Result> result = multiStorage.get(get1);
     assertThat(result.isPresent()).isFalse();
@@ -608,6 +624,184 @@ public class MultiStorageIntegrationTest {
   }
 
   @Test
+  public void whenPutDataIntoTable1InNamespace2_DataShouldBeWrittenIntoMySql()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new TextValue(COL_NAME2, "val2"))
+            .withValue(new IntValue(COL_NAME3, 3))
+            .withValue(new BooleanValue(COL_NAME5, true))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    // Act
+    multiStorage.put(put);
+
+    // Assert
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    Optional<Result> result = multiStorage.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((IntValue) result.get().getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((TextValue) result.get().getValue(COL_NAME2).get()).getString().get())
+        .isEqualTo("val2");
+    assertThat(((IntValue) result.get().getValue(COL_NAME3).get()).get()).isEqualTo(3);
+    assertThat(((IntValue) result.get().getValue(COL_NAME4).get()).get()).isEqualTo(4);
+    assertThat(((BooleanValue) result.get().getValue(COL_NAME5).get()).get()).isTrue();
+
+    result = cassandra.get(get);
+    assertThat(result.isPresent()).isFalse();
+
+    result = mysql.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((IntValue) result.get().getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((TextValue) result.get().getValue(COL_NAME2).get()).getString().get())
+        .isEqualTo("val2");
+    assertThat(((IntValue) result.get().getValue(COL_NAME3).get()).get()).isEqualTo(3);
+    assertThat(((IntValue) result.get().getValue(COL_NAME4).get()).get()).isEqualTo(4);
+    assertThat(((BooleanValue) result.get().getValue(COL_NAME5).get()).get()).isTrue();
+  }
+
+  @Test
+  public void whenScanDataFromTable1InNamespace2_DataShouldBeScannedFromMySql() throws Exception {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 0));
+    Key clusteringKey2 = new Key(new IntValue(COL_NAME4, 1));
+    Key clusteringKey3 = new Key(new IntValue(COL_NAME4, 2));
+
+    mysql.mutate(
+        Arrays.asList(
+            new Put(partitionKey, clusteringKey1)
+                .withValue(new IntValue(COL_NAME3, 2))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Put(partitionKey, clusteringKey2)
+                .withValue(new IntValue(COL_NAME3, 1))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Put(partitionKey, clusteringKey3)
+                .withValue(new IntValue(COL_NAME3, 0))
+                .forNamespace(namespace)
+                .forTable(table)));
+
+    // Act
+    List<Result> results = scanAll(new Scan(partitionKey).forNamespace(namespace).forTable(table));
+
+    // Assert
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(((IntValue) results.get(0).getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) results.get(0).getValue(COL_NAME3).get()).get()).isEqualTo(2);
+    assertThat(((IntValue) results.get(0).getValue(COL_NAME4).get()).get()).isEqualTo(0);
+    assertThat(((IntValue) results.get(1).getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) results.get(1).getValue(COL_NAME3).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) results.get(1).getValue(COL_NAME4).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) results.get(2).getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) results.get(2).getValue(COL_NAME3).get()).get()).isEqualTo(0);
+    assertThat(((IntValue) results.get(2).getValue(COL_NAME4).get()).get()).isEqualTo(2);
+  }
+
+  @Test
+  public void whenDeleteDataFromTable1InNamespace2_DataShouldBeDeletedFromMySql()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME4, 4));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(COL_NAME3, 3))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    cassandra.put(put);
+    mysql.put(put);
+
+    // Act
+    multiStorage.delete(
+        new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table));
+
+    // Assert
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    Optional<Result> result = multiStorage.get(get);
+    assertThat(result.isPresent()).isFalse();
+
+    result = cassandra.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((IntValue) result.get().getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) result.get().getValue(COL_NAME3).get()).get()).isEqualTo(3);
+    assertThat(((IntValue) result.get().getValue(COL_NAME4).get()).get()).isEqualTo(4);
+
+    result = mysql.get(get);
+    assertThat(result.isPresent()).isFalse();
+  }
+
+  @Test
+  public void whenMutateDataToTable1InNamespace2_ShouldExecuteForCassandra()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey1 = new Key(new IntValue(COL_NAME4, 1));
+    Key clusteringKey2 = new Key(new IntValue(COL_NAME4, 2));
+    Put put =
+        new Put(partitionKey, clusteringKey1)
+            .withValue(new IntValue(COL_NAME3, 3))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    cassandra.put(put);
+    mysql.put(put);
+
+    // Act
+    multiStorage.mutate(
+        Arrays.asList(
+            new Put(partitionKey, clusteringKey2)
+                .withValue(new IntValue(COL_NAME3, 3))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+
+    // Assert
+    Get get1 = new Get(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table);
+    Get get2 = new Get(partitionKey, clusteringKey2).forNamespace(namespace).forTable(table);
+
+    Optional<Result> result = multiStorage.get(get1);
+    assertThat(result.isPresent()).isFalse();
+    result = multiStorage.get(get2);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((IntValue) result.get().getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) result.get().getValue(COL_NAME3).get()).get()).isEqualTo(3);
+    assertThat(((IntValue) result.get().getValue(COL_NAME4).get()).get()).isEqualTo(2);
+
+    result = cassandra.get(get1);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((IntValue) result.get().getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) result.get().getValue(COL_NAME3).get()).get()).isEqualTo(3);
+    assertThat(((IntValue) result.get().getValue(COL_NAME4).get()).get()).isEqualTo(1);
+    result = cassandra.get(get2);
+    assertThat(result.isPresent()).isFalse();
+
+    result = mysql.get(get1);
+    assertThat(result.isPresent()).isFalse();
+    result = mysql.get(get2);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((IntValue) result.get().getValue(COL_NAME1).get()).get()).isEqualTo(1);
+    assertThat(((IntValue) result.get().getValue(COL_NAME3).get()).get()).isEqualTo(3);
+    assertThat(((IntValue) result.get().getValue(COL_NAME4).get()).get()).isEqualTo(2);
+  }
+
+  @Test
   public void whenCallMutateWithEmptyList_ShouldThrowIllegalArgumentException() {
     // Arrange Act Assert
     assertThatThrownBy(() -> multiStorage.mutate(Collections.emptyList()))
@@ -622,40 +816,13 @@ public class MultiStorageIntegrationTest {
   }
 
   private static void initCassandra() throws Exception {
-    ProcessBuilder builder;
-    Process process;
-    int ret;
-
-    String createKeyspaceStmt =
-        "CREATE KEYSPACE "
-            + NAMESPACE
-            + " WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1 }";
-    builder =
-        new ProcessBuilder(
-            "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", createKeyspaceStmt);
-    process = builder.start();
-    ret = process.waitFor();
-    if (ret != 0) {
-      Assert.fail("CREATE KEYSPACE failed.");
-    }
+    createKeyspace(NAMESPACE1);
+    createKeyspace(NAMESPACE2);
 
     for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
-      String createTableStmt =
-          "CREATE TABLE "
-              + NAMESPACE
-              + "."
-              + table
-              + " (c1 int, c2 text, c3 int, c4 int, c5 boolean, PRIMARY KEY((c1), c4))";
-
-      builder =
-          new ProcessBuilder(
-              "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", createTableStmt);
-      process = builder.start();
-      ret = process.waitFor();
-      if (ret != 0) {
-        Assert.fail("CREATE TABLE failed: " + table);
-      }
+      createTable(NAMESPACE1, table);
     }
+    createTable(NAMESPACE2, TABLE1);
 
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, CASSANDRA_CONTACT_POINT);
@@ -664,12 +831,46 @@ public class MultiStorageIntegrationTest {
     cassandra = new Cassandra(new DatabaseConfig(props));
   }
 
+  private static void createKeyspace(String keyspace) throws IOException, InterruptedException {
+    String createKeyspaceStmt =
+        "CREATE KEYSPACE "
+            + keyspace
+            + " WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1 }";
+    ProcessBuilder builder =
+        new ProcessBuilder(
+            "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", createKeyspaceStmt);
+    Process process = builder.start();
+    int ret = process.waitFor();
+    if (ret != 0) {
+      Assert.fail("CREATE KEYSPACE failed: " + keyspace);
+    }
+  }
+
+  private static void createTable(String keyspace, String table)
+      throws IOException, InterruptedException {
+    String createTableStmt =
+        "CREATE TABLE "
+            + keyspace
+            + "."
+            + table
+            + " (c1 int, c2 text, c3 int, c4 int, c5 boolean, PRIMARY KEY((c1), c4))";
+
+    ProcessBuilder builder =
+        new ProcessBuilder(
+            "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", createTableStmt);
+    Process process = builder.start();
+    int ret = process.waitFor();
+    if (ret != 0) {
+      Assert.fail("CREATE TABLE failed: " + keyspace + "." + table);
+    }
+  }
+
   private static void initMySql() throws Exception {
     testEnv = new TestEnv(MYSQL_CONTACT_POINT, MYSQL_USERNAME, MYSQL_PASSWORD, Optional.empty());
 
     for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
       testEnv.register(
-          NAMESPACE,
+          NAMESPACE1,
           table,
           TableMetadata.newBuilder()
               .addColumn(COL_NAME1, DataType.INT)
@@ -681,6 +882,18 @@ public class MultiStorageIntegrationTest {
               .addClusteringKey(COL_NAME4)
               .build());
     }
+    testEnv.register(
+        NAMESPACE2,
+        TABLE1,
+        TableMetadata.newBuilder()
+            .addColumn(COL_NAME1, DataType.INT)
+            .addColumn(COL_NAME2, DataType.TEXT)
+            .addColumn(COL_NAME3, DataType.INT)
+            .addColumn(COL_NAME4, DataType.INT)
+            .addColumn(COL_NAME5, DataType.BOOLEAN)
+            .addPartitionKey(COL_NAME1)
+            .addClusteringKey(COL_NAME4)
+            .build());
     testEnv.createMetadataTable();
     testEnv.createTables();
     testEnv.insertMetadata();
@@ -707,7 +920,10 @@ public class MultiStorageIntegrationTest {
     // Define table mapping from table1 to cassandra, and from table2 to mysql
     props.setProperty(
         MultiStorageConfig.TABLE_MAPPING,
-        NAMESPACE + "." + TABLE1 + ":cassandra," + NAMESPACE + "." + TABLE2 + ":mysql");
+        NAMESPACE1 + "." + TABLE1 + ":cassandra," + NAMESPACE1 + "." + TABLE2 + ":mysql");
+
+    // Define namespace mapping from namespace2 to mysql
+    props.setProperty(MultiStorageConfig.NAMESPACE_MAPPING, NAMESPACE2 + ":mysql");
 
     // The default storage is cassandra
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
@@ -724,19 +940,19 @@ public class MultiStorageIntegrationTest {
 
   private static void cleanUpCassandra() throws Exception {
     cassandra.close();
+    dropKeyspace(NAMESPACE1);
+    dropKeyspace(NAMESPACE2);
+  }
 
-    ProcessBuilder builder;
-    Process process;
-    int ret;
-
-    String dropKeyspaceStmt = "DROP KEYSPACE " + NAMESPACE;
-    builder =
+  private static void dropKeyspace(String keyspace) throws IOException, InterruptedException {
+    String dropKeyspaceStmt = "DROP KEYSPACE " + keyspace;
+    ProcessBuilder builder =
         new ProcessBuilder(
             "cqlsh", "-u", CASSANDRA_USERNAME, "-p", CASSANDRA_PASSWORD, "-e", dropKeyspaceStmt);
-    process = builder.start();
-    ret = process.waitFor();
+    Process process = builder.start();
+    int ret = process.waitFor();
     if (ret != 0) {
-      Assert.fail("DROP KEYSPACE failed.");
+      Assert.fail("DROP KEYSPACE failed: " + keyspace);
     }
   }
 

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A storage implementation with multi-storage for {@link DistributedStorage}.
  *
  * <p>This storage implementation holds multiple storage instances. It chooses a storage instance on
- * the basis of the specified configuration and a given operation. If conflicting mapping between a
+ * the basis of the specified configuration and a given operation. If there is a conflict between a
  * table mapping and a namespace mapping, it prefers the table mapping because table mappings are
  * more specific than namespace mappings.
  *

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -29,7 +29,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * A storage implementation with multi-storage for {@link DistributedStorage}.
  *
  * <p>This storage implementation holds multiple storage instances. It chooses a storage instance on
- * the basis of the specified configuration and a given operation.
+ * the basis of the specified configuration and a given operation. If conflicting mapping between a
+ * table mapping and a namespace mapping, it prefers the table mapping because table mappings are
+ * more specific than namespace mappings.
  *
  * @author Toshihiro Suzuki
  */

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -17,9 +17,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * An implementation with multi-storage for {@link DistributedStorageAdmin}.
  *
  * <p>This implementation holds multiple DistributedStorageAdmin instances. It chooses a instance on
- * the basis of the specified configuration and a given operation. If there is a conflict between a table
- * mapping and a namespace mapping, it prefers the table mapping because table mappings are more
- * specific than namespace mappings.
+ * the basis of the specified configuration and a given operation. If there is a conflict between a
+ * table mapping and a namespace mapping, it prefers the table mapping because table mappings are
+ * more specific than namespace mappings.
  *
  * @author Toshihiro Suzuki
  */

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -13,6 +13,16 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
+/**
+ * An implementation with multi-storage for {@link DistributedStorageAdmin}.
+ *
+ * <p>This implementation holds multiple DistributedStorageAdmin instances. It chooses a instance on
+ * the basis of the specified configuration and a given operation. If conflicting between a table
+ * mapping and a namespace mapping, it prefers the table mapping because table mappings are more
+ * specific than namespace mappings.
+ *
+ * @author Toshihiro Suzuki
+ */
 @ThreadSafe
 public class MultiStorageAdmin implements DistributedStorageAdmin {
 

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -17,7 +17,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * An implementation with multi-storage for {@link DistributedStorageAdmin}.
  *
  * <p>This implementation holds multiple DistributedStorageAdmin instances. It chooses a instance on
- * the basis of the specified configuration and a given operation. If conflicting between a table
+ * the basis of the specified configuration and a given operation. If there is a conflict between a table
  * mapping and a namespace mapping, it prefers the table mapping because table mappings are more
  * specific than namespace mappings.
  *

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -1,40 +1,64 @@
 package com.scalar.db.storage.multistorage;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.service.StorageModule;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class MultiStorageAdmin implements DistributedStorageAdmin {
 
-  private final Map<String, DistributedStorageAdmin> adminMap;
+  private final Map<String, DistributedStorageAdmin> tableAdminMap;
+  private final Map<String, DistributedStorageAdmin> namespaceAdminMap;
   private final DistributedStorageAdmin defaultAdmin;
+  private final List<DistributedStorageAdmin> admins;
 
   @Inject
   public MultiStorageAdmin(MultiStorageConfig config) {
+    admins = new ArrayList<>();
     Map<String, DistributedStorageAdmin> nameAdminMap = new HashMap<>();
     config
         .getDatabaseConfigMap()
         .forEach(
-            (storage, databaseConfig) -> {
+            (storageName, databaseConfig) -> {
               // Instantiate admins with Guice
               Injector injector = Guice.createInjector(new StorageModule(databaseConfig));
-              nameAdminMap.put(storage, injector.getInstance(DistributedStorageAdmin.class));
+              DistributedStorageAdmin admin = injector.getInstance(DistributedStorageAdmin.class);
+              nameAdminMap.put(storageName, admin);
+              admins.add(admin);
             });
 
-    Builder<String, DistributedStorageAdmin> builder = ImmutableMap.builder();
+    tableAdminMap = new HashMap<>();
     config
         .getTableStorageMap()
-        .forEach((table, storage) -> builder.put(table, nameAdminMap.get(storage)));
-    adminMap = builder.build();
+        .forEach((table, storageName) -> tableAdminMap.put(table, nameAdminMap.get(storageName)));
+
+    namespaceAdminMap = new HashMap<>();
+    config
+        .getNamespaceStorageMap()
+        .forEach(
+            (table, storageName) -> namespaceAdminMap.put(table, nameAdminMap.get(storageName)));
 
     defaultAdmin = nameAdminMap.get(config.getDefaultStorage());
+  }
+
+  @VisibleForTesting
+  MultiStorageAdmin(
+      Map<String, DistributedStorageAdmin> tableAdminMap,
+      Map<String, DistributedStorageAdmin> namespaceAdminMap,
+      DistributedStorageAdmin defaultAdmin) {
+    this.tableAdminMap = tableAdminMap;
+    this.namespaceAdminMap = namespaceAdminMap;
+    this.defaultAdmin = defaultAdmin;
+    admins = null;
   }
 
   @Override
@@ -60,16 +84,17 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
 
   private DistributedStorageAdmin getAdmin(String namespace, String table) {
     String fullTaleName = namespace + "." + table;
-    DistributedStorageAdmin admin = adminMap.get(fullTaleName);
-    if (admin == null) {
-      return defaultAdmin;
+    DistributedStorageAdmin admin = tableAdminMap.get(fullTaleName);
+    if (admin != null) {
+      return admin;
     }
-    return admin;
+    admin = namespaceAdminMap.get(namespace);
+    return admin != null ? admin : defaultAdmin;
   }
 
   @Override
   public void close() {
-    for (DistributedStorageAdmin admin : adminMap.values()) {
+    for (DistributedStorageAdmin admin : admins) {
       admin.close();
     }
   }

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -17,6 +17,7 @@ public class MultiStorageConfig {
   public static final String PREFIX = DatabaseConfig.PREFIX + "multi_storage.";
   public static final String STORAGES = PREFIX + "storages";
   public static final String TABLE_MAPPING = PREFIX + "table_mapping";
+  public static final String NAMESPACE_MAPPING = PREFIX + "namespace_mapping";
   public static final String DEFAULT_STORAGE = PREFIX + "default_storage";
 
   private static final String MULTI_STORAGE = "multi-storage";
@@ -25,6 +26,7 @@ public class MultiStorageConfig {
 
   private Map<String, DatabaseConfig> databaseConfigMap;
   private Map<String, String> tableStorageMap;
+  private Map<String, String> namespaceStorageMap;
   private String defaultStorage;
 
   public MultiStorageConfig(File propertiesFile) throws IOException {
@@ -54,6 +56,7 @@ public class MultiStorageConfig {
 
     loadDatabaseConfigs();
     loadTableStorageMapping();
+    loadNamespaceStorageMapping();
 
     defaultStorage = props.getProperty(DEFAULT_STORAGE);
     checkIfStorageExists(defaultStorage);
@@ -88,15 +91,32 @@ public class MultiStorageConfig {
     Builder<String, String> builder = ImmutableMap.builder();
 
     String tableMapping = props.getProperty(TABLE_MAPPING);
-    for (String tableAndStorage : tableMapping.split(",")) {
-      String[] s = tableAndStorage.split(":");
-      String table = s[0];
-      String storage = s[1];
-
-      checkIfStorageExists(storage);
-      builder.put(table, storage);
+    if (tableMapping != null) {
+      for (String tableAndStorage : tableMapping.split(",")) {
+        String[] s = tableAndStorage.split(":");
+        String table = s[0];
+        String storage = s[1];
+        checkIfStorageExists(storage);
+        builder.put(table, storage);
+      }
     }
     tableStorageMap = builder.build();
+  }
+
+  private void loadNamespaceStorageMapping() {
+    Builder<String, String> builder = ImmutableMap.builder();
+
+    String namespaceMapping = props.getProperty(NAMESPACE_MAPPING);
+    if (namespaceMapping != null) {
+      for (String namespaceAndStorage : namespaceMapping.split(",")) {
+        String[] s = namespaceAndStorage.split(":");
+        String namespace = s[0];
+        String storage = s[1];
+        checkIfStorageExists(storage);
+        builder.put(namespace, storage);
+      }
+    }
+    namespaceStorageMap = builder.build();
   }
 
   private void checkIfStorageExists(String storage) {
@@ -111,6 +131,10 @@ public class MultiStorageConfig {
 
   public Map<String, String> getTableStorageMap() {
     return tableStorageMap;
+  }
+
+  public Map<String, String> getNamespaceStorageMap() {
+    return namespaceStorageMap;
   }
 
   public String getDefaultStorage() {

--- a/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.concurrent.Immutable;
@@ -63,58 +64,61 @@ public class MultiStorageConfig {
   }
 
   private void loadDatabaseConfigs() {
-    Builder<String, DatabaseConfig> builder = ImmutableMap.builder();
-
     String storages = props.getProperty(STORAGES);
-    if (storages != null) {
-      for (String storage : storages.split(",")) {
-        Properties dbProps = new Properties();
-        for (String propertyName : props.stringPropertyNames()) {
-          if (propertyName.startsWith(STORAGES + "." + storage + ".")) {
-            dbProps.put(
-                propertyName.replace("multi_storage.storages." + storage + ".", ""),
-                props.getProperty(propertyName));
-          }
+    if (storages == null) {
+      databaseConfigMap = Collections.emptyMap();
+      return;
+    }
+    Builder<String, DatabaseConfig> builder = ImmutableMap.builder();
+    for (String storage : storages.split(",")) {
+      Properties dbProps = new Properties();
+      for (String propertyName : props.stringPropertyNames()) {
+        if (propertyName.startsWith(STORAGES + "." + storage + ".")) {
+          dbProps.put(
+              propertyName.replace("multi_storage.storages." + storage + ".", ""),
+              props.getProperty(propertyName));
         }
-
-        if (dbProps.getProperty(DatabaseConfig.STORAGE).equals(MULTI_STORAGE)) {
-          throw new IllegalArgumentException(
-              "Does not support nested " + MULTI_STORAGE + ": " + storage);
-        }
-        builder.put(storage, new DatabaseConfig(dbProps));
       }
+
+      if (dbProps.getProperty(DatabaseConfig.STORAGE).equals(MULTI_STORAGE)) {
+        throw new IllegalArgumentException(
+            "Does not support nested " + MULTI_STORAGE + ": " + storage);
+      }
+      builder.put(storage, new DatabaseConfig(dbProps));
     }
     databaseConfigMap = builder.build();
   }
 
   private void loadTableStorageMapping() {
-    Builder<String, String> builder = ImmutableMap.builder();
-
     String tableMapping = props.getProperty(TABLE_MAPPING);
-    if (tableMapping != null) {
-      for (String tableAndStorage : tableMapping.split(",")) {
-        String[] s = tableAndStorage.split(":");
-        String table = s[0];
-        String storage = s[1];
-        checkIfStorageExists(storage);
-        builder.put(table, storage);
-      }
+    if (tableMapping == null) {
+      tableStorageMap = Collections.emptyMap();
+      return;
+    }
+    Builder<String, String> builder = ImmutableMap.builder();
+    for (String tableAndStorage : tableMapping.split(",")) {
+      String[] s = tableAndStorage.split(":");
+      String table = s[0];
+      String storage = s[1];
+      checkIfStorageExists(storage);
+      builder.put(table, storage);
     }
     tableStorageMap = builder.build();
   }
 
   private void loadNamespaceStorageMapping() {
-    Builder<String, String> builder = ImmutableMap.builder();
-
     String namespaceMapping = props.getProperty(NAMESPACE_MAPPING);
-    if (namespaceMapping != null) {
-      for (String namespaceAndStorage : namespaceMapping.split(",")) {
-        String[] s = namespaceAndStorage.split(":");
-        String namespace = s[0];
-        String storage = s[1];
-        checkIfStorageExists(storage);
-        builder.put(namespace, storage);
-      }
+    if (namespaceMapping == null) {
+      namespaceStorageMap = Collections.emptyMap();
+      return;
+    }
+    Builder<String, String> builder = ImmutableMap.builder();
+    for (String namespaceAndStorage : namespaceMapping.split(",")) {
+      String[] s = namespaceAndStorage.split(":");
+      String namespace = s[0];
+      String storage = s[1];
+      checkIfStorageExists(storage);
+      builder.put(namespace, storage);
     }
     namespaceStorageMap = builder.build();
   }

--- a/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -1,0 +1,93 @@
+package com.scalar.db.storage.multistorage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.DistributedStorageAdmin;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class MultiStorageAdminTest {
+
+  protected static final String NAMESPACE1 = "test_ns1";
+  protected static final String NAMESPACE2 = "test_ns2";
+  protected static final String TABLE1 = "test_table1";
+  protected static final String TABLE2 = "test_table2";
+  protected static final String TABLE3 = "test_table3";
+
+  @Mock private DistributedStorageAdmin admin1;
+  @Mock private DistributedStorageAdmin admin2;
+  @Mock private DistributedStorageAdmin admin3;
+
+  private MultiStorageAdmin multiStorageAdmin;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    // Arrange
+    Map<String, DistributedStorageAdmin> tableAdminMap = new HashMap<>();
+    tableAdminMap.put(NAMESPACE1 + "." + TABLE1, admin1);
+    tableAdminMap.put(NAMESPACE1 + "." + TABLE2, admin2);
+    Map<String, DistributedStorageAdmin> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put(NAMESPACE2, admin2);
+    DistributedStorageAdmin defaultAdmin = admin3;
+    multiStorageAdmin = new MultiStorageAdmin(tableAdminMap, namespaceAdminMap, defaultAdmin);
+  }
+
+  @Test
+  public void getTableMetadata_ForTable1_ShouldReturnMetadataFromAdmin1() {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+
+    // Act
+    multiStorageAdmin.getTableMetadata(namespace, table);
+
+    // Assert
+    verify(admin1).getTableMetadata(any(), any());
+  }
+
+  @Test
+  public void getTableMetadata_ForTable2_ShouldReturnMetadataFromAdmin2() {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+
+    // Act
+    multiStorageAdmin.getTableMetadata(namespace, table);
+
+    // Assert
+    verify(admin2).getTableMetadata(any(), any());
+  }
+
+  @Test
+  public void getTableMetadata_ForTable3_ShouldReturnMetadataFromDefaultAdmin() {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+
+    // Act
+    multiStorageAdmin.getTableMetadata(namespace, table);
+
+    // Assert
+    verify(admin3).getTableMetadata(any(), any());
+  }
+
+  @Test
+  public void getTableMetadata_ForTable1InNamespace2_ShouldReturnMetadataFromAdmin2() {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+
+    // Act
+    multiStorageAdmin.getTableMetadata(namespace, table);
+
+    // Assert
+    verify(admin2).getTableMetadata(any(), any());
+  }
+}

--- a/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
+++ b/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
@@ -35,6 +35,9 @@ public class MultiStorageConfigTest {
         MultiStorageConfig.TABLE_MAPPING,
         "user.order:cassandra,user.customer:mysql,coordinator.state:cassandra");
 
+    props.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING, "namespace1:cassandra,namespace2:mysql");
+
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 
     // Act
@@ -69,6 +72,10 @@ public class MultiStorageConfigTest {
     assertThat(config.getTableStorageMap().get("user.customer")).isEqualTo("mysql");
     assertThat(config.getTableStorageMap().get("coordinator.state")).isEqualTo("cassandra");
 
+    assertThat(config.getNamespaceStorageMap().size()).isEqualTo(2);
+    assertThat(config.getNamespaceStorageMap().get("namespace1")).isEqualTo("cassandra");
+    assertThat(config.getNamespaceStorageMap().get("namespace2")).isEqualTo("mysql");
+
     assertThat(config.getDefaultStorage()).isEqualTo("cassandra");
   }
 
@@ -94,6 +101,9 @@ public class MultiStorageConfigTest {
         MultiStorageConfig.TABLE_MAPPING,
         "user.order:cassandra,user.customer:mysql,coordinator.state:cassandra");
 
+    props.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING, "namespace1:cassandra,namespace2:mysql");
+
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 
     // Act Assert
@@ -102,7 +112,8 @@ public class MultiStorageConfigTest {
   }
 
   @Test
-  public void constructor_NonExistentStorageGiven_ShouldThrowIllegalArgumentException() {
+  public void
+      constructor_NonExistentStorageGivenInTableMapping_ShouldThrowIllegalArgumentException() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.STORAGE, "multi-storage");
@@ -124,6 +135,44 @@ public class MultiStorageConfigTest {
         MultiStorageConfig.TABLE_MAPPING,
         "user.order:cassandra,user.customer:mysql,"
             + "coordinator.state:dynamo"); // non-existent storage
+
+    props.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING, "namespace1:cassandra,namespace2:mysql");
+
+    props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
+
+    // Act Assert
+    assertThatThrownBy(() -> new MultiStorageConfig(props))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_NonExistentStorageGivenInNamespaceMapping_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "multi-storage");
+
+    props.setProperty(MultiStorageConfig.STORAGES, "cassandra,mysql");
+    props.setProperty(MultiStorageConfig.STORAGES + ".cassandra.storage", "cassandra");
+    props.setProperty(MultiStorageConfig.STORAGES + ".cassandra.contact_points", "localhost");
+    props.setProperty(MultiStorageConfig.STORAGES + ".cassandra.contact_port", "7000");
+    props.setProperty(MultiStorageConfig.STORAGES + ".cassandra.username", "cassandra");
+    props.setProperty(MultiStorageConfig.STORAGES + ".cassandra.password", "cassandra");
+    props.setProperty(MultiStorageConfig.STORAGES + ".cassandra.namespace_prefix", "prefix");
+    props.setProperty(MultiStorageConfig.STORAGES + ".mysql.storage", "jdbc");
+    props.setProperty(
+        MultiStorageConfig.STORAGES + ".mysql.contact_points", "jdbc:mysql://localhost:3306/");
+    props.setProperty(MultiStorageConfig.STORAGES + ".mysql.username", "root");
+    props.setProperty(MultiStorageConfig.STORAGES + ".mysql.password", "mysql");
+
+    props.setProperty(
+        MultiStorageConfig.TABLE_MAPPING,
+        "user.order:cassandra,user.customer:mysql,coordinator.state:cassandra");
+
+    props.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING,
+        "namespace1:cassandra,namespace2:dynamo"); // non-existent storage
 
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 
@@ -155,6 +204,9 @@ public class MultiStorageConfigTest {
         MultiStorageConfig.TABLE_MAPPING,
         "user.order:cassandra,user.customer:mysql,coordinator.state:cassandra");
 
+    props.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING, "namespace1:cassandra,namespace2:mysql");
+
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "dynamo"); // non-existent storage
 
     // Act Assert
@@ -182,6 +234,9 @@ public class MultiStorageConfigTest {
     props.setProperty(
         MultiStorageConfig.TABLE_MAPPING,
         "user.order:cassandra,user.customer:mysql,coordinator.state:cassandra");
+
+    props.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING, "namespace1:cassandra,namespace2:mysql");
 
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 

--- a/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -1,0 +1,426 @@
+package com.scalar.db.storage.multistorage;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class MultiStorageTest {
+
+  protected static final String NAMESPACE1 = "test_ns1";
+  protected static final String NAMESPACE2 = "test_ns2";
+  protected static final String TABLE1 = "test_table1";
+  protected static final String TABLE2 = "test_table2";
+  protected static final String TABLE3 = "test_table3";
+  protected static final String COL_NAME1 = "c1";
+  protected static final String COL_NAME2 = "c2";
+  protected static final String COL_NAME3 = "c3";
+
+  @Mock private DistributedStorage storage1;
+  @Mock private DistributedStorage storage2;
+  @Mock private DistributedStorage storage3;
+
+  private MultiStorage multiStorage;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    // Arrange
+    Map<String, DistributedStorage> tableStorageMap = new HashMap<>();
+    tableStorageMap.put(NAMESPACE1 + "." + TABLE1, storage1);
+    tableStorageMap.put(NAMESPACE1 + "." + TABLE2, storage2);
+    Map<String, DistributedStorage> namespaceStorageMap = new HashMap<>();
+    namespaceStorageMap.put(NAMESPACE2, storage2);
+    DistributedStorage defaultStorage = storage3;
+    multiStorage = new MultiStorage(tableStorageMap, namespaceStorageMap, defaultStorage);
+  }
+
+  @Test
+  public void whenGetDataFromTable1_DataShouldBeGottenFromStorage1() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.get(get);
+
+    // Assert
+    verify(storage1).get(any(Get.class));
+  }
+
+  @Test
+  public void whenGetDataFromTable2_DataShouldBeGottenFromStorage2() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.get(get);
+
+    // Assert
+    verify(storage2).get(any(Get.class));
+  }
+
+  @Test
+  public void whenGetDataFromTable3_DataShouldBeGottenFromDefaultStorage()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.get(get);
+
+    // Assert
+    verify(storage3).get(any(Get.class));
+  }
+
+  @Test
+  public void whenScanDataFromTable1_DataShouldBeScannedFromStorage1() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.scan(scan);
+
+    // Assert
+    verify(storage1).scan(any(Scan.class));
+  }
+
+  @Test
+  public void whenScanDataFromTable2_DataShouldBeScannedFromStorage2() throws ExecutionException {
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.scan(scan);
+
+    // Assert
+    verify(storage2).scan(any(Scan.class));
+  }
+
+  @Test
+  public void whenScanDataFromTable3_DataShouldBeScannedFromDefaultStorage()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.scan(scan);
+
+    // Assert
+    verify(storage3).scan(any(Scan.class));
+  }
+
+  @Test
+  public void whenPutDataIntoTable1_DataShouldBeWrittenIntoStorage1() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(COL_NAME3, 3))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    // Act
+    multiStorage.put(put);
+
+    // Assert
+    verify(storage1).put(any(Put.class));
+  }
+
+  @Test
+  public void whenPutDataIntoTable2_DataShouldBeWrittenIntoStorage2() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(COL_NAME3, 3))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    // Act
+    multiStorage.put(put);
+
+    // Assert
+    verify(storage2).put(any(Put.class));
+  }
+
+  @Test
+  public void whenPutDataIntoTable3_DataShouldBeWrittenIntoDefaultStorage()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(COL_NAME3, 3))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    // Act
+    multiStorage.put(put);
+
+    // Assert
+    verify(storage3).put(any(Put.class));
+  }
+
+  @Test
+  public void whenDeleteDataFromTable1_DataShouldBeDeletedFromStorage1() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.delete(delete);
+
+    // Assert
+    verify(storage1).delete(any(Delete.class));
+  }
+
+  @Test
+  public void whenDeleteDataFromTable2_DataShouldBeDeletedFromStorage2() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.delete(delete);
+
+    // Assert
+    verify(storage2).delete(any(Delete.class));
+  }
+
+  @Test
+  public void whenDeleteDataFromTable3_DataShouldBeDeletedFromDefaultStorage()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.delete(delete);
+
+    // Assert
+    verify(storage3).delete(any(Delete.class));
+  }
+
+  @Test
+  public void whenMutateDataToTable1_ShouldExecuteForStorage1() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey1 = new Key(new IntValue(COL_NAME2, 2));
+    Key clusteringKey2 = new Key(new IntValue(COL_NAME2, 3));
+
+    // Act
+    multiStorage.mutate(
+        Arrays.asList(
+            new Put(partitionKey, clusteringKey2)
+                .withValue(new IntValue(COL_NAME3, 3))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+
+    // Assert
+    verify(storage1).mutate(anyList());
+  }
+
+  @Test
+  public void whenMutateDataToTable2_ShouldExecuteForStorage2() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE2;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey1 = new Key(new IntValue(COL_NAME2, 2));
+    Key clusteringKey2 = new Key(new IntValue(COL_NAME2, 3));
+
+    // Act
+    multiStorage.mutate(
+        Arrays.asList(
+            new Put(partitionKey, clusteringKey2)
+                .withValue(new IntValue(COL_NAME3, 3))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+
+    // Assert
+    verify(storage2).mutate(anyList());
+  }
+
+  @Test
+  public void whenMutateDataToTable3_ShouldExecuteForDefaultStorage() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE3;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey1 = new Key(new IntValue(COL_NAME2, 2));
+    Key clusteringKey2 = new Key(new IntValue(COL_NAME2, 3));
+
+    // Act
+    multiStorage.mutate(
+        Arrays.asList(
+            new Put(partitionKey, clusteringKey2)
+                .withValue(new IntValue(COL_NAME3, 3))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+
+    // Assert
+    verify(storage3).mutate(anyList());
+  }
+
+  @Test
+  public void whenCallMutateWithEmptyList_ShouldThrowIllegalArgumentException() {
+    // Arrange Act Assert
+    assertThatThrownBy(() -> multiStorage.mutate(Collections.emptyList()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void whenGetDataFromTable1InNamespace2_DataShouldBeGottenFromStorage2()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Get get = new Get(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.get(get);
+
+    // Assert
+    verify(storage2).get(any(Get.class));
+  }
+
+  @Test
+  public void whenScanDataFromTable1InNamespace2_DataShouldBeScannedFromStorage2()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Scan scan = new Scan(partitionKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.scan(scan);
+
+    // Assert
+    verify(storage2).scan(any(Scan.class));
+  }
+
+  @Test
+  public void whenPutDataIntoTable1InNamespace2_DataShouldBeWrittenIntoStorage2()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(new IntValue(COL_NAME3, 3))
+            .forNamespace(namespace)
+            .forTable(table);
+
+    // Act
+    multiStorage.put(put);
+
+    // Assert
+    verify(storage2).put(any(Put.class));
+  }
+
+  @Test
+  public void whenDeleteDataFromTable1InNamespace2_DataShouldBeDeletedFromStorage1()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey = new Key(new IntValue(COL_NAME2, 2));
+    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace(namespace).forTable(table);
+
+    // Act
+    multiStorage.delete(delete);
+
+    // Assert
+    verify(storage2).delete(any(Delete.class));
+  }
+
+  @Test
+  public void whenMutateDataToTable1InNamespace2_ShouldExecuteForStorage2()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE2;
+    String table = TABLE1;
+    Key partitionKey = new Key(new IntValue(COL_NAME1, 1));
+    Key clusteringKey1 = new Key(new IntValue(COL_NAME2, 2));
+    Key clusteringKey2 = new Key(new IntValue(COL_NAME2, 3));
+
+    // Act
+    multiStorage.mutate(
+        Arrays.asList(
+            new Put(partitionKey, clusteringKey2)
+                .withValue(new IntValue(COL_NAME3, 3))
+                .forNamespace(namespace)
+                .forTable(table),
+            new Delete(partitionKey, clusteringKey1).forNamespace(namespace).forTable(table)));
+
+    // Assert
+    verify(storage2).mutate(anyList());
+  }
+}


### PR DESCRIPTION
Currently, we only have a table mapping support in MultiStorage as follows:
```
# Define table mappings from table names to storages. The format is “<table name>:<storage name>,...”
scalar.db.multi_storage.table_mapping=user.ORDER:cassandra,user.CUSTOMER:mysql,coordinator.state:cassandra
```

This PR adds a namespace mapping support where we can define namespace mappings as follows:
```
# Define namespace mappings from namespace names to storages. The format is “<namespace name>:<storage name>,...”
scalar.db.multi_storage.namespace_mapping=user:cassandra,coordinator:mysql
```

Please take a look!