### PR TITLE
Add dockerize to Dockerfile for grpc-server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/busybox:1.32 AS tools
 
 ENV GRPC_HEALTH_PROBE_VERSION v0.3.2
+ENV DOCKERIZE_VERSION v0.6.1
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/
@@ -8,8 +9,16 @@ RUN set -x && \
     wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" && \
     chmod +x grpc_health_probe
 
+# Install dockerize
+# Support for use cases where environment variables are used to configure the database
+RUN set -x && \
+    wget -q "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
+    tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
+    ./dockerize --version
+
 FROM openjdk:8u292-jre-slim
 
+COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/
 
 # Fix CVE-2021-3520, CVE-2021-33560, CVE-2021-20231, CVE-2021-20232, CVE-2020-24659, CVE-2021-20305, and CVE-2021-3711
@@ -21,16 +30,26 @@ WORKDIR /scalardb
 
 # The path should be relative from build/docker. Running `gradle docker`
 # (provided by com.palantir.docker plugin) will copy this Dockerfile and
-# server.tar and log4j2.properties to build/docker.
+# server.tar, log4j2.properties and database.properties.tmpl to build/docker.
 ADD server.tar .
+
+ENV SCALAR_DB_CONTACT_POINTS 'cassandra'
+ENV SCALAR_DB_CONTACT_PORT '9042'
+ENV SCALAR_DB_USERNAME ''
+ENV SCALAR_DB_PASSWORD ''
+ENV SCALAR_DB_STORAGE 'cassandra'
+ENV SCALAR_DB_TRANSACTION_MANAGER 'consensus-commit'
+ENV SCALAR_DB_ISOLATION_LEVEL ''
+ENV SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY ''
 
 WORKDIR /scalardb/server
 
 COPY log4j2.properties .
+# Support for use cases where environment variables are used to configure the database
+COPY database.properties.tmpl .
 
 ENV SCALARDB_SERVER_OPTS -Dlog4j.configurationFile=file:log4j2.properties
 
-ENTRYPOINT ["./bin/scalardb-server"]
-CMD ["--config", "database.properties"]
+CMD ["./bin/scalardb-server", "--config", "database.properties"]
 
 EXPOSE 60051 8080

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,7 +45,7 @@ ENV SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY ''
 WORKDIR /scalardb/server
 
 COPY log4j2.properties .
-# Support for use cases where environment variables are used to configure the database
+# Support use cases where environment variables are used to configure the database
 COPY database.properties.tmpl .
 
 ENV SCALARDB_SERVER_OPTS -Dlog4j.configurationFile=file:log4j2.properties

--- a/server/README.md
+++ b/server/README.md
@@ -41,6 +41,9 @@ $ docker run -v <your local configuration file path>:/scalardb/server/database.p
 # For custom log configuration
 $ docker run -v <your local configuration file path>:/scalardb/server/database.properties -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
+# For set in environment variables
+docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PORT=9042 --env SCALAR_DB_USERNAME=cassandra --env SCALAR_DB_PASSWORD=cassandra --env SCALAR_DB_STORAGE=cassandra -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version> dockerize -template database.properties.tmpl:database.properties /scalardb/server/bin/scalardb-server --config=database.properties
+
 # For JMX
 $ docker run -v <your local configuration file path>:/scalardb/server/database.properties -e JAVA_OPTS="-Djava.rmi.server.hostname=<your container hostname or IP address> -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9990 -Dcom.sun.management.jmxremote.rmi.port=9990 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" -d -p 60051:60051 -p 8080:8080 -p 9990:9990 ghcr.io/scalar-labs/scalardb-server:<version>
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -41,7 +41,7 @@ $ docker run -v <your local configuration file path>:/scalardb/server/database.p
 # For custom log configuration
 $ docker run -v <your local configuration file path>:/scalardb/server/database.properties -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
-# For set in environment variables
+# Use environment variables
 docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PORT=9042 --env SCALAR_DB_USERNAME=cassandra --env SCALAR_DB_PASSWORD=cassandra --env SCALAR_DB_STORAGE=cassandra -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version> dockerize -template database.properties.tmpl:database.properties /scalardb/server/bin/scalardb-server --config=database.properties
 
 # For JMX

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -65,7 +65,7 @@ application {
 
 docker {
     name "ghcr.io/scalar-labs/scalardb-server:${project.version}"
-    files tasks.distTar.outputs, 'conf/log4j2.properties'
+    files tasks.distTar.outputs, 'conf/log4j2.properties', 'conf/database.properties.tmpl'
 }
 
 task integrationTestScalarDbServer(type: Test) {

--- a/server/conf/database.properties.tmpl
+++ b/server/conf/database.properties.tmpl
@@ -1,0 +1,23 @@
+# Comma separated contact points. For DynamoDB, the region is specified by this parameter.
+scalar.db.contact_points={{ default .Env.SCALAR_DB_CONTACT_POINTS "" }}
+
+# Port number for all the contact points. Default port number for each database is used if empty.
+scalar.db.contact_port={{ default .Env.SCALAR_DB_CONTACT_PORT "" }}
+
+# Credential information to access the database. For Cosmos DB, username isn't used. For DynamoDB, AWS_ACCESS_KEY_ID is specified by the username and AWS_ACCESS_SECRET_KEY is specified by the password.
+scalar.db.username={{ default .Env.SCALAR_DB_USERNAME "" }}
+scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
+
+# Storage implementation. "cassandra" or "cosmos" or "dynamo" or "jdbc" or "grpc" can be set. Default storage is "cassandra".
+scalar.db.storage={{ default .Env.SCALAR_DB_STORAGE "cassandra" }}
+
+# The type of the transaction manager. "consensus-commit" or "jdbc" or "grpc" can be set. The default is "consensus-commit"
+scalar.db.transaction_manager={{ default .Env.SCALAR_DB_TRANSACTION_MANAGER "consensus-commit" }}
+
+# Default isolation level. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
+scalar.db.isolation_level={{ default .Env.SCALAR_DB_ISOLATION_LEVEL "" }}
+
+# Default serializable strategy for ConsensusCommit transaction manager.
+# Either EXTRA_READ or EXTRA_WRITE can be specified. EXTRA_READ is used by default.
+# If SNAPSHOT is specified, this is ignored.
+scalar.db.consensus_commit.serializable_strategy={{ default .Env.SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY "" }}


### PR DESCRIPTION
## Summary
- Add dockerize to Dockerfile

## Why?
- Since we have a use case where we want to be able to configure the database with environment variables.

## Usage
``` shell
$ docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PORT=9042 --env SCALAR_DB_USERNAME=cassandra --env SCALAR_DB_PASSWORD=cassandra --env SCALAR_DB_STORAGE=cassandra -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version> dockerize -template database.properties.tmpl:database.properties /scalardb/server/bin/scalardb-server --config=database.properties
```