### PR TITLE
Refactor Prometheus exporter

### DIFF
--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -40,8 +40,8 @@ It contains two sections, Server configurations and Underlining storage/database
 # Port number of Scalar DB server. 60051 by deafult
 #scalar.db.server.port=60051
 
-# Port number of Prometheus HTTP endpoint. 8080 by default
-#scalar.db.server.prometheus_http_endpoint_port=8080
+# Prometheus exporter port. Use 8080 if this is not given. Prometheus exporter will not be started if a negative number is given.
+#scalar.db.server.prometheus_exporter_port=8080
 
 #
 # Underlining storage/database configurations

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
@@ -108,7 +108,7 @@ public class ConsensusCommitWithDistributedStorageServiceIntegrationTest
     testEnv.insertMetadata();
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminServiceIntegrationTest.java
@@ -60,7 +60,7 @@ public class DistributedStorageAdminServiceIntegrationTest extends AdminIntegrat
     testEnv.insertMetadata();
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceIntegrationTest.java
@@ -118,7 +118,7 @@ public class DistributedStorageServiceIntegrationTest extends IntegrationTestBas
     testEnv.insertMetadata();
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitIntegrationTest.java
@@ -1136,7 +1136,7 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
     testEnv.insertMetadata();
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraReadIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraReadIntegrationTest.java
@@ -296,7 +296,7 @@ public class DistributedTransactionServiceWithConsensusCommitWithExtraReadIntegr
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
     serverProperties.setProperty(DatabaseConfig.ISOLATION_LEVEL, "SERIALIZABLE");
     serverProperties.setProperty(DatabaseConfig.SERIALIZABLE_STRATEGY, "EXTRA_READ");
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraWriteIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraWriteIntegrationTest.java
@@ -256,7 +256,7 @@ public class DistributedTransactionServiceWithConsensusCommitWithExtraWriteInteg
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
     serverProperties.setProperty(DatabaseConfig.ISOLATION_LEVEL, "SERIALIZABLE");
     serverProperties.setProperty(DatabaseConfig.SERIALIZABLE_STRATEGY, "EXTRA_WRITE");
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithJdbcTransactionIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithJdbcTransactionIntegrationTest.java
@@ -328,7 +328,7 @@ public class DistributedTransactionServiceWithJdbcTransactionIntegrationTest {
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
     serverProperties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
-    serverProperties.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "0");
+    serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();
 

--- a/server/src/main/java/com/scalar/db/server/config/ServerConfig.java
+++ b/server/src/main/java/com/scalar/db/server/config/ServerConfig.java
@@ -18,15 +18,14 @@ public class ServerConfig {
 
   public static final String PREFIX = "scalar.db.server.";
   public static final String PORT = PREFIX + "port";
-  public static final String PROMETHEUS_HTTP_ENDPOINT_PORT =
-      PREFIX + "prometheus_http_endpoint_port";
+  public static final String PROMETHEUS_EXPORTER_PORT = PREFIX + "prometheus_exporter_port";
 
   public static final int DEFAULT_PORT = 60051;
-  public static final int DEFAULT_PROMETHEUS_HTTP_ENDPOINT_PORT = 8080;
+  public static final int DEFAULT_PROMETHEUS_EXPORTER_PORT = 8080;
 
   private final Properties props;
   private int port;
-  private int prometheusHttpEndpointPort;
+  private int prometheusExporterPort;
 
   public ServerConfig(File propertiesFile) throws IOException {
     this(new FileInputStream(propertiesFile));
@@ -49,8 +48,7 @@ public class ServerConfig {
 
   private void load() {
     port = getInt(PORT, DEFAULT_PORT);
-    prometheusHttpEndpointPort =
-        getInt(PROMETHEUS_HTTP_ENDPOINT_PORT, DEFAULT_PROMETHEUS_HTTP_ENDPOINT_PORT);
+    prometheusExporterPort = getInt(PROMETHEUS_EXPORTER_PORT, DEFAULT_PROMETHEUS_EXPORTER_PORT);
   }
 
   private int getInt(String name, int defaultValue) {
@@ -73,7 +71,7 @@ public class ServerConfig {
     return port;
   }
 
-  public int getPrometheusHttpEndpointPort() {
-    return prometheusHttpEndpointPort;
+  public int getPrometheusExporterPort() {
+    return prometheusExporterPort;
   }
 }

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -89,7 +89,7 @@ public class ServerModule extends AbstractModule {
     ServletContextHandler context = new ServletContextHandler();
     context.setContextPath("/");
     server.setHandler(context);
-    context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+    context.addServlet(new ServletHolder(new MetricsServlet()), "/stats/prometheus");
     server.setStopAtShutdown(true);
     try {
       server.start();

--- a/server/src/test/java/com/scalar/db/server/config/ServerConfigTest.java
+++ b/server/src/test/java/com/scalar/db/server/config/ServerConfigTest.java
@@ -19,8 +19,8 @@ public class ServerConfigTest {
 
     // Assert
     assertThat(config.getPort()).isEqualTo(ServerConfig.DEFAULT_PORT);
-    assertThat(config.getPrometheusHttpEndpointPort())
-        .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_HTTP_ENDPOINT_PORT);
+    assertThat(config.getPrometheusExporterPort())
+        .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_EXPORTER_PORT);
   }
 
   @Test
@@ -50,29 +50,29 @@ public class ServerConfigTest {
   }
 
   @Test
-  public void constructor_ValidPrometheusHttpEndpointPortGiven_ShouldLoadProperly() {
+  public void constructor_ValidPrometheusExporterPortGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
-    props.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, Integer.toString(ANY_PORT));
+    props.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, Integer.toString(ANY_PORT));
 
     // Act
     ServerConfig config = new ServerConfig(props);
 
     // Assert
-    assertThat(config.getPrometheusHttpEndpointPort()).isEqualTo(ANY_PORT);
+    assertThat(config.getPrometheusExporterPort()).isEqualTo(ANY_PORT);
   }
 
   @Test
-  public void constructor_InvalidPrometheusHttpEndpointPortGiven_ShouldUseDefault() {
+  public void constructor_InvalidPrometheusExporterPortGiven_ShouldUseDefault() {
     // Arrange
     Properties props = new Properties();
-    props.setProperty(ServerConfig.PROMETHEUS_HTTP_ENDPOINT_PORT, "abc");
+    props.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "abc");
 
     // Act
     ServerConfig config = new ServerConfig(props);
 
     // Assert
-    assertThat(config.getPrometheusHttpEndpointPort())
-        .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_HTTP_ENDPOINT_PORT);
+    assertThat(config.getPrometheusExporterPort())
+        .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_EXPORTER_PORT);
   }
 }


### PR DESCRIPTION
The changes are as follows:
- Rename the config name `scalar.db.server.prometheus_http_endpoint_port` to `scalar.db.server.prometheus_exporter_port`
- Change the behavior to disable the Prometheus exporter when a negative number port is given
- Change the Prometheus HTTP endpoint path from `/metrics` to `/stats/prometheus`

Please take a look!