### PR TITLE
Make table metadata database name configurable in Cosmos DB adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           key: v1-dependencies-{{ checksum "core/build.gradle" }}
 
       # run tests!
-      - run: gradle integrationTestCosmos -Dscalardb.cosmos.uri=${COSMOS_URI} -Dscalardb.cosmos.username=${COSMOS_USERNAME} -Dscalardb.cosmos.password=${COSMOS_PASSWORD} -Dscalardb.namespace_prefix=${CIRCLE_BUILD_NUM}
+      - run: gradle integrationTestCosmos -Dscalardb.cosmos.uri=${COSMOS_URI} -Dscalardb.cosmos.password=${COSMOS_PASSWORD} -Dscalardb.namespace_prefix=${CIRCLE_BUILD_NUM}
 
       - run:
           name: Save Gradle integration test reports

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -18,22 +18,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class CosmosAdminIntegrationTest extends AdminIntegrationTestBase {
+  private static final String PROP_COSMOSDB_URI = "scalardb.cosmos.uri";
+  private static final String PROP_COSMOSDB_PASSWORD = "scalardb.cosmos.password";
+  private static final String PROP_NAMESPACE_PREFIX = "scalardb.namespace_prefix";
 
-  private static Optional<String> namespacePrefix;
   private static DistributedStorageAdmin admin;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    String contactPoint = System.getProperty("scalardb.cosmos.uri");
-    String password = System.getProperty("scalardb.cosmos.password");
-    namespacePrefix = Optional.ofNullable(System.getProperty("scalardb.namespace_prefix"));
+    String contactPoint = System.getProperty(PROP_COSMOSDB_URI);
+    String password = System.getProperty(PROP_COSMOSDB_PASSWORD);
+    Optional<String> namespacePrefix =
+        Optional.ofNullable(System.getProperty(PROP_NAMESPACE_PREFIX));
 
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, contactPoint);
     props.setProperty(DatabaseConfig.PASSWORD, password);
     props.setProperty(DatabaseConfig.STORAGE, "cosmos");
     namespacePrefix.ifPresent(n -> props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, n));
