### PR TITLE
Fixed broken link.

### DIFF
--- a/docs/two-phase-commit-transactions.md
+++ b/docs/two-phase-commit-transactions.md
@@ -169,4 +169,4 @@ In other cases, `validate()` does nothing.
 
 One of the use cases for Two-phase Commit Transactions is Microservice Transaction.
 Please see the following sample to learn Two-phase Commit Transactions further:
-- [Microservice Transaction Sample](https://github.com/scalar-labs/scalardb-samples/microservice-transaction-sample/)
+- [Microservice Transaction Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/microservice-transaction-sample)


### PR DESCRIPTION
The link to the `Microservice Transaction Sample` was broken, so I fixed it.