### PR TITLE
Support Prometheus in Scalar DB Server

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     }
     implementation group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.2.2'
     implementation group: 'io.dropwizard.metrics', name: 'metrics-jmx', version: '4.2.2'
+    implementation group: 'io.prometheus', name: 'simpleclient_dropwizard', version: '0.11.0'
+    implementation group: 'io.prometheus', name: 'simpleclient_servlet', version: '0.11.0'
+    implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.43.v20210629'
     testImplementation project(':core').sourceSets.integrationTest.output
 }
 

--- a/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
+++ b/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
@@ -54,7 +54,8 @@ public class ScalarDbServer implements Callable<Integer> {
     }
 
     ServerConfig config = new ServerConfig(properties);
-    Injector injector = Guice.createInjector(new ServerModule(new DatabaseConfig(properties)));
+    Injector injector =
+        Guice.createInjector(new ServerModule(config, new DatabaseConfig(properties)));
     server =
         ServerBuilder.forPort(config.getPort())
             .addService(injector.getInstance(DistributedStorageService.class))

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -15,8 +15,18 @@ import com.scalar.db.server.Metrics;
 import com.scalar.db.server.Pauser;
 import com.scalar.db.service.StorageModule;
 import com.scalar.db.service.TransactionModule;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.exporter.MetricsServlet;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ServerModule extends AbstractModule {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerModule.class);
+
   private final Injector storageInjector;
   private final Injector transactionInjector;
 
@@ -53,12 +63,30 @@ public class ServerModule extends AbstractModule {
   @Singleton
   Metrics provideMetrics() {
     MetricRegistry metricRegistry = new MetricRegistry();
+    startJmxReporter(metricRegistry);
+    startPrometheusHttpEndpoint(metricRegistry);
+    return new Metrics(metricRegistry);
+  }
 
-    // start JMX reporter
+  private void startJmxReporter(MetricRegistry metricRegistry) {
     JmxReporter reporter = JmxReporter.forRegistry(metricRegistry).build();
     reporter.start();
     Runtime.getRuntime().addShutdownHook(new Thread(reporter::stop));
+  }
 
-    return new Metrics(metricRegistry);
+  private void startPrometheusHttpEndpoint(MetricRegistry metricRegistry) {
+    CollectorRegistry.defaultRegistry.register(new DropwizardExports(metricRegistry));
+
+    Server server = new Server(8080);
+    ServletContextHandler context = new ServletContextHandler();
+    context.setContextPath("/");
+    server.setHandler(context);
+    context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+    server.setStopAtShutdown(true);
+    try {
+      server.start();
+    } catch (Exception e) {
+      LOGGER.error("failed to start Jetty server", e);
+    }
   }
 }

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.server.Metrics;
 import com.scalar.db.server.Pauser;
+import com.scalar.db.server.config.ServerConfig;
 import com.scalar.db.service.StorageModule;
 import com.scalar.db.service.TransactionModule;
 import io.prometheus.client.CollectorRegistry;
@@ -27,12 +28,14 @@ import org.slf4j.LoggerFactory;
 public class ServerModule extends AbstractModule {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerModule.class);
 
+  private final ServerConfig config;
   private final Injector storageInjector;
   private final Injector transactionInjector;
 
-  public ServerModule(DatabaseConfig config) {
-    storageInjector = Guice.createInjector(new StorageModule(config));
-    transactionInjector = Guice.createInjector(new TransactionModule(config));
+  public ServerModule(ServerConfig config, DatabaseConfig databaseConfig) {
+    this.config = config;
+    storageInjector = Guice.createInjector(new StorageModule(databaseConfig));
+    transactionInjector = Guice.createInjector(new TransactionModule(databaseConfig));
   }
 
   @Provides
@@ -77,7 +80,7 @@ public class ServerModule extends AbstractModule {
   private void startPrometheusHttpEndpoint(MetricRegistry metricRegistry) {
     CollectorRegistry.defaultRegistry.register(new DropwizardExports(metricRegistry));
 
-    Server server = new Server(8080);
+    Server server = new Server(config.getPrometheusHttpEndpointPort());
     ServletContextHandler context = new ServletContextHandler();
     context.setContextPath("/");
     server.setHandler(context);

--- a/server/src/test/java/com/scalar/db/server/config/ServerConfigTest.java
+++ b/server/src/test/java/com/scalar/db/server/config/ServerConfigTest.java
@@ -10,6 +10,20 @@ public class ServerConfigTest {
   private static final int ANY_PORT = 9999;
 
   @Test
+  public void constructor_NothingGiven_ShouldUseDefault() {
+    // Arrange
+    Properties props = new Properties();
+
+    // Act
+    ServerConfig config = new ServerConfig(props);
+
+    // Assert
+    assertThat(config.getPort()).isEqualTo(ServerConfig.DEFAULT_PORT);
+    assertThat(config.getPrometheusHttpEndpointPort())
+        .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_HTTP_ENDPOINT_PORT);
+  }
+
+  @Test
   public void constructor_ValidPortGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
@@ -23,7 +37,7 @@ public class ServerConfigTest {
   }
 
   @Test
-  public void constructor_InvalidPortGiven_ShouldUseDefaultPort() {
+  public void constructor_InvalidPortGiven_ShouldUseDefault() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(ServerConfig.PORT, "abc");
@@ -33,5 +47,32 @@ public class ServerConfigTest {
 
     // Assert
     assertThat(config.getPort()).isEqualTo(ServerConfig.DEFAULT_PORT);
+  }
+
+  @Test
+  public void constructor_ValidPrometheusHttpEndpointPortGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, Integer.toString(ANY_PORT));
+
+    // Act
+    ServerConfig config = new ServerConfig(props);
+
+    // Assert
+    assertThat(config.getPrometheusHttpEndpointPort()).isEqualTo(ANY_PORT);
+  }
+
+  @Test
+  public void constructor_InvalidPrometheusHttpEndpointPortGiven_ShouldUseDefault() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "abc");
+
+    // Act
+    ServerConfig config = new ServerConfig(props);
+
+    // Assert
+    assertThat(config.getPrometheusHttpEndpointPort())
+        .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_HTTP_ENDPOINT_PORT);
   }
 }


### PR DESCRIPTION
To support Prometheus, I used `simpleclient_dropwizard` (https://github.com/prometheus/client_java/tree/master/simpleclient_dropwizard) published by Prometheus officially instead of `jmx_exporter` (https://github.com/prometheus/jmx_exporter) that's also published by Prometheus officially.

This change will start an HTTP endpoint for Prometheus (port: 8080, path: /metrics).

Please take a look!
