### PR TITLE
Separate consensus commit related config from DatabaseConfig

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -50,7 +50,12 @@ public class ConsensusCommitWithCassandraIntegrationTest
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(storage, config, coordinator, recovery, commit);
+        new ConsensusCommitManager(
+            storage,
+            new ConsensusCommitConfig(config.getProperties()),
+            coordinator,
+            recovery,
+            commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
@@ -54,7 +54,12 @@ public class ConsensusCommitWithCosmosIntegrationTest extends ConsensusCommitInt
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(storage, config, coordinator, recovery, commit);
+        new ConsensusCommitManager(
+            storage,
+            new ConsensusCommitConfig(config.getProperties()),
+            coordinator,
+            recovery,
+            commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithDynamoIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithDynamoIntegrationTest.java
@@ -59,7 +59,12 @@ public class ConsensusCommitWithDynamoIntegrationTest extends ConsensusCommitInt
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(storage, config, coordinator, recovery, commit);
+        new ConsensusCommitManager(
+            storage,
+            new ConsensusCommitConfig(config.getProperties()),
+            coordinator,
+            recovery,
+            commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java
@@ -38,7 +38,12 @@ public class ConsensusCommitWithJdbcDatabaseIntegrationTest
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(storage, testEnv.getJdbcConfig(), coordinator, recovery, commit);
+        new ConsensusCommitManager(
+            storage,
+            new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties()),
+            coordinator,
+            recovery,
+            commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMultiStorageIntegrationTest.java
@@ -189,7 +189,7 @@ public class ConsensusCommitWithMultiStorageIntegrationTest
 
     ConsensusCommitManager manager =
         new ConsensusCommitManager(
-            storage, new DatabaseConfig(props), coordinator, recovery, commit);
+            storage, new ConsensusCommitConfig(props), coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/main/java/com/scalar/db/api/SerializableStrategy.java
+++ b/core/src/main/java/com/scalar/db/api/SerializableStrategy.java
@@ -1,3 +1,5 @@
 package com.scalar.db.api;
 
+/** @deprecated As of release 3.2.0. Will be removed in release 4.0.0. */
+@Deprecated
 public interface SerializableStrategy {}

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -21,7 +21,6 @@ import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcStorage;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
-import com.scalar.db.transaction.consensuscommit.SerializableStrategy;
 import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -48,7 +47,6 @@ public class DatabaseConfig {
   private Optional<String> namespacePrefix;
   private Class<? extends DistributedTransactionManager> transactionManagerClass;
   private Isolation isolation = Isolation.SNAPSHOT;
-  private SerializableStrategy strategy = SerializableStrategy.EXTRA_READ;
   public static final String PREFIX = "scalar.db.";
   public static final String CONTACT_POINTS = PREFIX + "contact_points";
   public static final String CONTACT_PORT = PREFIX + "contact_port";
@@ -58,9 +56,6 @@ public class DatabaseConfig {
   public static final String NAMESPACE_PREFIX = PREFIX + "namespace_prefix";
   public static final String TRANSACTION_MANAGER = PREFIX + "transaction_manager";
   public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
-  public static final String CONSENSUS_COMMIT_PREFIX = PREFIX + "consensus_commit.";
-  public static final String SERIALIZABLE_STRATEGY =
-      CONSENSUS_COMMIT_PREFIX + "serializable_strategy";
 
   public DatabaseConfig(File propertiesFile) throws IOException {
     this(new FileInputStream(propertiesFile));
@@ -179,11 +174,6 @@ public class DatabaseConfig {
     if (!Strings.isNullOrEmpty(props.getProperty(ISOLATION_LEVEL))) {
       isolation = Isolation.valueOf(props.getProperty(ISOLATION_LEVEL).toUpperCase());
     }
-
-    if (!Strings.isNullOrEmpty(props.getProperty(SERIALIZABLE_STRATEGY))) {
-      strategy =
-          SerializableStrategy.valueOf(props.getProperty(SERIALIZABLE_STRATEGY).toUpperCase());
-    }
   }
 
   public List<String> getContactPoints() {
@@ -220,9 +210,5 @@ public class DatabaseConfig {
 
   public Isolation getIsolation() {
     return isolation;
-  }
-
-  public com.scalar.db.api.SerializableStrategy getSerializableStrategy() {
-    return strategy;
   }
 }

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -10,6 +10,7 @@ import com.scalar.db.storage.dynamo.DynamoConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.multistorage.MultiStorageConfig;
 import com.scalar.db.storage.rpc.GrpcConfig;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 
 public class TransactionModule extends AbstractModule {
   private final DatabaseConfig config;
@@ -54,5 +55,11 @@ public class TransactionModule extends AbstractModule {
   @Provides
   GrpcConfig provideGrpcConfig() {
     return new GrpcConfig(config.getProperties());
+  }
+
+  @Singleton
+  @Provides
+  ConsensusCommitConfig provideConsensusCommitConfig() {
+    return new ConsensusCommitConfig(config.getProperties());
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -1,0 +1,54 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.google.common.base.Strings;
+import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
+public class ConsensusCommitConfig extends DatabaseConfig {
+  public static final String PREFIX = DatabaseConfig.PREFIX + "consensus_commit.";
+  public static final String SERIALIZABLE_STRATEGY = PREFIX + "serializable_strategy";
+
+  private SerializableStrategy strategy;
+
+  public ConsensusCommitConfig(File propertiesFile) throws IOException {
+    super(propertiesFile);
+  }
+
+  public ConsensusCommitConfig(InputStream stream) throws IOException {
+    super(stream);
+  }
+
+  public ConsensusCommitConfig(Properties properties) {
+    super(properties);
+  }
+
+  @Override
+  protected void load() {
+    String transactionManager = getProperties().getProperty(DatabaseConfig.TRANSACTION_MANAGER);
+    if (transactionManager != null && !transactionManager.equals("consensus-commit")) {
+      throw new IllegalArgumentException(
+          DatabaseConfig.TRANSACTION_MANAGER + " should be 'consensus-commit'");
+    }
+
+    super.load();
+
+    if (!Strings.isNullOrEmpty(getProperties().getProperty(SERIALIZABLE_STRATEGY))) {
+      strategy =
+          SerializableStrategy.valueOf(
+              getProperties().getProperty(SERIALIZABLE_STRATEGY).toUpperCase());
+    } else {
+      strategy = SerializableStrategy.EXTRA_READ;
+    }
+  }
+
+  public SerializableStrategy getSerializableStrategy() {
+    return strategy;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -9,7 +9,6 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Isolation;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
@@ -23,7 +22,7 @@ import org.slf4j.LoggerFactory;
 public class ConsensusCommitManager implements DistributedTransactionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusCommitManager.class);
   private final DistributedStorage storage;
-  private final DatabaseConfig config;
+  private final ConsensusCommitConfig config;
   private final Coordinator coordinator;
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
@@ -31,7 +30,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   private Optional<String> tableName;
 
   @Inject
-  public ConsensusCommitManager(DistributedStorage storage, DatabaseConfig config) {
+  public ConsensusCommitManager(DistributedStorage storage, ConsensusCommitConfig config) {
     this.storage = storage;
     this.config = config;
     this.coordinator = new Coordinator(storage);
@@ -44,7 +43,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   @VisibleForTesting
   public ConsensusCommitManager(
       DistributedStorage storage,
-      DatabaseConfig config,
+      ConsensusCommitConfig config,
       Coordinator coordinator,
       RecoveryHandler recovery,
       CommitHandler commit) {

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -17,7 +17,6 @@ import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcStorage;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
-import com.scalar.db.transaction.consensuscommit.SerializableStrategy;
 import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
 import java.util.Collections;
@@ -53,7 +52,6 @@ public class DatabaseConfigTest {
     assertThat(config.getNamespacePrefix()).isNotPresent();
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
   }
 
   @Test
@@ -78,7 +76,6 @@ public class DatabaseConfigTest {
     assertThat(config.getNamespacePrefix()).isNotPresent();
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
   }
 
   @Test
@@ -103,7 +100,6 @@ public class DatabaseConfigTest {
     assertThat(config.getNamespacePrefix()).isNotPresent();
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
   }
 
   @Test
@@ -130,7 +126,6 @@ public class DatabaseConfigTest {
     assertThat(config.getNamespacePrefix()).isNotPresent();
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
   }
 
   @Test
@@ -442,44 +437,6 @@ public class DatabaseConfigTest {
     props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.ISOLATION_LEVEL, "READ_COMMITTED");
-
-    // Act Assert
-    assertThatThrownBy(() -> new DatabaseConfig(props))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void constructor_PropertiesWithSerializableStrategyGiven_ShouldLoadProperly() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
-    props.setProperty(
-        DatabaseConfig.SERIALIZABLE_STRATEGY, SerializableStrategy.EXTRA_WRITE.toString());
-
-    // Act
-    DatabaseConfig config = new DatabaseConfig(props);
-
-    // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_WRITE);
-  }
-
-  @Test
-  public void
-      constructor_UnsupportedSerializableStrategyGiven_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
-    props.setProperty(DatabaseConfig.SERIALIZABLE_STRATEGY, "NO_STRATEGY");
 
     // Act Assert
     assertThatThrownBy(() -> new DatabaseConfig(props))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -1,0 +1,57 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Collections;
+import java.util.Properties;
+import org.junit.Test;
+
+public class ConsensusCommitConfigTest {
+
+  private static final String ANY_HOST = "localhost";
+
+  @Test
+  public void constructor_PropertiesWithoutPortGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
+  }
+
+  @Test
+  public void constructor_PropertiesWithSerializableStrategyGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(
+        ConsensusCommitConfig.SERIALIZABLE_STRATEGY, SerializableStrategy.EXTRA_WRITE.toString());
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_WRITE);
+  }
+
+  @Test
+  public void
+      constructor_UnsupportedSerializableStrategyGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, "NO_STRATEGY");
+
+    // Act Assert
+    assertThatThrownBy(() -> new ConsensusCommitConfig(props))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Isolation;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
@@ -26,7 +25,7 @@ public class ConsensusCommitManagerTest {
   @SuppressWarnings("unused")
   private DistributedStorage storage;
 
-  @Mock private DatabaseConfig config;
+  @Mock private ConsensusCommitConfig config;
   @Mock private Coordinator coordinator;
   @Mock private RecoveryHandler recovery;
   @Mock private CommitHandler commit;

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
@@ -23,6 +23,7 @@ import com.scalar.db.storage.jdbc.test.TestEnv;
 import com.scalar.db.storage.rpc.GrpcConfig;
 import com.scalar.db.storage.rpc.GrpcStorage;
 import com.scalar.db.transaction.consensuscommit.CommitHandler;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
@@ -53,7 +54,12 @@ public class ConsensusCommitWithDistributedStorageServiceIntegrationTest
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(storage, testEnv.getJdbcConfig(), coordinator, recovery, commit);
+        new ConsensusCommitManager(
+            storage,
+            new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties()),
+            coordinator,
+            recovery,
+            commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraReadIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraReadIntegrationTest.java
@@ -39,6 +39,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.server.config.ServerConfig;
 import com.scalar.db.storage.jdbc.test.TestEnv;
 import com.scalar.db.storage.rpc.GrpcConfig;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.db.transaction.rpc.GrpcTransaction;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
@@ -291,7 +292,7 @@ public class DistributedTransactionServiceWithConsensusCommitWithExtraReadIntegr
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
     serverProperties.setProperty(DatabaseConfig.ISOLATION_LEVEL, "SERIALIZABLE");
-    serverProperties.setProperty(DatabaseConfig.SERIALIZABLE_STRATEGY, "EXTRA_READ");
+    serverProperties.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, "EXTRA_READ");
     serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraWriteIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitWithExtraWriteIntegrationTest.java
@@ -39,6 +39,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.server.config.ServerConfig;
 import com.scalar.db.storage.jdbc.test.TestEnv;
 import com.scalar.db.storage.rpc.GrpcConfig;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.db.transaction.rpc.GrpcTransaction;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
@@ -251,7 +252,7 @@ public class DistributedTransactionServiceWithConsensusCommitWithExtraWriteInteg
 
     Properties serverProperties = new Properties(testEnv.getJdbcConfig().getProperties());
     serverProperties.setProperty(DatabaseConfig.ISOLATION_LEVEL, "SERIALIZABLE");
-    serverProperties.setProperty(DatabaseConfig.SERIALIZABLE_STRATEGY, "EXTRA_WRITE");
+    serverProperties.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, "EXTRA_WRITE");
     serverProperties.setProperty(ServerConfig.PROMETHEUS_EXPORTER_PORT, "-1");
     server = new ScalarDbServer(serverProperties);
     server.start();


### PR DESCRIPTION
I moved the consensus commit related config from `DatabaseConfig` to `ConsensusCommitConfig` that I added in this PR. After this change, we will add new consensus commit related config to `ConsensusCommitConfig`.

Please take a look!