### PR TITLE
Make table metadata schema name configurable in JDBC adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -6,7 +6,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +26,7 @@ public class JdbcConfig extends DatabaseConfig {
       PREFIX + "prepared_statements_pool.enabled";
   public static final String PREPARED_STATEMENTS_POOL_MAX_OPEN =
       PREFIX + "prepared_statements_pool.max_open";
+  public static final String TABLE_METADATA_SCHEMA = PREFIX + "table_metadata.schema";
 
   public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 5;
   public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 10;
@@ -36,6 +39,7 @@ public class JdbcConfig extends DatabaseConfig {
   private int connectionPoolMaxTotal;
   private boolean preparedStatementsPoolEnabled;
   private int preparedStatementsPoolMaxOpen;
+  @Nullable private String tableMetadataSchema;
 
   public JdbcConfig(File propertiesFile) throws IOException {
     super(propertiesFile);
@@ -65,6 +69,10 @@ public class JdbcConfig extends DatabaseConfig {
         getBoolean(PREPARED_STATEMENTS_POOL_ENABLED, DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     preparedStatementsPoolMaxOpen =
         getInt(PREPARED_STATEMENTS_POOL_MAX_OPEN, DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
+
+    if (!Strings.isNullOrEmpty(getProperties().getProperty(TABLE_METADATA_SCHEMA))) {
+      tableMetadataSchema = getProperties().getProperty(TABLE_METADATA_SCHEMA);
+    }
   }
 
   private int getInt(String name, int defaultValue) {
@@ -109,5 +117,9 @@ public class JdbcConfig extends DatabaseConfig {
 
   public int getPreparedStatementsPoolMaxOpen() {
     return preparedStatementsPoolMaxOpen;
+  }
+
+  public Optional<String> getTableMetadataSchema() {
+    return Optional.ofNullable(tableMetadataSchema);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -15,6 +15,7 @@ public class JdbcConfigTest {
   private static final String ANY_PASSWORD = "mysql";
   private static final String ANY_NAMESPACE_PREFIX = "prefix";
   private static final String JDBC_STORAGE = "jdbc";
+  private static final String ANY_TABLE_METADATA_SCHEMA = "any_schema";
 
   @Test
   public void constructor_AllPropertiesGiven_ShouldLoadProperly() {
@@ -30,6 +31,7 @@ public class JdbcConfigTest {
     props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "200");
     props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
     props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "300");
+    props.setProperty(JdbcConfig.TABLE_METADATA_SCHEMA, ANY_TABLE_METADATA_SCHEMA);
 
     // Act
     JdbcConfig config = new JdbcConfig(props);
@@ -50,6 +52,8 @@ public class JdbcConfigTest {
     assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(200);
     assertThat(config.isPreparedStatementsPoolEnabled()).isEqualTo(true);
     assertThat(config.getPreparedStatementsPoolMaxOpen()).isEqualTo(300);
+    assertThat(config.getTableMetadataSchema()).isPresent();
+    assertThat(config.getTableMetadataSchema().get()).isEqualTo(ANY_TABLE_METADATA_SCHEMA);
   }
 
   @Test
@@ -87,6 +91,7 @@ public class JdbcConfigTest {
         .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     assertThat(config.getPreparedStatementsPoolMaxOpen())
         .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
+    assertThat(config.getTableMetadataSchema()).isNotPresent();
   }
 
   @Test
@@ -143,5 +148,6 @@ public class JdbcConfigTest {
         .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     assertThat(config.getPreparedStatementsPoolMaxOpen())
         .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
+    assertThat(config.getTableMetadataSchema()).isNotPresent();
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdminTest.java
@@ -34,8 +34,9 @@ import org.mockito.invocation.InvocationOnMock;
 @SuppressFBWarnings({"OBL_UNSATISFIED_OBLIGATION", "ODR_OPEN_DATABASE_RESOURCE"})
 public class JdbcDatabaseAdminTest {
 
-  @Mock BasicDataSource dataSource;
-  @Mock Connection connection;
+  @Mock private BasicDataSource dataSource;
+  @Mock private Connection connection;
+  @Mock private JdbcConfig config;
 
   @Before
   public void setUp() {
@@ -43,7 +44,81 @@ public class JdbcDatabaseAdminTest {
   }
 
   @Test
-  public void getTableMetadata_withExistingTable_ShouldReturnTableMetadata()
+  public void getTableMetadata_forMysql_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.MYSQL,
+        Optional.empty(),
+        "SELECT `column_name`,`data_type`,`key_type`,`clustering_order`,`indexed` FROM `scalardb`.`metadata` WHERE `full_table_name`=? ORDER BY `ordinal_position` ASC");
+  }
+
+  @Test
+  public void getTableMetadata_forPostgresql_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.POSTGRESQL,
+        Optional.empty(),
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+  }
+
+  @Test
+  public void getTableMetadata_forSqlServer_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.SQL_SERVER,
+        Optional.empty(),
+        "SELECT [column_name],[data_type],[key_type],[clustering_order],[indexed] FROM [scalardb].[metadata] WHERE [full_table_name]=? ORDER BY [ordinal_position] ASC");
+  }
+
+  @Test
+  public void getTableMetadata_forOracle_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.ORACLE,
+        Optional.empty(),
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+  }
+
+  @Test
+  public void getTableMetadata_forMysqlWithTableMetadataSchemaChanged_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.MYSQL,
+        Optional.of("changed"),
+        "SELECT `column_name`,`data_type`,`key_type`,`clustering_order`,`indexed` FROM `changed`.`metadata` WHERE `full_table_name`=? ORDER BY `ordinal_position` ASC");
+  }
+
+  @Test
+  public void
+      getTableMetadata_forPostgresqlWithTableMetadataSchemaChanged_ShouldReturnTableMetadata()
+          throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.POSTGRESQL,
+        Optional.of("changed"),
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \"changed\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+  }
+
+  @Test
+  public void
+      getTableMetadata_forSqlServerWithTableMetadataSchemaChanged_ShouldReturnTableMetadata()
+          throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.SQL_SERVER,
+        Optional.of("changed"),
+        "SELECT [column_name],[data_type],[key_type],[clustering_order],[indexed] FROM [changed].[metadata] WHERE [full_table_name]=? ORDER BY [ordinal_position] ASC");
+  }
+
+  @Test
+  public void getTableMetadata_forOracleWithTableMetadataSchemaChanged_ShouldReturnTableMetadata()
+      throws SQLException, ExecutionException {
+    getTableMetadata_forX_ShouldReturnTableMetadata(
+        RdbEngine.ORACLE,
+        Optional.of("changed"),
+        "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \"changed\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+  }
+
+  private void getTableMetadata_forX_ShouldReturnTableMetadata(
+      RdbEngine rdbEngine, Optional<String> tableMetadataSchema, String expectedSelectStatements)
       throws ExecutionException, SQLException {
     // Arrange
     String namespace = "ns";
@@ -70,7 +145,10 @@ public class JdbcDatabaseAdminTest {
     when(connection.prepareStatement(any())).thenReturn(selectStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), RdbEngine.MYSQL);
+    if (tableMetadataSchema.isPresent()) {
+      when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
+    }
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     // Act
     TableMetadata actualMetadata = admin.getTableMetadata(namespace, table);
@@ -91,6 +169,7 @@ public class JdbcDatabaseAdminTest {
             .addSecondaryIndex("c4")
             .build();
     assertThat(actualMetadata).isEqualTo(expectedMetadata);
+    verify(connection).prepareStatement(expectedSelectStatements);
   }
 
   public ResultSet mockResultSet(List<GetColumnsResultSetMocker.Row> rows) throws SQLException {
@@ -136,7 +215,7 @@ public class JdbcDatabaseAdminTest {
       throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
     List<Statement> mockedStatements = new ArrayList<>();
 
     for (int i = 0; i < expectedSqlStatements.length; i++) {
@@ -162,6 +241,7 @@ public class JdbcDatabaseAdminTest {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.MYSQL,
+        Optional.empty(),
         "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` FLOAT, PRIMARY KEY (`c3`,`c1`,`c4`))",
         "CREATE INDEX index_my_ns_foo_table_c4 ON `my_ns`.`foo_table` (`c4`)",
         "CREATE INDEX index_my_ns_foo_table_c1 ON `my_ns`.`foo_table` (`c1`)",
@@ -189,6 +269,7 @@ public class JdbcDatabaseAdminTest {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.POSTGRESQL,
+        Optional.empty(),
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
         "CREATE INDEX index_my_ns_foo_table_c4 ON \"my_ns\".\"foo_table\" (\"c4\")",
         "CREATE INDEX index_my_ns_foo_table_c1 ON \"my_ns\".\"foo_table\" (\"c1\")",
@@ -216,6 +297,7 @@ public class JdbcDatabaseAdminTest {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.SQL_SERVER,
+        Optional.empty(),
         "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3],[c1],[c4]))",
         "CREATE INDEX index_my_ns_foo_table_c4 ON [my_ns].[foo_table] ([c4])",
         "CREATE INDEX index_my_ns_foo_table_c1 ON [my_ns].[foo_table] ([c1])",
@@ -243,6 +325,7 @@ public class JdbcDatabaseAdminTest {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.ORACLE,
+        Optional.empty(),
         "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" INT,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
         "CREATE INDEX index_my_ns_foo_table_c4 ON \"my_ns\".\"foo_table\" (\"c4\")",
@@ -259,13 +342,121 @@ public class JdbcDatabaseAdminTest {
         "INSERT INTO \"scalardb\".\"metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,0,7)");
   }
 
+  @Test
+  public void createTable_forMysqlWithTableMetadataSchemaChanged_shouldExecuteCreateTableStatement()
+      throws ExecutionException, SQLException {
+    createTable_forX_shouldExecuteCreateTableStatement(
+        RdbEngine.MYSQL,
+        Optional.of("changed"),
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` FLOAT, PRIMARY KEY (`c3`,`c1`,`c4`))",
+        "CREATE INDEX index_my_ns_foo_table_c4 ON `my_ns`.`foo_table` (`c4`)",
+        "CREATE INDEX index_my_ns_foo_table_c1 ON `my_ns`.`foo_table` (`c1`)",
+        "CREATE SCHEMA IF NOT EXISTS `changed`",
+        "CREATE TABLE IF NOT EXISTS `changed`.`metadata`("
+            + "`full_table_name` VARCHAR(128),"
+            + "`column_name` VARCHAR(128),"
+            + "`data_type` VARCHAR(20) NOT NULL,"
+            + "`key_type` VARCHAR(20),"
+            + "`clustering_order` VARCHAR(10),"
+            + "`indexed` BOOLEAN NOT NULL,"
+            + "`ordinal_position` INTEGER NOT NULL,"
+            + "PRIMARY KEY (`full_table_name`, `column_name`))",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,false,1)",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',true,2)",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
+        "INSERT INTO `changed`.`metadata` VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,false,7)");
+  }
+
+  @Test
+  public void
+      createTable_forPostgresqlWithTableMetadataSchemaChanged_shouldExecuteCreateTableStatement()
+          throws ExecutionException, SQLException {
+    createTable_forX_shouldExecuteCreateTableStatement(
+        RdbEngine.POSTGRESQL,
+        Optional.of("changed"),
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE INDEX index_my_ns_foo_table_c4 ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX index_my_ns_foo_table_c1 ON \"my_ns\".\"foo_table\" (\"c1\")",
+        "CREATE SCHEMA IF NOT EXISTS \"changed\"",
+        "CREATE TABLE IF NOT EXISTS \"changed\".\"metadata\"("
+            + "\"full_table_name\" VARCHAR(128),"
+            + "\"column_name\" VARCHAR(128),"
+            + "\"data_type\" VARCHAR(20) NOT NULL,"
+            + "\"key_type\" VARCHAR(20),"
+            + "\"clustering_order\" VARCHAR(10),"
+            + "\"indexed\" BOOLEAN NOT NULL,"
+            + "\"ordinal_position\" INTEGER NOT NULL,"
+            + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,false,1)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',true,2)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',true,3)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,false,4)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,false,5)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,false,6)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,false,7)");
+  }
+
+  @Test
+  public void
+      createTable_forSqlServerWithTableMetadataSchemaChanged_shouldExecuteCreateTableStatement()
+          throws ExecutionException, SQLException {
+    createTable_forX_shouldExecuteCreateTableStatement(
+        RdbEngine.SQL_SERVER,
+        Optional.of("changed"),
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3],[c1],[c4]))",
+        "CREATE INDEX index_my_ns_foo_table_c4 ON [my_ns].[foo_table] ([c4])",
+        "CREATE INDEX index_my_ns_foo_table_c1 ON [my_ns].[foo_table] ([c1])",
+        "CREATE SCHEMA [changed]",
+        "CREATE TABLE [changed].[metadata]("
+            + "[full_table_name] VARCHAR(128),"
+            + "[column_name] VARCHAR(128),"
+            + "[data_type] VARCHAR(20) NOT NULL,"
+            + "[key_type] VARCHAR(20),"
+            + "[clustering_order] VARCHAR(10),"
+            + "[indexed] BIT NOT NULL,"
+            + "[ordinal_position] INTEGER NOT NULL,"
+            + "PRIMARY KEY ([full_table_name], [column_name]))",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,0,1)",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',1,2)",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
+        "INSERT INTO [changed].[metadata] VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,0,7)");
+  }
+
+  @Test
+  public void
+      createTable_forOracleWithTableMetadataSchemaChanged_shouldExecuteCreateTableStatement()
+          throws ExecutionException, SQLException {
+    createTable_forX_shouldExecuteCreateTableStatement(
+        RdbEngine.ORACLE,
+        Optional.of("changed"),
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" INT,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
+        "CREATE INDEX index_my_ns_foo_table_c4 ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX index_my_ns_foo_table_c1 ON \"my_ns\".\"foo_table\" (\"c1\")",
+        "CREATE USER \"changed\" IDENTIFIED BY \"oracle\"",
+        "ALTER USER \"changed\" quota unlimited on USERS",
+        "CREATE TABLE \"changed\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,0,1)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',1,2)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',1,3)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,0,4)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,0,5)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,0,6)",
+        "INSERT INTO \"changed\".\"metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,0,7)");
+  }
+
   private void createTable_forX_shouldExecuteCreateTableStatement(
-      RdbEngine rdbEngine, String... expectedSqlStatements)
+      RdbEngine rdbEngine, Optional<String> tableMetadataSchema, String... expectedSqlStatements)
       throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
     TableMetadata metadata =
         TableMetadata.newBuilder()
             .addPartitionKey("c3")
@@ -291,6 +482,11 @@ public class JdbcDatabaseAdminTest {
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
+
+    if (tableMetadataSchema.isPresent()) {
+      when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
+    }
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.createTable(namespace, table, metadata, new HashMap<>());
@@ -335,7 +531,7 @@ public class JdbcDatabaseAdminTest {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     Statement truncateTableStatement = mock(Statement.class);
     when(connection.createStatement()).thenReturn(truncateTableStatement);
@@ -353,6 +549,7 @@ public class JdbcDatabaseAdminTest {
       throws Exception {
     dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
         RdbEngine.MYSQL,
+        Optional.empty(),
         "DROP TABLE `my_ns`.`foo_table`",
         "DELETE FROM `scalardb`.`metadata` WHERE `full_table_name` = 'my_ns.foo_table'",
         "SELECT DISTINCT `full_table_name` FROM `scalardb`.`metadata`",
@@ -366,6 +563,7 @@ public class JdbcDatabaseAdminTest {
           throws Exception {
     dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
         RdbEngine.POSTGRESQL,
+        Optional.empty(),
         "DROP TABLE \"my_ns\".\"foo_table\"",
         "DELETE FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
         "SELECT DISTINCT \"full_table_name\" FROM \"scalardb\".\"metadata\"",
@@ -379,6 +577,7 @@ public class JdbcDatabaseAdminTest {
           throws Exception {
     dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
         RdbEngine.SQL_SERVER,
+        Optional.empty(),
         "DROP TABLE [my_ns].[foo_table]",
         "DELETE FROM [scalardb].[metadata] WHERE [full_table_name] = 'my_ns.foo_table'",
         "SELECT DISTINCT [full_table_name] FROM [scalardb].[metadata]",
@@ -391,6 +590,7 @@ public class JdbcDatabaseAdminTest {
       throws Exception {
     dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
         RdbEngine.ORACLE,
+        Optional.empty(),
         "DROP TABLE \"my_ns\".\"foo_table\"",
         "DELETE FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
         "SELECT DISTINCT \"full_table_name\" FROM \"scalardb\".\"metadata\"",
@@ -398,13 +598,69 @@ public class JdbcDatabaseAdminTest {
         "DROP USER \"scalardb\"");
   }
 
+  @Test
+  public void
+      dropTable_forMysqlWithNoMoreMetadataAfterDeletionWithTableMetadataSchemaChanged_shouldDropTableAndDeleteMetadata()
+          throws Exception {
+    dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
+        RdbEngine.MYSQL,
+        Optional.of("changed"),
+        "DROP TABLE `my_ns`.`foo_table`",
+        "DELETE FROM `changed`.`metadata` WHERE `full_table_name` = 'my_ns.foo_table'",
+        "SELECT DISTINCT `full_table_name` FROM `changed`.`metadata`",
+        "DROP TABLE `changed`.`metadata`",
+        "DROP SCHEMA `changed`");
+  }
+
+  @Test
+  public void
+      dropTable_forPostgresqlWithNoMoreMetadataAfterDeletionWithTableMetadataSchemaChanged_shouldDropTableAndDeleteMetadata()
+          throws Exception {
+    dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
+        RdbEngine.POSTGRESQL,
+        Optional.of("changed"),
+        "DROP TABLE \"my_ns\".\"foo_table\"",
+        "DELETE FROM \"changed\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"changed\".\"metadata\"",
+        "DROP TABLE \"changed\".\"metadata\"",
+        "DROP SCHEMA \"changed\"");
+  }
+
+  @Test
+  public void
+      dropTable_forSqlServerWithNoMoreMetadataAfterDeletionWithTableMetadataSchemaChanged_shouldDropTableAndDeleteMetadata()
+          throws Exception {
+    dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
+        RdbEngine.SQL_SERVER,
+        Optional.of("changed"),
+        "DROP TABLE [my_ns].[foo_table]",
+        "DELETE FROM [changed].[metadata] WHERE [full_table_name] = 'my_ns.foo_table'",
+        "SELECT DISTINCT [full_table_name] FROM [changed].[metadata]",
+        "DROP TABLE [changed].[metadata]",
+        "DROP SCHEMA [changed]");
+  }
+
+  @Test
+  public void
+      dropTable_forOracleWithNoMoreMetadataAfterDeletionWithTableMetadataSchemaChanged_shouldDropTableAndDeleteMetadata()
+          throws Exception {
+    dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
+        RdbEngine.ORACLE,
+        Optional.of("changed"),
+        "DROP TABLE \"my_ns\".\"foo_table\"",
+        "DELETE FROM \"changed\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"changed\".\"metadata\"",
+        "DROP TABLE \"changed\".\"metadata\"",
+        "DROP USER \"changed\"");
+  }
+
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
   private void dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
-      RdbEngine rdbEngine, String... expectedSqlStatements) throws Exception {
+      RdbEngine rdbEngine, Optional<String> tableMetadataSchema, String... expectedSqlStatements)
+      throws Exception {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
 
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(false);
@@ -423,6 +679,11 @@ public class JdbcDatabaseAdminTest {
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
+
+    if (tableMetadataSchema.isPresent()) {
+      when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
+    }
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.dropTable(namespace, table);
@@ -443,6 +704,7 @@ public class JdbcDatabaseAdminTest {
           throws Exception {
     dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
         RdbEngine.MYSQL,
+        Optional.empty(),
         "DROP TABLE `my_ns`.`foo_table`",
         "DELETE FROM `scalardb`.`metadata` WHERE `full_table_name` = 'my_ns.foo_table'",
         "SELECT DISTINCT `full_table_name` FROM `scalardb`.`metadata`");
@@ -454,6 +716,7 @@ public class JdbcDatabaseAdminTest {
           throws Exception {
     dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
         RdbEngine.POSTGRESQL,
+        Optional.empty(),
         "DROP TABLE \"my_ns\".\"foo_table\"",
         "DELETE FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
         "SELECT DISTINCT \"full_table_name\" FROM \"scalardb\".\"metadata\"");
@@ -465,6 +728,7 @@ public class JdbcDatabaseAdminTest {
           throws Exception {
     dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
         RdbEngine.SQL_SERVER,
+        Optional.empty(),
         "DROP TABLE [my_ns].[foo_table]",
         "DELETE FROM [scalardb].[metadata] WHERE [full_table_name] = 'my_ns.foo_table'",
         "SELECT DISTINCT [full_table_name] FROM [scalardb].[metadata]");
@@ -476,19 +740,70 @@ public class JdbcDatabaseAdminTest {
           throws Exception {
     dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
         RdbEngine.ORACLE,
+        Optional.empty(),
         "DROP TABLE \"my_ns\".\"foo_table\"",
         "DELETE FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
         "SELECT DISTINCT \"full_table_name\" FROM \"scalardb\".\"metadata\"");
   }
 
+  @Test
+  public void
+      dropTable_forMysqlWithOtherMetadataAfterDeletionWithTableMetadataSchemaChanged_ShouldDropTableAndDeleteMetadataButNotMetadataTable()
+          throws Exception {
+    dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
+        RdbEngine.MYSQL,
+        Optional.of("changed"),
+        "DROP TABLE `my_ns`.`foo_table`",
+        "DELETE FROM `changed`.`metadata` WHERE `full_table_name` = 'my_ns.foo_table'",
+        "SELECT DISTINCT `full_table_name` FROM `changed`.`metadata`");
+  }
+
+  @Test
+  public void
+      dropTable_forPostgresqlWithOtherMetadataAfterDeletionWithTableMetadataSchemaChanged_ShouldDropTableAndDeleteMetadataButNotMetadataTable()
+          throws Exception {
+    dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
+        RdbEngine.POSTGRESQL,
+        Optional.of("changed"),
+        "DROP TABLE \"my_ns\".\"foo_table\"",
+        "DELETE FROM \"changed\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"changed\".\"metadata\"");
+  }
+
+  @Test
+  public void
+      dropTable_forSqlServerWithOtherMetadataAfterDeletionWithTableMetadataSchemaChanged_ShouldDropTableAndDeleteMetadataButNotMetadataTable()
+          throws Exception {
+    dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
+        RdbEngine.SQL_SERVER,
+        Optional.of("changed"),
+        "DROP TABLE [my_ns].[foo_table]",
+        "DELETE FROM [changed].[metadata] WHERE [full_table_name] = 'my_ns.foo_table'",
+        "SELECT DISTINCT [full_table_name] FROM [changed].[metadata]");
+  }
+
+  @Test
+  public void
+      dropTable_forOracleWithOtherMetadataAfterDeletionWithTableMetadataSchemaChanged_ShouldDropTableAndDeleteMetadataButNotMetadataTable()
+          throws Exception {
+    dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
+        RdbEngine.ORACLE,
+        Optional.of("changed"),
+        "DROP TABLE \"my_ns\".\"foo_table\"",
+        "DELETE FROM \"changed\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"changed\".\"metadata\"");
+  }
+
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
   private void
       dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
-          RdbEngine rdbEngine, String... expectedSqlStatements) throws Exception {
+          RdbEngine rdbEngine,
+          Optional<String> tableMetadataSchema,
+          String... expectedSqlStatements)
+          throws Exception {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
 
     ResultSet resultSet = mock(ResultSet.class);
     when(resultSet.next()).thenReturn(true);
@@ -507,6 +822,11 @@ public class JdbcDatabaseAdminTest {
             mockedStatements.get(0),
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
+
+    if (tableMetadataSchema.isPresent()) {
+      when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
+    }
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.dropTable(namespace, table);
@@ -545,7 +865,7 @@ public class JdbcDatabaseAdminTest {
       RdbEngine rdbEngine, String expectedDropSchemaStatement) throws Exception {
     // Arrange
     String namespace = "my_ns";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     Connection connection = mock(Connection.class);
     Statement dropSchemaStatement = mock(Statement.class);
@@ -564,6 +884,7 @@ public class JdbcDatabaseAdminTest {
   public void getNamespaceTables_forMysql_ShouldReturnTableNames() throws Exception {
     getNamespaceTables_forX_ShouldReturnTableNames(
         RdbEngine.MYSQL,
+        Optional.empty(),
         "SELECT DISTINCT `full_table_name` FROM `scalardb`.`metadata` WHERE `full_table_name` LIKE ?");
   }
 
@@ -571,6 +892,7 @@ public class JdbcDatabaseAdminTest {
   public void getNamespaceTables_forPostgresql_ShouldReturnTableNames() throws Exception {
     getNamespaceTables_forX_ShouldReturnTableNames(
         RdbEngine.POSTGRESQL,
+        Optional.empty(),
         "SELECT DISTINCT \"full_table_name\" FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" LIKE ?");
   }
 
@@ -578,6 +900,7 @@ public class JdbcDatabaseAdminTest {
   public void getNamespaceTables_forSqlServer_ShouldReturnTableNames() throws Exception {
     getNamespaceTables_forX_ShouldReturnTableNames(
         RdbEngine.SQL_SERVER,
+        Optional.empty(),
         "SELECT DISTINCT [full_table_name] FROM [scalardb].[metadata] WHERE [full_table_name] LIKE ?");
   }
 
@@ -585,18 +908,55 @@ public class JdbcDatabaseAdminTest {
   public void getNamespaceTables_forOracle_ShouldReturnTableNames() throws Exception {
     getNamespaceTables_forX_ShouldReturnTableNames(
         RdbEngine.ORACLE,
+        Optional.empty(),
         "SELECT DISTINCT \"full_table_name\" FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" LIKE ?");
   }
 
+  @Test
+  public void getNamespaceTables_forMysqlWithTableMetadataSchemaChanged_ShouldReturnTableNames()
+      throws Exception {
+    getNamespaceTables_forX_ShouldReturnTableNames(
+        RdbEngine.MYSQL,
+        Optional.of("changed"),
+        "SELECT DISTINCT `full_table_name` FROM `changed`.`metadata` WHERE `full_table_name` LIKE ?");
+  }
+
+  @Test
+  public void
+      getNamespaceTables_forPostgresqlWithTableMetadataSchemaChanged_ShouldReturnTableNames()
+          throws Exception {
+    getNamespaceTables_forX_ShouldReturnTableNames(
+        RdbEngine.POSTGRESQL,
+        Optional.of("changed"),
+        "SELECT DISTINCT \"full_table_name\" FROM \"changed\".\"metadata\" WHERE \"full_table_name\" LIKE ?");
+  }
+
+  @Test
+  public void getNamespaceTables_forSqlServerWithTableMetadataSchemaChanged_ShouldReturnTableNames()
+      throws Exception {
+    getNamespaceTables_forX_ShouldReturnTableNames(
+        RdbEngine.SQL_SERVER,
+        Optional.of("changed"),
+        "SELECT DISTINCT [full_table_name] FROM [changed].[metadata] WHERE [full_table_name] LIKE ?");
+  }
+
+  @Test
+  public void getNamespaceTables_forOracleWithTableMetadataSchemaChanged_ShouldReturnTableNames()
+      throws Exception {
+    getNamespaceTables_forX_ShouldReturnTableNames(
+        RdbEngine.ORACLE,
+        Optional.of("changed"),
+        "SELECT DISTINCT \"full_table_name\" FROM \"changed\".\"metadata\" WHERE \"full_table_name\" LIKE ?");
+  }
+
   private void getNamespaceTables_forX_ShouldReturnTableNames(
-      RdbEngine rdbEngine, String expectedSelectStatement) throws Exception {
+      RdbEngine rdbEngine, Optional<String> tableMetadataSchema, String expectedSelectStatement)
+      throws Exception {
     // Arrange
     String namespace = "ns1";
     String table1 = "t1";
     String table2 = "t2";
     ResultSet resultSet = mock(ResultSet.class);
-
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
 
     // Everytime the ResultSet.next() method will be called, the ResultSet.getXXX methods call be
     // mocked to return the current row data
@@ -611,6 +971,11 @@ public class JdbcDatabaseAdminTest {
     when(preparedStatement.executeQuery()).thenReturn(resultSet);
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
     when(dataSource.getConnection()).thenReturn(connection);
+
+    if (tableMetadataSchema.isPresent()) {
+      when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
+    }
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     // Act
     Set<String> actualTableNames = admin.getNamespaceTableNames(namespace);
@@ -653,7 +1018,7 @@ public class JdbcDatabaseAdminTest {
       RdbEngine rdbEngine, String expectedSelectStatement) throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, Optional.empty(), rdbEngine);
+    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
 
     Connection connection = mock(Connection.class);
     PreparedStatement selectStatement = mock(PreparedStatement.class);


### PR DESCRIPTION
Currently, the table metadata schema name in the JDBC adapter is fixed `scalardb`. This PR allows us to change it with the `scalar.db.jdbc.table_metadata.schema` property. Please take a look!