-    admin = new CosmosAdmin(new DatabaseConfig(props));
+    admin = new CosmosAdmin(new CosmosConfig(props));
     admin.createNamespace(NAMESPACE, ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000"));
     admin.createTable(
         NAMESPACE,

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -15,7 +15,6 @@ import org.junit.BeforeClass;
 
 public class CosmosIntegrationTest extends IntegrationTestBase {
   private static final String PROP_COSMOSDB_URI = "scalardb.cosmos.uri";
-  private static final String PROP_COSMOSDB_USERNAME = "scalardb.cosmos.username";
   private static final String PROP_COSMOSDB_PASSWORD = "scalardb.cosmos.password";
   private static final String PROP_NAMESPACE_PREFIX = "scalardb.namespace_prefix";
 
@@ -24,7 +23,6 @@ public class CosmosIntegrationTest extends IntegrationTestBase {
   @BeforeClass
   public static void setUpBeforeClass() throws IOException, ExecutionException {
     String contactPoint = System.getProperty(PROP_COSMOSDB_URI);
-    String username = System.getProperty(PROP_COSMOSDB_USERNAME);
     String password = System.getProperty(PROP_COSMOSDB_PASSWORD);
     Optional<String> namespacePrefix =
         Optional.ofNullable(System.getProperty(PROP_NAMESPACE_PREFIX));
@@ -32,11 +30,11 @@ public class CosmosIntegrationTest extends IntegrationTestBase {
     // reuse this storage instance through the tests
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, contactPoint);
-    props.setProperty(DatabaseConfig.USERNAME, username);
     props.setProperty(DatabaseConfig.PASSWORD, password);
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
     namespacePrefix.ifPresent(n -> props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, n));
 
-    DatabaseConfig config = new DatabaseConfig(props);
+    CosmosConfig config = new CosmosConfig(props);
     admin = new CosmosAdmin(config);
     storage = new Cosmos(config);
     createTable(ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000"));

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithCosmosIntegrationTest.java
@@ -8,6 +8,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.cosmos.Cosmos;
 import com.scalar.db.storage.cosmos.CosmosAdmin;
+import com.scalar.db.storage.cosmos.CosmosConfig;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
@@ -17,24 +18,26 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 public class ConsensusCommitWithCosmosIntegrationTest extends ConsensusCommitIntegrationTestBase {
+  private static final String PROP_COSMOSDB_URI = "scalardb.cosmos.uri";
+  private static final String PROP_COSMOSDB_PASSWORD = "scalardb.cosmos.password";
+  private static final String PROP_NAMESPACE_PREFIX = "scalardb.namespace_prefix";
 
-  private static Optional<String> namespacePrefix;
   private static DistributedStorage originalStorage;
-  private static DatabaseConfig config;
+  private static CosmosConfig config;
 
   @BeforeClass
   public static void setUpBeforeClass() throws IOException, ExecutionException {
-    String contactPoint = System.getProperty("scalardb.cosmos.uri");
-    String username = System.getProperty("scalardb.cosmos.username");
-    String password = System.getProperty("scalardb.cosmos.password");
-    namespacePrefix = Optional.ofNullable(System.getProperty("scalardb.namespace_prefix"));
+    String contactPoint = System.getProperty(PROP_COSMOSDB_URI);
+    String password = System.getProperty(PROP_COSMOSDB_PASSWORD);
+    Optional<String> namespacePrefix =
+        Optional.ofNullable(System.getProperty(PROP_NAMESPACE_PREFIX));
 
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, contactPoint);
-    props.setProperty(DatabaseConfig.USERNAME, username);
     props.setProperty(DatabaseConfig.PASSWORD, password);
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
     namespacePrefix.ifPresent(n -> props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, n));
-    config = new DatabaseConfig(props);
+    config = new CosmosConfig(props);
     originalStorage = new Cosmos(config);
     admin = new CosmosAdmin(config);
     createTables(ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000"));

--- a/core/src/main/java/com/scalar/db/service/StorageModule.java
+++ b/core/src/main/java/com/scalar/db/service/StorageModule.java
@@ -6,6 +6,7 @@ import com.google.inject.Singleton;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.storage.dynamo.DynamoConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.multistorage.MultiStorageConfig;
@@ -28,6 +29,12 @@ public class StorageModule extends AbstractModule {
   @Provides
   DatabaseConfig provideDatabaseConfig() {
     return config;
+  }
+
+  @Singleton
+  @Provides
+  CosmosConfig provideCosmosConfig() {
+    return new CosmosConfig(config.getProperties());
   }
 
   @Singleton

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.storage.dynamo.DynamoConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.multistorage.MultiStorageConfig;
@@ -37,6 +38,12 @@ public class TransactionModule extends AbstractModule {
   @Provides
   DatabaseConfig provideDatabaseConfig() {
     return config;
+  }
+
+  @Singleton
+  @Provides
+  CosmosConfig provideCosmosConfig() {
+    return new CosmosConfig(config.getProperties());
   }
 
   @Singleton

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -15,7 +15,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.common.TableMetadataManager;
 import com.scalar.db.storage.common.checker.OperationChecker;
@@ -48,7 +47,7 @@ public class Cosmos implements DistributedStorage {
   private Optional<String> tableName;
 
   @Inject
-  public Cosmos(DatabaseConfig config) {
+  public Cosmos(CosmosConfig config) {
     client =
         new CosmosClientBuilder()
             .endpoint(config.getContactPoints().get(0))

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
@@ -1,0 +1,52 @@
+package com.scalar.db.storage.cosmos;
+
+import com.google.common.base.Strings;
+import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
+public class CosmosConfig extends DatabaseConfig {
+
+  public static final String PREFIX = DatabaseConfig.PREFIX + "cosmos.";
+  public static final String TABLE_METADATA_DATABASE = PREFIX + "table_metadata.database";
+
+  @Nullable private String tableMetadataDatabase;
+
+  public CosmosConfig(File propertiesFile) throws IOException {
+    super(propertiesFile);
+  }
+
+  public CosmosConfig(InputStream stream) throws IOException {
+    super(stream);
+  }
+
+  public CosmosConfig(Properties properties) {
+    super(properties);
+  }
+
+  @Override
+  protected void load() {
+    String storage = getProperties().getProperty(DatabaseConfig.STORAGE);
+    if (storage == null || !storage.equals("cosmos")) {
+      throw new IllegalArgumentException(DatabaseConfig.STORAGE + " should be 'cosmos'");
+    }
+
+    super.load();
+
+    if (!Strings.isNullOrEmpty(getProperties().getProperty(TABLE_METADATA_DATABASE))) {
+      tableMetadataDatabase = getProperties().getProperty(TABLE_METADATA_DATABASE);
+    }
+  }
+
+  public Optional<String> getTableMetadataDatabase() {
+    return Optional.ofNullable(tableMetadataDatabase);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
@@ -7,10 +7,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import java.util.Arrays;
@@ -50,7 +49,7 @@ import org.mockito.MockitoAnnotations;
 
 public class CosmosAdminTest {
   @Mock private CosmosClient client;
-  @Mock private DatabaseConfig config;
+  @Mock private CosmosConfig config;
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
   private CosmosAdmin admin;
@@ -65,27 +64,65 @@ public class CosmosAdminTest {
   }
 
   @Test
-  public void getTableMetadata_ContainerShouldBeCalledProperly() throws ExecutionException {
+  public void
+      getTableMetadata_WithoutTableMetadataDatabaseChanged_ShouldReturnCorrectTableMetadata()
+          throws ExecutionException {
+    getTableMetadata_ShouldReturnCorrectTableMetadata(Optional.empty());
+  }
+
+  @Test
+  public void getTableMetadata_WithTableMetadataDatabaseChanged_ShouldReturnCorrectTableMetadata()
+      throws ExecutionException {
+    getTableMetadata_ShouldReturnCorrectTableMetadata(Optional.of("changed"));
+  }
+
+  private void getTableMetadata_ShouldReturnCorrectTableMetadata(
+      Optional<String> tableMetadataDatabase) throws ExecutionException {
     // Arrange
     String namespace = "ns";
     String table = "table";
     String fullName = getFullTableName(Optional.empty(), namespace, table);
+    String metadataDatabaseName = tableMetadataDatabase.orElse(CosmosAdmin.METADATA_DATABASE);
 
     @SuppressWarnings("unchecked")
     CosmosItemResponse<CosmosTableMetadata> response = mock(CosmosItemResponse.class);
 
-    when(client.getDatabase(any())).thenReturn(database);
-    when(database.getContainer(any())).thenReturn(container);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
+    when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
     when(container.readItem(
             anyString(),
             any(PartitionKey.class),
             ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
         .thenReturn(response);
 
+    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
+    cosmosTableMetadata.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
+    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c1"));
+    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
+    cosmosTableMetadata.setSecondaryIndexNames(Collections.emptySet());
+
+    when(response.getItem()).thenReturn(cosmosTableMetadata);
+
+    if (tableMetadataDatabase.isPresent()) {
+      when(config.getTableMetadataDatabase()).thenReturn(tableMetadataDatabase);
+      admin = new CosmosAdmin(client, config);
+    }
+
     // Act
-    admin.getTableMetadata(namespace, table);
+    TableMetadata actual = admin.getTableMetadata(namespace, table);
 
     // Assert
+    assertThat(actual)
+        .isEqualTo(
+            TableMetadata.newBuilder()
+                .addColumn("c1", DataType.INT)
+                .addColumn("c2", DataType.TEXT)
+                .addColumn("c3", DataType.BIGINT)
+                .addPartitionKey("c1")
+                .build());
+
+    verify(client).getDatabase(metadataDatabaseName);
+    verify(database).getContainer(CosmosAdmin.METADATA_CONTAINER);
     verify(container).readItem(fullName, new PartitionKey(fullName), CosmosTableMetadata.class);
     verify(response).getItem();
   }
@@ -148,7 +185,19 @@ public class CosmosAdminTest {
   }
 
   @Test
-  public void createTable_WithCorrectParams_ShouldCreateContainer() throws ExecutionException {
+  public void createTable_WithoutTableMetadataDatabaseChanged_ShouldCreateContainer()
+      throws ExecutionException {
+    createTable_ShouldCreateContainer(Optional.empty());
+  }
+
+  @Test
+  public void createTable_WithTableMetadataDatabaseChanged_ShouldCreateContainer()
+      throws ExecutionException {
+    createTable_ShouldCreateContainer(Optional.of("changed"));
+  }
+
+  private void createTable_ShouldCreateContainer(Optional<String> tableMetadataDatabase)
+      throws ExecutionException {
     // Arrange
     String namespace = "ns";
     String table = "sample_table";
@@ -167,10 +216,24 @@ public class CosmosAdminTest {
             .addSecondaryIndex("c4")
             .build();
 
-    when(client.getDatabase(any())).thenReturn(database);
-    when(database.getContainer(any())).thenReturn(container);
+    when(client.getDatabase(namespace)).thenReturn(database);
+    when(database.getContainer(table)).thenReturn(container);
     CosmosScripts cosmosScripts = Mockito.mock(CosmosScripts.class);
     when(container.getScripts()).thenReturn(cosmosScripts);
+
+    // for metadata table
+    String metadataDatabaseName = tableMetadataDatabase.orElse(CosmosAdmin.METADATA_DATABASE);
+
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
+
+    if (tableMetadataDatabase.isPresent()) {
+      when(config.getTableMetadataDatabase()).thenReturn(tableMetadataDatabase);
+      admin = new CosmosAdmin(client, config);
+    }
 
     // Act
     admin.createTable(namespace, table, metadata, Collections.emptyMap());
@@ -179,13 +242,14 @@ public class CosmosAdminTest {
     verify(database).createContainer(any(CosmosContainerProperties.class));
     verify(cosmosScripts).createStoredProcedure(any(CosmosStoredProcedureProperties.class));
 
+    // for metadata table
     verify(client)
         .createDatabaseIfNotExists(
-            eq(getFullNamespaceName(Optional.empty(), CosmosAdmin.METADATA_DATABASE)),
+            eq(getFullNamespaceName(Optional.empty(), metadataDatabaseName)),
             refEq(ThroughputProperties.createManualThroughput(Integer.parseInt("400"))));
     ArgumentCaptor<CosmosContainerProperties> containerPropertiesCaptor =
         ArgumentCaptor.forClass(CosmosContainerProperties.class);
-    verify(database).createContainerIfNotExists(containerPropertiesCaptor.capture());
+    verify(metadataDatabase).createContainerIfNotExists(containerPropertiesCaptor.capture());
     assertThat(containerPropertiesCaptor.getValue().getId())
         .isEqualTo(CosmosAdmin.METADATA_CONTAINER);
     assertThat(containerPropertiesCaptor.getValue().getPartitionKeyDefinition().getPaths())
@@ -205,61 +269,126 @@ public class CosmosAdminTest {
             .put("c7", "float")
             .build());
     cosmosTableMetadata.setSecondaryIndexNames(ImmutableSet.of("c4"));
-    verify(container).upsertItem(cosmosTableMetadata);
+    verify(metadataContainer).upsertItem(cosmosTableMetadata);
   }
 
   @Test
   public void
-      dropTable_WithExistingContainerWithNoMetadataLeft_ShouldDropContainerAndDeleteMetadataAndDatabase()
+      dropTable_WithNoMetadataLeftWithoutTableMetadataDatabaseChanged_ShouldDropContainerAndDeleteMetadataAndDatabase()
           throws ExecutionException {
+    dropTable_WithNoMetadataLeft_ShouldDropContainerAndDeleteMetadataAndDatabase(Optional.empty());
+  }
+
+  @Test
+  public void
+      dropTable_WithNoMetadataLeftWithTableMetadataDatabaseChanged_ShouldDropContainerAndDeleteMetadataAndDatabase()
+          throws ExecutionException {
+    dropTable_WithNoMetadataLeft_ShouldDropContainerAndDeleteMetadataAndDatabase(
+        Optional.of("changed"));
+  }
+
+  private void dropTable_WithNoMetadataLeft_ShouldDropContainerAndDeleteMetadataAndDatabase(
+      Optional<String> tableMetadataDatabase) throws ExecutionException {
     // Arrange
     String namespace = "ns";
     String table = "sample_table";
 
-    when(client.getDatabase(anyString())).thenReturn(database);
-    when(database.getContainer(anyString())).thenReturn(container);
+    when(client.getDatabase(namespace)).thenReturn(database);
+    when(database.getContainer(table)).thenReturn(container);
+
+    // for metadata table
+    String metadataDatabaseName = tableMetadataDatabase.orElse(CosmosAdmin.METADATA_DATABASE);
+
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
     @SuppressWarnings("unchecked")
     CosmosPagedIterable<Object> queryResults = mock(CosmosPagedIterable.class);
-    when(container.queryItems(anyString(), any(), eq(Object.class))).thenReturn(queryResults);
+    when(metadataContainer.queryItems(anyString(), any(), eq(Object.class)))
+        .thenReturn(queryResults);
     when(queryResults.stream()).thenReturn(Stream.empty());
 
-    // Act
-    admin.dropTable(namespace, table);
-
-    // Assert
-    verify(container, times(2)).delete();
-    String fullTable = getFullTableName(Optional.empty(), namespace, table);
-    verify(container)
-        .deleteItem(
-            eq(fullTable), eq(new PartitionKey(fullTable)), refEq(new CosmosItemRequestOptions()));
-    verify(database).delete();
-  }
-
-  @Test
-  public void
-      dropTable_WithExistingContainerWithMetadataLeft_ShouldDropContainerAndOnlyDeleteMetadata()
-          throws ExecutionException {
-    // Arrange
-    String namespace = "ns";
-    String table = "sample_table";
-
-    when(client.getDatabase(anyString())).thenReturn(database);
-    when(database.getContainer(anyString())).thenReturn(container);
-    @SuppressWarnings("unchecked")
-    CosmosPagedIterable<Object> queryResults = mock(CosmosPagedIterable.class);
-    when(container.queryItems(anyString(), any(), eq(Object.class))).thenReturn(queryResults);
-    when(queryResults.stream()).thenReturn(Stream.of(new CosmosTableMetadata()));
+    if (tableMetadataDatabase.isPresent()) {
+      when(config.getTableMetadataDatabase()).thenReturn(tableMetadataDatabase);
+      admin = new CosmosAdmin(client, config);
+    }
 
     // Act
     admin.dropTable(namespace, table);
 
     // Assert
     verify(container).delete();
+
+    // for metadata table
+    verify(client, atLeastOnce()).getDatabase(metadataDatabaseName);
+    verify(metadataDatabase, atLeastOnce()).getContainer(CosmosAdmin.METADATA_CONTAINER);
     String fullTable = getFullTableName(Optional.empty(), namespace, table);
-    verify(container)
+    verify(metadataContainer)
         .deleteItem(
             eq(fullTable), eq(new PartitionKey(fullTable)), refEq(new CosmosItemRequestOptions()));
-    verify(database, never()).delete();
+    verify(metadataContainer).delete();
+    verify(metadataDatabase).delete();
+  }
+
+  @Test
+  public void
+      dropTable_WithMetadataLeftWithoutTableMetadataDatabaseChanged_ShouldDropContainerAndOnlyDeleteMetadata()
+          throws ExecutionException {
+    dropTable_WithMetadataLeft_ShouldDropContainerAndOnlyDeleteMetadata(Optional.empty());
+  }
+
+  @Test
+  public void
+      dropTable_WithMetadataLeftWithTableMetadataDatabaseChanged_ShouldDropContainerAndOnlyDeleteMetadata()
+          throws ExecutionException {
+    dropTable_WithMetadataLeft_ShouldDropContainerAndOnlyDeleteMetadata(Optional.of("changed"));
+  }
+
+  private void dropTable_WithMetadataLeft_ShouldDropContainerAndOnlyDeleteMetadata(
+      Optional<String> tableMetadataDatabase) throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "sample_table";
+
+    when(client.getDatabase(anyString())).thenReturn(database);
+    when(database.getContainer(anyString())).thenReturn(container);
+
+    // for metadata table
+    String metadataDatabaseName = tableMetadataDatabase.orElse(CosmosAdmin.METADATA_DATABASE);
+
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer metadataContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(metadataContainer);
+    @SuppressWarnings("unchecked")
+    CosmosPagedIterable<Object> queryResults = mock(CosmosPagedIterable.class);
+    when(metadataContainer.queryItems(anyString(), any(), eq(Object.class)))
+        .thenReturn(queryResults);
+    when(queryResults.stream()).thenReturn(Stream.of(new CosmosTableMetadata()));
+
+    if (tableMetadataDatabase.isPresent()) {
+      when(config.getTableMetadataDatabase()).thenReturn(tableMetadataDatabase);
+      admin = new CosmosAdmin(client, config);
+    }
+
+    // Act
+    admin.dropTable(namespace, table);
+
+    // Assert
+    verify(container).delete();
+
+    // for metadata table
+    verify(client, atLeastOnce()).getDatabase(metadataDatabaseName);
+    verify(metadataDatabase, atLeastOnce()).getContainer(CosmosAdmin.METADATA_CONTAINER);
+    String fullTable = getFullTableName(Optional.empty(), namespace, table);
+    verify(metadataContainer)
+        .deleteItem(
+            eq(fullTable), eq(new PartitionKey(fullTable)), refEq(new CosmosItemRequestOptions()));
+    verify(metadataContainer, never()).delete();
+    verify(metadataDatabase, never()).delete();
   }
 
   @Test
@@ -316,28 +445,49 @@ public class CosmosAdminTest {
   }
 
   @Test
-  public void getNamespaceTableNames_ShouldGetTableNamesProperly() throws ExecutionException {
+  public void
+      getNamespaceTableNames_WithoutTableMetadataDatabaseChanged_ShouldGetTableNamesProperly()
+          throws ExecutionException {
+    getNamespaceTableNames_ShouldGetTableNamesProperly(Optional.empty());
+  }
+
+  @Test
+  public void getNamespaceTableNames_WithTableMetadataDatabaseChanged_ShouldGetTableNamesProperly()
+      throws ExecutionException {
+    getNamespaceTableNames_ShouldGetTableNamesProperly(Optional.of("changed"));
+  }
+
+  private void getNamespaceTableNames_ShouldGetTableNamesProperly(
+      Optional<String> tableMetadataDatabase) throws ExecutionException {
     // Arrange
     String namespace = "ns";
+    String metadataDatabaseName = tableMetadataDatabase.orElse(CosmosAdmin.METADATA_DATABASE);
 
     CosmosTableMetadata t1 = new CosmosTableMetadata();
     t1.setId(getFullTableName(Optional.empty(), namespace, "t1"));
     CosmosTableMetadata t2 = new CosmosTableMetadata();
     t2.setId(getFullTableName(Optional.empty(), namespace, "t2"));
 
-    when(client.getDatabase(anyString())).thenReturn(database);
-    when(database.getContainer(anyString())).thenReturn(container);
+    when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
+    when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
     @SuppressWarnings("unchecked")
     CosmosPagedIterable<CosmosTableMetadata> queryResults = mock(CosmosPagedIterable.class);
     when(container.queryItems(anyString(), any(), eq(CosmosTableMetadata.class)))
         .thenReturn(queryResults);
     when(queryResults.stream()).thenReturn(Stream.of(t1, t2));
 
+    if (tableMetadataDatabase.isPresent()) {
+      when(config.getTableMetadataDatabase()).thenReturn(tableMetadataDatabase);
+      admin = new CosmosAdmin(client, config);
+    }
+
     // Act
     Set<String> actualTableNames = admin.getNamespaceTableNames(namespace);
 
     // Assert
     assertThat(actualTableNames).containsExactly("t1", "t2");
+    verify(client, atLeastOnce()).getDatabase(metadataDatabaseName);
+    verify(database, atLeastOnce()).getContainer(CosmosAdmin.METADATA_CONTAINER);
     verify(container)
         .queryItems(
             eq("SELECT * FROM metadata WHERE metadata.id LIKE 'ns.%'"),

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
@@ -1,0 +1,79 @@
+package com.scalar.db.storage.cosmos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Collections;
+import java.util.Properties;
+import org.junit.Test;
+
+public class CosmosConfigTest {
+
+  private static final String ANY_ENDPOINT = "http://localhost:8081";
+  private static final String ANY_KEY = "any_key";
+  private static final String ANY_NAMESPACE_PREFIX = "any_prefix";
+  private static final String COSMOS_STORAGE = "cosmos";
+  private static final String ANY_TABLE_METADATA_DATABASE = "any_database";
+
+  @Test
+  public void constructor_AllPropertiesGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
+    props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
+    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
+    props.setProperty(CosmosConfig.TABLE_METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+
+    // Act
+    CosmosConfig config = new CosmosConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_ENDPOINT));
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_KEY);
+    assertThat(config.getNamespacePrefix().isPresent()).isTrue();
+    assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
+    assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
+    assertThat(config.getAdminClass()).isEqualTo(CosmosAdmin.class);
+    assertThat(config.getTableMetadataDatabase()).isPresent();
+    assertThat(config.getTableMetadataDatabase().get()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
+  }
+
+  @Test
+  public void constructor_WithoutStorage_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
+    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
+    props.setProperty(CosmosConfig.TABLE_METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+
+    // Act Assert
+    assertThatThrownBy(() -> new CosmosConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_WithoutTableMetadataDatabase_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
+    props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
+    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
+
+    // Act
+    CosmosConfig config = new CosmosConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_ENDPOINT));
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_KEY);
+    assertThat(config.getNamespacePrefix().isPresent()).isTrue();
+    assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
+    assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
+    assertThat(config.getAdminClass()).isEqualTo(CosmosAdmin.class);
+    assertThat(config.getTableMetadataDatabase()).isNotPresent();
+  }
+}


### PR DESCRIPTION
Currently, the table metadata database name in the Cosmos DB adapter is fixed `scalardb`. In some cases, we need to change it. This PR allows us to do that with the `scalar.db.cosmos.table_metadata.database` property. Please take a look!