### PR TITLE
Use the Scalar DB server default port if not specified in the Scalar DB server client

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class GrpcStorage implements DistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcStorage.class);
+  private static final int DEFAULT_SCALAR_DB_SERVER_PORT = 60051;
 
   private static final Retry.ExceptionFactory<ExecutionException> EXCEPTION_FACTORY =
       (message, cause) -> {
@@ -64,7 +65,11 @@ public class GrpcStorage implements DistributedStorage {
   public GrpcStorage(GrpcConfig config) {
     this.config = config;
     channel =
-        NettyChannelBuilder.forAddress(config.getContactPoints().get(0), config.getContactPort())
+        NettyChannelBuilder.forAddress(
+                config.getContactPoints().get(0),
+                config.getContactPort() == 0
+                    ? DEFAULT_SCALAR_DB_SERVER_PORT
+                    : config.getContactPort())
             .usePlaintext()
             .build();
     stub = DistributedStorageGrpc.newStub(channel);

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class GrpcTransactionManager implements DistributedTransactionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcTransactionManager.class);
+  private static final int DEFAULT_SCALAR_DB_SERVER_PORT = 60051;
 
   private static final Retry.ExceptionFactory<TransactionException> EXCEPTION_FACTORY =
       (message, cause) -> {
@@ -61,7 +62,11 @@ public class GrpcTransactionManager implements DistributedTransactionManager {
   public GrpcTransactionManager(GrpcConfig config) {
     this.config = config;
     channel =
-        NettyChannelBuilder.forAddress(config.getContactPoints().get(0), config.getContactPort())
+        NettyChannelBuilder.forAddress(
+                config.getContactPoints().get(0),
+                config.getContactPort() == 0
+                    ? DEFAULT_SCALAR_DB_SERVER_PORT
+                    : config.getContactPort())
             .usePlaintext()
             .build();
     stub = DistributedTransactionGrpc.newStub(channel);


### PR DESCRIPTION
I changed to use the default port (`60051`) if `contact_port` is not specified in Scalar DB server client.

Please take a look!