### PR TITLE
Rename ConsensusCommitWithGrpcStorageIntegrationTest

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,9 +4,6 @@ sourceSets {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
             srcDir file('src/integration-test/java')
-            include '**/com/scalar/db/storage/*.java'
-            include '**/com/scalar/db/storage/jdbc/test/*.java'
-            include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java'
         }
         resources.srcDir file('src/integration-test/resources')
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -41,7 +41,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   }
 
   @VisibleForTesting
-  ConsensusCommitManager(
+  public ConsensusCommitManager(
       DistributedStorage storage,
       DatabaseConfig config,
       Coordinator coordinator,

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.scalar.db.transaction.consensuscommit;
+package com.scalar.db.server;
 
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_COMMITTED_AT;
 import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_ID;
@@ -18,9 +18,13 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.io.DataType;
-import com.scalar.db.server.ScalarDbServer;
 import com.scalar.db.storage.jdbc.test.TestEnv;
 import com.scalar.db.storage.rpc.GrpcStorage;
+import com.scalar.db.transaction.consensuscommit.CommitHandler;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.RecoveryHandler;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Optional;
@@ -30,7 +34,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-public class ConsensusCommitWithGrpcStorageIntegrationTest
+public class ConsensusCommitWithDistributedStorageServiceIntegrationTest
     extends ConsensusCommitIntegrationTestBase {
 
   private static final String MYSQL_CONTACT_POINT = "jdbc:mysql://localhost:3306/";


### PR DESCRIPTION
I found that I forgot to rename (move) ConsensusCommitWithGrpcStorageIntegrationTest to the `server` subproject when converting this project to multi-project. This PR does that.

Please take a look!