### PR TITLE
Make table metadata namespace name configurable in DynamoDB adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -16,8 +17,10 @@ public class DynamoConfig extends DatabaseConfig {
 
   public static final String PREFIX = DatabaseConfig.PREFIX + "dynamo.";
   public static final String ENDPOINT_OVERRIDE = PREFIX + "endpoint-override";
+  public static final String TABLE_METADATA_NAMESPACE = PREFIX + "table_metadata.namespace";
 
   private Optional<String> endpointOverride;
+  @Nullable private String tableMetadataNamespace;
 
   public DynamoConfig(File propertiesFile) throws IOException {
     super(propertiesFile);
@@ -45,9 +48,17 @@ public class DynamoConfig extends DatabaseConfig {
     } else {
       endpointOverride = Optional.empty();
     }
+
+    if (!Strings.isNullOrEmpty(getProperties().getProperty(TABLE_METADATA_NAMESPACE))) {
+      tableMetadataNamespace = getProperties().getProperty(TABLE_METADATA_NAMESPACE);
+    }
   }
 
   public Optional<String> getEndpointOverride() {
     return endpointOverride;
+  }
+
+  public Optional<String> getTableMetadataNamespace() {
+    return Optional.ofNullable(tableMetadataNamespace);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.dynamo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.scalar.db.config.DatabaseConfig;
 import java.util.Collections;
@@ -9,15 +10,93 @@ import org.junit.Test;
 
 public class DynamoConfigTest {
 
-  private static final String ANY_REGION = "us-west";
-  private static final String ANY_ACCESS_KEY_ID = "accessKeyId";
-  private static final String ANY_SECRET_ACCESS_ID = "secret_access_id";
-  private static final String ANY_NAMESPACE_PREFIX = "prefix";
+  private static final String ANY_REGION = "any_region";
+  private static final String ANY_ACCESS_KEY_ID = "any_access_key_id";
+  private static final String ANY_SECRET_ACCESS_ID = "any_secret_access_id";
+  private static final String ANY_NAMESPACE_PREFIX = "any_prefix";
   private static final String DYNAMO_STORAGE = "dynamo";
   private static final String ANY_ENDPOINT_OVERRIDE = "http://localhost:8000";
+  private static final String ANY_TABLE_METADATA_NAMESPACE = "any_namespace";
 
   @Test
   public void constructor_AllPropertiesGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_REGION);
+    props.setProperty(DatabaseConfig.USERNAME, ANY_ACCESS_KEY_ID);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_SECRET_ACCESS_ID);
+    props.setProperty(DatabaseConfig.STORAGE, DYNAMO_STORAGE);
+    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
+    props.setProperty(DynamoConfig.ENDPOINT_OVERRIDE, ANY_ENDPOINT_OVERRIDE);
+    props.setProperty(DynamoConfig.TABLE_METADATA_NAMESPACE, ANY_TABLE_METADATA_NAMESPACE);
+
+    // Act
+    DynamoConfig config = new DynamoConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_REGION));
+    assertThat(config.getContactPort()).isEqualTo(0);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_ACCESS_KEY_ID);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_SECRET_ACCESS_ID);
+    assertThat(config.getNamespacePrefix().isPresent()).isTrue();
+    assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
+    assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
+    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
+    assertThat(config.getEndpointOverride().isPresent()).isTrue();
+    assertThat(config.getEndpointOverride().get()).isEqualTo(ANY_ENDPOINT_OVERRIDE);
+    assertThat(config.getTableMetadataNamespace()).isPresent();
+    assertThat(config.getTableMetadataNamespace().get()).isEqualTo(ANY_TABLE_METADATA_NAMESPACE);
+  }
+
+  @Test
+  public void constructor_WithoutStorage_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_REGION);
+    props.setProperty(DatabaseConfig.USERNAME, ANY_ACCESS_KEY_ID);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_SECRET_ACCESS_ID);
+    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
+    props.setProperty(DynamoConfig.ENDPOINT_OVERRIDE, ANY_ENDPOINT_OVERRIDE);
+    props.setProperty(DynamoConfig.TABLE_METADATA_NAMESPACE, ANY_TABLE_METADATA_NAMESPACE);
+
+    // Act Assert
+    assertThatThrownBy(() -> new DynamoConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_PropertiesWithoutEndpointOverrideGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_REGION);
+    props.setProperty(DatabaseConfig.USERNAME, ANY_ACCESS_KEY_ID);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_SECRET_ACCESS_ID);
+    props.setProperty(DatabaseConfig.STORAGE, DYNAMO_STORAGE);
+    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
+    props.setProperty(DynamoConfig.TABLE_METADATA_NAMESPACE, ANY_TABLE_METADATA_NAMESPACE);
+
+    // Act
+    DynamoConfig config = new DynamoConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_REGION));
+    assertThat(config.getContactPort()).isEqualTo(0);
+    assertThat(config.getUsername().isPresent()).isTrue();
+    assertThat(config.getUsername().get()).isEqualTo(ANY_ACCESS_KEY_ID);
+    assertThat(config.getPassword().isPresent()).isTrue();
+    assertThat(config.getPassword().get()).isEqualTo(ANY_SECRET_ACCESS_ID);
+    assertThat(config.getNamespacePrefix().isPresent()).isTrue();
+    assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
+    assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
+    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
+    assertThat(config.getEndpointOverride().isPresent()).isFalse();
+    assertThat(config.getTableMetadataNamespace()).isPresent();
+    assertThat(config.getTableMetadataNamespace().get()).isEqualTo(ANY_TABLE_METADATA_NAMESPACE);
+  }
+
+  @Test
+  public void constructor_PropertiesWithoutTableMetadataNamespaceGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_REGION);
@@ -43,32 +122,6 @@ public class DynamoConfigTest {
     assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
     assertThat(config.getEndpointOverride().isPresent()).isTrue();
     assertThat(config.getEndpointOverride().get()).isEqualTo(ANY_ENDPOINT_OVERRIDE);
-  }
-
-  @Test
-  public void constructor_PropertiesWithoutEndpointOverrideGiven_ShouldLoadProperly() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_REGION);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_ACCESS_KEY_ID);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_SECRET_ACCESS_ID);
-    props.setProperty(DatabaseConfig.STORAGE, DYNAMO_STORAGE);
-    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
-
-    // Act
-    DynamoConfig config = new DynamoConfig(props);
-
-    // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_REGION));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_ACCESS_KEY_ID);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_SECRET_ACCESS_ID);
-    assertThat(config.getNamespacePrefix().isPresent()).isTrue();
-    assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX + "_");
-    assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
-    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
-    assertThat(config.getEndpointOverride().isPresent()).isFalse();
+    assertThat(config.getTableMetadataNamespace()).isNotPresent();
   }
 }


### PR DESCRIPTION
Currently, the table metadata namespace name in the DynamoDB adapter is fixed `scalardb`. This PR allows us to change it with the `scalar.db.dynamo.table_metadata.namespace` property. Please take a look!