### PR TITLE
Fix hashCode() in XXXValue and Key classes

### DIFF
--- a/core/src/main/java/com/scalar/db/io/BigIntValue.java
+++ b/core/src/main/java/com/scalar/db/io/BigIntValue.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -84,7 +85,7 @@ public final class BigIntValue implements Value<Long> {
 
   @Override
   public int hashCode() {
-    return Long.hashCode(value);
+    return Objects.hash(name, value);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/BlobValue.java
+++ b/core/src/main/java/com/scalar/db/io/BlobValue.java
@@ -6,6 +6,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.primitives.UnsignedBytes;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,7 +89,7 @@ public final class BlobValue implements Value<Optional<byte[]>> {
 
   @Override
   public int hashCode() {
-    return value.hashCode();
+    return Objects.hash(name, value);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/BooleanValue.java
+++ b/core/src/main/java/com/scalar/db/io/BooleanValue.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -68,7 +69,7 @@ public final class BooleanValue implements Value<Boolean> {
 
   @Override
   public int hashCode() {
-    return Boolean.hashCode(value);
+    return Objects.hash(name, value);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/DoubleValue.java
+++ b/core/src/main/java/com/scalar/db/io/DoubleValue.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -67,7 +68,7 @@ public final class DoubleValue implements Value<Double> {
 
   @Override
   public int hashCode() {
-    return Double.hashCode(value);
+    return Objects.hash(name, value);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/FloatValue.java
+++ b/core/src/main/java/com/scalar/db/io/FloatValue.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -72,7 +73,7 @@ public final class FloatValue implements Value<Float> {
 
   @Override
   public int hashCode() {
-    return Float.hashCode(value);
+    return Objects.hash(name, value);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/IntValue.java
+++ b/core/src/main/java/com/scalar/db/io/IntValue.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -82,7 +83,7 @@ public final class IntValue implements Value<Integer> {
 
   @Override
   public int hashCode() {
-    return Integer.hashCode(value);
+    return Objects.hash(name, value);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -137,7 +138,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
 
   @Override
   public int hashCode() {
-    return values.hashCode();
+    return Objects.hash(values);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/io/TextValue.java
+++ b/core/src/main/java/com/scalar/db/io/TextValue.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -134,7 +135,7 @@ public final class TextValue implements Value<Optional<String>> {
 
   @Override
   public int hashCode() {
-    return value.hashCode();
+    return Objects.hash(name, value);
   }
 
   /**


### PR DESCRIPTION
I think we need to use `name` in `hashCode()` as well as `equals()` in `XXXValue` and `Key` classes. Please take a look!