### PR TITLE
Fix optimization warnings

### DIFF
--- a/rpc/build.gradle
+++ b/rpc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.google.protobuf' version '0.8.16'
+    id 'com.google.protobuf' version '0.8.17'
 }
 
 dependencies {
@@ -21,6 +21,14 @@ protobuf {
 }
 
 archivesBaseName = "scalardb-rpc"
+
+// plugin com.google.protobuf generates tasks in runtime so that we have do declare dependencies dynamically
+tasks.whenTaskAdded { t ->
+    if (t.name.equals('generateProto')) {
+        processResources.dependsOn += t
+        sourcesJar.dependsOn += t
+    }
+}
 
 // for archiving and uploading to maven central
 if (!project.gradle.startParameter.taskNames.isEmpty() &&


### PR DESCRIPTION
This change fixes the following warnings in the `:rpc:processResources` and `:rpc:sourcesJar` gradle tasks:
```
> Task :rpc:processResources
Execution optimizations have been disabled for task ':rpc:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/toshihiro.suzuki/work/scalar-labs/scalardb/rpc/src/main/proto'. Reason: Task ':rpc:processResources' uses this output of task ':rpc:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/Users/toshihiro.suzuki/work/scalar-labs/scalardb/rpc/src/main/resources'. Reason: Task ':rpc:processResources' uses this output of task ':rpc:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :rpc:sourcesJar
Execution optimizations have been disabled for task ':rpc:sourcesJar' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/toshihiro.suzuki/work/scalar-labs/scalardb/rpc/src/main/java'. Reason: Task ':rpc:sourcesJar' uses this output of task ':rpc:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/Users/toshihiro.suzuki/work/scalar-labs/scalardb/rpc/src/main/resources'. Reason: Task ':rpc:sourcesJar' uses this output of task ':rpc:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

Please take a look!