### PR TITLE
Change the default values of JDBC connection pool configurations

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -28,9 +28,9 @@ public class JdbcConfig extends DatabaseConfig {
       PREFIX + "prepared_statements_pool.max_open";
   public static final String TABLE_METADATA_SCHEMA = PREFIX + "table_metadata.schema";
 
-  public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 5;
-  public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 10;
-  public static final int DEFAULT_CONNECTION_POOL_MAX_TOTAL = 25;
+  public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 20;
+  public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 50;
+  public static final int DEFAULT_CONNECTION_POOL_MAX_TOTAL = 200;
   public static final boolean DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED = false;
   public static final int DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN = -1;
 


### PR DESCRIPTION
The current default values of JDBC connection pool configurations might be too low for most cases. This PR changes it to new values. I'm not sure the new values are reasonable. I also want to discuss it here as well. 

the configurations `maxTotal`, `maxIdle` and `minIdle` are explained in the following document:
https://commons.apache.org/proper/commons-dbcp/configuration.html

Please take a look! 

