### PR TITLE
Use Cassandra Admin in MultiStorage integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,16 +106,6 @@ jobs:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "core/build.gradle" }}
 
-      - run:
-          name: Install cqlsh
-          # We need to edit DEFAULT_CQLVER defined in the cqlsh script
-          # to connect to the server without --cqlversion command line option
-          command: |
-            curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py
-            sudo python get-pip.py
-            sudo pip install cqlsh
-            sudo sed -i "s/^DEFAULT_CQLVER = .*/DEFAULT_CQLVER = '3.4.4'/" /usr/local/bin/cqlsh
-
       # https://support.circleci.com/hc/en-us/articles/360006773953-Race-Conditions-Wait-For-Database
       - run:
           name: Wait for Cassandra
@@ -431,16 +421,6 @@ jobs:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "core/build.gradle" }}
-
-      - run:
-          name: Install cqlsh
-          # We need to edit DEFAULT_CQLVER defined in the cqlsh script
-          # to connect to the server without --cqlversion command line option
-          command: |
-            curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py
-            sudo python get-pip.py
-            sudo pip install cqlsh
-            sudo sed -i "s/^DEFAULT_CQLVER = .*/DEFAULT_CQLVER = '3.4.4'/" /usr/local/bin/cqlsh
 
       # https://support.circleci.com/hc/en-us/articles/360006773953-Race-Conditions-Wait-For-Database
       - run:

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
@@ -58,13 +58,13 @@ public class MultiStorageAdminIntegrationTest {
     cassandraAdmin.createNamespace(NAMESPACE2);
     TableMetadata tableMetadata =
         TableMetadata.newBuilder()
-            .addPartitionKey("c1")
-            .addClusteringKey("c4")
-            .addColumn("c1", DataType.INT)
-            .addColumn("c2", DataType.TEXT)
-            .addColumn("c3", DataType.INT)
-            .addColumn("c4", DataType.INT)
-            .addColumn("c5", DataType.BOOLEAN)
+            .addPartitionKey(COL_NAME1)
+            .addClusteringKey(COL_NAME4)
+            .addColumn(COL_NAME1, DataType.INT)
+            .addColumn(COL_NAME2, DataType.TEXT)
+            .addColumn(COL_NAME3, DataType.INT)
+            .addColumn(COL_NAME4, DataType.INT)
+            .addColumn(COL_NAME5, DataType.BOOLEAN)
             .build();
     for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
       cassandraAdmin.createTable(NAMESPACE1, table, tableMetadata);


### PR DESCRIPTION
This refactor the MultiStorage integration test classes to rely on the Cassandra Admin instead of managing schema using cqlsh. Thanks to that, cqlsh is not needed anymore by the integration testing so I removed it from the CI configuration.