### PR TITLE
Fix duplicate of equal fields in the query when do range scanning with multiple clustering keys in Cassandra adapter

### DIFF
--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -227,8 +227,6 @@ public class SelectStatementHandlerTest {
                   "AND",
                   ANY_NAME_3 + ">=?",
                   "AND",
-                  ANY_NAME_2 + "=?",
-                  "AND",
                   ANY_NAME_3 + "<=?;",
                 });
     configureBehavior(expected);
@@ -385,8 +383,7 @@ public class SelectStatementHandlerTest {
     verify(bound).setString(0, ANY_TEXT_1);
     verify(bound).setString(1, ANY_TEXT_2);
     verify(bound).setString(2, ANY_TEXT_3);
-    verify(bound).setString(3, ANY_TEXT_2);
-    verify(bound).setString(4, ANY_TEXT_4);
+    verify(bound).setString(3, ANY_TEXT_4);
   }
 
   @Test


### PR DESCRIPTION
When do integration testing with multiple clustering keys, I found that with the current implementation, it conducts duplicate of the equal fields in the query when doing range scanning with provided start and end clustering keys so got failed from Cassandra. For example, the wrong query is `SELECT * FROM integration_testing_FLOAT.test_table_mul_key_FLOAT_BIGINT WHERE c1=? AND c2=? AND c3>=? AND c2=? AND c3<=? ORDER BY c2 ASC,c3 ASC;` should be corrected to `SELECT * FROM integration_testing_FLOAT.test_table_mul_key_FLOAT_BIGINT WHERE c1=? AND c2=? AND c3>=?  AND c3<=? ORDER BY c2 ASC,c3 ASC;` (remove one `AND c2=?`)
This PR was made for fixing it. 
Please take a look. Thank you.