### PR TITLE
Refactor CassandraAdmin and CosmosAdmin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -34,7 +34,7 @@ public class CosmosAdminIntegrationTest extends AdminIntegrationTestBase {
     props.setProperty(DatabaseConfig.STORAGE, "cosmos");
     namespacePrefix.ifPresent(n -> props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, n));
     admin = new CosmosAdmin(new DatabaseConfig(props));
-    admin.createNamespace(NAMESPACE, ImmutableMap.of(CosmosAdmin.RU, "4000"));
+    admin.createNamespace(NAMESPACE, ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000"));
     admin.createTable(
         NAMESPACE,
         TABLE,

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -39,7 +39,7 @@ public class CosmosIntegrationTest extends IntegrationTestBase {
     DatabaseConfig config = new DatabaseConfig(props);
     admin = new CosmosAdmin(config);
     storage = new Cosmos(config);
-    createTable(ImmutableMap.of(CosmosAdmin.RU, "4000"));
+    createTable(ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000"));
   }
 
   @AfterClass

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
@@ -37,7 +37,7 @@ public class ConsensusCommitWithCosmosIntegrationTest extends ConsensusCommitInt
     config = new DatabaseConfig(props);
     originalStorage = new Cosmos(config);
     admin = new CosmosAdmin(config);
-    createTables(ImmutableMap.of(CosmosAdmin.RU, "4000"));
+    createTables(ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000"));
   }
 
   @AfterClass

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -274,13 +274,13 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     }
   }
 
-  enum CompactionStrategy {
+  public enum CompactionStrategy {
     STCS,
     LCS,
     TWCS
   }
 
-  enum ReplicationStrategy {
+  public enum ReplicationStrategy {
     SIMPLE_STRATEGY("SimpleStrategy"),
     NETWORK_TOPOLOGY_STRATEGY("NetworkTopologyStrategy");
     private final String strategyName;

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -40,8 +40,8 @@ import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public class CosmosAdmin implements DistributedStorageAdmin {
-  public static final String RU = "ru";
-  public static final String DEFAULT_RU = "400";
+  public static final String REQUEST_UNIT = "ru";
+  public static final String DEFAULT_REQUEST_UNIT = "400";
   public static final String NO_SCALING = "no-scaling";
   public static final String DEFAULT_NO_SCALING = "false";
   private static final String ID = "id";
@@ -229,7 +229,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   }
 
   private ThroughputProperties calculateThroughput(Map<String, String> options) {
-    int ru = Integer.parseInt(options.getOrDefault(RU, DEFAULT_RU));
+    int ru = Integer.parseInt(options.getOrDefault(REQUEST_UNIT, DEFAULT_REQUEST_UNIT));
     boolean noScaling = Boolean.parseBoolean(options.getOrDefault(NO_SCALING, DEFAULT_NO_SCALING));
     if (ru < 4000 || noScaling) {
       return ThroughputProperties.createManualThroughput(ru);

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadataManager.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadataManager.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.cosmos;
 
-import static com.scalar.db.storage.cosmos.CosmosAdmin.DEFAULT_RU;
+import static com.scalar.db.storage.cosmos.CosmosAdmin.DEFAULT_REQUEST_UNIT;
 import static com.scalar.db.util.Utility.getFullNamespaceName;
 import static com.scalar.db.util.Utility.getFullTableName;
 
@@ -181,7 +181,7 @@ public class CosmosTableMetadataManager implements TableMetadataManager {
   private void createMetadataDatabaseAndContainerIfNotExists() {
     String metadataDatabase = getFullNamespaceName(databasePrefix, METADATA_DATABASE);
     ThroughputProperties manualThroughput =
-        ThroughputProperties.createManualThroughput(Integer.parseInt(DEFAULT_RU));
+        ThroughputProperties.createManualThroughput(Integer.parseInt(DEFAULT_REQUEST_UNIT));
     client.createDatabaseIfNotExists(metadataDatabase, manualThroughput);
     CosmosContainerProperties containerProperties =
         new CosmosContainerProperties(METADATA_CONTAINER, "/id");

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.cosmos;
 
-import static com.scalar.db.storage.cosmos.CosmosAdmin.DEFAULT_RU;
+import static com.scalar.db.storage.cosmos.CosmosAdmin.DEFAULT_REQUEST_UNIT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -81,7 +81,9 @@ public class CosmosAdminTest {
     verify(client)
         .createDatabase(
             eq(DATABASE_PREFIX + namespace),
-            refEq(ThroughputProperties.createManualThroughput(Integer.parseInt(DEFAULT_RU))));
+            refEq(
+                ThroughputProperties.createManualThroughput(
+                    Integer.parseInt(DEFAULT_REQUEST_UNIT))));
   }
 
   @Test
@@ -92,7 +94,8 @@ public class CosmosAdminTest {
     String throughput = "2000";
 
     // Act
-    admin.createNamespace(namespace, Collections.singletonMap(CosmosAdmin.RU, throughput));
+    admin.createNamespace(
+        namespace, Collections.singletonMap(CosmosAdmin.REQUEST_UNIT, throughput));
 
     // Assert
     verify(client)
@@ -109,7 +112,8 @@ public class CosmosAdminTest {
     String throughput = "4000";
 
     // Act
-    admin.createNamespace(namespace, Collections.singletonMap(CosmosAdmin.RU, throughput));
+    admin.createNamespace(
+        namespace, Collections.singletonMap(CosmosAdmin.REQUEST_UNIT, throughput));
 
     // Assert
     verify(client)
@@ -129,7 +133,8 @@ public class CosmosAdminTest {
 
     // Act
     admin.createNamespace(
-        namespace, ImmutableMap.of(CosmosAdmin.RU, throughput, CosmosAdmin.NO_SCALING, noScaling));
+        namespace,
+        ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, throughput, CosmosAdmin.NO_SCALING, noScaling));
 
     // Assert
     verify(client)


### PR DESCRIPTION
What I did in this PR are:
- Rename `CosmosAdmin.RU` to `CosmosAdmin.REQUEST_UNIT` and `CosmosAdmin.DEFAULT_RU` to `CosmosAdmin.DEFAULT_REQUEST_UNIT` for consistency
- Make `CompactionStrategy` and `ReplicationStrategy` in `CassandraAdmin` public

Please take a look!