### PR TITLE
Use MockitoAnnotations.openMocks() instead of MockitoAnnotations.initMocks()

### DIFF
--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchComposerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchComposerTest.java
@@ -34,8 +34,8 @@ public class BatchComposerTest {
   @Mock private Delete del;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     spy = Mockito.spy(new BatchComposer(batch, handlers));
     doNothing().when(spy).composeWith(any(StatementHandler.class), any(Operation.class));

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
@@ -56,8 +56,8 @@ public class BatchHandlerTest {
   @Mock private ResultSet results;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handlers =
         StatementHandlerManager.builder()

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -49,8 +49,8 @@ public class CassandraAdminTest {
   @Mock private KeyspaceMetadata keyspaceMetadata;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     when(clusterManager.getSession()).thenReturn(cassandraSession);
     cassandraAdmin = new CassandraAdmin(clusterManager, config);
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ClusterManagerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ClusterManagerTest.java
@@ -26,8 +26,8 @@ public class ClusterManagerTest {
   private ClusterManager manager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     manager = Mockito.spy(new ClusterManager(cluster, session));

--- a/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/DeleteStatementHandlerTest.java
@@ -49,8 +49,8 @@ public class DeleteStatementHandlerTest {
   @Mock private BoundStatement bound;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new DeleteStatementHandler(session);
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
@@ -54,8 +54,8 @@ public class InsertStatementHandlerTest {
   @Mock private BoundStatement bound;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new InsertStatementHandler(session);
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ResultInterpreterTest.java
@@ -38,8 +38,8 @@ public class ResultInterpreterTest {
   @Mock private TableMetadata tableMetadata;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -50,8 +50,8 @@ public class SelectStatementHandlerTest {
   @Mock private BoundStatement bound;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new SelectStatementHandler(session);
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/StatementHandlerManagerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/StatementHandlerManagerTest.java
@@ -31,8 +31,8 @@ public class StatementHandlerManagerTest {
   @Mock private PutIfNotExists putIfNotExists;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   private StatementHandlerManager prepareManager() {

--- a/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/UpdateStatementHandlerTest.java
@@ -47,8 +47,8 @@ public class UpdateStatementHandlerTest {
   @Mock private BoundStatement bound;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new UpdateStatementHandler(session);
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/ValueBinderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/ValueBinderTest.java
@@ -34,8 +34,8 @@ public class ValueBinderTest {
   @Mock private BoundStatement bound;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/common/TableMetadataManagerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/TableMetadataManagerTest.java
@@ -28,8 +28,8 @@ public class TableMetadataManagerTest {
   @Mock DatabaseConfig config;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -52,8 +52,8 @@ public class OperationCheckerTest {
   private OperationChecker operationChecker;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Dummy metadata
     when(metadataManager.getTableMetadata(any()))

--- a/core/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/BatchHandlerTest.java
@@ -65,8 +65,8 @@ public class BatchHandlerTest {
   @Captor ArgumentCaptor<List<Object>> captor;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new BatchHandler(client, metadataManager);
     when(client.getDatabase(anyString())).thenReturn(database);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilderTest.java
@@ -31,8 +31,8 @@ public class ConditionalQueryBuilderTest {
   @Mock private SelectConditionStep<org.jooq.Record> select;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
@@ -57,8 +57,8 @@ public class CosmosAdminTest {
   private CosmosAdmin admin;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     admin = new CosmosAdmin(client, config);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosMutationTest.java
@@ -36,8 +36,8 @@ public class CosmosMutationTest {
   @Mock private TableMetadata metadata;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     when(metadata.getPartitionKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_1)));

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
@@ -33,8 +33,8 @@ public class CosmosOperationTest {
   @Mock private TableMetadata metadata;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -65,8 +65,8 @@ public class DeleteStatementHandlerTest {
   @Captor ArgumentCaptor<List<Object>> captor;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new DeleteStatementHandler(client, metadataManager);
     when(client.getDatabase(anyString())).thenReturn(database);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/PutStatementHandlerTest.java
@@ -24,7 +24,6 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.Key;
@@ -64,8 +63,8 @@ public class PutStatementHandlerTest {
   @Captor ArgumentCaptor<List<Object>> captor;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new PutStatementHandler(client, metadataManager);
     when(client.getDatabase(anyString())).thenReturn(database);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -61,8 +61,8 @@ public class SelectStatementHandlerTest {
   @Mock private CosmosPagedIterable<Record> responseIterable;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new SelectStatementHandler(client, metadataManager);
     when(client.getDatabase(anyString())).thenReturn(database);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
@@ -12,8 +12,8 @@ public class StatementHandlerTest {
   @Mock private TableMetadataManager metadataManager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTest.java
@@ -59,8 +59,8 @@ public class BatchHandlerTest {
   @Mock private TransactWriteItemsResponse transactWriteResponse;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new BatchHandler(client, metadataManager);
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilderTest.java
@@ -20,8 +20,8 @@ public class ConditionExpressionBuilderTest {
   private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerTest.java
@@ -45,8 +45,8 @@ public class DeleteStatementHandlerTest {
   @Mock private DeleteItemResponse response;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new DeleteStatementHandler(client, metadataManager);
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTest.java
@@ -62,8 +62,8 @@ public class DynamoAdminTest {
   private DynamoAdmin admin;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     admin = new DynamoAdmin(client, applicationAutoScalingClient, config);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoMutationTest.java
@@ -38,8 +38,8 @@ public class DynamoMutationTest {
   @Mock private TableMetadata metadata;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     when(metadata.getPartitionKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_1)));

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationTest.java
@@ -27,8 +27,8 @@ public class DynamoOperationTest {
   @Mock private TableMetadata metadata;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     when(metadata.getPartitionKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_1)));

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTest.java
@@ -52,8 +52,8 @@ public class PutStatementHandlerTest {
   @Mock private UpdateItemResponse updateResponse;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new PutStatementHandler(client, metadataManager);
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -57,8 +57,8 @@ public class SelectStatementHandlerTest {
   @Mock private QueryResponse queryResponse;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     handler = new SelectStatementHandler(client, metadataManager);
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdminTest.java
@@ -39,8 +39,8 @@ public class JdbcDatabaseAdminTest {
   @Mock private JdbcConfig config;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -41,7 +41,7 @@ public class JdbcDatabaseTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this).close();
     jdbcDatabase = new JdbcDatabase(dataSource, jdbcService);
 
     when(dataSource.getConnection()).thenReturn(connection);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -20,7 +20,6 @@ import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
@@ -73,8 +72,8 @@ public class JdbcServiceTest {
   private JdbcService jdbcService;
 
   @Before
-  public void setUp() throws ExecutionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     jdbcService = new JdbcService(tableMetadataManager, operationChecker, queryBuilder);
 
     // Arrange

--- a/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/ResultInterpreterTest.java
@@ -37,8 +37,8 @@ public class ResultInterpreterTest {
   @Mock private ResultSet resultSet;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -57,8 +57,8 @@ public class QueryBuilderTest {
   }
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     queryBuilder = new QueryBuilder(rdbEngine);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -29,8 +29,8 @@ public class MultiStorageAdminTest {
   private MultiStorageAdmin multiStorageAdmin;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     Map<String, DistributedStorageAdmin> tableAdminMap = new HashMap<>();

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -39,8 +39,8 @@ public class MultiStorageTest {
   private MultiStorage multiStorage;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     Map<String, DistributedStorage> tableStorageMap = new HashMap<>();

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
@@ -29,8 +29,8 @@ public class GrpcAdminTest {
   private GrpcAdmin admin;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     admin = new GrpcAdmin(stub, config);

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcStorageTest.java
@@ -34,8 +34,8 @@ public class GrpcStorageTest {
   private GrpcStorage storage;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     storage = new GrpcStorage(config, stub, blockingStub, metadataManager);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -48,8 +48,8 @@ public class CommitHandlerTest {
   @Mock private RecoveryHandler recovery;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   private Put preparePut1() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
@@ -28,8 +28,8 @@ public class ConsensusCommitAdminTest {
   private ConsensusCommitAdmin admin;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     admin = new ConsensusCommitAdmin(distributedStorageAdmin, config);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -32,8 +32,8 @@ public class ConsensusCommitManagerTest {
   @InjectMocks private ConsensusCommitManager manager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);
     when(config.getSerializableStrategy()).thenReturn(SerializableStrategy.EXTRA_READ);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -43,8 +43,8 @@ public class ConsensusCommitTest {
   @InjectMocks private ConsensusCommit consensus;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     when(get.forNamespace()).thenReturn(Optional.of(ANY_NAMESPACE));
     when(get.forTable()).thenReturn(Optional.of(ANY_TABLE_NAME));

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -39,8 +39,8 @@ public class CoordinatorTest {
   private Coordinator coordinator;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     coordinator = new Coordinator(storage, config);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -51,8 +51,8 @@ public class CrudHandlerTest {
   @Mock private Result result;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   private Get prepareGet() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -30,8 +30,8 @@ public class RecoveryHandlerTest {
   @Mock private Selection selection;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
     handler = Mockito.spy(new RecoveryHandler(storage, coordinator));
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -57,9 +57,9 @@ public class RollbackMutationComposerTest {
   @Mock private DistributedStorage storage;
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
     mutations = new ArrayList<>();
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this).close();
   }
 
   private Get prepareGet() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -66,8 +66,8 @@ public class SnapshotTest {
   @Mock private TransactionResult result;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   private Snapshot prepareSnapshot(Isolation isolation) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -30,8 +30,8 @@ public class TwoPhaseConsensusCommitManagerTest {
   private TwoPhaseConsensusCommitManager manager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -48,8 +48,8 @@ public class TwoPhaseConsensusCommitTest {
   @Mock private TwoPhaseConsensusCommitManager manager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     when(get.forNamespace()).thenReturn(Optional.of(ANY_NAMESPACE));
     when(get.forTable()).thenReturn(Optional.of(ANY_TABLE_NAME));

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -39,7 +39,7 @@ public class JdbcTransactionManagerTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this).close();
     manager = new JdbcTransactionManager(dataSource, RdbEngine.MYSQL, jdbcService);
 
     when(dataSource.getConnection()).thenReturn(connection);

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
@@ -32,8 +32,8 @@ public class GrpcTransactionManagerTest {
   private GrpcTransactionManager manager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     manager = new GrpcTransactionManager(config, stub, blockingStub, metadataManager);

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
@@ -32,8 +32,8 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
   private GrpcTwoPhaseCommitTransactionManager manager;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     manager = new GrpcTwoPhaseCommitTransactionManager(config, stub, blockingStub, metadataManager);

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CassandraCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CassandraCommandTest.java
@@ -25,7 +25,7 @@ public class CassandraCommandTest extends CommandTestBase {
   private static final String schemaFile = "path_to_file";
 
   @Override
-  public void setUp() throws Exception {
+  public void setUp() {
     super.setUp();
     commandLine = new CommandLine(new CassandraCommand());
     setCommandLineOutput();

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CommandTestBase.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CommandTestBase.java
@@ -21,12 +21,13 @@ public abstract class CommandTestBase {
   protected CommandLine commandLine;
   protected StringWriter stringWriter;
 
+  private AutoCloseable closeable;
   private MockedStatic<SchemaParser> schemaParserMockedStatic;
   private MockedStatic<SchemaOperatorFactory> schemaOperatorFactoryMockedStatic;
 
   @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.openMocks(this);
+  public void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
     schemaParserMockedStatic = Mockito.mockStatic(SchemaParser.class);
     schemaParserMockedStatic
         .when(() -> SchemaParser.parse(Mockito.anyString(), Mockito.anyMap()))
@@ -42,9 +43,10 @@ public abstract class CommandTestBase {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws Exception {
     schemaParserMockedStatic.close();
     schemaOperatorFactoryMockedStatic.close();
+    closeable.close();
   }
 
   protected void setCommandLineOutput() {

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CosmosCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CosmosCommandTest.java
@@ -22,7 +22,7 @@ public class CosmosCommandTest extends CommandTestBase {
   private static final String schemaFile = "path_to_file";
 
   @Override
-  public void setUp() throws Exception {
+  public void setUp() {
     super.setUp();
     commandLine = new CommandLine(new CosmosCommand());
     setCommandLineOutput();

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/DynamoCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/DynamoCommandTest.java
@@ -24,7 +24,7 @@ public class DynamoCommandTest extends CommandTestBase {
   private static final String schemaFile = "path_to_file";
 
   @Override
-  public void setUp() throws Exception {
+  public void setUp() {
     super.setUp();
     commandLine = new CommandLine(new DynamoCommand());
     setCommandLineOutput();

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/JdbcCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/JdbcCommandTest.java
@@ -19,7 +19,7 @@ public class JdbcCommandTest extends CommandTestBase {
   private static final String schemaFile = "path_to_file";
 
   @Override
-  public void setUp() throws Exception {
+  public void setUp() {
     super.setUp();
     commandLine = new CommandLine(new JdbcCommand());
     setCommandLineOutput();

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
@@ -27,7 +27,7 @@ public class SchemaLoaderCommandTest extends CommandTestBase {
   private static final String configFile = "path_to_config_file";
 
   @Override
-  public void setUp() throws Exception {
+  public void setUp() {
     super.setUp();
     commandLine = new CommandLine(new SchemaLoaderCommand());
     setCommandLineOutput();

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/core/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/core/SchemaOperatorTest.java
@@ -25,8 +25,8 @@ public class SchemaOperatorTest {
   private SchemaOperator operator;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @After

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/schema/TableTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/schema/TableTest.java
@@ -27,8 +27,8 @@ public class TableTest {
   @Mock private JsonObject tableDefinition;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
   }
 
   @Test

--- a/server/src/test/java/com/scalar/db/server/DistributedStorageAdminServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedStorageAdminServiceTest.java
@@ -36,8 +36,8 @@ public class DistributedStorageAdminServiceTest {
   private DistributedStorageAdminService adminService;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     adminService = new DistributedStorageAdminService(admin, new Metrics());

--- a/server/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
@@ -40,8 +40,8 @@ public class DistributedStorageServiceTest {
   private DistributedStorageService storageService;
 
   @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     storageService = new DistributedStorageService(storage, gateKeeper, new Metrics());

--- a/server/src/test/java/com/scalar/db/server/DistributedTransactionServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedTransactionServiceTest.java
@@ -37,8 +37,8 @@ public class DistributedTransactionServiceTest {
   private DistributedTransactionService transactionService;
 
   @Before
-  public void setUp() throws TransactionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     transactionService = new DistributedTransactionService(manager, gateKeeper, new Metrics());

--- a/server/src/test/java/com/scalar/db/server/TwoPhaseCommitTransactionServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/TwoPhaseCommitTransactionServiceTest.java
@@ -37,8 +37,8 @@ public class TwoPhaseCommitTransactionServiceTest {
   private TwoPhaseCommitTransactionService service;
 
   @Before
-  public void setUp() throws TransactionException {
-    MockitoAnnotations.initMocks(this);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
 
     // Arrange
     service = new TwoPhaseCommitTransactionService(manager, gateKeeper, new Metrics());


### PR DESCRIPTION
We introduced Mockito 3 in #348. And `MockitoAnnotations.initMock()` is deprecated and replaced with `MockitoAnnotations.openMocks()` in Mockito 3. This PR replaces `MockitoAnnotations.initMock()` with `MockitoAnnotations.openMocks()`. Please take a look!