### PR TITLE
Add methods to truncate and drop coordinator table to ConsensusCommitAdmin

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -49,7 +49,7 @@ public class ConsensusCommitAdmin {
   /**
    * Creates a coordinator namespace and table if it does not exist.
    *
-   * @param options options to create namespace/table
+   * @param options options to create namespace and table
    * @throws ExecutionException if the operation failed
    */
   public void createCoordinatorTable(Map<String, String> options) throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -59,6 +59,25 @@ public class ConsensusCommitAdmin {
   }
 
   /**
+   * Truncates a coordinator table.
+   *
+   * @throws ExecutionException if the operation failed
+   */
+  public void truncateCoordinatorTable() throws ExecutionException {
+    admin.truncateTable(coordinatorNamespace, Coordinator.TABLE);
+  }
+
+  /**
+   * Drops a coordinator namespace/table.
+   *
+   * @throws ExecutionException if the operation failed
+   */
+  public void dropCoordinatorTable() throws ExecutionException {
+    admin.dropTable(coordinatorNamespace, Coordinator.TABLE);
+    admin.dropNamespace(coordinatorNamespace);
+  }
+
+  /**
    * Creates a new transactional table.
    *
    * @param namespace a namespace already created

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -37,7 +37,7 @@ public class ConsensusCommitAdmin {
   }
 
   /**
-   * Creates a coordinator namespace/table if it does not exist.
+   * Creates a coordinator namespace and table if it does not exist.
    *
    * @throws ExecutionException if the operation failed
    */
@@ -47,7 +47,7 @@ public class ConsensusCommitAdmin {
   }
 
   /**
-   * Creates a coordinator namespace/table if it does not exist.
+   * Creates a coordinator namespace and table if it does not exist.
    *
    * @param options options to create namespace/table
    * @throws ExecutionException if the operation failed
@@ -68,7 +68,7 @@ public class ConsensusCommitAdmin {
   }
 
   /**
-   * Drops a coordinator namespace/table.
+   * Drops a coordinator namespace and table.
    *
    * @throws ExecutionException if the operation failed
    */

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
@@ -35,68 +35,126 @@ public class ConsensusCommitAdminTest {
   @Test
   public void createCoordinatorTable_shouldCreateCoordinatorTableProperly()
       throws ExecutionException {
-    // Arrange
-
-    // Act
-    admin.createCoordinatorTable();
-
-    // Assert
-    verify(distributedStorageAdmin).createNamespace(Coordinator.NAMESPACE, true);
-    verify(distributedStorageAdmin)
-        .createTable(Coordinator.NAMESPACE, Coordinator.TABLE, Coordinator.TABLE_METADATA, true);
+    createCoordinatorTable_shouldCreateCoordinatorTableProperly(Optional.empty());
   }
 
   @Test
   public void
       createCoordinatorTable_WithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
           throws ExecutionException {
+    createCoordinatorTable_shouldCreateCoordinatorTableProperly(Optional.of("changed_coordinator"));
+  }
+
+  private void createCoordinatorTable_shouldCreateCoordinatorTableProperly(
+      Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
-    when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
-    admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
+    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
+    if (coordinatorNamespace.isPresent()) {
+      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
+      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
+    }
 
     // Act
     admin.createCoordinatorTable();
 
     // Assert
-    verify(distributedStorageAdmin).createNamespace("changed_coordinator", true);
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true);
     verify(distributedStorageAdmin)
-        .createTable("changed_coordinator", Coordinator.TABLE, Coordinator.TABLE_METADATA, true);
+        .createTable(coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, true);
   }
 
   @Test
   public void createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly()
       throws ExecutionException {
-    // Arrange
-    Map<String, String> options = ImmutableMap.of("name", "value");
-
-    // Act
-    admin.createCoordinatorTable(options);
-
-    // Assert
-    verify(distributedStorageAdmin).createNamespace(Coordinator.NAMESPACE, true, options);
-    verify(distributedStorageAdmin)
-        .createTable(
-            Coordinator.NAMESPACE, Coordinator.TABLE, Coordinator.TABLE_METADATA, true, options);
+    createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly(Optional.empty());
   }
 
   @Test
   public void
       createCoordinatorTable_WithOptionsWithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
           throws ExecutionException {
-    // Arrange
-    Map<String, String> options = ImmutableMap.of("name", "value");
+    createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly(
+        Optional.of("changed_coordinator"));
+  }
 
-    when(config.getCoordinatorNamespace()).thenReturn(Optional.of("changed_coordinator"));
-    admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
+  private void createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly(
+      Optional<String> coordinatorNamespace) throws ExecutionException {
+    // Arrange
+    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
+    if (coordinatorNamespace.isPresent()) {
+      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
+      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
+    }
+
+    Map<String, String> options = ImmutableMap.of("name", "value");
 
     // Act
     admin.createCoordinatorTable(options);
 
     // Assert
-    verify(distributedStorageAdmin).createNamespace("changed_coordinator", true, options);
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true, options);
     verify(distributedStorageAdmin)
         .createTable(
-            "changed_coordinator", Coordinator.TABLE, Coordinator.TABLE_METADATA, true, options);
+            coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, true, options);
+  }
+
+  @Test
+  public void truncateCoordinatorTable_shouldTruncateCoordinatorTableProperly()
+      throws ExecutionException {
+    truncateCoordinatorTable_shouldTruncateCoordinatorTableProperly(Optional.empty());
+  }
+
+  @Test
+  public void
+      truncateCoordinatorTable_WithCoordinatorNamespaceChanged_shouldTruncateCoordinatorTableProperly()
+          throws ExecutionException {
+    truncateCoordinatorTable_shouldTruncateCoordinatorTableProperly(
+        Optional.of("changed_coordinator"));
+  }
+
+  private void truncateCoordinatorTable_shouldTruncateCoordinatorTableProperly(
+      Optional<String> coordinatorNamespace) throws ExecutionException {
+    // Arrange
+    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
+    if (coordinatorNamespace.isPresent()) {
+      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
+      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
+    }
+
+    // Act
+    admin.truncateCoordinatorTable();
+
+    // Assert
+    verify(distributedStorageAdmin).truncateTable(coordinatorNamespaceName, Coordinator.TABLE);
+  }
+
+  @Test
+  public void dropCoordinatorTable_shouldDropCoordinatorTableProperly() throws ExecutionException {
+    dropCoordinatorTable_shouldDropCoordinatorTableProperly(Optional.empty());
+  }
+
+  @Test
+  public void
+      dropCoordinatorTable_WithCoordinatorNamespaceChanged_shouldDropCoordinatorTableProperly()
+          throws ExecutionException {
+    dropCoordinatorTable_shouldDropCoordinatorTableProperly(Optional.of("changed_coordinator"));
+  }
+
+  private void dropCoordinatorTable_shouldDropCoordinatorTableProperly(
+      Optional<String> coordinatorNamespace) throws ExecutionException {
+    // Arrange
+    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
+    if (coordinatorNamespace.isPresent()) {
+      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
+      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
+    }
+
+    // Act
+    admin.dropCoordinatorTable();
+
+    // Assert
+    verify(distributedStorageAdmin).dropTable(coordinatorNamespaceName, Coordinator.TABLE);
+    verify(distributedStorageAdmin).dropNamespace(coordinatorNamespaceName);
   }
 
   @Test


### PR DESCRIPTION
I forgot to add methods to truncate and drop coordinator table to ConsensusCommitAdmin in the previous PRs 😞  This PR adds those method. Please take a look.