### PR TITLE
Reduce the Cassandra heap size for the multi-storage integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,8 +406,8 @@ jobs:
       - image: circleci/openjdk:8-jdk
       - image: cassandra:3.11
         environment:
-          MAX_HEAP_SIZE: 2048m
-          HEAP_NEWSIZE: 512m
+          MAX_HEAP_SIZE: 1536m
+          HEAP_NEWSIZE: 256m
       - image: circleci/mysql:8.0.23
         environment:
           MYSQL_ROOT_PASSWORD: mysql


### PR DESCRIPTION
This is for avoiding the multi-storage integration test failure with exit code `137`:
https://support.circleci.com/hc/en-us/articles/115014359648-Exit-code-137-Out-of-memory

Please take a look!
