### PR TITLE
Make Coordinator namespace name configurable

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCassandraIntegrationTest.java
@@ -45,17 +45,13 @@ public class ConsensusCommitWithCassandraIntegrationTest
 
   @Before
   public void setUp() {
+    ConsensusCommitConfig consensusCommitConfig = new ConsensusCommitConfig(config.getProperties());
     DistributedStorage storage = spy(originalStorage);
-    Coordinator coordinator = spy(new Coordinator(storage));
+    Coordinator coordinator = spy(new Coordinator(storage, consensusCommitConfig));
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(
-            storage,
-            new ConsensusCommitConfig(config.getProperties()),
-            coordinator,
-            recovery,
-            commit);
+        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
@@ -49,17 +49,13 @@ public class ConsensusCommitWithCosmosIntegrationTest extends ConsensusCommitInt
 
   @Before
   public void setUp() throws IOException {
+    ConsensusCommitConfig consensusCommitConfig = new ConsensusCommitConfig(config.getProperties());
     DistributedStorage storage = spy(originalStorage);
-    Coordinator coordinator = spy(new Coordinator(storage));
+    Coordinator coordinator = spy(new Coordinator(storage, consensusCommitConfig));
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(
-            storage,
-            new ConsensusCommitConfig(config.getProperties()),
-            coordinator,
-            recovery,
-            commit);
+        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithDynamoIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithDynamoIntegrationTest.java
@@ -54,17 +54,13 @@ public class ConsensusCommitWithDynamoIntegrationTest extends ConsensusCommitInt
 
   @Before
   public void setUp() {
+    ConsensusCommitConfig consensusCommitConfig = new ConsensusCommitConfig(config.getProperties());
     DistributedStorage storage = spy(originalStorage);
-    Coordinator coordinator = spy(new Coordinator(storage));
+    Coordinator coordinator = spy(new Coordinator(storage, consensusCommitConfig));
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(
-            storage,
-            new ConsensusCommitConfig(config.getProperties()),
-            coordinator,
-            recovery,
-            commit);
+        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java
@@ -33,17 +33,14 @@ public class ConsensusCommitWithJdbcDatabaseIntegrationTest
 
   @Before
   public void setUp() {
+    ConsensusCommitConfig consensusCommitConfig =
+        new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties());
     DistributedStorage storage = spy(originalStorage);
-    Coordinator coordinator = spy(new Coordinator(storage));
+    Coordinator coordinator = spy(new Coordinator(storage, consensusCommitConfig));
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(
-            storage,
-            new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties()),
-            coordinator,
-            recovery,
-            commit);
+        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMultiStorageIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithMultiStorageIntegrationTest.java
@@ -177,19 +177,20 @@ public class ConsensusCommitWithMultiStorageIntegrationTest
 
   @Before
   public void setUp() {
-    DistributedStorage storage = spy(originalStorage);
-    Coordinator coordinator = spy(new Coordinator(storage));
-    RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
-    CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
-
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, "dummy");
     props.setProperty(DatabaseConfig.USERNAME, "dummy");
     props.setProperty(DatabaseConfig.PASSWORD, "dummy");
 
+    ConsensusCommitConfig consensusCommitConfig = new ConsensusCommitConfig(props);
+
+    DistributedStorage storage = spy(originalStorage);
+    Coordinator coordinator = spy(new Coordinator(storage, consensusCommitConfig));
+    RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
+    CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
+
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(
-            storage, new ConsensusCommitConfig(props), coordinator, recovery, commit);
+        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
@@ -2374,10 +2374,10 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   private static void initStorageAndManagerAndCoordinator() {
     storage = new JdbcDatabase(testEnv.getJdbcConfig());
-    manager =
-        new TwoPhaseConsensusCommitManager(
-            storage, new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties()));
-    coordinator = new Coordinator(storage);
+    ConsensusCommitConfig consensusCommitConfig =
+        new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties());
+    manager = new TwoPhaseConsensusCommitManager(storage, consensusCommitConfig);
+    coordinator = new Coordinator(storage, consensusCommitConfig);
   }
 
   @AfterClass

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -29,13 +29,11 @@ public class ConsensusCommitAdmin {
           .build();
 
   private final DistributedStorageAdmin admin;
-
-  @SuppressWarnings("unused")
-  private final ConsensusCommitConfig config;
+  private final String coordinatorNamespace;
 
   public ConsensusCommitAdmin(DistributedStorageAdmin admin, ConsensusCommitConfig config) {
     this.admin = admin;
-    this.config = config;
+    coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
   }
 
   /**
@@ -45,7 +43,7 @@ public class ConsensusCommitAdmin {
    */
   public void createCoordinatorTable() throws ExecutionException {
     admin.createTable(
-        Coordinator.NAMESPACE,
+        coordinatorNamespace,
         Coordinator.TABLE,
         Coordinator.TABLE_METADATA,
         true,
@@ -60,7 +58,7 @@ public class ConsensusCommitAdmin {
    */
   public void createCoordinatorTable(Map<String, String> options) throws ExecutionException {
     admin.createTable(
-        Coordinator.NAMESPACE, Coordinator.TABLE, Coordinator.TABLE_METADATA, true, options);
+        coordinatorNamespace, Coordinator.TABLE, Coordinator.TABLE_METADATA, true, options);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -7,7 +7,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -15,8 +17,10 @@ import javax.annotation.concurrent.Immutable;
 public class ConsensusCommitConfig extends DatabaseConfig {
   public static final String PREFIX = DatabaseConfig.PREFIX + "consensus_commit.";
   public static final String SERIALIZABLE_STRATEGY = PREFIX + "serializable_strategy";
+  public static final String COORDINATOR_NAMESPACE = PREFIX + "coordinator.namespace";
 
   private SerializableStrategy strategy;
+  @Nullable private String coordinatorNamespace;
 
   // for two-phase consensus commit
   public static final String TWO_PHASE_CONSENSUS_COMMIT_PREFIX = PREFIX + "2pcc.";
@@ -63,6 +67,10 @@ public class ConsensusCommitConfig extends DatabaseConfig {
     } else {
       activeTransactionsManagementEnabled = true;
     }
+
+    if (!Strings.isNullOrEmpty(getProperties().getProperty(COORDINATOR_NAMESPACE))) {
+      coordinatorNamespace = getProperties().getProperty(COORDINATOR_NAMESPACE);
+    }
   }
 
   public SerializableStrategy getSerializableStrategy() {
@@ -71,5 +79,9 @@ public class ConsensusCommitConfig extends DatabaseConfig {
 
   public boolean isActiveTransactionsManagementEnabled() {
     return activeTransactionsManagementEnabled;
+  }
+
+  public Optional<String> getCoordinatorNamespace() {
+    return Optional.ofNullable(coordinatorNamespace);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -33,7 +33,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   public ConsensusCommitManager(DistributedStorage storage, ConsensusCommitConfig config) {
     this.storage = storage;
     this.config = config;
-    this.coordinator = new Coordinator(storage);
+    this.coordinator = new Coordinator(storage, config);
     this.recovery = new RecoveryHandler(storage, coordinator);
     this.commit = new CommitHandler(storage, coordinator, recovery);
     this.namespace = storage.getNamespace();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -42,9 +42,11 @@ public class Coordinator {
   private static final long SLEEP_BASE_MILLIS = 50;
   private static final Logger LOGGER = LoggerFactory.getLogger(Coordinator.class);
   private final DistributedStorage storage;
+  private final String coordinatorNamespace;
 
-  public Coordinator(DistributedStorage storage) {
+  public Coordinator(DistributedStorage storage, ConsensusCommitConfig config) {
     this.storage = storage;
+    coordinatorNamespace = config.getCoordinatorNamespace().orElse(NAMESPACE);
   }
 
   public Optional<Coordinator.State> getState(String id) throws CoordinatorException {
@@ -60,7 +62,7 @@ public class Coordinator {
   private Get createGetWith(String id) {
     return new Get(new Key(Attribute.toIdValue(id)))
         .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(NAMESPACE)
+        .forNamespace(coordinatorNamespace)
         .forTable(TABLE);
   }
 
@@ -86,7 +88,7 @@ public class Coordinator {
         .withValue(Attribute.toCreatedAtValue(state.getCreatedAt()))
         .withConsistency(Consistency.LINEARIZABLE)
         .withCondition(new PutIfNotExists())
-        .forNamespace(NAMESPACE)
+        .forNamespace(coordinatorNamespace)
         .forTable(TABLE);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -45,7 +45,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
     this.storage = storage;
     this.config = config;
 
-    coordinator = new Coordinator(storage);
+    coordinator = new Coordinator(storage, config);
     recovery = new RecoveryHandler(storage, coordinator);
     commit = new CommitHandler(storage, coordinator, recovery);
     if (config.isActiveTransactionsManagementEnabled()) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -13,7 +13,7 @@ public class ConsensusCommitConfigTest {
   private static final String ANY_HOST = "localhost";
 
   @Test
-  public void constructor_PropertiesWithoutPortGiven_ShouldLoadProperly() {
+  public void constructor_PropertiesWithOnlyContactPointsGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
@@ -25,6 +25,7 @@ public class ConsensusCommitConfigTest {
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
     assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(true);
+    assertThat(config.getCoordinatorNamespace()).isNotPresent();
   }
 
   @Test
@@ -86,5 +87,21 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
     assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(true);
+  }
+
+  @Test
+  public void constructor_PropertiesWithCoordinatorNamespaceGiven_ShouldLoadAsDefaultValue() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, "changed_coordinator");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.getCoordinatorNamespace()).isPresent();
+    assertThat(config.getCoordinatorNamespace().get()).isEqualTo("changed_coordinator");
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -35,11 +35,13 @@ public class CoordinatorTest {
   private static final long ANY_TIME_1 = 1;
 
   @Mock private DistributedStorage storage;
-  @InjectMocks private Coordinator coordinator;
+  @Mock private ConsensusCommitConfig config;
+  private Coordinator coordinator;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+    coordinator = new Coordinator(storage, config);
   }
 
   @Test
@@ -80,7 +82,7 @@ public class CoordinatorTest {
   public void putState_StateGiven_ShouldPutWithCorrectValues()
       throws ExecutionException, CoordinatorException {
     // Arrange
-    coordinator = spy(new Coordinator(storage));
+    coordinator = spy(new Coordinator(storage, config));
     long current = System.currentTimeMillis();
     Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
     doNothing().when(storage).put(any(Put.class));
@@ -118,7 +120,7 @@ public class CoordinatorTest {
   public void putState_StateGivenAndExceptionThrownInPut_ShouldThrowCoordinatorException()
       throws ExecutionException {
     // Arrange
-    coordinator = spy(new Coordinator(storage));
+    coordinator = spy(new Coordinator(storage, config));
     long current = System.currentTimeMillis();
     Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
     ExecutionException toThrow = mock(ExecutionException.class);
@@ -129,5 +131,58 @@ public class CoordinatorTest {
 
     // Assert
     verify(coordinator).createPutWith(state);
+  }
+
+  @Test
+  public void getState_WithCoordinatorNamespaceChanged_ShouldGetWithChangedNamespace()
+      throws ExecutionException, CoordinatorException {
+    // Arrange
+    when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
+    coordinator = new Coordinator(storage, config);
+
+    Result result = mock(Result.class);
+    when(result.getValue(Attribute.ID))
+        .thenReturn(Optional.of(new TextValue(Attribute.ID, ANY_ID_1)));
+    when(result.getValue(Attribute.STATE))
+        .thenReturn(Optional.of(new IntValue(Attribute.STATE, TransactionState.COMMITTED.get())));
+    when(result.getValue(Attribute.CREATED_AT))
+        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
+    when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
+
+    // Act
+    Optional<Coordinator.State> state = coordinator.getState(ANY_ID_1);
+
+    // Assert
+    ArgumentCaptor<Get> captor = ArgumentCaptor.forClass(Get.class);
+    verify(storage).get(captor.capture());
+    assertThat(captor.getValue().forNamespace().get()).isEqualTo("changed_coordinator");
+    assertThat(captor.getValue().forTable().get()).isEqualTo(Coordinator.TABLE);
+
+    assertThat(state.get().getId()).isEqualTo(ANY_ID_1);
+    Assertions.assertThat(state.get().getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(state.get().getCreatedAt()).isEqualTo(ANY_TIME_1);
+  }
+
+  @Test
+  public void putState_WithCoordinatorNamespaceChanged_ShouldPutWithChangedNamespace()
+      throws ExecutionException, CoordinatorException {
+    // Arrange
+    when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
+    coordinator = spy(new Coordinator(storage, config));
+
+    long current = System.currentTimeMillis();
+    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED, current);
+    doNothing().when(storage).put(any(Put.class));
+
+    // Act
+    coordinator.putState(state);
+
+    // Assert
+    verify(coordinator).createPutWith(state);
+
+    ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+    verify(storage).put(captor.capture());
+    assertThat(captor.getValue().forNamespace().get()).isEqualTo("changed_coordinator");
+    assertThat(captor.getValue().forTable().get()).isEqualTo(Coordinator.TABLE);
   }
 }

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitWithDistributedStorageServiceIntegrationTest.java
@@ -49,17 +49,14 @@ public class ConsensusCommitWithDistributedStorageServiceIntegrationTest
 
   @Before
   public void setUp() {
+    ConsensusCommitConfig consensusCommitConfig =
+        new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties());
     DistributedStorage storage = spy(originalStorage);
-    Coordinator coordinator = spy(new Coordinator(storage));
+    Coordinator coordinator = spy(new Coordinator(storage, consensusCommitConfig));
     RecoveryHandler recovery = spy(new RecoveryHandler(storage, coordinator));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery));
     ConsensusCommitManager manager =
-        new ConsensusCommitManager(
-            storage,
-            new ConsensusCommitConfig(testEnv.getJdbcConfig().getProperties()),
-            coordinator,
-            recovery,
-            commit);
+        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
     setUp(manager, storage, coordinator, recovery);
   }
 


### PR DESCRIPTION
Currently, the table metadata database name is fixed `coordinator`. This PR makes it configurable with the `scalar.db.consensus_commit.coordinator.namespace` property. Please take a look!