### PR TITLE
Add duplicatesStrategy to installDist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,10 @@ distTar {
     duplicatesStrategy 'exclude'
 }
 
+installDist {
+    duplicatesStrategy 'exclude'
+}
+
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-9205

This issue is created by upgrading Gradle version to 7 in #217. 

It looks like we need to add `duplicatesStrategy` to the `installDist` task to fix the issue described in the above Jira. 
Please take a look!