### PR TITLE
Make properties in DatabaseConfig visible

### DIFF
--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -74,7 +74,8 @@ public class DatabaseConfig {
   }
 
   public DatabaseConfig(Properties properties) {
-    props = new Properties(properties);
+    props = new Properties();
+    props.putAll(properties);
     load();
   }
 

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -42,7 +42,8 @@ public class MultiStorageConfig {
   }
 
   public MultiStorageConfig(Properties properties) {
-    props = new Properties(properties);
+    props = new Properties();
+    props.putAll(properties);
     load();
   }
 

--- a/server/src/main/java/com/scalar/db/server/config/ServerConfig.java
+++ b/server/src/main/java/com/scalar/db/server/config/ServerConfig.java
@@ -43,7 +43,8 @@ public class ServerConfig {
   }
 
   public ServerConfig(Properties properties) {
-    props = new Properties(properties);
+    props = new Properties();
+    props.putAll(properties);
     load();
   }
 

--- a/server/src/main/java/com/scalar/db/server/service/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/service/ServerModule.java
@@ -29,7 +29,8 @@ public class ServerModule extends AbstractModule {
     this.config = config;
     storageFactory = new StorageFactory(databaseConfig);
 
-    Properties transactionProperties = new Properties(databaseConfig.getProperties());
+    Properties transactionProperties = new Properties();
+    transactionProperties.putAll(databaseConfig.getProperties());
 
     // For two-phase consensus commit transactions in Scalar DB server, disable the active
     // transactions management because Scalar DB server takes care of active transactions management


### PR DESCRIPTION
We change to use `putAll` to copy the properties instead of passing them to the constructor. This change makes the storing the properties to file `dbConfig.getProperties().store(.....)` not be empty. PTAL. Thank you!