### PR TITLE
Using scan to count items in the table instead of using table description.

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -397,7 +397,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
 
     try {
-      ScanRequest scanRequest = ScanRequest.builder().tableName(getMetadataTable()).limit(1).build();
+      ScanRequest scanRequest =
+          ScanRequest.builder().tableName(getMetadataTable()).limit(1).build();
       ScanResponse scanResponse = client.scan(scanRequest);
       if (scanResponse.count() == 0) {
         try {

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTest.java
@@ -162,12 +162,6 @@ public class DynamoAdminTest {
     when(client.getItem(any(GetItemRequest.class))).thenReturn(response);
     when(response.item()).thenReturn(Collections.emptyMap());
 
-    DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
-    when(client.describeTable(any(DescribeTableRequest.class))).thenReturn(describeTableResponse);
-    TableDescription tableDescription = mock(TableDescription.class);
-    when(describeTableResponse.table()).thenReturn(tableDescription);
-    when(tableDescription.tableStatus()).thenReturn(TableStatus.ACTIVE);
-
     ScanResponse scanResponse = mock(ScanResponse.class);
     when(scanResponse.count()).thenReturn(1);
     when(client.scan(any(ScanRequest.class))).thenReturn(scanResponse);


### PR DESCRIPTION
Regarding AWS document when getting `itemCount` from table description:

> The number of items in the specified table. DynamoDB updates this value approximately every six hours. Recent changes might not be reflected in this value.

So we have to use scan to count items for proper results.
This PR was made to fix it. PTAL! Thank you.