### PR TITLE
Some refactoring for the gRPC services

### DIFF
--- a/src/main/java/com/scalar/db/server/DistributedStorageAdminService.java
+++ b/src/main/java/com/scalar/db/server/DistributedStorageAdminService.java
@@ -38,7 +38,7 @@ public class DistributedStorageAdminService
               request.getTable(),
               ProtoUtil.toTableMetadata(request.getTableMetadata()),
               request.getOptionsMap());
-          responseObserver.onNext(Empty.newBuilder().build());
+          responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();
         },
         responseObserver);
@@ -49,7 +49,7 @@ public class DistributedStorageAdminService
     execute(
         () -> {
           admin.dropTable(request.getNamespace(), request.getTable());
-          responseObserver.onNext(Empty.newBuilder().build());
+          responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();
         },
         responseObserver);
@@ -60,7 +60,7 @@ public class DistributedStorageAdminService
     execute(
         () -> {
           admin.truncateTable(request.getNamespace(), request.getTable());
-          responseObserver.onNext(Empty.newBuilder().build());
+          responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();
         },
         responseObserver);
@@ -91,12 +91,12 @@ public class DistributedStorageAdminService
       LOGGER.error("an invalid argument error happened during the execution", e);
       responseObserver.onError(
           Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());
-    } catch (Throwable e) {
-      LOGGER.error("an internal error happened during the execution", e);
+    } catch (Throwable t) {
+      LOGGER.error("an internal error happened during the execution", t);
       responseObserver.onError(
-          Status.INTERNAL.withDescription(e.getMessage()).asRuntimeException());
-      if (e instanceof Error) {
-        throw (Error) e;
+          Status.INTERNAL.withDescription(t.getMessage()).asRuntimeException());
+      if (t instanceof Error) {
+        throw (Error) t;
       }
     }
   }

--- a/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -2,12 +2,10 @@ package com.scalar.db.server;
 
 import com.google.inject.Inject;
 import com.google.protobuf.Empty;
-import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
-import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TransactionState;
@@ -39,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,36 +144,8 @@ public class DistributedTransactionService
           for (com.scalar.db.rpc.Mutation mutation : request.getMutationsList()) {
             mutations.add(ProtoUtil.toMutation(mutation));
           }
-
-          if (mutations.size() == 1) {
-            Mutation mutation = mutations.get(0);
-            if (mutation instanceof Put) {
-              transaction.put((Put) mutation);
-            } else {
-              transaction.delete((Delete) mutation);
-            }
-          } else {
-            boolean hasPut = false;
-            boolean hasDelete = false;
-            for (Mutation mutation : mutations) {
-              if (mutation instanceof Put) {
-                hasPut = true;
-              } else {
-                hasDelete = true;
-              }
-            }
-            boolean mixed = hasPut & hasDelete;
-
-            if (mixed) {
-              transaction.mutate(mutations);
-            } else if (hasPut) {
-              transaction.put(mutations.stream().map(m -> (Put) m).collect(Collectors.toList()));
-            } else {
-              transaction.delete(
-                  mutations.stream().map(m -> (Delete) m).collect(Collectors.toList()));
-            }
-          }
-          responseObserver.onNext(Empty.newBuilder().build());
+          transaction.mutate(mutations);
+          responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();
         },
         responseObserver);
@@ -192,7 +161,7 @@ public class DistributedTransactionService
           } finally {
             activeTransactions.remove(transaction.getId());
           }
-          responseObserver.onNext(Empty.newBuilder().build());
+          responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();
         },
         responseObserver);
@@ -208,7 +177,7 @@ public class DistributedTransactionService
           } finally {
             activeTransactions.remove(transaction.getId());
           }
-          responseObserver.onNext(Empty.newBuilder().build());
+          responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();
         },
         responseObserver);
@@ -253,12 +222,12 @@ public class DistributedTransactionService
     } catch (UnknownTransactionStatusException e) {
       LOGGER.error("an unknown transaction error happened during the execution", e);
       responseObserver.onError(Status.UNKNOWN.withDescription(e.getMessage()).asRuntimeException());
-    } catch (Throwable e) {
-      LOGGER.error("an internal error happened during the execution", e);
+    } catch (Throwable t) {
+      LOGGER.error("an internal error happened during the execution", t);
       responseObserver.onError(
-          Status.INTERNAL.withDescription(e.getMessage()).asRuntimeException());
-      if (e instanceof Error) {
-        throw (Error) e;
+          Status.INTERNAL.withDescription(t.getMessage()).asRuntimeException());
+      if (t instanceof Error) {
+        throw (Error) t;
       }
     }
   }

