### PR TITLE
Should close PreparedStatement and ResultSet in scan operations of Jd…

### DIFF
--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -105,7 +105,7 @@ public class JdbcDatabase implements DistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      return jdbcService.scan(scan, connection, namespace, tableName);
+      return jdbcService.getScanner(scan, connection, namespace, tableName);
     } catch (SQLException e) {
       close(connection);
       throw new ExecutionException("scan operation failed", e);

--- a/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -86,20 +86,7 @@ public class JdbcService {
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
     Utility.addProjectionsForKeys(scan, tableMetadata);
 
-    SelectQuery selectQuery =
-        queryBuilder
-            .select(scan.getProjections())
-            .from(scan.forFullNamespace().get(), scan.forTable().get())
-            .where(
-                scan.getPartitionKey(),
-                scan.getStartClusteringKey(),
-                scan.getStartInclusive(),
-                scan.getEndClusteringKey(),
-                scan.getEndInclusive())
-            .orderBy(scan.getOrderings())
-            .limit(scan.getLimit())
-            .build();
-
+    SelectQuery selectQuery = buildSelectQueryForScan(scan);
     PreparedStatement preparedStatement = selectQuery.prepareAndBind(connection);
     ResultSet resultSet = preparedStatement.executeQuery();
     return new ScannerImpl(
@@ -117,20 +104,7 @@ public class JdbcService {
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
     Utility.addProjectionsForKeys(scan, tableMetadata);
 
-    SelectQuery selectQuery =
-        queryBuilder
-            .select(scan.getProjections())
-            .from(scan.forFullNamespace().get(), scan.forTable().get())
-            .where(
-                scan.getPartitionKey(),
-                scan.getStartClusteringKey(),
-                scan.getStartInclusive(),
-                scan.getEndClusteringKey(),
-                scan.getEndInclusive())
-            .orderBy(scan.getOrderings())
-            .limit(scan.getLimit())
-            .build();
-
+    SelectQuery selectQuery = buildSelectQueryForScan(scan);
     try (PreparedStatement preparedStatement = selectQuery.prepareAndBind(connection);
         ResultSet resultSet = preparedStatement.executeQuery()) {
       List<Result> ret = new ArrayList<>();
@@ -141,6 +115,21 @@ public class JdbcService {
       }
       return ret;
     }
+  }
+
+  private SelectQuery buildSelectQueryForScan(Scan scan) {
+    return queryBuilder
+        .select(scan.getProjections())
+        .from(scan.forFullNamespace().get(), scan.forTable().get())
+        .where(
+            scan.getPartitionKey(),
+            scan.getStartClusteringKey(),
+            scan.getStartInclusive(),
+            scan.getEndClusteringKey(),
+            scan.getEndInclusive())
+        .orderBy(scan.getOrderings())
+        .limit(scan.getLimit())
+        .build();
   }
 
   public boolean put(

--- a/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -9,7 +9,6 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
@@ -100,8 +99,8 @@ public class JdbcTransaction implements DistributedTransaction {
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
     try {
-      return jdbcService.scan(scan, connection, namespace, tableName).all();
-    } catch (SQLException | ExecutionException e) {
+      return jdbcService.scan(scan, connection, namespace, tableName);
+    } catch (SQLException e) {
       throw new CrudException("scan operation failed", e);
     }
   }

--- a/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -81,7 +81,7 @@ public class JdbcDatabaseTest {
   @Test
   public void whenScanOperationExecutedAndScannerClosed_shouldCallJdbcService() throws Exception {
     // Arrange
-    when(jdbcService.scan(any(), any(), any(), any()))
+    when(jdbcService.getScanner(any(), any(), any(), any()))
         .thenReturn(new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet));
 
     // Act
@@ -90,7 +90,7 @@ public class JdbcDatabaseTest {
     scanner.close();
 
     // Assert
-    verify(jdbcService).scan(any(), any(), any(), any());
+    verify(jdbcService).getScanner(any(), any(), any(), any());
     verify(connection).close();
   }
 
@@ -99,7 +99,7 @@ public class JdbcDatabaseTest {
       whenScanOperationExecutedAndJdbcServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
     // Arrange
-    when(jdbcService.scan(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.getScanner(any(), any(), any(), any())).thenThrow(sqlException);
 
     // Act Assert
     assertThatThrownBy(

--- a/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -105,7 +105,32 @@ public class JdbcServiceTest {
   }
 
   @Test
-  public void whenScanOperationExecuted_shouldCallQueryBuilder() throws Exception {
+  public void whenGetScannerExecuted_shouldCallQueryBuilder() throws Exception {
+    // Arrange
+    when(queryBuilder.select(any())).thenReturn(selectQueryBuilder);
+
+    when(selectQueryBuilder.from(any(), any())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.where(any(), any(), anyBoolean(), any(), anyBoolean()))
+        .thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.orderBy(any())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.limit(anyInt())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.build()).thenReturn(selectQuery);
+
+    when(selectQuery.prepareAndBind(any())).thenReturn(preparedStatement);
+    when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(false);
+
+    // Act
+    Scan scan = new Scan(new Key(new TextValue("p1", "val")));
+    jdbcService.getScanner(scan, connection, NAMESPACE, TABLE);
+
+    // Assert
+    verify(operationChecker).check(any(Scan.class));
+    verify(queryBuilder).select(any());
+  }
+
+  @Test
+  public void whenScanExecuted_shouldCallQueryBuilder() throws Exception {
     // Arrange
     when(queryBuilder.select(any())).thenReturn(selectQueryBuilder);
 

--- a/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -20,12 +20,12 @@ import com.scalar.db.io.TextValue;
 import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.ResultInterpreter;
-import com.scalar.db.storage.jdbc.ScannerImpl;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +56,7 @@ public class JdbcTransactionManagerTest {
   @Test
   public void whenSomeOperationsExecutedAndCommit_shouldCallJdbcService() throws Exception {
     // Arrange
-    when(jdbcService.scan(any(), any(), any(), any()))
-        .thenReturn(new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet));
-    when(resultSet.next()).thenReturn(false);
+    when(jdbcService.scan(any(), any(), any(), any())).thenReturn(Collections.emptyList());
     when(jdbcService.put(any(), any(), any(), any())).thenReturn(true);
     when(jdbcService.delete(any(), any(), any(), any())).thenReturn(true);
 


### PR DESCRIPTION
…bcTransaction

I found we don't close PreparedStatement and ResultSet in scan operations of JdbcTransaction. This PR will fix this issue.

Please take a look!