### PR TITLE
Make Coordinator backward compatible

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -44,6 +44,13 @@ public class Coordinator {
   private final DistributedStorage storage;
   private final String coordinatorNamespace;
 
+  /** @deprecated As of release 3.3.0. Will be removed in release 4.0.0. */
+  @Deprecated
+  public Coordinator(DistributedStorage storage) {
+    this.storage = storage;
+    coordinatorNamespace = NAMESPACE;
+  }
+
   public Coordinator(DistributedStorage storage, ConsensusCommitConfig config) {
     this.storage = storage;
     coordinatorNamespace = config.getCoordinatorNamespace().orElse(NAMESPACE);


### PR DESCRIPTION
#320 changed the signature of the Coordinator's constructor, which breaks backward compatibility. This PR will add a constructor that has the original signature again and fix the issue. Please take a look!