--- a/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
+++ b/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
@@ -173,7 +173,7 @@ public class DistributedStorageServiceTest {
     storageService.mutate(request, responseObserver);
 
     // Assert
-    verify(storage).put(any(Put.class));
+    verify(storage).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -197,7 +197,7 @@ public class DistributedStorageServiceTest {
     storageService.mutate(request, responseObserver);
 
     // Assert
-    verify(storage).put(anyList());
+    verify(storage).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -218,7 +218,7 @@ public class DistributedStorageServiceTest {
     storageService.mutate(request, responseObserver);
 
     // Assert
-    verify(storage).delete(any(Delete.class));
+    verify(storage).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -242,7 +242,7 @@ public class DistributedStorageServiceTest {
     storageService.mutate(request, responseObserver);
 
     // Assert
-    verify(storage).delete(anyList());
+    verify(storage).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -282,7 +282,7 @@ public class DistributedStorageServiceTest {
             .build();
     @SuppressWarnings("unchecked")
     StreamObserver<Empty> responseObserver = mock(StreamObserver.class);
-    doThrow(IllegalArgumentException.class).when(storage).put(any(Put.class));
+    doThrow(IllegalArgumentException.class).when(storage).mutate(anyList());
 
     // Act
     storageService.mutate(request, responseObserver);
@@ -304,7 +304,7 @@ public class DistributedStorageServiceTest {
             .build();
     @SuppressWarnings("unchecked")
     StreamObserver<Empty> responseObserver = mock(StreamObserver.class);
-    doThrow(NoMutationException.class).when(storage).put(any(Put.class));
+    doThrow(NoMutationException.class).when(storage).mutate(anyList());
 
     // Act
     storageService.mutate(request, responseObserver);
@@ -326,7 +326,7 @@ public class DistributedStorageServiceTest {
             .build();
     @SuppressWarnings("unchecked")
     StreamObserver<Empty> responseObserver = mock(StreamObserver.class);
-    doThrow(ExecutionException.class).when(storage).put(any(Put.class));
+    doThrow(ExecutionException.class).when(storage).mutate(anyList());
 
     // Act
     storageService.mutate(request, responseObserver);

--- a/src/test/java/com/scalar/db/server/DistributedTransactionServiceTest.java
+++ b/src/test/java/com/scalar/db/server/DistributedTransactionServiceTest.java
@@ -328,7 +328,7 @@ public class DistributedTransactionServiceTest {
     transactionService.mutate(request, responseObserver);
 
     // Assert
-    verify(transaction).put(any(Put.class));
+    verify(transaction).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -360,7 +360,7 @@ public class DistributedTransactionServiceTest {
     transactionService.mutate(request, responseObserver);
 
     // Assert
-    verify(transaction).put(anyList());
+    verify(transaction).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -389,7 +389,7 @@ public class DistributedTransactionServiceTest {
     transactionService.mutate(request, responseObserver);
 
     // Assert
-    verify(transaction).delete(any(Delete.class));
+    verify(transaction).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -421,7 +421,7 @@ public class DistributedTransactionServiceTest {
     transactionService.mutate(request, responseObserver);
 
     // Assert
-    verify(transaction).delete(anyList());
+    verify(transaction).mutate(anyList());
     verify(responseObserver).onNext(any());
     verify(responseObserver).onCompleted();
   }
@@ -477,7 +477,7 @@ public class DistributedTransactionServiceTest {
             .build();
     @SuppressWarnings("unchecked")
     StreamObserver<Empty> responseObserver = mock(StreamObserver.class);
-    doThrow(IllegalArgumentException.class).when(transaction).put(any(Put.class));
+    doThrow(IllegalArgumentException.class).when(transaction).mutate(anyList());
 
     // Act
     transactionService.mutate(request, responseObserver);
@@ -507,7 +507,7 @@ public class DistributedTransactionServiceTest {
             .build();
     @SuppressWarnings("unchecked")
     StreamObserver<Empty> responseObserver = mock(StreamObserver.class);
-    doThrow(CrudConflictException.class).when(transaction).put(any(Put.class));
+    doThrow(CrudConflictException.class).when(transaction).mutate(anyList());
 
     // Act
     transactionService.mutate(request, responseObserver);
@@ -537,7 +537,7 @@ public class DistributedTransactionServiceTest {
             .build();
     @SuppressWarnings("unchecked")
     StreamObserver<Empty> responseObserver = mock(StreamObserver.class);
-    doThrow(CrudException.class).when(transaction).put(any(Put.class));
+    doThrow(CrudException.class).when(transaction).mutate(anyList());
 
     // Act
     transactionService.mutate(request, responseObserver);


### PR DESCRIPTION
What I did in this PR is as follows:
- Use `Empty.getDefaultInstance()` instead of `Empty.newBuilder().build()`
- Rename Throwable `e` to `t`
- Use the `mutate(List)` method for all mutation cases in DistributedStorageService and DistributedTransactionService

Please take a look!