### PR TITLE
Add tableExists method

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -240,7 +240,7 @@ public interface DistributedStorageAdmin {
    * Returns the names of the table belonging to the given namespace.
    *
    * @param namespace a namespace
-   * @return a set of table names
+   * @return a set of table names, an empty list if the namespace doesn't exist
    * @throws ExecutionException if the operation failed
    */
   Set<String> getNamespaceTableNames(String namespace) throws ExecutionException;
@@ -253,6 +253,18 @@ public interface DistributedStorageAdmin {
    * @throws ExecutionException if the operation failed
    */
   boolean namespaceExists(String namespace) throws ExecutionException;
+
+  /**
+   * Return true if the table exists.
+   *
+   * @param namespace a namespace
+   * @param table a table
+   * @return true if the table exists, false otherwise
+   * @throws ExecutionException if the operation failed
+   */
+  default boolean tableExists(String namespace, String table) throws ExecutionException {
+    return getNamespaceTableNames(namespace).contains(table);
+  }
 
   /** Closes connections to the storage. */
   void close();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -78,6 +78,16 @@ public class ConsensusCommitAdmin {
   }
 
   /**
+   * Return true if a coordinator table exists.
+   *
+   * @return true if a coordinator table exists, false otherwise
+   * @throws ExecutionException if the operation failed
+   */
+  public boolean coordinatorTableExists() throws ExecutionException {
+    return admin.tableExists(coordinatorNamespace, Coordinator.TABLE);
+  }
+
+  /**
    * Creates a new transactional table.
    *
    * @param namespace a namespace already created

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -155,6 +156,36 @@ public class ConsensusCommitAdminTest {
     // Assert
     verify(distributedStorageAdmin).dropTable(coordinatorNamespaceName, Coordinator.TABLE);
     verify(distributedStorageAdmin).dropNamespace(coordinatorNamespaceName);
+  }
+
+  @Test
+  public void coordinatorTableExists_WhenCoordinatorTableNotExist_shouldReturnFalse()
+      throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.tableExists(Coordinator.NAMESPACE, Coordinator.TABLE))
+        .thenReturn(false);
+
+    // Act
+    boolean actual = admin.coordinatorTableExists();
+
+    // Assert
+    verify(distributedStorageAdmin).tableExists(Coordinator.NAMESPACE, Coordinator.TABLE);
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  public void coordinatorTableExists_WhenCoordinatorTableExists_shouldReturnTrue()
+      throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.tableExists(Coordinator.NAMESPACE, Coordinator.TABLE))
+        .thenReturn(true);
+
+    // Act
+    boolean actual = admin.coordinatorTableExists();
+
+    // Assert
+    verify(distributedStorageAdmin).tableExists(Coordinator.NAMESPACE, Coordinator.TABLE);
+    assertThat(actual).isTrue();
   }
 
   @Test


### PR DESCRIPTION
This PR adds `tableExists()` to `DistributedStorageAdmin` and `coordinatorTableExists()` to `ConsensusCommitAdmin` that return whether the specified table or the coordinator table exists or not. Please take a look!