### PR TITLE
Restrict BigIntValue range

### DIFF
--- a/core/src/main/java/com/scalar/db/io/BigIntValue.java
+++ b/core/src/main/java/com/scalar/db/io/BigIntValue.java
@@ -1,5 +1,6 @@
 package com.scalar.db.io;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
@@ -8,13 +9,18 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a 64-bit singed integer
+ * A {@code Value} for a signed integer from -2^53 to 2^53. The range is determined by the numbers
+ * Double-precision floating-point format can exactly represent.
  *
  * @author Hiroyuki Yamada
  */
 @Immutable
 public final class BigIntValue implements Value<Long> {
+  public static final long MAX_VALUE = 9007199254740992L;
+  public static final long MIN_VALUE = -9007199254740992L;
+
   private static final String ANONYMOUS = "";
+
   private final String name;
   private final long value;
 
@@ -26,6 +32,7 @@ public final class BigIntValue implements Value<Long> {
    */
   public BigIntValue(String name, long value) {
     this.name = checkNotNull(name);
+    checkArgument(value >= MIN_VALUE && value <= MAX_VALUE, "Out of range value for BigIntValue");
     this.value = value;
   }
 

--- a/core/src/test/java/com/scalar/db/io/BigIntValueTest.java
+++ b/core/src/test/java/com/scalar/db/io/BigIntValueTest.java
@@ -13,7 +13,7 @@ public class BigIntValueTest {
   @Test
   public void get_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     BigIntValue value = new BigIntValue(ANY_NAME, expected);
 
     // Act
@@ -26,7 +26,7 @@ public class BigIntValueTest {
   @Test
   public void getAsLong_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act
@@ -39,7 +39,7 @@ public class BigIntValueTest {
   @Test
   public void getAsFloat_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act
@@ -52,7 +52,7 @@ public class BigIntValueTest {
   @Test
   public void getAsDouble_ProperValueGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act
@@ -66,7 +66,7 @@ public class BigIntValueTest {
   public void
       getAsBoolean_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act Assert
@@ -76,7 +76,7 @@ public class BigIntValueTest {
   @Test
   public void getAsInt_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act Assert
@@ -86,7 +86,7 @@ public class BigIntValueTest {
   @Test
   public void getAsString_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act Assert
@@ -96,7 +96,7 @@ public class BigIntValueTest {
   @Test
   public void getAsBytes_ProperValueGivenInConstructor_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    long expected = Long.MAX_VALUE;
+    long expected = BigIntValue.MAX_VALUE;
     Value<?> value = new BigIntValue(ANY_NAME, expected);
 
     // Act Assert
@@ -106,7 +106,7 @@ public class BigIntValueTest {
   @Test
   public void equals_DifferentObjectsSameValuesGiven_ShouldReturnTrue() {
     // Arrange
-    long some = Long.MAX_VALUE;
+    long some = BigIntValue.MAX_VALUE;
     BigIntValue one = new BigIntValue(ANY_NAME, some);
     BigIntValue another = new BigIntValue(ANY_NAME, some);
 
@@ -120,7 +120,7 @@ public class BigIntValueTest {
   @Test
   public void equals_DifferentObjectsSameValuesDifferentNamesGiven_ShouldReturnFalse() {
     // Arrange
-    long some = Long.MAX_VALUE;
+    long some = BigIntValue.MAX_VALUE;
     BigIntValue one = new BigIntValue(ANY_NAME, some);
     BigIntValue another = new BigIntValue(ANOTHER_NAME, some);
 
@@ -134,7 +134,7 @@ public class BigIntValueTest {
   @Test
   public void equals_SameObjectsGiven_ShouldReturnTrue() {
     // Arrange
-    long some = Long.MAX_VALUE;
+    long some = BigIntValue.MAX_VALUE;
     BigIntValue value = new BigIntValue(ANY_NAME, some);
 
     // Act
@@ -148,8 +148,8 @@ public class BigIntValueTest {
   @Test
   public void equals_DifferentObjectsDifferentValuesGiven_ShouldReturnFalse() {
     // Arrange
-    long one = Long.MAX_VALUE;
-    long another = Long.MAX_VALUE - 1;
+    long one = BigIntValue.MAX_VALUE;
+    long another = BigIntValue.MAX_VALUE - 1;
     BigIntValue oneValue = new BigIntValue(ANY_NAME, one);
     BigIntValue anotherValue = new BigIntValue(ANY_NAME, another);
 
@@ -179,8 +179,8 @@ public class BigIntValueTest {
   @Test
   public void compareTo_ThisBiggerThanGiven_ShouldReturnPositive() {
     // Arrange
-    long one = Long.MAX_VALUE;
-    long another = Long.MAX_VALUE - 1;
+    long one = BigIntValue.MAX_VALUE;
+    long another = BigIntValue.MAX_VALUE - 1;
     BigIntValue oneValue = new BigIntValue(ANY_NAME, one);
     BigIntValue anotherValue = new BigIntValue(ANY_NAME, another);
 
@@ -194,8 +194,8 @@ public class BigIntValueTest {
   @Test
   public void compareTo_ThisEqualsToGiven_ShouldReturnZero() {
     // Arrange
-    long one = Long.MAX_VALUE;
-    long another = Long.MAX_VALUE;
+    long one = BigIntValue.MAX_VALUE;
+    long another = BigIntValue.MAX_VALUE;
     BigIntValue oneValue = new BigIntValue(ANY_NAME, one);
     BigIntValue anotherValue = new BigIntValue(ANY_NAME, another);
 
@@ -209,8 +209,8 @@ public class BigIntValueTest {
   @Test
   public void compareTo_ThisSmallerThanGiven_ShouldReturnNegative() {
     // Arrange
-    long one = Long.MAX_VALUE - 1;
-    long another = Long.MAX_VALUE;
+    long one = BigIntValue.MAX_VALUE - 1;
+    long another = BigIntValue.MAX_VALUE;
     BigIntValue oneValue = new BigIntValue(ANY_NAME, one);
     BigIntValue anotherValue = new BigIntValue(ANY_NAME, another);
 
@@ -225,5 +225,19 @@ public class BigIntValueTest {
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
     assertThatThrownBy(() -> new BigIntValue(null, 0)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_NumberOverMaxValueGiven_ShouldThrowIllegalArgumentException() {
+    // Act Assert
+    assertThatThrownBy(() -> new BigIntValue(ANY_NAME, BigIntValue.MAX_VALUE + 1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_NumberUnderMinValueGiven_ShouldThrowIllegalArgumentException() {
+    // Act Assert
+    assertThatThrownBy(() -> new BigIntValue(ANY_NAME, BigIntValue.MIN_VALUE - 1))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
@@ -9,6 +9,7 @@ import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Row;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.Value;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -48,7 +49,7 @@ public class ResultInterpreterTest {
     when(row.getString(ANY_NAME_2)).thenReturn(ANY_TEXT_2);
     when(row.getBool(ANY_COLUMN_NAME_1)).thenReturn(true);
     when(row.getInt(ANY_COLUMN_NAME_2)).thenReturn(Integer.MAX_VALUE);
-    when(row.getLong(ANY_COLUMN_NAME_3)).thenReturn(Long.MAX_VALUE);
+    when(row.getLong(ANY_COLUMN_NAME_3)).thenReturn(BigIntValue.MAX_VALUE);
     when(row.getFloat(ANY_COLUMN_NAME_4)).thenReturn(Float.MAX_VALUE);
     when(row.getDouble(ANY_COLUMN_NAME_5)).thenReturn(Double.MAX_VALUE);
     when(row.getString(ANY_COLUMN_NAME_6)).thenReturn("string");
@@ -85,7 +86,8 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_2).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_2).get().getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_3).isPresent()).isTrue();
-    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong())
+        .isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_4).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_4).get().getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_5).isPresent()).isTrue();
@@ -110,7 +112,7 @@ public class ResultInterpreterTest {
     assertThat(values.containsKey(ANY_COLUMN_NAME_2)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_2).getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_3)).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_4)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_4).getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_5)).isTrue();

--- a/core/src/test/java/com/scalar/db/storage/common/ResultImplTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/ResultImplTest.java
@@ -62,7 +62,7 @@ public class ResultImplTest {
             .put(ANY_NAME_2, new TextValue(ANY_NAME_2, ANY_TEXT_2))
             .put(ANY_COLUMN_NAME_1, new BooleanValue(ANY_COLUMN_NAME_1, true))
             .put(ANY_COLUMN_NAME_2, new IntValue(ANY_COLUMN_NAME_2, Integer.MAX_VALUE))
-            .put(ANY_COLUMN_NAME_3, new BigIntValue(ANY_COLUMN_NAME_3, Long.MAX_VALUE))
+            .put(ANY_COLUMN_NAME_3, new BigIntValue(ANY_COLUMN_NAME_3, BigIntValue.MAX_VALUE))
             .put(ANY_COLUMN_NAME_4, new FloatValue(ANY_COLUMN_NAME_4, Float.MAX_VALUE))
             .put(ANY_COLUMN_NAME_5, new DoubleValue(ANY_COLUMN_NAME_5, Double.MAX_VALUE))
             .put(ANY_COLUMN_NAME_6, new TextValue(ANY_COLUMN_NAME_6, "string"))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
@@ -19,7 +19,7 @@ public class ConcatenationVisitorTest {
       new BooleanValue("any_boolean", ANY_BOOLEAN);
   private static final int ANY_INT = Integer.MIN_VALUE;
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
-  private static final long ANY_BIGINT = Long.MAX_VALUE;
+  private static final long ANY_BIGINT = BigIntValue.MAX_VALUE;
   private static final BigIntValue ANY_BIGINT_VALUE = new BigIntValue("any_bigint", ANY_BIGINT);
   private static final float ANY_FLOAT = Float.MIN_NORMAL;
   private static final FloatValue ANY_FLOAT_VALUE = new FloatValue("any_float", ANY_FLOAT);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/MapVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/MapVisitorTest.java
@@ -20,7 +20,7 @@ public class MapVisitorTest {
       new BooleanValue("any_boolean", ANY_BOOLEAN);
   private static final int ANY_INT = Integer.MIN_VALUE;
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
-  private static final long ANY_BIGINT = Long.MAX_VALUE;
+  private static final long ANY_BIGINT = BigIntValue.MAX_VALUE;
   private static final BigIntValue ANY_BIGINT_VALUE = new BigIntValue("any_bigint", ANY_BIGINT);
   private static final float ANY_FLOAT = Float.MIN_NORMAL;
   private static final FloatValue ANY_FLOAT_VALUE = new FloatValue("any_float", ANY_FLOAT);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ResultInterpreterTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.spy;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Value;
 import java.nio.charset.StandardCharsets;
@@ -57,7 +58,7 @@ public class ResultInterpreterTest {
         ImmutableMap.<String, Object>builder()
             .put(ANY_COLUMN_NAME_1, true)
             .put(ANY_COLUMN_NAME_2, Integer.MAX_VALUE)
-            .put(ANY_COLUMN_NAME_3, Long.MAX_VALUE)
+            .put(ANY_COLUMN_NAME_3, BigIntValue.MAX_VALUE)
             .put(ANY_COLUMN_NAME_4, Float.MAX_VALUE)
             .put(ANY_COLUMN_NAME_5, Double.MAX_VALUE)
             .put(ANY_COLUMN_NAME_6, "string")
@@ -84,7 +85,8 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_2).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_2).get().getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_3).isPresent()).isTrue();
-    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong())
+        .isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_4).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_4).get().getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_5).isPresent()).isTrue();
@@ -109,7 +111,7 @@ public class ResultInterpreterTest {
     assertThat(values.containsKey(ANY_COLUMN_NAME_2)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_2).getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_3)).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_4)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_4).getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_5)).isTrue();

--- a/core/src/test/java/com/scalar/db/storage/dynamo/MapVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/MapVisitorTest.java
@@ -20,7 +20,7 @@ public class MapVisitorTest {
       new BooleanValue("any_boolean", ANY_BOOLEAN);
   private static final int ANY_INT = Integer.MIN_VALUE;
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
-  private static final long ANY_BIGINT = Long.MAX_VALUE;
+  private static final long ANY_BIGINT = BigIntValue.MAX_VALUE;
   private static final BigIntValue ANY_BIGINT_VALUE = new BigIntValue("any_bigint", ANY_BIGINT);
   private static final float ANY_FLOAT = Float.MIN_NORMAL;
   private static final FloatValue ANY_FLOAT_VALUE = new FloatValue("any_float", ANY_FLOAT);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/ResultInterpreterTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.spy;
 
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Value;
 import java.nio.charset.StandardCharsets;
@@ -55,7 +56,9 @@ public class ResultInterpreterTest {
     item.put(ANY_COLUMN_NAME_1, AttributeValue.builder().bool(true).build());
     item.put(
         ANY_COLUMN_NAME_2, AttributeValue.builder().n(String.valueOf(Integer.MAX_VALUE)).build());
-    item.put(ANY_COLUMN_NAME_3, AttributeValue.builder().n(String.valueOf(Long.MAX_VALUE)).build());
+    item.put(
+        ANY_COLUMN_NAME_3,
+        AttributeValue.builder().n(String.valueOf(BigIntValue.MAX_VALUE)).build());
     item.put(
         ANY_COLUMN_NAME_4, AttributeValue.builder().n(String.valueOf(Float.MAX_VALUE)).build());
     item.put(
@@ -85,7 +88,8 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_2).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_2).get().getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_3).isPresent()).isTrue();
-    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong())
+        .isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_4).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_4).get().getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_5).isPresent()).isTrue();
@@ -110,7 +114,7 @@ public class ResultInterpreterTest {
     assertThat(values.containsKey(ANY_COLUMN_NAME_2)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_2).getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_3)).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_4)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_4).getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_5)).isTrue();

