### PR TITLE
Introduce Spotbugs plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ jobs:
       # run check!
       - run: gradle check
 
-      # check code format!
-      - run: gradle spotlessCheck
-
       - run:
           name: Save Gradle test reports
           command: |
@@ -52,9 +49,31 @@ jobs:
             cp -a core/build/reports/tests/test /tmp/gradle_test_reports/
           when: always
 
+      - run:
+          name: Save SpotBugs reports for core
+          command: |
+            mkdir -p /tmp/gradle_spotbugs_reports_for_core
+            cp -a core/build/reports/spotbugs /tmp/gradle_spotbugs_reports_for_core/
+          when: always
+
+      - run:
+          name: Save SpotBugs reports for server
+          command: |
+            mkdir -p /tmp/gradle_spotbugs_reports_for_server
+            cp -a server/build/reports/spotbugs /tmp/gradle_spotbugs_reports_for_server/
+          when: always
+
       - store_artifacts:
           path: /tmp/gradle_test_reports
           destination: gradle_test_reports
+
+      - store_artifacts:
+          path: /tmp/gradle_spotbugs_reports_for_core
+          destination: gradle_spotbugs_reports_for_core
+
+      - store_artifacts:
+          path: /tmp/gradle_spotbugs_reports_for_server
+          destination: gradle_spotbugs_reports_for_server
 
   integration-test-for-cassandra:
     docker:

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
         junitVersion = '4.12'
         assertjVersion = '3.9.1'
         mockitoVersion = '2.16.0'
