### PR TITLE
Rename the integrationTest source set to integrationTestAll

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 sourceSets {
-    integrationTest {
+    integrationTestAll {
         java {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
@@ -77,9 +77,9 @@ sourceSets {
 }
 
 configurations {
-    integrationTestImplementation.extendsFrom testImplementation
-    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
-    integrationTestCompileOnly.extendsFrom testCompileOnly
+    integrationTestAllImplementation.extendsFrom testImplementation
+    integrationTestAllRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestAllCompileOnly.extendsFrom testCompileOnly
     integrationTestCassandraImplementation.extendsFrom testImplementation
     integrationTestCassandraRuntimeOnly.extendsFrom testRuntimeOnly
     integrationTestCassandraCompileOnly.extendsFrom testCompileOnly
@@ -209,10 +209,10 @@ task spotbugsTest(type: SpotBugsTask) {
 }
 
 task spotbugsIntegrationTest(type: SpotBugsTask) {
-    dependsOn 'integrationTestClasses'
-    classDirs = sourceSets.integrationTest.output
-    sourceDirs = sourceSets.integrationTest.allSource.sourceDirectories
-    auxClassPaths = sourceSets.integrationTest.compileClasspath
+    dependsOn 'integrationTestAllClasses'
+    classDirs = sourceSets.integrationTestAll.output
+    sourceDirs = sourceSets.integrationTestAll.allSource.sourceDirectories
+    auxClassPaths = sourceSets.integrationTestAll.compileClasspath
     reports { html.enabled = true }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation group: 'org.assertj', name: 'assertj-core', version: "${assertjVersion}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockitoVersion}"
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: "${mockitoVersion}"
-    integrationTestScalarDbServerImplementation project(':core').sourceSets.integrationTest.output
+    integrationTestScalarDbServerImplementation project(':core').sourceSets.integrationTestAll.output
     // for SpotBugs
     compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: "${spotbugsVersion}"
     testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: "${spotbugsVersion}"


### PR DESCRIPTION
This is a very trivial thing. Just renamed the `integrationTest` source set to `integrationTestAll` to avoid compile errors in Scalar DB Server integration tests in my intelliJ.

Please take a look!