### PR TITLE
Allow empty value for partition key and clustering key

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/common/checker/ColumnChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/ColumnChecker.java
@@ -16,13 +16,13 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 class ColumnChecker implements ValueVisitor {
   private final TableMetadata tableMetadata;
-  private final boolean neitherNullNorEmpty;
+  private final boolean notNull;
   private String name;
   private boolean isValid;
 
-  public ColumnChecker(TableMetadata tableMetadata, boolean neitherNullNorEmpty) {
+  public ColumnChecker(TableMetadata tableMetadata, boolean notNull) {
     this.tableMetadata = tableMetadata;
-    this.neitherNullNorEmpty = neitherNullNorEmpty;
+    this.notNull = notNull;
   }
 
   public boolean check(Value<?> value) {
@@ -72,22 +72,18 @@ class ColumnChecker implements ValueVisitor {
 
   @Override
   public void visit(TextValue value) {
-    if (neitherNullNorEmpty) {
-      if (!value.getAsString().isPresent() || value.getAsString().get().isEmpty()) {
-        isValid = false;
-        return;
-      }
+    if (notNull && !value.getAsString().isPresent()) {
+      isValid = false;
+      return;
     }
     isValid = tableMetadata.getColumnDataType(getName(value)) == DataType.TEXT;
   }
 
   @Override
   public void visit(BlobValue value) {
-    if (neitherNullNorEmpty) {
-      if (!value.getAsBytes().isPresent() || value.getAsBytes().get().length == 0) {
-        isValid = false;
-        return;
-      }
+    if (notNull && !value.getAsBytes().isPresent()) {
+      isValid = false;
+      return;
     }
     isValid = tableMetadata.getColumnDataType(getName(value)) == DataType.BLOB;
   }

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -724,40 +724,6 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingPutOperationWithPartitionKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
-    // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-
-    // Act Assert
-    assertThatThrownBy(() -> operationChecker.check(put))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      whenCheckingPutOperationWithClusteringKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
-    // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "").build();
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-
-    // Act Assert
-    assertThatThrownBy(() -> operationChecker.check(put))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
       whenCheckingPutOperationWithPartitionKeyWithNullBlobValue_shouldThrowIllegalArgumentException()
           throws ExecutionException {
     // Arrange
@@ -840,33 +806,6 @@ public class OperationCheckerTest {
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      whenCheckingPutOperationWithClusteringKeyWithEmptyBlobValue_shouldThrowIllegalArgumentException()
-          throws ExecutionException {
-    // Arrange
-    when(metadataManager.getTableMetadata(any()))
-        .thenReturn(
-            TableMetadata.newBuilder()
-                .addColumn(PKEY1, DataType.BLOB)
-                .addColumn(CKEY1, DataType.BLOB)
-                .addColumn(COL1, DataType.INT)
-                .addPartitionKey(PKEY1)
-                .addClusteringKey(CKEY1)
-                .build());
-
-    operationChecker = new OperationChecker(metadataManager);
-
-    Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
-    Key clusteringKey = new Key(CKEY1, new byte[0]);
-    Get get = new Get(partitionKey, clusteringKey);
-    Utility.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
-
-    // Act Assert
-    assertThatThrownBy(() -> operationChecker.check(get))
         .isInstanceOf(IllegalArgumentException.class);
   }
 


### PR DESCRIPTION
Sorry, I didn't have to add an empty check for partition key and clustering key in #370. I needed to add only null check there. This PR reverts the empty check. Please take a look!