+        spotbugsVersion = '4.3.0'
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.spotbugs-base' version '4.7.1'
+}
+
 sourceSets {
     integrationTest {
         java {
@@ -74,16 +78,22 @@ sourceSets {
 configurations {
     integrationTestImplementation.extendsFrom testImplementation
     integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestCompileOnly.extendsFrom testCompileOnly
     integrationTestCassandraImplementation.extendsFrom testImplementation
     integrationTestCassandraRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestCassandraCompileOnly.extendsFrom testCompileOnly
     integrationTestCosmosImplementation.extendsFrom testImplementation
     integrationTestCosmosRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestCosmosCompileOnly.extendsFrom testCompileOnly
     integrationTestDynamoImplementation.extendsFrom testImplementation
     integrationTestDynamoRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestDynamoCompileOnly.extendsFrom testCompileOnly
     integrationTestJdbcImplementation.extendsFrom testImplementation
     integrationTestJdbcRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestJdbcCompileOnly.extendsFrom testCompileOnly
     integrationTestMultiStorageImplementation.extendsFrom testImplementation
     integrationTestMultiStorageRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestMultiStorageCompileOnly.extendsFrom testCompileOnly
 }
 
 dependencies {
@@ -105,6 +115,8 @@ dependencies {
     testImplementation group: 'org.assertj', name: 'assertj-core', version: "${assertjVersion}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: "${mockitoVersion}"
+    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: "${spotbugsVersion}"
+    testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: "${spotbugsVersion}"
 }
 
 task integrationTestCassandra(type: Test) {
@@ -172,6 +184,36 @@ spotless {
         googleJavaFormat()
     }
 }
+
+import com.github.spotbugs.snom.SpotBugsTask
+
+task spotbugsMain(type: SpotBugsTask) {
+    dependsOn 'classes'
+    classDirs = sourceSets.main.output
+    sourceDirs = sourceSets.main.allSource.sourceDirectories
+    auxClassPaths = sourceSets.main.compileClasspath
+    reports { html.enabled = true }
+}
+
+task spotbugsTest(type: SpotBugsTask) {
+    dependsOn 'testClasses'
+    classDirs = sourceSets.test.output
+    sourceDirs = sourceSets.test.allSource.sourceDirectories
+    auxClassPaths = sourceSets.test.compileClasspath
+    reports { html.enabled = true }
+}
+
+task spotbugsIntegrationTest(type: SpotBugsTask) {
+    dependsOn 'integrationTestClasses'
+    classDirs = sourceSets.integrationTest.output
+    sourceDirs = sourceSets.integrationTest.allSource.sourceDirectories
+    auxClassPaths = sourceSets.integrationTest.compileClasspath
+    reports { html.enabled = true }
+}
+
+check.dependsOn += spotbugsMain
+check.dependsOn += spotbugsTest
+check.dependsOn += spotbugsIntegrationTest
 
 archivesBaseName = "scalardb"
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/test/TestEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/test/TestEnv.java
@@ -9,6 +9,7 @@ import com.scalar.db.storage.jdbc.JdbcTableMetadataManager;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.query.QueryUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Closeable;
 import java.io.IOException;
 import java.sql.Connection;
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
 
+@SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
 public class TestEnv implements Closeable {
 
   private static final Map<RdbEngine, Map<DataType, String>> DATA_TYPE_MAPPING =

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -10,6 +10,7 @@ import com.scalar.db.storage.cassandra.Cassandra;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -192,7 +193,9 @@ public class ConsensusCommitWithCassandraIntegrationTest
     BufferedReader reader = null;
     try {
       Process process = builder.start();
-      reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      reader =
+          new BufferedReader(
+              new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
       while (true) {
         String line = reader.readLine();
         if (line == null) break;

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMultiStorageIntegrationTest.java
@@ -24,6 +24,7 @@ import com.scalar.db.storage.multistorage.MultiStorageConfig;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Properties;
@@ -281,7 +282,9 @@ public class ConsensusCommitWithMultiStorageIntegrationTest
     BufferedReader reader = null;
     try {
       Process process = builder.start();
-      reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      reader =
+          new BufferedReader(
+              new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
       while (true) {
         String line = reader.readLine();
         if (line == null) break;

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -24,6 +24,7 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
 import com.scalar.db.transaction.consensuscommit.SerializableStrategy;
 import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -35,6 +36,7 @@ import java.util.Properties;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
 public class DatabaseConfig {
   private final Properties props;
   private List<String> contactPoints;

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -21,7 +21,6 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   @Inject
   public CassandraAdmin(DatabaseConfig config) {
     clusterManager = new ClusterManager(config);
-    clusterManager.getSession();
     metadataManager = new CassandraTableMetadataManager(clusterManager);
     namespacePrefix = config.getNamespacePrefix();
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
@@ -9,6 +9,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.ValueVisitor;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -102,7 +103,7 @@ public class ConcatenationVisitor implements ValueVisitor {
         .ifPresent(
             b -> {
               ByteBuffer buffer = (ByteBuffer) ByteBuffer.allocate(b.length).put(b).flip();
-              values.add(new String(buffer.array()));
+              values.add(new String(buffer.array(), StandardCharsets.UTF_8));
             });
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cosmos;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A record class that Cosmos DB uses for storing a document based on Scalar DB data model.
@@ -85,5 +86,10 @@ public class Record {
     }
 
     return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, concatenatedPartitionKey, partitionKey, clusteringKey, values);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import com.google.common.base.Strings;
 import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +11,7 @@ import java.util.Properties;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
 public class DynamoConfig extends DatabaseConfig {
 
   public static final String PREFIX = DatabaseConfig.PREFIX + "dynamo.";

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.jdbc;
 
 import com.google.common.base.Strings;
 import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
 public class JdbcConfig extends DatabaseConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcConfig.class);
 

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.multistorage;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -13,6 +14,7 @@ import java.util.Properties;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
 public class MultiStorageConfig {
 
   public static final String PREFIX = DatabaseConfig.PREFIX + "multi_storage.";

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
@@ -13,9 +13,9 @@ public class GrpcConfig extends DatabaseConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcConfig.class);
 
   public static final String PREFIX = DatabaseConfig.PREFIX + "grpc.";
-  public static String DEADLINE_DURATION_MILLIS = PREFIX + "deadline_duration_millis";
+  public static final String DEADLINE_DURATION_MILLIS = PREFIX + "deadline_duration_millis";
 
-  public static long DEFAULT_DEADLINE_DURATION_MILLIS = 60000; // 60 seconds
+  public static final long DEFAULT_DEADLINE_DURATION_MILLIS = 60000; // 60 seconds
 
   private long deadlineDurationMillis;
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -19,6 +19,7 @@ import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
@@ -178,6 +179,11 @@ public class Coordinator {
       State other = (State) o;
       // NOTICE: createdAt and metadata are not taken into account
       return (getId().equals(other.getId()) && getState().equals(other.getState()));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, state);
     }
 
     private void checkNotMissingRequired(Result result) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/PartitionedMutations.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/PartitionedMutations.java
@@ -89,4 +89,9 @@ public class PartitionedMutations {
     PartitionedMutations other = (PartitionedMutations) o;
     return partitions.equals(other.partitions);
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitions);
+  }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
@@ -1,10 +1,13 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * A Serializable strategy used in Consensus Commit algorithm. Both strategies basically make
  * transactions avoid an anti-dependency that is the root cause of the anomalies in Snapshot
  * Isolation.
  */
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_INTERFACE")
 public enum SerializableStrategy implements com.scalar.db.api.SerializableStrategy {
   /**
    * Extra-write strategy converts all read set into write set when preparing records to remove

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -400,8 +400,7 @@ public class Snapshot {
       return this.namespace.equals(another.namespace)
           && this.table.equals(another.table)
           && this.partitionKey.equals(another.partitionKey)
-          && ((this.clusteringKey == null && another.clusteringKey == null)
-              || this.clusteringKey.equals(another.clusteringKey));
+          && this.clusteringKey.equals(another.clusteringKey);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/util/ImmutableLinkedHashSet.java
+++ b/core/src/main/java/com/scalar/db/util/ImmutableLinkedHashSet.java
@@ -1,8 +1,10 @@
 package com.scalar.db.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
+@SuppressFBWarnings("UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR")
 public class ImmutableLinkedHashSet<E> extends LinkedHashSet<E> {
 
   private final boolean immutable;

--- a/core/src/test/java/com/scalar/db/api/GetTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -247,6 +248,7 @@ public class GetTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_AnotherOperationGiven_ShouldReturnFalse() {
     // Arrange
     Get get = prepareGet();

--- a/core/src/test/java/com/scalar/db/api/PutTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutTest.java
@@ -13,6 +13,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -102,7 +103,7 @@ public class PutTest {
         .withValue("val4", 4.56f)
         .withValue("val5", 1.23)
         .withValue("val6", "string_value")
-        .withValue("val7", "blob_value".getBytes());
+        .withValue("val7", "blob_value".getBytes(StandardCharsets.UTF_8));
 
     // Assert
     Map<String, Value<?>> values = put.getValues();
@@ -113,7 +114,8 @@ public class PutTest {
     assertThat(values.get("val4")).isEqualTo(new FloatValue("val4", 4.56f));
     assertThat(values.get("val5")).isEqualTo(new DoubleValue("val5", 1.23));
     assertThat(values.get("val6")).isEqualTo(new TextValue("val6", "string_value"));
-    assertThat(values.get("val7")).isEqualTo(new BlobValue("val7", "blob_value".getBytes()));
+    assertThat(values.get("val7"))
+        .isEqualTo(new BlobValue("val7", "blob_value".getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/io/BigIntValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/BigIntValueTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
 
 /** */
@@ -160,6 +161,7 @@ public class BigIntValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
     int some = Integer.MAX_VALUE;

--- a/core/src/test/java/com/scalar/db/io/BlobValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/BlobValueTest.java
@@ -3,6 +3,8 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 import org.junit.Test;
@@ -11,11 +13,13 @@ import org.junit.Test;
 public class BlobValueTest {
   private static final String ANY_NAME = "name";
   private static final String ANOTHER_NAME = "another_name";
+  private static final String SOME_TEXT = "some_text";
+  private static final byte[] SOME_TEXT_BYTES = SOME_TEXT.getBytes(StandardCharsets.UTF_8);
 
   @Test
   public void get_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     BlobValue value = new BlobValue(ANY_NAME, expected);
 
     // Act
@@ -30,7 +34,7 @@ public class BlobValueTest {
   @Test
   public void getAsBytes_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act
@@ -46,7 +50,7 @@ public class BlobValueTest {
   public void
       getAsBoolean_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act Assert
@@ -56,7 +60,7 @@ public class BlobValueTest {
   @Test
   public void getAsInt_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act Assert
@@ -66,7 +70,7 @@ public class BlobValueTest {
   @Test
   public void getAsLong_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act Assert
@@ -76,7 +80,7 @@ public class BlobValueTest {
   @Test
   public void getAsFloat_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act Assert
@@ -86,7 +90,7 @@ public class BlobValueTest {
   @Test
   public void getAsDouble_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act Assert
@@ -96,7 +100,7 @@ public class BlobValueTest {
   @Test
   public void getAsString_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = SOME_TEXT_BYTES;
     Value<?> value = new BlobValue(ANY_NAME, expected);
 
     // Act Assert
@@ -106,7 +110,7 @@ public class BlobValueTest {
   @Test
   public void copyWith_WithValuePresent_ShouldReturnNewBlobWithSameValue() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_text".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, SOME_TEXT_BYTES);
 
     // Act
     BlobValue newValue = oneValue.copyWith("new name");
@@ -130,8 +134,8 @@ public class BlobValueTest {
   @Test
   public void equals_DifferentObjectsSameValuesGiven_ShouldReturnTrue() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_text".getBytes());
-    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_text".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, SOME_TEXT_BYTES);
+    BlobValue anotherValue = new BlobValue(ANY_NAME, SOME_TEXT.getBytes(StandardCharsets.UTF_8));
 
     // Act
     boolean result = oneValue.equals(anotherValue);
@@ -143,8 +147,9 @@ public class BlobValueTest {
   @Test
   public void equals_DifferentObjectsSameValuesDifferentNamesGiven_ShouldReturnFalse() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_text".getBytes());
-    BlobValue anotherValue = new BlobValue(ANOTHER_NAME, "some_text".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, SOME_TEXT_BYTES);
+    BlobValue anotherValue =
+        new BlobValue(ANOTHER_NAME, SOME_TEXT.getBytes(StandardCharsets.UTF_8));
 
     // Act
     boolean result = oneValue.equals(anotherValue);
@@ -156,7 +161,7 @@ public class BlobValueTest {
   @Test
   public void equals_SameObjectsGiven_ShouldReturnTrue() {
     // Arrange
-    BlobValue value = new BlobValue(ANY_NAME, "some_text".getBytes());
+    BlobValue value = new BlobValue(ANY_NAME, SOME_TEXT_BYTES);
 
     // Act
     boolean result = value.equals(value);
@@ -168,8 +173,9 @@ public class BlobValueTest {
   @Test
   public void equals_DifferentObjectsDifferentValuesGiven_ShouldReturnFalse() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_text".getBytes());
-    BlobValue anotherValue = new BlobValue(ANY_NAME, "another_text".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, SOME_TEXT_BYTES);
+    BlobValue anotherValue =
+        new BlobValue(ANY_NAME, "another_text".getBytes(StandardCharsets.UTF_8));
 
     // Act
     boolean result = oneValue.equals(anotherValue);
@@ -179,10 +185,11 @@ public class BlobValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_text".getBytes());
-    TextValue anotherValue = new TextValue(ANY_NAME, "some_text");
+    BlobValue oneValue = new BlobValue(ANY_NAME, SOME_TEXT_BYTES);
+    TextValue anotherValue = new TextValue(ANY_NAME, SOME_TEXT);
 
     // Act
     boolean result = oneValue.equals(anotherValue);
@@ -194,8 +201,9 @@ public class BlobValueTest {
   @Test
   public void compareTo_ThisBiggerThanGiven_ShouldReturnPositive() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value2".getBytes());
-    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_value1".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value2".getBytes(StandardCharsets.UTF_8));
+    BlobValue anotherValue =
+        new BlobValue(ANY_NAME, "some_value1".getBytes(StandardCharsets.UTF_8));
 
     // Act
     int actual = oneValue.compareTo(anotherValue);
@@ -207,8 +215,8 @@ public class BlobValueTest {
   @Test
   public void compareTo_ThisEqualsToGiven_ShouldReturnZero() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value".getBytes());
-    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_value".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value".getBytes(StandardCharsets.UTF_8));
+    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_value".getBytes(StandardCharsets.UTF_8));
 
     // Act
     int actual = oneValue.compareTo(anotherValue);
@@ -220,8 +228,9 @@ public class BlobValueTest {
   @Test
   public void compareTo_ThisSmallerThanGiven_ShouldReturnNegative() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value1".getBytes());
-    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_value2".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value1".getBytes(StandardCharsets.UTF_8));
+    BlobValue anotherValue =
+        new BlobValue(ANY_NAME, "some_value2".getBytes(StandardCharsets.UTF_8));
 
     // Act
     int actual = oneValue.compareTo(anotherValue);
@@ -233,7 +242,7 @@ public class BlobValueTest {
   @Test
   public void compareTo_ThisNonNullAndGivenNull_ShouldReturnPositive() {
     // Arrange
-    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value".getBytes());
+    BlobValue oneValue = new BlobValue(ANY_NAME, "some_value".getBytes(StandardCharsets.UTF_8));
     BlobValue anotherValue = new BlobValue(ANY_NAME, null);
 
     // Act
@@ -247,7 +256,7 @@ public class BlobValueTest {
   public void compareTo_ThisNullAndGivenNonNull_ShouldReturnNegative() {
     // Arrange
     BlobValue oneValue = new BlobValue(ANY_NAME, null);
-    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_value".getBytes());
+    BlobValue anotherValue = new BlobValue(ANY_NAME, "some_value".getBytes(StandardCharsets.UTF_8));
 
     // Act
     int actual = oneValue.compareTo(anotherValue);
@@ -272,10 +281,6 @@ public class BlobValueTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(
-            () -> {
-              new BlobValue(null, null);
-            })
-        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new BlobValue(null, null)).isInstanceOf(NullPointerException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/io/BooleanValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/BooleanValueTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
 
 /** */
@@ -153,11 +154,12 @@ public class BooleanValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
     boolean some = Boolean.TRUE;
     BooleanValue one = new BooleanValue(ANY_NAME, some);
-    Boolean another = new Boolean(some);
+    Boolean another = Boolean.valueOf(some);
 
     // Act
     boolean result = one.equals(another);

--- a/core/src/test/java/com/scalar/db/io/DoubleValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/DoubleValueTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
 
 /** */
@@ -154,6 +155,7 @@ public class DoubleValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
     double some = 1.0;

--- a/core/src/test/java/com/scalar/db/io/FloatValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/FloatValueTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
 
 /** */
@@ -157,6 +158,7 @@ public class FloatValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
     float some = Float.MAX_VALUE;

--- a/core/src/test/java/com/scalar/db/io/IntValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/IntValueTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
 
 /** */
@@ -163,6 +164,7 @@ public class IntValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
     int some = Integer.MAX_VALUE;

--- a/core/src/test/java/com/scalar/db/io/KeyTest.java
+++ b/core/src/test/java/com/scalar/db/io/KeyTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class KeyTest {
             .addFloat("key4", 4.56f)
             .addDouble("key5", 1.23)
             .addText("key6", "string_key")
-            .addBlob("key7", "blob_key".getBytes())
+            .addBlob("key7", "blob_key".getBytes(StandardCharsets.UTF_8))
             .add(new IntValue("key8", 1357))
             .addAll(Arrays.asList(new IntValue("key9", 2468), new BigIntValue("key10", 1111L)))
             .build();
@@ -61,7 +62,8 @@ public class KeyTest {
     assertThat(values.get(3)).isEqualTo(new FloatValue("key4", 4.56f));
     assertThat(values.get(4)).isEqualTo(new DoubleValue("key5", 1.23));
     assertThat(values.get(5)).isEqualTo(new TextValue("key6", "string_key"));
-    assertThat(values.get(6)).isEqualTo(new BlobValue("key7", "blob_key".getBytes()));
+    assertThat(values.get(6))
+        .isEqualTo(new BlobValue("key7", "blob_key".getBytes(StandardCharsets.UTF_8)));
     assertThat(values.get(7)).isEqualTo(new IntValue("key8", 1357));
     assertThat(values.get(8)).isEqualTo(new IntValue("key9", 2468));
     assertThat(values.get(9)).isEqualTo(new BigIntValue("key10", 1111L));
@@ -137,8 +139,8 @@ public class KeyTest {
     TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
     TextValue oneKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
     Key oneKey = new Key(oneKey1, oneKey2);
-    BlobValue anotherKey1 = new BlobValue(ANY_NAME_1, ANY_TEXT_1.getBytes());
-    BlobValue anotherKey2 = new BlobValue(ANY_NAME_2, ANY_TEXT_2.getBytes());
+    BlobValue anotherKey1 = new BlobValue(ANY_NAME_1, ANY_TEXT_1.getBytes(StandardCharsets.UTF_8));
+    BlobValue anotherKey2 = new BlobValue(ANY_NAME_2, ANY_TEXT_2.getBytes(StandardCharsets.UTF_8));
     Key anotherKey = new Key(anotherKey1, anotherKey2);
 
     // Act

--- a/core/src/test/java/com/scalar/db/io/TextValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/TextValueTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.io;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
@@ -16,7 +17,7 @@ public class TextValueTest {
   @Test
   public void getBytes_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = "some_text".getBytes(StandardCharsets.UTF_8);
     TextValue value = new TextValue(ANY_NAME, expected);
 
     // Act
@@ -61,7 +62,7 @@ public class TextValueTest {
   @Test
   public void getAsBytes_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    byte[] expected = "some_text".getBytes();
+    byte[] expected = "some_text".getBytes(StandardCharsets.UTF_8);
     Value<?> value = new TextValue(ANY_NAME, expected);
 
     // Act
@@ -127,7 +128,7 @@ public class TextValueTest {
   @Test
   public void getStringWithTwoBytesCharacter_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    String expected = new String("あいうえお");
+    String expected = "あいうえお";
     TextValue value = new TextValue(ANY_NAME, expected);
 
     // Act
@@ -135,7 +136,6 @@ public class TextValueTest {
 
     // Assert
     assertThat(expected.equals(actual.get())).isTrue();
-    assertThat(expected == actual.get()).isFalse();
   }
 
   @Test
@@ -190,6 +190,7 @@ public class TextValueTest {
   }
 
   @Test
+  @SuppressFBWarnings("EC_UNRELATED_TYPES")
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
     TextValue oneValue = new TextValue(ANY_NAME, "some_text");

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchComposerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchComposerTest.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -42,6 +43,7 @@ public class BatchComposerTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void visit_GetGiven_ShouldComposeWithSelectHandler() {
     // Arrange
     when(handlers.select()).thenReturn(select);
@@ -59,6 +61,7 @@ public class BatchComposerTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void visit_ScanGiven_ShouldComposeWithSelectHandler() {
     // Arrange
     when(handlers.select()).thenReturn(select);

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ClusterManagerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ClusterManagerTest.java
@@ -1,13 +1,9 @@
 package com.scalar.db.storage.cassandra;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datastax.driver.core.Cluster;
@@ -15,11 +11,8 @@ import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TableMetadata;
-import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ConnectionException;
-import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -28,133 +21,29 @@ import org.mockito.MockitoAnnotations;
 
 /** */
 public class ClusterManagerTest {
-  private static final String VALID_ADDRESS = "127.0.0.1";
-  private static final String INVALID_ADDRESS = "1024.0.0.1";
-  private static final String ANY_USERNAME = "username";
-  private static final String ANY_PASSWORD = "password";
   private static final String ANY_KEYSPACE_NAME = "keyspace";
   private static final String ANY_TABLE_NAME = "table";
   @Mock private Cluster cluster;
   @Mock private Session session;
   private ClusterManager manager;
-  private Properties props;
-  private DatabaseConfig config;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, VALID_ADDRESS);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
-    config = new DatabaseConfig(props);
-
-    manager = Mockito.spy(new ClusterManager(config));
-    doReturn(cluster).when(manager).getCluster(config);
-    when(cluster.connect()).thenReturn(session);
-  }
-
-  @Test
-  public void getSession_CalledOnce_ShouldConnectAndReturn() {
-    // Act Assert
-    assertThatCode(
-            () -> {
-              manager.getSession();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    verify(manager).build();
-    verify(cluster).connect();
-  }
-
-  @Test
-  public void getSession_ConfigWithInvalidEndpointGiven_ShouldThrowExceptionProperly() {
     // Arrange
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, INVALID_ADDRESS);
-    config = new DatabaseConfig(props);
-    manager = Mockito.spy(new ClusterManager(config));
-
-    // Act Assert
-    assertThatThrownBy(
-            () -> {
-              manager.getSession();
-            })
-        .isInstanceOf(ConnectionException.class)
-        .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
-
-    // Assert
-    verify(cluster, never()).connect();
-  }
-
-  @Test
-  public void getSession_CalledOnceAndDriverExceptionThrown_ShouldThrowConnectionException() {
-    // Arrange
-    DriverException toThrow = mock(DriverException.class);
-    when(cluster.connect()).thenThrow(toThrow);
-
-    // Act Assert
-    assertThatThrownBy(
-            () -> {
-              manager.getSession();
-            })
-        .isInstanceOf(ConnectionException.class)
-        .hasCause(toThrow);
-
-    // Assert
-    verify(manager).build();
-    verify(cluster).connect();
-  }
-
-  @Test
-  public void getSession_CalledAfterBuilt_ShouldNotBuild() {
-    // Arrange
-    manager.build();
-
-    // Act Assert
-    assertThatCode(
-            () -> {
-              manager.getSession();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    verify(manager).build();
-    verify(cluster).connect();
-  }
-
-  @Test
-  public void getSession_CalledTwice_ShouldReuseSession() {
-    // Arrange
-    manager.getSession();
-
-    // Act Assert
-    assertThatCode(
-            () -> {
-              manager.getSession();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    verify(manager).build();
-    verify(cluster).connect();
+    manager = Mockito.spy(new ClusterManager(cluster, session));
   }
 
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(
-            () -> {
-              new ClusterManager(null);
-            })
-        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new ClusterManager(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
   public void getMetadata_ExistingKeyspaceAndTableGiven_ShouldReturnMetadata() {
     // Arrange
-    manager.getSession();
     Metadata metadata = mock(Metadata.class);
     KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
     TableMetadata tableMetadata = mock(TableMetadata.class);
@@ -172,7 +61,6 @@ public class ClusterManagerTest {
   @Test
   public void getMetadata_NoHostAvailable_ShouldThrowConnectionException() {
     // Arrange
-    manager.getSession();
     NoHostAvailableException toThrow = mock(NoHostAvailableException.class);
     when(cluster.getMetadata()).thenThrow(toThrow);
 
@@ -188,7 +76,6 @@ public class ClusterManagerTest {
   @Test
   public void getMetadata_KeyspaceNotExists_ShouldReturnNull() {
     // Arrange
-    manager.getSession();
     Metadata metadata = mock(Metadata.class);
     when(cluster.getMetadata()).thenReturn(metadata);
     when(metadata.getKeyspace(anyString())).thenReturn(null);
@@ -203,7 +90,6 @@ public class ClusterManagerTest {
   @Test
   public void getMetadata_TableNotExists_ShouldReturnNull() {
     // Arrange
-    manager.getSession();
     Metadata metadata = mock(Metadata.class);
     KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
     when(cluster.getMetadata()).thenReturn(metadata);

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
@@ -11,6 +11,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.Value;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -52,7 +53,7 @@ public class ResultInterpreterTest {
     when(row.getFloat(ANY_COLUMN_NAME_4)).thenReturn(Float.MAX_VALUE);
     when(row.getDouble(ANY_COLUMN_NAME_5)).thenReturn(Double.MAX_VALUE);
     when(row.getString(ANY_COLUMN_NAME_6)).thenReturn("string");
-    byte[] bytesValue = "bytes".getBytes();
+    byte[] bytesValue = "bytes".getBytes(StandardCharsets.UTF_8);
     when(row.getBytes(ANY_COLUMN_NAME_7))
         .thenReturn((ByteBuffer) ByteBuffer.allocate(bytesValue.length).put(bytesValue).flip());
 
@@ -96,7 +97,7 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_7).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().get())
-        .isEqualTo("bytes".getBytes());
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
 
     Map<String, Value<?>> values = result.getValues();
     assertThat(values.containsKey(ANY_NAME_1)).isTrue();
@@ -120,6 +121,7 @@ public class ResultInterpreterTest {
     assertThat(values.get(ANY_COLUMN_NAME_6).getAsString().get()).isEqualTo("string");
     assertThat(values.containsKey(ANY_COLUMN_NAME_7)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().isPresent()).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get()).isEqualTo("bytes".getBytes());
+    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get())
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ValueBinderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ValueBinderTest.java
@@ -16,6 +16,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -119,7 +120,7 @@ public class ValueBinderTest {
   @Test
   public void visit_BlobValueAcceptCalled_ShouldCallSetString() {
     // Arrange
-    BlobValue value = new BlobValue(ANY_NAME, ANY_STRING.getBytes());
+    BlobValue value = new BlobValue(ANY_NAME, ANY_STRING.getBytes(StandardCharsets.UTF_8));
     ValueBinder binder = new ValueBinder(bound);
 
     // Act
@@ -130,7 +131,9 @@ public class ValueBinderTest {
         .setBytes(
             0,
             (ByteBuffer)
-                ByteBuffer.allocate(ANY_STRING.length()).put(ANY_STRING.getBytes()).flip());
+                ByteBuffer.allocate(ANY_STRING.length())
+                    .put(ANY_STRING.getBytes(StandardCharsets.UTF_8))
+                    .flip());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/common/ResultImplTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/ResultImplTest.java
@@ -15,6 +15,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -65,7 +66,9 @@ public class ResultImplTest {
             .put(ANY_COLUMN_NAME_4, new FloatValue(ANY_COLUMN_NAME_4, Float.MAX_VALUE))
             .put(ANY_COLUMN_NAME_5, new DoubleValue(ANY_COLUMN_NAME_5, Double.MAX_VALUE))
             .put(ANY_COLUMN_NAME_6, new TextValue(ANY_COLUMN_NAME_6, "string"))
-            .put(ANY_COLUMN_NAME_7, new BlobValue(ANY_COLUMN_NAME_7, "bytes".getBytes()))
+            .put(
+                ANY_COLUMN_NAME_7,
+                new BlobValue(ANY_COLUMN_NAME_7, "bytes".getBytes(StandardCharsets.UTF_8)))
             .build();
   }
 
@@ -94,7 +97,7 @@ public class ResultImplTest {
     assertThat(actual.get(ANY_NAME_2)).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
     assertThat(actual.get(ANY_COLUMN_NAME_1)).isEqualTo(new BooleanValue(ANY_COLUMN_NAME_1, true));
     assertThat(actual.get(ANY_COLUMN_NAME_7))
-        .isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, "bytes".getBytes()));
+        .isEqualTo(new BlobValue(ANY_COLUMN_NAME_7, "bytes".getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
@@ -9,6 +9,7 @@ import com.scalar.db.io.DoubleValue;
 import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
+import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class ConcatenationVisitorTest {
   private static final DoubleValue ANY_DOUBLE_VALUE = new DoubleValue("any_double", ANY_DOUBLE);
   private static final String ANY_TEXT = "test";
   private static final TextValue ANY_TEXT_VALUE = new TextValue("any_text", ANY_TEXT);
-  private static final byte[] ANY_BLOB = "scalar".getBytes();
+  private static final byte[] ANY_BLOB = "scalar".getBytes(StandardCharsets.UTF_8);
   private static final BlobValue ANY_BLOB_VALUE = new BlobValue("any_blob", ANY_BLOB);
   private ConcatenationVisitor visitor;
 
@@ -56,7 +57,7 @@ public class ConcatenationVisitorTest {
     assertThat(values[3]).isEqualTo(String.valueOf(ANY_FLOAT));
     assertThat(values[4]).isEqualTo(String.valueOf(ANY_DOUBLE));
     assertThat(values[5]).isEqualTo(ANY_TEXT);
-    assertThat(values[6]).isEqualTo(new String(ANY_BLOB));
+    assertThat(values[6]).isEqualTo(new String(ANY_BLOB, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -119,6 +120,6 @@ public class ConcatenationVisitorTest {
     ANY_BLOB_VALUE.accept(visitor);
 
     // Assert
-    assertThat(visitor.build()).isEqualTo(new String(ANY_BLOB));
+    assertThat(visitor.build()).isEqualTo(new String(ANY_BLOB, StandardCharsets.UTF_8));
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/MapVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/MapVisitorTest.java
@@ -98,7 +98,10 @@ public class MapVisitorTest {
 
     // Assert
     ByteBuffer expected =
-        (ByteBuffer) ByteBuffer.allocate(ANY_TEXT.length()).put(ANY_TEXT.getBytes()).flip();
+        (ByteBuffer)
+            ByteBuffer.allocate(ANY_TEXT.length())
+                .put(ANY_TEXT.getBytes(StandardCharsets.UTF_8))
+                .flip();
     assertThat(visitor.get().get(ANY_BLOB_VALUE.getName())).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ResultInterpreterTest.java
@@ -98,7 +98,7 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_7).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().get())
-        .isEqualTo("bytes".getBytes());
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
 
     Map<String, Value<?>> values = result.getValues();
     assertThat(values.containsKey(ANY_NAME_1)).isTrue();
@@ -122,6 +122,7 @@ public class ResultInterpreterTest {
     assertThat(values.get(ANY_COLUMN_NAME_6).getAsString().get()).isEqualTo("string");
     assertThat(values.containsKey(ANY_COLUMN_NAME_7)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().isPresent()).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get()).isEqualTo("bytes".getBytes());
+    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get())
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -144,7 +144,6 @@ public class SelectStatementHandlerTest {
         .readItem(anyString(), any(PartitionKey.class), eq(Record.class));
     when(toThrow.getStatusCode()).thenReturn(CosmosErrorCode.NOT_FOUND.get());
 
-    Record expected = new Record();
     Get get = prepareGet();
 
     // Act Assert

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
@@ -39,7 +39,6 @@ public class DeleteStatementHandlerTest {
   private static final String ANY_TEXT_2 = "text2";
 
   private DeleteStatementHandler handler;
-  private String concatenatedPartitionKey;
   @Mock private DynamoDbClient client;
   @Mock private DynamoTableMetadataManager metadataManager;
   @Mock private TableMetadata metadata;
@@ -59,7 +58,6 @@ public class DeleteStatementHandlerTest {
   private Delete prepareDelete() {
     Key partitionKey = new Key(new TextValue(ANY_NAME_1, ANY_TEXT_1));
     Key clusteringKey = new Key(new TextValue(ANY_NAME_2, ANY_TEXT_2));
-    concatenatedPartitionKey = ANY_TEXT_1 + ":" + ANY_TEXT_2;
     Delete del =
         new Delete(partitionKey, clusteringKey)
             .forNamespace(ANY_KEYSPACE_NAME)

--- a/core/src/test/java/com/scalar/db/storage/dynamo/ItemSorterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/ItemSorterTest.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,8 +40,8 @@ public class ItemSorterTest {
   private static final double ANY_SMALL_DOUBLE = -10.0;
   private static final String ANY_LARGE_TEXT = "sssssss";
   private static final String ANY_SMALL_TEXT = "aa";
-  private static final byte[] ANY_LARGE_BLOB = "scalar".getBytes();
-  private static final byte[] ANY_SMALL_BLOB = "a".getBytes();
+  private static final byte[] ANY_LARGE_BLOB = "scalar".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] ANY_SMALL_BLOB = "a".getBytes(StandardCharsets.UTF_8);
   private static final String ANY_COLUMN_NAME_1 = "val1";
 
   private TableMetadata metadata;

--- a/core/src/test/java/com/scalar/db/storage/dynamo/MapVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/MapVisitorTest.java
@@ -101,7 +101,10 @@ public class MapVisitorTest {
 
     // Assert
     ByteBuffer expected =
-        (ByteBuffer) ByteBuffer.allocate(ANY_TEXT.length()).put(ANY_TEXT.getBytes()).flip();
+        (ByteBuffer)
+            ByteBuffer.allocate(ANY_TEXT.length())
+                .put(ANY_TEXT.getBytes(StandardCharsets.UTF_8))
+                .flip();
     assertThat(visitor.get().get(ANY_BLOB_VALUE.getName()).b().asByteBuffer()).isEqualTo(expected);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
@@ -84,7 +84,6 @@ public class PutStatementHandlerTest {
     DynamoMutation dynamoMutation = new DynamoMutation(put, metadataManager);
     Map<String, AttributeValue> expectedKeys = dynamoMutation.getKeyMap();
     String updateExpression = dynamoMutation.getUpdateExpressionWithKey();
-    String expectedCondition = dynamoMutation.getIfExistsCondition();
     Map<String, AttributeValue> expectedBindMap = dynamoMutation.getValueBindMapWithKey();
 
     // Act Assert

--- a/core/src/test/java/com/scalar/db/storage/dynamo/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/ResultInterpreterTest.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +63,9 @@ public class ResultInterpreterTest {
     item.put(ANY_COLUMN_NAME_6, AttributeValue.builder().s("string").build());
     item.put(
         ANY_COLUMN_NAME_7,
-        AttributeValue.builder().b(SdkBytes.fromByteArray("bytes".getBytes())).build());
+        AttributeValue.builder()
+            .b(SdkBytes.fromByteArray("bytes".getBytes(StandardCharsets.UTF_8)))
+            .build());
 
     List<String> projections = Collections.emptyList();
     ResultInterpreter spy = spy(new ResultInterpreter(projections, metadata));
@@ -93,7 +96,7 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_7).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().get())
-        .isEqualTo("bytes".getBytes());
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
 
     Map<String, Value<?>> values = result.getValues();
     assertThat(values.containsKey(ANY_NAME_1)).isTrue();
@@ -117,6 +120,7 @@ public class ResultInterpreterTest {
     assertThat(values.get(ANY_COLUMN_NAME_6).getAsString().get()).isEqualTo("string");
     assertThat(values.containsKey(ANY_COLUMN_NAME_7)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().isPresent()).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get()).isEqualTo("bytes".getBytes());
+    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get())
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -30,6 +30,7 @@ import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpdateQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -41,6 +42,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public class JdbcServiceTest {
 
   private static final Optional<String> NAMESPACE = Optional.of("s1");
@@ -85,6 +87,7 @@ public class JdbcServiceTest {
   }
 
   @Test
+  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
   public void whenGetOperationExecuted_shouldCallQueryBuilder() throws Exception {
     // Arrange
     when(queryBuilder.select(any())).thenReturn(selectQueryBuilder);
@@ -105,6 +108,7 @@ public class JdbcServiceTest {
   }
 
   @Test
+  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
   public void whenGetScannerExecuted_shouldCallQueryBuilder() throws Exception {
     // Arrange
     when(queryBuilder.select(any())).thenReturn(selectQueryBuilder);
@@ -130,6 +134,7 @@ public class JdbcServiceTest {
   }
 
   @Test
+  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
   public void whenScanExecuted_shouldCallQueryBuilder() throws Exception {
     // Arrange
     when(queryBuilder.select(any())).thenReturn(selectQueryBuilder);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
@@ -8,6 +8,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Value;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -65,7 +66,8 @@ public class ResultInterpreterTest {
     when(resultSet.getFloat(ANY_COLUMN_NAME_4)).thenReturn(Float.MAX_VALUE);
     when(resultSet.getDouble(ANY_COLUMN_NAME_5)).thenReturn(Double.MAX_VALUE);
     when(resultSet.getString(ANY_COLUMN_NAME_6)).thenReturn("string");
-    when(resultSet.getBytes(ANY_COLUMN_NAME_7)).thenReturn("bytes".getBytes());
+    when(resultSet.getBytes(ANY_COLUMN_NAME_7))
+        .thenReturn("bytes".getBytes(StandardCharsets.UTF_8));
 
     List<String> projections = Collections.emptyList();
     ResultInterpreter spy = spy(new ResultInterpreter(projections, metadata));
@@ -96,7 +98,7 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_7).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_7).get().getAsBytes().get())
-        .isEqualTo("bytes".getBytes());
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
 
     Map<String, Value<?>> values = result.getValues();
     assertThat(values.containsKey(ANY_NAME_1)).isTrue();
@@ -120,6 +122,7 @@ public class ResultInterpreterTest {
     assertThat(values.get(ANY_COLUMN_NAME_6).getAsString().get()).isEqualTo("string");
     assertThat(values.containsKey(ANY_COLUMN_NAME_7)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().isPresent()).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get()).isEqualTo("bytes".getBytes());
+    assertThat(values.get(ANY_COLUMN_NAME_7).getAsBytes().get())
+        .isEqualTo("bytes".getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -316,7 +316,6 @@ public class SnapshotTest {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();
-    Delete delete = prepareDelete();
     snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'application'
     id 'com.palantir.docker' version '0.25.0'
+    id 'com.github.spotbugs' version '4.7.1'
 }
 
 sourceSets {
@@ -17,6 +18,7 @@ sourceSets {
 configurations {
     integrationTestScalarDbServerImplementation.extendsFrom testImplementation
     integrationTestScalarDbServerRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestScalarDbServerCompileOnly.extendsFrom testCompileOnly
 }
 
 dependencies {
@@ -41,6 +43,8 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: "${mockitoVersion}"
     integrationTestScalarDbServerImplementation project(':core').sourceSets.integrationTest.output
+    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: "${spotbugsVersion}"
+    testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: "${spotbugsVersion}"
 }
 
 application {
@@ -68,6 +72,18 @@ spotless {
         removeUnusedImports()
         googleJavaFormat()
     }
+}
+
+spotbugsMain.reports {
+    html.enabled = true
+}
+
+spotbugsTest.reports {
+    html.enabled = true
+}
+
+spotbugsIntegrationTestScalarDbServer.reports {
+    html.enabled = true
 }
 
 archivesBaseName = "scalardb-server"

--- a/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
+++ b/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
@@ -50,7 +50,9 @@ public class ScalarDbServer implements Callable<Integer> {
   public void start() throws IOException {
     if (configFile != null) {
       properties = new Properties();
-      properties.load(new FileInputStream(configFile));
+      try (FileInputStream fis = new FileInputStream(configFile)) {
+        properties.load(fis);
+      }
     }
 
     ServerConfig config = new ServerConfig(properties);

--- a/server/src/main/java/com/scalar/db/server/config/ServerConfig.java
+++ b/server/src/main/java/com/scalar/db/server/config/ServerConfig.java
@@ -1,6 +1,7 @@
 package com.scalar.db.server.config;
 
 import com.google.common.base.Strings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -11,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
 public class ServerConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerConfig.class);
 


### PR DESCRIPTION
This PR introduces the `Spotbugs` plugin that uses static analysis to look for bugs in Java code. Also, I fixed some Spotbugs errors in this PR.

Honestly, I'm not sure it's a good idea for us to use this plugin because it shows some false positives, and we need to use `SuppressFBWarnings` annotation to remove them, which might be annoying. But of course, I think it brings many benefits to us. So I would like to discuss whether or not we use this plugin here.

Besides this plugin, I'm thinking that we can use the `errorprone` plugin, as well:
https://errorprone.info/
https://github.com/tbroyer/gradle-errorprone-plugin

Please take a look!