--- a/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Value;
 import java.nio.charset.StandardCharsets;
@@ -62,7 +63,7 @@ public class ResultInterpreterTest {
     when(resultSet.getString(ANY_NAME_2)).thenReturn(ANY_TEXT_2);
     when(resultSet.getBoolean(ANY_COLUMN_NAME_1)).thenReturn(true);
     when(resultSet.getInt(ANY_COLUMN_NAME_2)).thenReturn(Integer.MAX_VALUE);
-    when(resultSet.getLong(ANY_COLUMN_NAME_3)).thenReturn(Long.MAX_VALUE);
+    when(resultSet.getLong(ANY_COLUMN_NAME_3)).thenReturn(BigIntValue.MAX_VALUE);
     when(resultSet.getFloat(ANY_COLUMN_NAME_4)).thenReturn(Float.MAX_VALUE);
     when(resultSet.getDouble(ANY_COLUMN_NAME_5)).thenReturn(Double.MAX_VALUE);
     when(resultSet.getString(ANY_COLUMN_NAME_6)).thenReturn("string");
@@ -87,7 +88,8 @@ public class ResultInterpreterTest {
     assertThat(result.getValue(ANY_COLUMN_NAME_2).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_2).get().getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_3).isPresent()).isTrue();
-    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(result.getValue(ANY_COLUMN_NAME_3).get().getAsLong())
+        .isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_4).isPresent()).isTrue();
     assertThat(result.getValue(ANY_COLUMN_NAME_4).get().getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(result.getValue(ANY_COLUMN_NAME_5).isPresent()).isTrue();
@@ -112,7 +114,7 @@ public class ResultInterpreterTest {
     assertThat(values.containsKey(ANY_COLUMN_NAME_2)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_2).getAsInt()).isEqualTo(Integer.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_3)).isTrue();
-    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(values.get(ANY_COLUMN_NAME_3).getAsLong()).isEqualTo(BigIntValue.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_4)).isTrue();
     assertThat(values.get(ANY_COLUMN_NAME_4).getAsFloat()).isEqualTo(Float.MAX_VALUE);
     assertThat(values.containsKey(ANY_COLUMN_NAME_5)).isTrue();


### PR DESCRIPTION
This PRs restricts `BigIntValue` range from `-2^53` to `2^53`. The range is determined by the numbers Double-precision floating-point format can exactly represent. After this change, we can treat `BigIntValue` as Json's Number type without precision error. Please take a look!