### PR TITLE
Add clustering order support to Dynamo adapter

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -1,14 +1,8 @@
 package com.scalar.db.storage.dynamo;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.AdminIntegrationTestBase;
 import java.util.Map;
-import org.junit.Test;
 
 public class DynamoAdminIntegrationTest extends AdminIntegrationTestBase {
 
@@ -20,25 +14,5 @@ public class DynamoAdminIntegrationTest extends AdminIntegrationTestBase {
   @Override
   protected Map<String, String> getCreateOptions() {
     return DynamoEnv.getCreateOptions();
-  }
-
-  @Test
-  @Override
-  public void getTableMetadata_CorrectTableGiven_ShouldReturnCorrectClusteringOrders()
-      throws ExecutionException {
-    TableMetadata tableMetadata = admin.getTableMetadata(NAMESPACE, TABLE);
-
-    // Fow now, the clustering order is always ASC in the DynamoDB adapter
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME1)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME2)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME3)).isEqualTo(Scan.Ordering.Order.ASC);
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME4)).isEqualTo(Scan.Ordering.Order.ASC);
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME5)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME6)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME7)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME8)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME9)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME10)).isNull();
-    assertThat(tableMetadata.getClusteringOrder(COL_NAME11)).isNull();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -396,8 +396,8 @@ public class SelectStatementHandler extends StatementHandler {
               DynamoOperation.START_CLUSTERING_KEY_ALIAS,
               AttributeValue.builder().b(SdkBytes.fromByteBuffer(closestNextBytes.get())).build());
         } else {
-          // TODO comment
-
+          // if we can't find the closest next bytes of the start key bytes, return false. That
+          // means we should return empty results in this case
           return false;
         }
       }


### PR DESCRIPTION
This PR adds clustering order support to the Dynamo adapter. The main changes for it are in `SelectStatementHandler`, and I put some comments for the points there. Please take a look!