### PR TITLE
Rename metrics names of Scalar DB server

### DIFF
--- a/server/src/main/java/com/scalar/db/server/DistributedStorageAdminService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedStorageAdminService.java
@@ -21,6 +21,7 @@ public class DistributedStorageAdminService
     extends DistributedStorageAdminGrpc.DistributedStorageAdminImplBase {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DistributedStorageAdminService.class);
+  private static final String SERVICE_NAME = "distributed_storage_admin";
 
   private final DistributedStorageAdmin admin;
   private final Metrics metrics;
@@ -44,7 +45,7 @@ public class DistributedStorageAdminService
           responseObserver.onCompleted();
         },
         responseObserver,
-        "createTable");
+        "create_table");
   }
 
   @Override
@@ -56,7 +57,7 @@ public class DistributedStorageAdminService
           responseObserver.onCompleted();
         },
         responseObserver,
-        "dropTable");
+        "drop_table");
   }
 
   @Override
@@ -68,7 +69,7 @@ public class DistributedStorageAdminService
           responseObserver.onCompleted();
         },
         responseObserver,
-        "truncateTable");
+        "truncate_table");
   }
 
   @Override
@@ -86,13 +87,13 @@ public class DistributedStorageAdminService
           responseObserver.onCompleted();
         },
         responseObserver,
