### PR TITLE
Add Clustering order support to Cosmos DB adapter

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -1,15 +1,9 @@
 package com.scalar.db.storage.cosmos;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.AdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Test;
 
 public class CosmosAdminIntegrationTest extends AdminIntegrationTestBase {
 
@@ -27,25 +21,5 @@ public class CosmosAdminIntegrationTest extends AdminIntegrationTestBase {
   @Override
   protected Map<String, String> getCreateOptions() {
     return CosmosEnv.getCreateOptions();
-  }
-
-  @Test
-  @Override
-  public void getTableMetadata_CorrectTableGiven_ShouldReturnCorrectClusteringOrders()
-      throws ExecutionException {
-    TableMetadata tableMetadata = admin.getTableMetadata(namespace, TABLE);
-
-    // Fow now, the clustering order is always ASC in the Cosmos DB adapter
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME1)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME2)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME3)).isEqualTo(Scan.Ordering.Order.ASC);
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME4)).isEqualTo(Scan.Ordering.Order.ASC);
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME5)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME6)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME7)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME8)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME9)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME10)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME11)).isNull();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
@@ -18,6 +18,7 @@ public class CosmosTableMetadata {
   private String id;
   private LinkedHashSet<String> partitionKeyNames;
   private LinkedHashSet<String> clusteringKeyNames;
+  private Map<String, String> clusteringOrders;
   private Set<String> secondaryIndexNames;
   private Map<String, String> columns;
 
@@ -33,6 +34,10 @@ public class CosmosTableMetadata {
 
   public void setClusteringKeyNames(List<String> clusteringKeyNames) {
     this.clusteringKeyNames = new ImmutableLinkedHashSet<>(clusteringKeyNames);
+  }
+
+  public void setClusteringOrders(Map<String, String> clusteringOrders) {
+    this.clusteringOrders = clusteringOrders;
   }
 
   public void setSecondaryIndexNames(Set<String> secondaryIndexNames) {
@@ -55,6 +60,10 @@ public class CosmosTableMetadata {
     return clusteringKeyNames;
   }
 
+  public Map<String, String> getClusteringOrders() {
+    return clusteringOrders;
+  }
+
   public Set<String> getSecondaryIndexNames() {
     return secondaryIndexNames;
   }
@@ -72,20 +81,17 @@ public class CosmosTableMetadata {
       return false;
     }
     CosmosTableMetadata that = (CosmosTableMetadata) o;
-    return Objects.equals(getId(), that.getId())
-        && Objects.equals(getPartitionKeyNames(), that.getPartitionKeyNames())
-        && Objects.equals(getClusteringKeyNames(), that.getClusteringKeyNames())
-        && Objects.equals(getSecondaryIndexNames(), that.getSecondaryIndexNames())
-        && Objects.equals(getColumns(), that.getColumns());
+    return Objects.equals(id, that.id)
+        && Objects.equals(partitionKeyNames, that.partitionKeyNames)
+        && Objects.equals(clusteringKeyNames, that.clusteringKeyNames)
+        && Objects.equals(clusteringOrders, that.clusteringOrders)
+        && Objects.equals(secondaryIndexNames, that.secondaryIndexNames)
+        && Objects.equals(columns, that.columns);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        getId(),
-        getPartitionKeyNames(),
-        getClusteringKeyNames(),
-        getSecondaryIndexNames(),
-        getColumns());
+        id, partitionKeyNames, clusteringKeyNames, clusteringOrders, secondaryIndexNames, columns);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
@@ -261,11 +261,11 @@ public class CosmosAdminTest {
     assertThat(indexingPolicy.getCompositeIndexes().get(0).get(1).getPath())
         .isEqualTo("/clusteringKey/c1");
     assertThat(indexingPolicy.getCompositeIndexes().get(0).get(1).getOrder())
-        .isEqualTo(CompositePathSortOrder.ASCENDING); // always ASCENDING for now
+        .isEqualTo(CompositePathSortOrder.DESCENDING);
     assertThat(indexingPolicy.getCompositeIndexes().get(0).get(2).getPath())
         .isEqualTo("/clusteringKey/c2");
     assertThat(indexingPolicy.getCompositeIndexes().get(0).get(2).getOrder())
-        .isEqualTo(CompositePathSortOrder.ASCENDING); // always ASCENDING for now
+        .isEqualTo(CompositePathSortOrder.ASCENDING);
 
     verify(cosmosScripts).createStoredProcedure(any(CosmosStoredProcedureProperties.class));
 
@@ -283,6 +283,7 @@ public class CosmosAdminTest {
     cosmosTableMetadata.setId(getFullTableName(namespace, table));
     cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c3"));
     cosmosTableMetadata.setClusteringKeyNames(Arrays.asList("c1", "c2"));
+    cosmosTableMetadata.setClusteringOrders(ImmutableMap.of("c1", "DESC", "c2", "ASC"));
     cosmosTableMetadata.setColumns(
         new ImmutableMap.Builder<String, String>()
             .put("c1", "text")
@@ -384,6 +385,7 @@ public class CosmosAdminTest {
     CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
     cosmosTableMetadata.setId(getFullTableName(namespace, table));
     cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c3"));
+    cosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
     cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
     cosmosTableMetadata.setColumns(
         new ImmutableMap.Builder<String, String>()


### PR DESCRIPTION
This PR adds the clustering order support to the Cosmos DB adapter. Please take a look!