### PR TITLE
Add getTableMetadata() to DistributedStorage

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -158,4 +158,13 @@ public interface DistributedStorage {
    * StorageService and TransactionService, thus this should only be used when closing applications.
    */
   void close();
+
+  /**
+   * Returns the {@link TableMetadata} for the table in the storage.
+   *
+   * @param namespace a namespace of the table to get the metadata for
+   * @param tableName a table name to get the metadata for
+   * @return a {@code TableMetadata} for the specified table
+   */
+  TableMetadata getTableMetadata(String namespace, String tableName);
 }

--- a/core/src/main/java/com/scalar/db/service/StorageService.java
+++ b/core/src/main/java/com/scalar/db/service/StorageService.java
@@ -9,6 +9,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
+import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import java.util.List;
 import java.util.Optional;
@@ -86,5 +87,10 @@ public class StorageService implements DistributedStorage {
   @Override
   public void close() {
     storage.close();
+  }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    return storage.getTableMetadata(namespace, tableName);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -181,4 +181,9 @@ public class Cassandra implements DistributedStorage {
   public void close() {
     clusterManager.close();
   }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    return metadataManager.getTableMetadata(namespace, tableName);
+  }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -176,4 +176,9 @@ public class Cosmos implements DistributedStorage {
   public void close() {
     client.close();
   }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    return metadataManager.getTableMetadata(namespace, tableName);
+  }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -184,4 +184,9 @@ public class Dynamo implements DistributedStorage {
   public void close() {
     client.close();
   }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    return metadataManager.getTableMetadata(namespace, tableName);
+  }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -10,6 +10,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
+import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.storage.common.checker.OperationChecker;
@@ -213,5 +214,10 @@ public class JdbcDatabase implements DistributedStorage {
     } catch (SQLException e) {
       LOGGER.error("failed to close the dataSource", e);
     }
+  }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    return jdbcService.getTableMetadataManager().getTableMetadata(namespace, tableName);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -10,6 +10,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.storage.common.TableMetadataManager;
 import com.scalar.db.storage.common.checker.OperationChecker;
 import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
@@ -199,5 +200,9 @@ public class JdbcService {
       }
     }
     return true;
+  }
+
+  TableMetadataManager getTableMetadataManager() {
+    return tableMetadataManager;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
+import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.Utility;
@@ -177,5 +178,18 @@ public class MultiStorage implements DistributedStorage {
     for (DistributedStorage storage : storages) {
       storage.close();
     }
+  }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    String fullTaleName = Utility.getFullTableName(Optional.empty(), namespace, tableName);
+    DistributedStorage storage = tableStorageMap.get(fullTaleName);
+    if (storage == null) {
+      storage = namespaceStorageMap.get(namespace);
+      if (storage == null) {
+        storage = defaultStorage;
+      }
+    }
+    return storage.getTableMetadata(namespace, tableName);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
@@ -225,4 +225,9 @@ public class GrpcStorage implements DistributedStorage {
       LOGGER.warn("failed to shutdown the channel", e);
     }
   }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String tableName) {
+    return metadataManager.getTableMetadata(namespace, tableName);
+  }
 }


### PR DESCRIPTION
In order to generate the GraphQL types based on the table metadata, added a getter to expose the `TableMetadata` in the `DatabaseStorage`.
