### PR TITLE
Disallow using BLOB type for clustering keys in Cosmos DB adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -85,10 +85,19 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
     try {
+      checkMetadata(metadata);
       createContainer(namespace, table, metadata);
       addTableMetadata(namespace, table, metadata);
     } catch (RuntimeException e) {
       throw new ExecutionException("creating the container failed", e);
+    }
+  }
+
+  private void checkMetadata(TableMetadata metadata) throws ExecutionException {
+    for (String clusteringKeyName : metadata.getClusteringKeyNames()) {
+      if (metadata.getColumnDataType(clusteringKeyName) == DataType.BLOB) {
+        throw new ExecutionException("BLOB type is not supported for clustering keys in Cosmos DB");
+      }
     }
   }
 


### PR DESCRIPTION
A BLOB value is automatically converted to Base64 representations in Cosmos DB SDK, which doesn't preserve the sort order of the original value. So we can't use BLOB type for clustering keys in Cosmos DB adapter. This PR disallows using BLOB type for clustering keys in Cosmos DB adapter. Please take a look!