### PR TITLE
Disallow empty values for Partition key and Clustering key

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/common/checker/ColumnChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/ColumnChecker.java
@@ -72,7 +72,7 @@ class ColumnChecker implements ValueVisitor {
 
   @Override
   public void visit(TextValue value) {
-    if (notNull && !value.getAsString().isPresent()) {
+    if (notNull && (!value.getAsString().isPresent() || value.getAsString().get().isEmpty())) {
       isValid = false;
       return;
     }
@@ -81,7 +81,7 @@ class ColumnChecker implements ValueVisitor {
 
   @Override
   public void visit(BlobValue value) {
-    if (notNull && !value.getAsBytes().isPresent()) {
+    if (notNull && (!value.getAsBytes().isPresent() || value.getAsBytes().get().length == 0)) {
       isValid = false;
       return;
     }

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -707,10 +707,44 @@ public class OperationCheckerTest {
 
   @Test
   public void
+      whenCheckingPutOperationWithPartitionKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "").build();
+    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    List<Value<?>> values =
+        Arrays.asList(
+            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
+    Put put = new Put(partitionKey, clusteringKey).withValues(values);
+    Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(put))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
       whenCheckingPutOperationWithClusteringKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
     Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, null).build();
+    List<Value<?>> values =
+        Arrays.asList(
+            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
+    Put put = new Put(partitionKey, clusteringKey).withValues(values);
+    Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(put))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingPutOperationWithClusteringKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
+    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "").build();
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -741,9 +775,35 @@ public class OperationCheckerTest {
 
     Key partitionKey = new Key(PKEY1, (byte[]) null);
     Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
+    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
+    Put put = new Put(partitionKey, clusteringKey).withValues(values);
+    Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(put))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingPutOperationWithPartitionKeyWithEmptyBlobValue_shouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    when(metadataManager.getTableMetadata(any()))
+        .thenReturn(
+            TableMetadata.newBuilder()
+                .addColumn(PKEY1, DataType.BLOB)
+                .addColumn(CKEY1, DataType.BLOB)
+                .addColumn(COL1, DataType.INT)
+                .addPartitionKey(PKEY1)
+                .addClusteringKey(CKEY1)
+                .build());
+
+    operationChecker = new OperationChecker(metadataManager);
+
+    Key partitionKey = new Key(PKEY1, new byte[0]);
+    Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
+    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put = new Put(partitionKey, clusteringKey).withValues(values);
     Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
 
@@ -771,17 +831,18 @@ public class OperationCheckerTest {
 
     Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = new Key(CKEY1, (byte[]) null);
-    Get get = new Get(partitionKey, clusteringKey);
-    Utility.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
+    Put put = new Put(partitionKey, clusteringKey).withValues(values);
+    Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
 
     // Act Assert
-    assertThatThrownBy(() -> operationChecker.check(get))
+    assertThatThrownBy(() -> operationChecker.check(put))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   public void
-      whenCheckingPutOperationWithPartitionKeyWithEmptyBlobValue_shouldThrowIllegalArgumentException()
+      whenCheckingPutOperationWithClusteringKeyWithEmptyBlobValue_shouldThrowIllegalArgumentException()
           throws ExecutionException {
     // Arrange
     when(metadataManager.getTableMetadata(any()))
@@ -796,11 +857,9 @@ public class OperationCheckerTest {
 
     operationChecker = new OperationChecker(metadataManager);
 
-    Key partitionKey = new Key(PKEY1, new byte[0]);
-    Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
-    List<Value<?>> values =
-        Arrays.asList(
-            new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
+    Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
+    Key clusteringKey = new Key(CKEY1, new byte[0]);
+    List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
     Put put = new Put(partitionKey, clusteringKey).withValues(values);
     Utility.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
 


### PR DESCRIPTION
I'm very sorry for the confusion. After all, I think we should disallow empty values for Partition key and Clustering key. This PR makes the change for it. Please take a look!