### PR TITLE
Add active_transactions_management config to GrpcTwoPhaseCommitTransactionManager

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.rpc;
 
 import com.google.common.base.Strings;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.util.Utility;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +23,13 @@ public class GrpcConfig extends DatabaseConfig {
   public static final long DEFAULT_DEADLINE_DURATION_MILLIS = 60000; // 60 seconds
 
   private long deadlineDurationMillis;
+
+  // for two-phase commit transactions
+  public static final String TWO_PHASE_COMMIT_TRANSACTION_PREFIX = PREFIX + "2pc.";
+  public static final String ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED =
+      TWO_PHASE_COMMIT_TRANSACTION_PREFIX + "active_transactions_management.enabled";
+
+  private boolean activeTransactionsManagementEnabled;
 
   public GrpcConfig(File propertiesFile) throws IOException {
     super(propertiesFile);
@@ -45,6 +53,15 @@ public class GrpcConfig extends DatabaseConfig {
     super.load();
 
     deadlineDurationMillis = getLong(DEADLINE_DURATION_MILLIS, DEFAULT_DEADLINE_DURATION_MILLIS);
+
+    String activeTransactionsManagementEnabledValue =
+        getProperties().getProperty(ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED);
+    if (Utility.isBooleanString(activeTransactionsManagementEnabledValue)) {
+      activeTransactionsManagementEnabled =
+          Boolean.parseBoolean(activeTransactionsManagementEnabledValue);
+    } else {
+      activeTransactionsManagementEnabled = true;
+    }
   }
 
   private long getLong(String name, long defaultValue) {
@@ -65,5 +82,9 @@ public class GrpcConfig extends DatabaseConfig {
 
   public long getDeadlineDurationMillis() {
     return deadlineDurationMillis;
+  }
+
+  public boolean isActiveTransactionsManagementEnabled() {
+    return activeTransactionsManagementEnabled;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -2,6 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 import com.google.common.base.Strings;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.util.Utility;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
@@ -54,10 +55,11 @@ public class ConsensusCommitConfig extends DatabaseConfig {
       strategy = SerializableStrategy.EXTRA_READ;
     }
 
-    if (!Strings.isNullOrEmpty(
-        getProperties().getProperty(ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED))) {
+    String activeTransactionsManagementEnabledValue =
+        getProperties().getProperty(ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED);
+    if (Utility.isBooleanString(activeTransactionsManagementEnabledValue)) {
       activeTransactionsManagementEnabled =
-          Boolean.parseBoolean(getProperties().getProperty(ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED));
+          Boolean.parseBoolean(activeTransactionsManagementEnabledValue);
     } else {
       activeTransactionsManagementEnabled = true;
     }

--- a/core/src/main/java/com/scalar/db/util/Utility.java
+++ b/core/src/main/java/com/scalar/db/util/Utility.java
@@ -1,5 +1,6 @@
 package com.scalar.db.util;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Streams;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Selection;
@@ -90,6 +91,11 @@ public final class Utility {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  public static boolean isBooleanString(String s) {
+    return !Strings.isNullOrEmpty(s)
+        && (Boolean.TRUE.toString().equals(s) || Boolean.FALSE.toString().equals(s));
   }
 
   /**

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
@@ -1,14 +1,13 @@
-package com.scalar.db.transaction.consensuscommit;
+package com.scalar.db.storage.rpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.scalar.db.config.DatabaseConfig;
 import java.util.Collections;
 import java.util.Properties;
 import org.junit.Test;
 
-public class ConsensusCommitConfigTest {
+public class GrpcConfigTest {
 
   private static final String ANY_HOST = "localhost";
 
@@ -17,43 +16,50 @@ public class ConsensusCommitConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
 
     // Act
-    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+    GrpcConfig config = new GrpcConfig(props);
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
+    assertThat(config.getDeadlineDurationMillis())
+        .isEqualTo(GrpcConfig.DEFAULT_DEADLINE_DURATION_MILLIS);
     assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(true);
   }
 
   @Test
-  public void constructor_PropertiesWithSerializableStrategyGiven_ShouldLoadProperly() {
+  public void constructor_PropertiesWithValidDeadlineDurationMillisGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(
-        ConsensusCommitConfig.SERIALIZABLE_STRATEGY, SerializableStrategy.EXTRA_WRITE.toString());
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
+    props.setProperty(GrpcConfig.DEADLINE_DURATION_MILLIS, "5000");
 
     // Act
-    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+    GrpcConfig config = new GrpcConfig(props);
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_WRITE);
+    assertThat(config.getDeadlineDurationMillis()).isEqualTo(5000);
   }
 
   @Test
   public void
-      constructor_UnsupportedSerializableStrategyGiven_ShouldThrowIllegalArgumentException() {
+      constructor_PropertiesWithInvalidDeadlineDurationMillisGiven_ShouldLoadAsDefaultValue() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, "NO_STRATEGY");
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
+    props.setProperty(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "aaa");
 
-    // Act Assert
-    assertThatThrownBy(() -> new ConsensusCommitConfig(props))
-        .isInstanceOf(IllegalArgumentException.class);
+    // Act
+    GrpcConfig config = new GrpcConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.getDeadlineDurationMillis())
+        .isEqualTo(GrpcConfig.DEFAULT_DEADLINE_DURATION_MILLIS);
   }
 
   @Test
@@ -62,10 +68,11 @@ public class ConsensusCommitConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(ConsensusCommitConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "false");
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
+    props.setProperty(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "false");
 
     // Act
-    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+    GrpcConfig config = new GrpcConfig(props);
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
@@ -78,10 +85,11 @@ public class ConsensusCommitConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(ConsensusCommitConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "aaa");
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
+    props.setProperty(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "aaa");
 
     // Act
-    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+    GrpcConfig config = new GrpcConfig(props);
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
@@ -15,6 +15,7 @@ import com.scalar.db.rpc.TwoPhaseCommitTransactionGrpc;
 import com.scalar.db.storage.rpc.GrpcConfig;
 import com.scalar.db.storage.rpc.GrpcTableMetadataManager;
 import io.grpc.Status;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -39,6 +40,18 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
     manager.with("namespace", "table");
     when(config.getDeadlineDurationMillis()).thenReturn(60000L);
     when(blockingStub.withDeadlineAfter(anyLong(), any())).thenReturn(blockingStub);
+  }
+
+  @Test
+  public void
+      resume_WhenActiveTransactionsManagementEnabledIsFalse_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    when(config.isActiveTransactionsManagementEnabled()).thenReturn(false);
+    manager = new GrpcTwoPhaseCommitTransactionManager(config, stub, blockingStub, metadataManager);
+
+    // Act Assert
+    AssertionsForClassTypes.assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test


### PR DESCRIPTION
This PR adds `active_transactions_management` config to `GrpcTwoPhaseCommitTransactionManager`. This config is basically the same as `TwoPhaseConsensusCommitManager`'s one. Please take a look!