### PR TITLE
Add transaction manager config

### DIFF
--- a/conf/database.properties
+++ b/conf/database.properties
@@ -14,6 +14,9 @@ scalar.db.password=cassandra
 # Namespace prefix. The default is empty.
 #scalar.db.namespace_prefix=
 
+# The type of the transaction manager. "consensus-commit" or "jdbc" or "grpc" can be set. The default is "consensus-commit"
+#scalar.db.transaction_manager=consensus-commit
+
 # Default isolation level. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
 #scalar.db.isolation_level=
 

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -80,10 +80,9 @@ public class DatabaseConfig {
   }
 
   protected void load() {
-    if (Strings.isNullOrEmpty(props.getProperty(STORAGE))) {
-      storageClass = Cassandra.class;
-      adminClass = CassandraAdmin.class;
-    } else {
+    storageClass = Cassandra.class;
+    adminClass = CassandraAdmin.class;
+    if (!Strings.isNullOrEmpty(props.getProperty(STORAGE))) {
       switch (props.getProperty(STORAGE).toLowerCase()) {
         case "cassandra":
           storageClass = Cassandra.class;
@@ -139,9 +138,8 @@ public class DatabaseConfig {
       namespacePrefix = Optional.empty();
     }
 
-    if (Strings.isNullOrEmpty(props.getProperty(TRANSACTION_MANAGER))) {
-      transactionManagerClass = ConsensusCommitManager.class;
-    } else {
+    transactionManagerClass = ConsensusCommitManager.class;
+    if (!Strings.isNullOrEmpty(props.getProperty(TRANSACTION_MANAGER))) {
       switch (props.getProperty(TRANSACTION_MANAGER).toLowerCase()) {
         case "consensus-commit":
           transactionManagerClass = ConsensusCommitManager.class;

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -7,11 +7,8 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.dynamo.DynamoDatabaseConfig;
-import com.scalar.db.storage.jdbc.JdbcDatabase;
 import com.scalar.db.storage.jdbc.JdbcDatabaseConfig;
 import com.scalar.db.storage.multistorage.MultiStorageConfig;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
-import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 
 public class TransactionModule extends AbstractModule {
   private final DatabaseConfig config;
@@ -23,25 +20,9 @@ public class TransactionModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(DistributedStorage.class).to(config.getStorageClass()).in(Singleton.class);
-
-    if (useJdbcTransaction()) {
-      bind(DistributedTransactionManager.class)
-          .to(JdbcTransactionManager.class)
-          .in(Singleton.class);
-      return;
-    }
-
-    bind(DistributedTransactionManager.class).to(ConsensusCommitManager.class).in(Singleton.class);
-  }
-
-  private boolean useJdbcTransaction() {
-    if (config.getStorageClass() == JdbcDatabase.class) {
-      JdbcDatabaseConfig jdbcDatabaseConfig = provideJdbcDatabaseConfig();
-      return jdbcDatabaseConfig
-          .getTransactionManagerType()
-          .equals(JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE_JDBC);
-    }
-    return false;
+    bind(DistributedTransactionManager.class)
+        .to(config.getTransactionManagerClass())
+        .in(Singleton.class);
   }
 
   @Singleton

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabaseConfig.java
@@ -23,24 +23,17 @@ public class JdbcDatabaseConfig extends DatabaseConfig {
   public static final String PREPARED_STATEMENTS_POOL_MAX_OPEN =
       PREFIX + "prepared_statements_pool.max_open";
 
-  public static final String TRANSACTION_MANAGER_TYPE = PREFIX + "transaction_manager_type";
-  public static final String TRANSACTION_MANAGER_TYPE_CONSENSUS_COMMIT = "consensus-commit";
-  public static final String TRANSACTION_MANAGER_TYPE_JDBC = "jdbc";
-
   public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 5;
   public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 10;
   public static final int DEFAULT_CONNECTION_POOL_MAX_TOTAL = 25;
   public static final boolean DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED = false;
   public static final int DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN = -1;
-  public static final String DEFAULT_TRANSACTION_MANAGER_TYPE =
-      TRANSACTION_MANAGER_TYPE_CONSENSUS_COMMIT;
 
   private int connectionPoolMinIdle;
   private int connectionPoolMaxIdle;
   private int connectionPoolMaxTotal;
   private boolean preparedStatementsPoolEnabled;
   private int preparedStatementsPoolMaxOpen;
-  private String transactionManagerType;
 
   public JdbcDatabaseConfig(File propertiesFile) throws IOException {
     super(propertiesFile);
@@ -70,19 +63,6 @@ public class JdbcDatabaseConfig extends DatabaseConfig {
         getBoolean(PREPARED_STATEMENTS_POOL_ENABLED, DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     preparedStatementsPoolMaxOpen =
         getInt(PREPARED_STATEMENTS_POOL_MAX_OPEN, DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
-
-    transactionManagerType =
-        getProperties().getProperty(TRANSACTION_MANAGER_TYPE, DEFAULT_TRANSACTION_MANAGER_TYPE);
-    if (!transactionManagerType.equals(TRANSACTION_MANAGER_TYPE_CONSENSUS_COMMIT)
-        && !transactionManagerType.equals(TRANSACTION_MANAGER_TYPE_JDBC)) {
-      if (!transactionManagerType.isEmpty()) {
-        LOGGER.warn(
-            "the specified value of '{}' is invalid. using the default value: {}",
-            TRANSACTION_MANAGER_TYPE,
-            DEFAULT_TRANSACTION_MANAGER_TYPE);
-      }
-      transactionManagerType = DEFAULT_TRANSACTION_MANAGER_TYPE;
-    }
   }
 
   private int getInt(String name, int defaultValue) {
@@ -127,9 +107,5 @@ public class JdbcDatabaseConfig extends DatabaseConfig {
 
   public int getPreparedStatementsPoolMaxOpen() {
     return preparedStatementsPoolMaxOpen;
-  }
-
-  public String getTransactionManagerType() {
-    return transactionManagerType;
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConfigTest.java
@@ -30,9 +30,6 @@ public class JdbcDatabaseConfigTest {
     props.setProperty(JdbcDatabaseConfig.CONNECTION_POOL_MAX_TOTAL, "200");
     props.setProperty(JdbcDatabaseConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
     props.setProperty(JdbcDatabaseConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "300");
-    props.setProperty(
-        JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE,
-        JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE_JDBC);
 
     // Act
     JdbcDatabaseConfig config = new JdbcDatabaseConfig(props);
@@ -53,8 +50,6 @@ public class JdbcDatabaseConfigTest {
     assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(200);
     assertThat(config.isPreparedStatementsPoolEnabled()).isEqualTo(true);
     assertThat(config.getPreparedStatementsPoolMaxOpen()).isEqualTo(300);
-    assertThat(config.getTransactionManagerType())
-        .isEqualTo(JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE_JDBC);
   }
 
   @Test
@@ -92,8 +87,6 @@ public class JdbcDatabaseConfigTest {
         .isEqualTo(JdbcDatabaseConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     assertThat(config.getPreparedStatementsPoolMaxOpen())
         .isEqualTo(JdbcDatabaseConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
-    assertThat(config.getTransactionManagerType())
-        .isEqualTo(JdbcDatabaseConfig.DEFAULT_TRANSACTION_MANAGER_TYPE);
   }
 
   @Test
@@ -126,7 +119,6 @@ public class JdbcDatabaseConfigTest {
     props.setProperty(JdbcDatabaseConfig.CONNECTION_POOL_MAX_TOTAL, "ccc");
     props.setProperty(JdbcDatabaseConfig.PREPARED_STATEMENTS_POOL_ENABLED, "ddd");
     props.setProperty(JdbcDatabaseConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "eee");
-    props.setProperty(JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE, "fff");
 
     // Act
     JdbcDatabaseConfig config = new JdbcDatabaseConfig(props);
@@ -152,7 +144,5 @@ public class JdbcDatabaseConfigTest {
         .isEqualTo(JdbcDatabaseConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     assertThat(config.getPreparedStatementsPoolMaxOpen())
         .isEqualTo(JdbcDatabaseConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
-    assertThat(config.getTransactionManagerType())
-        .isEqualTo(JdbcDatabaseConfig.DEFAULT_TRANSACTION_MANAGER_TYPE);
   }
 }

--- a/docs/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/getting-started-with-scalardb-on-jdbc.md
@@ -42,9 +42,6 @@ scalar.db.storage=jdbc
 
 # The maximum number of open statements that can be allocated from the statement pool at the same time, or negative for no limit. The default is -1
 #scalar.db.jdbc.prepared_statements_pool.max_open=-1
-
-# The type of the transaction manager. "consensus-commit" or "jdbc" can be set. The default is "consensus-commit"
-#scalar.db.jdbc.transaction_manager_type=consensus-commit
 ```
 
 Please follow [Getting Started with Scalar DB](getting-started-with-scalardb.md) to run the application.

--- a/docs/getting-started-with-scalardb.md
+++ b/docs/getting-started-with-scalardb.md
@@ -147,7 +147,7 @@ $ ../../gradlew run --args="-mode storage -action pay -amount 100 -to merchant1 
 
 ## Set up database schema for transaction
 
-To use transaction, we can just add a key `transaction` and value as `true` in the Scalar DB scheme we used.
+To use transaction, we can just add a key `transaction` and value as `true` in the Scalar DB schema we used.
 You can create a JSON file `emoney-transaction.json` with the JSON bellow.
 
 ```json
@@ -295,11 +295,11 @@ When you use a JDBC database as a backend database, you can optionally use the n
 To use the native transaction manager, you need to set `jdbc` to a transaction manager type in **scalardb.properties** as follows.
 
 ```
-scalar.db.jdbc.transaction_manager_type=jdbc
+scalar.db.transaction_manager=jdbc
 ```
 
-You don't need to set a key `transaction` to `true` in Scalar DB scheme for the native transaction manager.
-So you can use the same scheme file as **emoney-storage.json**.
+You don't need to set a key `transaction` to `true` in Scalar DB schema for the native transaction manager.
+So you can use the same schema file as **emoney-storage.json**.
 
 ## Further documentation
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithJdbcTransactionIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithJdbcTransactionIntegrationTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
-import com.scalar.db.storage.jdbc.JdbcDatabaseConfig;
 import com.scalar.db.storage.jdbc.test.TestEnv;
 import com.scalar.db.transaction.rpc.GrpcTransaction;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
@@ -326,9 +325,7 @@ public class DistributedTransactionServiceWithJdbcTransactionIntegrationTest {
     testEnv.insertMetadata();
 
     Properties serverProperties = new Properties(testEnv.getJdbcDatabaseConfig().getProperties());
-    serverProperties.setProperty(
-        JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE,
-        JdbcDatabaseConfig.TRANSACTION_MANAGER_TYPE_JDBC);
+    serverProperties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
     server = new ScalarDbServer(serverProperties);
     server.start();
 


### PR DESCRIPTION
To support transactions through the Scalar DB server, I added a new transaction manager property (`scalar.db.transaction_manager`). We can set `consensus-commit` (default) or `jdbc` or `grpc` to this property. When we set `grpc`, we can perform transactions through the Scalar DB server. And if we set `jdbc`, we also need to set `jdbc` to `scalar.db.storage`.

I also removed the `scalar.db.jdbc.transaction_manager_type` property in this PR because we can replace it with the new property. So this is an incompatible change.

Please take a look!