### PR TITLE
Remove metadata from Coordinator

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Attribute.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Attribute.java
@@ -12,7 +12,6 @@ public final class Attribute {
   public static final String PREPARED_AT = "tx_prepared_at";
   public static final String COMMITTED_AT = "tx_committed_at";
   public static final String CREATED_AT = "tx_created_at";
-  public static final String METADATA = "tx_metadata";
   public static final String BEFORE_PREFIX = "before_";
   public static final String BEFORE_ID = BEFORE_PREFIX + ID;
   public static final String BEFORE_STATE = BEFORE_PREFIX + STATE;
@@ -42,10 +41,6 @@ public final class Attribute {
 
   public static BigIntValue toCreatedAtValue(long createdAt) {
     return new BigIntValue(Attribute.CREATED_AT, createdAt);
-  }
-
-  public static TextValue toMetadataValue(String metadata) {
-    return new TextValue(Attribute.METADATA, metadata);
   }
 
   public static TextValue toBeforeIdValue(String transactionId) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -71,17 +71,13 @@ public class Coordinator {
 
   @VisibleForTesting
   Put createPutWith(Coordinator.State state) {
-    Put put =
-        new Put(new Key(Attribute.toIdValue(state.getId())))
-            .withValue(Attribute.toStateValue(state.getState()))
-            .withValue(Attribute.toCreatedAtValue(state.getCreatedAt()))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .withCondition(new PutIfNotExists())
-            .forNamespace(NAMESPACE)
-            .forTable(TABLE);
-
-    state.getMetadata().ifPresent(m -> put.withValue(Attribute.METADATA, m));
-    return put;
+    return new Put(new Key(Attribute.toIdValue(state.getId())))
+        .withValue(Attribute.toStateValue(state.getState()))
+        .withValue(Attribute.toCreatedAtValue(state.getCreatedAt()))
+        .withConsistency(Consistency.LINEARIZABLE)
+        .withCondition(new PutIfNotExists())
+        .forNamespace(NAMESPACE)
+        .forTable(TABLE);
   }
 
   private void put(Put put) throws CoordinatorException {
@@ -113,7 +109,6 @@ public class Coordinator {
     private final String id;
     private final TransactionState state;
     private final long createdAt;
-    private String metadata;
 
     public State(Result result) {
       checkNotMissingRequired(result);
@@ -145,15 +140,6 @@ public class Coordinator {
 
     public long getCreatedAt() {
       return createdAt;
-    }
-
-    @Nonnull
-    public Optional<String> getMetadata() {
-      return Optional.ofNullable(metadata);
-    }
-
-    public void setMetadata(String metadata) {
-      this.metadata = metadata;
     }
 
     @Override


### PR DESCRIPTION
The metadata column in `Coordinator` is no longer needed. This PR removes it. Please take a look!