### PR TITLE
FloatValue should be mapped to double type in MySQL

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdmin.java
@@ -46,7 +46,7 @@ public class JdbcDatabaseAdmin implements DistributedStorageAdmin {
                   .put(DataType.INT, "INT")
                   .put(DataType.BIGINT, "BIGINT")
                   .put(DataType.TEXT, "LONGTEXT")
-                  .put(DataType.FLOAT, "FLOAT")
+                  .put(DataType.FLOAT, "DOUBLE")
                   .put(DataType.DOUBLE, "DOUBLE")
                   .put(DataType.BOOLEAN, "BOOLEAN")
                   .put(DataType.BLOB, "LONGBLOB")

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdminTest.java
@@ -242,7 +242,7 @@ public class JdbcDatabaseAdminTest {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.MYSQL,
         Optional.empty(),
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` FLOAT, PRIMARY KEY (`c3`,`c1`,`c4`))",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` DOUBLE, PRIMARY KEY (`c3`,`c1`,`c4`))",
         "CREATE INDEX index_my_ns_foo_table_c4 ON `my_ns`.`foo_table` (`c4`)",
         "CREATE INDEX index_my_ns_foo_table_c1 ON `my_ns`.`foo_table` (`c1`)",
         "CREATE SCHEMA IF NOT EXISTS `scalardb`",
@@ -348,7 +348,7 @@ public class JdbcDatabaseAdminTest {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.MYSQL,
         Optional.of("changed"),
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` FLOAT, PRIMARY KEY (`c3`,`c1`,`c4`))",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` DOUBLE, PRIMARY KEY (`c3`,`c1`,`c4`))",
         "CREATE INDEX index_my_ns_foo_table_c4 ON `my_ns`.`foo_table` (`c4`)",
         "CREATE INDEX index_my_ns_foo_table_c1 ON `my_ns`.`foo_table` (`c1`)",
         "CREATE SCHEMA IF NOT EXISTS `changed`",

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,7 @@ Here are the supported data types in Scalar DB and their mapping to the data typ
 | BOOLEAN   | boolean   | boolean (JSON) | BOOL     | boolean  | boolean          | number(1)      | bit             |
 | INT       | int       | number (JSON)  | N        | int      | int              | int            | int             |
 | BIGINT    | bigint    | number (JSON)  | N        | bigint   | bigint           | number(19)     | bigint          |
-| FLOAT     | float     | number (JSON)  | N        | float    | float            | binary_float   | float(24)       |
+| FLOAT     | float     | number (JSON)  | N        | double   | float            | binary_float   | float(24)       |
 | DOUBLE    | double    | number (JSON)  | N        | double   | double precision | binary_double  | float           |
 | TEXT      | text      | string (JSON)  | S        | longtext | text             | varchar2(4000) | varchar(8000)   |
 | BLOB      | blob      | string (JSON)  | B        | longblob | bytea            | blob           | varbinary(8000) |


### PR DESCRIPTION
I found `FloatValue` should be mapped to `double` type in MySQL as mentioned in the following:
https://stackoverflow.com/questions/46247940/why-is-mysql-float-different-than-java-float

This PR fixes the issue. Note that I didn't fix the issue in the schema loader as it will be removed and replaced with the new one soon. Please take a look!
