### PR TITLE
Add metrics to Scalar DB Server

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation(group: 'com.scalar-labs', name: 'scalar-admin', version: '1.0.0') {
         exclude group: 'io.grpc'
     }
+    implementation group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.2.2'
+    implementation group: 'io.dropwizard.metrics', name: 'metrics-jmx', version: '4.2.2'
     testImplementation project(':core').sourceSets.integrationTest.output
 }
 

--- a/server/src/main/java/com/scalar/db/server/Metrics.java
+++ b/server/src/main/java/com/scalar/db/server/Metrics.java
@@ -1,0 +1,68 @@
+package com.scalar.db.server;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.Timer.Context;
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.util.ThrowableRunnable;
+import com.scalar.db.util.ThrowableSupplier;
+import java.util.Objects;
+
+public class Metrics {
+  private final MetricRegistry metricRegistry;
+
+  private final Counter totalSucceeded;
+  private final Counter totalFailed;
+
+  public Metrics(MetricRegistry metricRegistry) {
+    this.metricRegistry = Objects.requireNonNull(metricRegistry);
+
+    totalSucceeded = metricRegistry.counter(name(Metrics.class, "totalSucceeded"));
+    totalFailed = metricRegistry.counter(name(Metrics.class, "totalFailed"));
+  }
+
+  @VisibleForTesting
+  public Metrics() {
+    metricRegistry = null;
+    totalSucceeded = null;
+    totalFailed = null;
+  }
+
+  public void measure(Class<?> klass, String method, ThrowableRunnable<Throwable> runnable)
+      throws Throwable {
+    // For test
+    if (metricRegistry == null) {
+      runnable.run();
+    }
+
+    Timer timer = metricRegistry.timer(name(klass, method));
+    try (Context unused = timer.time()) {
+      runnable.run();
+      totalSucceeded.inc();
+    } catch (Throwable t) {
+      totalFailed.inc();
+      throw t;
+    }
+  }
+
+  public <T> T measure(Class<?> klass, String method, ThrowableSupplier<T, Throwable> supplier)
+      throws Throwable {
+    // For test
+    if (metricRegistry == null) {
+      return supplier.get();
+    }
+
+    Timer timer = metricRegistry.timer(name(klass, method));
+    try (Context unused = timer.time()) {
+      T ret = supplier.get();
+      totalSucceeded.inc();
+      return ret;
+    } catch (Throwable t) {
+      totalFailed.inc();
+      throw t;
+    }
+  }
+}

--- a/server/src/main/java/com/scalar/db/server/Metrics.java
+++ b/server/src/main/java/com/scalar/db/server/Metrics.java
@@ -36,6 +36,7 @@ public class Metrics {
     // For test
     if (metricRegistry == null) {
       runnable.run();
+      return;
     }
 
     Timer timer = metricRegistry.timer(name(klass, method));

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -1,5 +1,7 @@
 package com.scalar.db.server.service;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -9,6 +11,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.server.Metrics;
 import com.scalar.db.server.Pauser;
 import com.scalar.db.service.StorageModule;
 import com.scalar.db.service.TransactionModule;
@@ -44,5 +47,18 @@ public class ServerModule extends AbstractModule {
   @Singleton
   Pauser providePauser() {
     return new Pauser();
+  }
+
+  @Provides
+  @Singleton
+  Metrics provideMetrics() {
+    MetricRegistry metricRegistry = new MetricRegistry();
+
+    // start JMX reporter
+    JmxReporter reporter = JmxReporter.forRegistry(metricRegistry).build();
+    reporter.start();
+    Runtime.getRuntime().addShutdownHook(new Thread(reporter::stop));
+
+    return new Metrics(metricRegistry);
   }
 }

--- a/server/src/test/java/com/scalar/db/server/DistributedStorageAdminServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedStorageAdminServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.MockitoAnnotations;
 public class DistributedStorageAdminServiceTest {
 
   @Mock private DistributedStorageAdmin admin;
+
   private DistributedStorageAdminService adminService;
 
   @Before
@@ -32,7 +33,7 @@ public class DistributedStorageAdminServiceTest {
     MockitoAnnotations.initMocks(this);
 
     // Arrange
-    adminService = new DistributedStorageAdminService(admin);
+    adminService = new DistributedStorageAdminService(admin, new Metrics());
   }
 
   @Test

--- a/server/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
@@ -44,7 +44,7 @@ public class DistributedStorageServiceTest {
     MockitoAnnotations.initMocks(this);
 
     // Arrange
-    storageService = new DistributedStorageService(storage, pauser);
+    storageService = new DistributedStorageService(storage, pauser, new Metrics());
     when(pauser.preProcess()).thenReturn(true);
   }
 

--- a/server/src/test/java/com/scalar/db/server/DistributedTransactionServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedTransactionServiceTest.java
@@ -41,7 +41,7 @@ public class DistributedTransactionServiceTest {
     MockitoAnnotations.initMocks(this);
 
     // Arrange
-    transactionService = new DistributedTransactionService(manager, pauser);
+    transactionService = new DistributedTransactionService(manager, pauser, new Metrics());
     when(manager.start()).thenReturn(transaction);
     when(manager.start(anyString())).thenReturn(transaction);
     when(transaction.getId()).thenReturn(ANY_ID);


### PR DESCRIPTION
I used the `dropwizard metrics` lib to expose the Scalar DB Server metrics:
https://github.com/dropwizard/metrics

And the metrics are exposed via JMX by using `JmxReporter`  in `dropwizard metrics`.

The following metrics are exposed:
* totalSucceeded (produced by `Counter`)
* totalFailed (produced by `Counter`)
* metrics for per gRPC endpoint (produced by `Timer`)
  * Max
  * Min
  * Mean
  * 50thPercentile
  * 75thPercentile
  * 95thPercentile
  * 98thPercentile
  * 99thPercentile
  * 999thPercentile
  * StdDev
  * DurationUnit
  * Count
  * OneMinuteRate
  * FiveMinuteRate
  * FifteenMinuteRate
  * MeanRate 
  * RateUnit

Please take a look!