### PR TITLE
Introduce factory classes to instantiate storage and transaction

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -31,8 +31,8 @@ import java.util.Optional;
  * readability.)
  *
  * <pre>{@code
- * Injector injector = Guice.createInjector(new StorageModule(new DatabaseConfig(props)));
- * StorageService storage = injector.getInstance(StorageService.class);
+ * StorageFactory factory = new StorageFactory(databaseConfig);
+ * DistributedStorage storage = factory.getStorage();
  *
  * // Uses NAMESPACE and TABLE by default in this storage instance.
  * storage.with(NAMESPACE, TABLE);

--- a/core/src/main/java/com/scalar/db/service/StorageFactory.java
+++ b/core/src/main/java/com/scalar/db/service/StorageFactory.java
@@ -1,0 +1,34 @@
+package com.scalar.db.service;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.config.DatabaseConfig;
+
+/** A factory class to instantiate {@link DistributedStorage} and {@link DistributedStorageAdmin} */
+public class StorageFactory {
+  private final Injector injector;
+
+  public StorageFactory(DatabaseConfig config) {
+    injector = Guice.createInjector(new StorageModule(config));
+  }
+
+  /**
+   * Returns a {@link DistributedStorage} instance
+   *
+   * @return a {@link DistributedStorage} instance
+   */
+  public DistributedStorage getStorage() {
+    return injector.getInstance(StorageService.class);
+  }
+
+  /**
+   * Returns a {@link DistributedStorageAdmin} instance
+   *
+   * @return a {@link DistributedStorageAdmin} instance
+   */
+  public DistributedStorageAdmin getAdmin() {
+    return injector.getInstance(AdminService.class);
+  }
+}

--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -1,0 +1,24 @@
+package com.scalar.db.service;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.config.DatabaseConfig;
+
+/** A factory class to instantiate {@link DistributedTransactionManager} */
+public class TransactionFactory {
+  private final Injector injector;
+
+  public TransactionFactory(DatabaseConfig config) {
+    injector = Guice.createInjector(new TransactionModule(config));
+  }
+
+  /**
+   * Returns a {@link DistributedTransactionManager} instance
+   *
+   * @return a {@link DistributedTransactionManager} instance
+   */
+  public DistributedTransactionManager getTransactionManager() {
+    return injector.getInstance(TransactionService.class);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -3,9 +3,7 @@ package com.scalar.db.storage.multistorage;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
@@ -16,7 +14,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.service.StorageModule;
+import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.Utility;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,9 +52,8 @@ public class MultiStorage implements DistributedStorage {
         .getDatabaseConfigMap()
         .forEach(
             (storageName, databaseConfig) -> {
-              // Instantiate storages with Guice
-              Injector injector = Guice.createInjector(new StorageModule(databaseConfig));
-              DistributedStorage storage = injector.getInstance(DistributedStorage.class);
+              StorageFactory factory = new StorageFactory(databaseConfig);
+              DistributedStorage storage = factory.getStorage();
               nameStorageMap.put(storageName, storage);
               storages.add(storage);
             });

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -1,13 +1,11 @@
 package com.scalar.db.storage.multistorage;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.service.StorageModule;
+import com.scalar.db.service.StorageFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,9 +38,8 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
         .getDatabaseConfigMap()
         .forEach(
             (storageName, databaseConfig) -> {
-              // Instantiate admins with Guice
-              Injector injector = Guice.createInjector(new StorageModule(databaseConfig));
-              DistributedStorageAdmin admin = injector.getInstance(DistributedStorageAdmin.class);
+              StorageFactory factory = new StorageFactory(databaseConfig);
+              DistributedStorageAdmin admin = factory.getAdmin();
               nameAdminMap.put(storageName, admin);
               admins.add(admin);
             });

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -3,8 +3,6 @@ package com.scalar.db.server.service;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.google.inject.AbstractModule;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.scalar.db.api.DistributedStorage;
@@ -14,8 +12,8 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.server.Metrics;
 import com.scalar.db.server.Pauser;
 import com.scalar.db.server.config.ServerConfig;
-import com.scalar.db.service.StorageModule;
-import com.scalar.db.service.TransactionModule;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;
@@ -29,31 +27,31 @@ public class ServerModule extends AbstractModule {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerModule.class);
 
   private final ServerConfig config;
-  private final Injector storageInjector;
-  private final Injector transactionInjector;
+  private final StorageFactory storageFactory;
+  private final TransactionFactory transactionFactory;
 
   public ServerModule(ServerConfig config, DatabaseConfig databaseConfig) {
     this.config = config;
-    storageInjector = Guice.createInjector(new StorageModule(databaseConfig));
-    transactionInjector = Guice.createInjector(new TransactionModule(databaseConfig));
+    storageFactory = new StorageFactory(databaseConfig);
+    transactionFactory = new TransactionFactory(databaseConfig);
   }
 
   @Provides
   @Singleton
   DistributedStorage provideDistributedStorage() {
-    return storageInjector.getInstance(DistributedStorage.class);
+    return storageFactory.getStorage();
   }
 
   @Provides
   @Singleton
   DistributedStorageAdmin provideDistributedStorageAdmin() {
-    return storageInjector.getInstance(DistributedStorageAdmin.class);
+    return storageFactory.getAdmin();
   }
 
   @Provides
   @Singleton
   DistributedTransactionManager provideDistributedTransactionManager() {
-    return transactionInjector.getInstance(DistributedTransactionManager.class);
+    return transactionFactory.getTransactionManager();
   }
 
   @Provides


### PR DESCRIPTION
I think we can introduce factory classes to instantiate storage and transaction objects rather than expose the Guice dependency.

For example:

The original way to get a `DistributedStorage` instance, which exposes the Guice dependency:
```
Injector injector = Guice.createInjector(new StorageModule(new DatabaseConfig(props)));
StorageService storage = injector.getInstance(StorageService.class);
```

The new way to get a `DistributedStorage` instance:
```
StorageFactory factory = new StorageFactory(databaseConfig);
DistributedStorage storage = factory.getStorage();
```

Please take a look!