-        "getTableMetadata");
+        "get_table_metadata");
   }
 
   private void execute(
       ThrowableRunnable<Throwable> runnable, StreamObserver<?> responseObserver, String method) {
     try {
-      metrics.measure(DistributedStorageAdminService.class, method, runnable);
+      metrics.measure(SERVICE_NAME, method, runnable);
     } catch (IllegalArgumentException | IllegalStateException e) {
       responseObserver.onError(
           Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());

--- a/server/src/main/java/com/scalar/db/server/DistributedStorageService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedStorageService.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 public class DistributedStorageService extends DistributedStorageGrpc.DistributedStorageImplBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(DistributedStorageService.class);
-
+  private static final String SERVICE_NAME = "distributed_storage";
   private static final int DEFAULT_SCAN_FETCH_COUNT = 100;
 
   private final DistributedStorage storage;
@@ -90,7 +90,7 @@ public class DistributedStorageService extends DistributedStorageGrpc.Distribute
     }
 
     try {
-      metrics.measure(DistributedStorageService.class, method, runnable);
+      metrics.measure(SERVICE_NAME, method, runnable);
     } catch (IllegalArgumentException | IllegalStateException e) {
       responseObserver.onError(
           Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());
@@ -193,8 +193,8 @@ public class DistributedStorageService extends DistributedStorageGrpc.Distribute
     private boolean openScanner(ScanRequest request) {
       try {
         metrics.measure(
-            DistributedStorageService.class,
-            "scan.openScanner",
+            SERVICE_NAME,
+            "scan.open_scanner",
             () -> {
               Scan scan = ProtoUtil.toScan(request.getScan());
               scanner = storage.scan(scan);
@@ -215,7 +215,7 @@ public class DistributedStorageService extends DistributedStorageGrpc.Distribute
     private ScanResponse next(ScanRequest request) {
       try {
         return metrics.measure(
-            DistributedStorageService.class,
+            SERVICE_NAME,
             "scan.next",
             () -> {
               Iterator<Result> resultIterator = scanner.iterator();

--- a/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 public class DistributedTransactionService
     extends DistributedTransactionGrpc.DistributedTransactionImplBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(DistributedTransactionService.class);
+  private static final String SERVICE_NAME = "distributed_transaction";
 
   private final DistributedTransactionManager manager;
   private final Pauser pauser;
@@ -77,7 +78,7 @@ public class DistributedTransactionService
           responseObserver.onCompleted();
         },
         responseObserver,
-        "getState");
+        "get_state");
   }
 
   @Override
@@ -102,7 +103,7 @@ public class DistributedTransactionService
     }
 
     try {
-      metrics.measure(DistributedTransactionService.class, method, runnable);
+      metrics.measure(SERVICE_NAME, method, runnable);
     } catch (IllegalArgumentException | IllegalStateException e) {
       responseObserver.onError(
           Status.INVALID_ARGUMENT.withDescription(e.getMessage()).asRuntimeException());
@@ -182,7 +183,7 @@ public class DistributedTransactionService
 
       try {
         metrics.measure(
-            DistributedTransactionService.class,
+            SERVICE_NAME,
             "transaction.start",
             () -> {
               StartRequest request = transactionRequest.getStartRequest();
@@ -333,7 +334,7 @@ public class DistributedTransactionService
         TransactionResponse.Builder responseBuilder,
         String method) {
       try {
-        metrics.measure(DistributedTransactionService.class, method, runnable);
+        metrics.measure(SERVICE_NAME, method, runnable);
       } catch (IllegalArgumentException | IllegalStateException e) {
         responseBuilder.setError(
             TransactionResponse.Error.newBuilder()

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -10,8 +10,8 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.server.Metrics;
 import com.scalar.db.server.Pauser;
 import com.scalar.db.server.config.ServerConfig;
-import com.scalar.db.service.StorageModule;
-import com.scalar.db.service.TransactionModule;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
 
 public class ServerModule extends AbstractModule {
 

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -1,7 +1,5 @@
 package com.scalar.db.server.service;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.jmx.JmxReporter;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -16,17 +14,8 @@ import com.scalar.db.server.Pauser;
 import com.scalar.db.server.config.ServerConfig;
 import com.scalar.db.service.StorageModule;
 import com.scalar.db.service.TransactionModule;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.dropwizard.DropwizardExports;
-import io.prometheus.client.exporter.MetricsServlet;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ServerModule extends AbstractModule {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ServerModule.class);
 
   private final ServerConfig config;
   private final Injector storageInjector;
@@ -65,37 +54,6 @@ public class ServerModule extends AbstractModule {
   @Provides
   @Singleton
   Metrics provideMetrics() {
-    MetricRegistry metricRegistry = new MetricRegistry();
-    startJmxReporter(metricRegistry);
-    startPrometheusExporter(metricRegistry);
-    return new Metrics(metricRegistry);
-  }
-
-  private void startJmxReporter(MetricRegistry metricRegistry) {
-    JmxReporter reporter = JmxReporter.forRegistry(metricRegistry).build();
-    reporter.start();
-    Runtime.getRuntime().addShutdownHook(new Thread(reporter::stop));
-  }
-
-  private void startPrometheusExporter(MetricRegistry metricRegistry) {
-    int prometheusExporterPort = config.getPrometheusExporterPort();
-    if (prometheusExporterPort < 0) {
-      return;
-    }
-
-    CollectorRegistry.defaultRegistry.register(new DropwizardExports(metricRegistry));
-
-    Server server = new Server(prometheusExporterPort);
-    ServletContextHandler context = new ServletContextHandler();
-    context.setContextPath("/");
-    server.setHandler(context);
-    context.addServlet(new ServletHolder(new MetricsServlet()), "/stats/prometheus");
-    server.setStopAtShutdown(true);
-    try {
-      server.start();
-      LOGGER.info("Prometheus exporter started, listening on {}", prometheusExporterPort);
-    } catch (Exception e) {
-      LOGGER.error("failed to start Jetty server", e);
-    }
+    return new Metrics(config);
   }
 }


### PR DESCRIPTION
Renamed the names of the metrics on the basis of the following naming rule.

For JMX:
```
scalardb.stats.<grpc-service-name>.<some-request-identifier>…
```

For Prometheus:
```
scalardb_stats_<grpc-service-name>_<some-request-identifier>…
```

Examples for Prometheus:
```
// total
scalardb_stats_total_success 3268.0
scalardb_stats_total_failure 67.0

// DistributedStorage
scalardb_stats_distributed_storage_get{quantile="0.5",} 0.0026463000000000003
scalardb_stats_distributed_storage_get{quantile="0.75",} 0.0034989
scalardb_stats_distributed_storage_get{quantile="0.95",} 0.0057957
scalardb_stats_distributed_storage_get{quantile="0.98",} 0.007284400000000001
scalardb_stats_distributed_storage_get{quantile="0.99",} 0.0094631
scalardb_stats_distributed_storage_get{quantile="0.999",} 0.012586600000000002
scalardb_stats_distributed_storage_get_count 317.0
scalardb_stats_distributed_storage_get_success 313.0
scalardb_stats_distributed_storage_get_failure 4.0

scalardb_stats_distributed_storage_scan_open_scanner{quantile="0.5",} 0.0024397
scalardb_stats_distributed_storage_scan_open_scanner{quantile="0.75",} 0.0032456000000000004
scalardb_stats_distributed_storage_scan_open_scanner{quantile="0.95",} 0.006448400000000001
scalardb_stats_distributed_storage_scan_open_scanner{quantile="0.98",} 0.0087758
scalardb_stats_distributed_storage_scan_open_scanner{quantile="0.99",} 0.0126256
scalardb_stats_distributed_storage_scan_open_scanner{quantile="0.999",} 0.0126256
scalardb_stats_distributed_storage_scan_open_scanner_count 77.0
scalardb_stats_distributed_storage_scan_open_scanner_success 76.0
scalardb_stats_distributed_storage_scan_open_scanner_failure 1.0

// DistributedStorageAdmin
scalardb_stats_distributed_storage_admin_get_table_metadata{quantile="0.5",} 0.0015512000000000002
scalardb_stats_distributed_storage_admin_get_table_metadata{quantile="0.75",} 0.0032665000000000003
scalardb_stats_distributed_storage_admin_get_table_metadata{quantile="0.95",} 0.24264650000000001
scalardb_stats_distributed_storage_admin_get_table_metadata{quantile="0.98",} 0.24264650000000001
scalardb_stats_distributed_storage_admin_get_table_metadata{quantile="0.99",} 0.24264650000000001
scalardb_stats_distributed_storage_admin_get_table_metadata{quantile="0.999",} 0.24264650000000001
scalardb_stats_distributed_storage_admin_get_table_metadata_count 12.0
scalardb_stats_distributed_storage_admin_get_table_metadata_success 12.0

// DistributedTransaction
scalardb_stats_distributed_transaction_transaction_start{quantile="0.5",} 1.6690000000000002E-4
scalardb_stats_distributed_transaction_transaction_start{quantile="0.75",} 2.529E-4
scalardb_stats_distributed_transaction_transaction_start{quantile="0.95",} 7.295E-4
scalardb_stats_distributed_transaction_transaction_start{quantile="0.98",} 8.715000000000001E-4
scalardb_stats_distributed_transaction_transaction_start{quantile="0.99",} 0.0012335
scalardb_stats_distributed_transaction_transaction_start{quantile="0.999",} 0.0061697
scalardb_stats_distributed_transaction_transaction_start_count 162.0
scalardb_stats_distributed_transaction_transaction_start_success 161.0
scalardb_stats_distributed_transaction_transaction_start_failure 1.0

scalardb_stats_distributed_transaction_transaction_get{quantile="0.5",} 0.0031442
scalardb_stats_distributed_transaction_transaction_get{quantile="0.75",} 0.0040068000000000005
scalardb_stats_distributed_transaction_transaction_get{quantile="0.95",} 0.0061497
scalardb_stats_distributed_transaction_transaction_get{quantile="0.98",} 0.009380300000000001
scalardb_stats_distributed_transaction_transaction_get{quantile="0.99",} 0.0445351
scalardb_stats_distributed_transaction_transaction_get{quantile="0.999",} 0.0527895
scalardb_stats_distributed_transaction_transaction_get_count 183.0
scalardb_stats_distributed_transaction_transaction_get_success 183.0
```

Please take a look!