### PR TITLE
Add secondary index integration test

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/StorageSecondaryIndexIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageSecondaryIndexIntegrationTestBase.java
@@ -1,0 +1,250 @@
+package com.scalar.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.Value;
+import com.scalar.db.service.StorageFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressFBWarnings(value = {"MS_PKGPROTECT", "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"})
+public abstract class StorageSecondaryIndexIntegrationTestBase {
+
+  protected static final String NAMESPACE = "integration_testing";
+  protected static final String TABLE_BASE_NAME = "secondary_index_";
+  protected static final String PARTITION_KEY = "pkey";
+  protected static final String INDEX_COL_NAME = "idx_col";
+  protected static final String COL_NAME = "col";
+
+  private static final int ATTEMPT_COUNT = 50;
+  private static final int DATA_NUM = 10;
+
+  private static final Random RANDOM = new Random();
+
+  private static boolean initialized;
+  protected static DistributedStorageAdmin admin;
+  protected static DistributedStorage storage;
+  protected static String namespace;
+  protected static Set<DataType> secondaryIndexTypes;
+
+  private static long seed;
+
+  @Before
+  public void setUp() throws Exception {
+    if (!initialized) {
+      StorageFactory factory = new StorageFactory(getDatabaseConfig());
+      admin = factory.getAdmin();
+      namespace = getNamespace();
+      secondaryIndexTypes = getSecondaryIndexTypes();
+      createTables();
+      storage = factory.getStorage();
+      seed = System.currentTimeMillis();
+      System.out.println("The seed used in the secondary index integration test is " + seed);
+      initialized = true;
+    }
+  }
+
+  protected abstract DatabaseConfig getDatabaseConfig();
+
+  protected String getNamespace() {
+    return NAMESPACE;
+  }
+
+  protected Set<DataType> getSecondaryIndexTypes() {
+    return new HashSet<>(Arrays.asList(DataType.values()));
+  }
+
+  protected Map<String, String> getCreateOptions() {
+    return Collections.emptyMap();
+  }
+
+  private void createTables() throws ExecutionException {
+    Map<String, String> options = getCreateOptions();
+    admin.createNamespace(namespace, true, options);
+    for (DataType secondaryIndexType : secondaryIndexTypes) {
+      createTable(secondaryIndexType, options);
+    }
+  }
+
+  private void createTable(DataType secondaryIndexType, Map<String, String> options)
+      throws ExecutionException {
+    admin.createTable(
+        namespace,
+        getTableName(secondaryIndexType),
+        TableMetadata.newBuilder()
+            .addColumn(PARTITION_KEY, DataType.INT)
+            .addColumn(INDEX_COL_NAME, secondaryIndexType)
+            .addColumn(COL_NAME, DataType.INT)
+            .addPartitionKey(PARTITION_KEY)
+            .addSecondaryIndex(INDEX_COL_NAME)
+            .build(),
+        true,
+        options);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    deleteTables();
+    admin.close();
+    storage.close();
+  }
+
+  private static void deleteTables() throws ExecutionException {
+    for (DataType secondaryIndexType : secondaryIndexTypes) {
+      admin.dropTable(namespace, getTableName(secondaryIndexType));
+    }
+    admin.dropNamespace(namespace);
+  }
+
+  private void truncateTable(DataType secondaryIndexType) throws ExecutionException {
+    admin.truncateTable(namespace, getTableName(secondaryIndexType));
+  }
+
+  private static String getTableName(DataType secondaryIndexType) {
+    return TABLE_BASE_NAME + secondaryIndexType;
+  }
+
+  @Test
+  public void scan_WithRandomSecondaryIndexValue_ShouldReturnProperResult()
+      throws ExecutionException, IOException {
+    RANDOM.setSeed(seed);
+
+    for (DataType secondaryIndexType : secondaryIndexTypes) {
+      truncateTable(secondaryIndexType);
+
+      for (int i = 0; i < ATTEMPT_COUNT; i++) {
+        // Arrange
+        Value<?> secondaryIndexValue = getRandomValue(RANDOM, INDEX_COL_NAME, secondaryIndexType);
+        prepareRecords(secondaryIndexType, secondaryIndexValue);
+        Scan scan =
+            new Scan(new Key(secondaryIndexValue))
+                .forNamespace(namespace)
+                .forTable(getTableName(secondaryIndexType));
+
+        // Act
+        List<Result> results = scanAll(scan);
+
+        // Assert
+        assertResults(results, secondaryIndexValue);
+      }
+    }
+  }
+
+  @Test
+  public void scan_WithMaxSecondaryIndexValue_ShouldReturnProperResult()
+      throws ExecutionException, IOException {
+
+    for (DataType secondaryIndexType : secondaryIndexTypes) {
+      truncateTable(secondaryIndexType);
+
+      // Arrange
+      Value<?> secondaryIndexValue = getMaxValue(INDEX_COL_NAME, secondaryIndexType);
+      prepareRecords(secondaryIndexType, secondaryIndexValue);
+      Scan scan =
+          new Scan(new Key(secondaryIndexValue))
+              .forNamespace(namespace)
+              .forTable(getTableName(secondaryIndexType));
+
+      // Act
+      List<Result> results = scanAll(scan);
+
+      // Assert
+      assertResults(results, secondaryIndexValue);
+    }
+  }
+
+  @Test
+  public void scan_WithMinSecondaryIndexValue_ShouldReturnProperResult()
+      throws ExecutionException, IOException {
+
+    for (DataType secondaryIndexType : secondaryIndexTypes) {
+      truncateTable(secondaryIndexType);
+
+      // Arrange
+      Value<?> secondaryIndexValue = getMinValue(INDEX_COL_NAME, secondaryIndexType);
+      prepareRecords(secondaryIndexType, secondaryIndexValue);
+      Scan scan =
+          new Scan(new Key(secondaryIndexValue))
+              .forNamespace(namespace)
+              .forTable(getTableName(secondaryIndexType));
+
+      // Act
+      List<Result> results = scanAll(scan);
+
+      // Assert
+      assertResults(results, secondaryIndexValue);
+    }
+  }
+
+  private void prepareRecords(DataType secondaryIndexType, Value<?> secondaryIndexValue)
+      throws ExecutionException {
+    for (int i = 0; i < DATA_NUM; i++) {
+      Put put =
+          new Put(new Key(PARTITION_KEY, i))
+              .withValue(secondaryIndexValue)
+              .withValue(COL_NAME, 1)
+              .forNamespace(namespace)
+              .forTable(getTableName(secondaryIndexType));
+      storage.put(put);
+    }
+  }
+
+  private void assertResults(List<Result> results, Value<?> secondaryIndexValue) {
+    assertThat(results.size()).isEqualTo(DATA_NUM);
+
+    Set<Integer> partitionKeySet = new HashSet<>();
+    for (int i = 0; i < DATA_NUM; i++) {
+      partitionKeySet.add(i);
+    }
+
+    for (Result result : results) {
+      assertThat(result.getValue(PARTITION_KEY).isPresent()).isTrue();
+      partitionKeySet.remove(result.getValue(PARTITION_KEY).get().getAsInt());
+      assertThat(result.getValue(INDEX_COL_NAME).isPresent()).isTrue();
+      assertThat(result.getValue(INDEX_COL_NAME).get()).isEqualTo(secondaryIndexValue);
+      assertThat(result.getValue(COL_NAME).isPresent()).isTrue();
+      assertThat(result.getValue(COL_NAME).get().getAsInt()).isEqualTo(1);
+    }
+
+    assertThat(partitionKeySet).isEmpty();
+  }
+
+  private List<Result> scanAll(Scan scan) throws ExecutionException, IOException {
+    try (Scanner scanner = storage.scan(scan)) {
+      return scanner.all();
+    }
+  }
+
+  protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
+    return TestUtils.getRandomValue(random, columnName, dataType, true);
+  }
+
+  protected Value<?> getMinValue(String columnName, DataType dataType) {
+    return TestUtils.getMinValue(columnName, dataType, true);
+  }
+
+  protected Value<?> getMaxValue(String columnName, DataType dataType) {
+    return TestUtils.getMaxValue(columnName, dataType);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSecondaryIndexIntegrationTest.java
@@ -1,0 +1,12 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.StorageSecondaryIndexIntegrationTestBase;
+
+public class CassandraSecondaryIndexIntegrationTest
+    extends StorageSecondaryIndexIntegrationTestBase {
+  @Override
+  protected DatabaseConfig getDatabaseConfig() {
+    return CassandraEnv.getDatabaseConfig();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSecondaryIndexIntegrationTest.java
@@ -1,0 +1,24 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.StorageSecondaryIndexIntegrationTestBase;
+import java.util.Map;
+import java.util.Optional;
+
+public class CosmosSecondaryIndexIntegrationTest extends StorageSecondaryIndexIntegrationTestBase {
+  @Override
+  protected DatabaseConfig getDatabaseConfig() {
+    return CosmosEnv.getCosmosConfig();
+  }
+
+  @Override
+  protected String getNamespace() {
+    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
+    return databasePrefix.map(prefix -> prefix + NAMESPACE).orElse(NAMESPACE);
+  }
+
+  @Override
+  protected Map<String, String> getCreateOptions() {
+    return CosmosEnv.getCreateOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSecondaryIndexIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Value;
+import com.scalar.db.storage.StorageSecondaryIndexIntegrationTestBase;
+import com.scalar.db.storage.TestUtils;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+public class DynamoSecondaryIndexIntegrationTest extends StorageSecondaryIndexIntegrationTestBase {
+  @Override
+  protected DatabaseConfig getDatabaseConfig() {
+    return DynamoEnv.getDynamoConfig();
+  }
+
+  @Override
+  protected Set<DataType> getSecondaryIndexTypes() {
+    // Return types without BOOLEAN because boolean is not supported for secondary index for now
+    Set<DataType> clusteringKeyTypes = new HashSet<>();
+    for (DataType dataType : DataType.values()) {
+      if (dataType == DataType.BOOLEAN) {
+        continue;
+      }
+      clusteringKeyTypes.add(dataType);
+    }
+    return clusteringKeyTypes;
+  }
+
+  @Override
+  protected Map<String, String> getCreateOptions() {
+    return DynamoEnv.getCreateOptions();
+  }
+
+  @Override
+  protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
+    if (dataType == DataType.DOUBLE) {
+      return DynamoTestUtils.getRandomDynamoDoubleValue(random, columnName);
+    }
+    // don't allow empty value since secondary index cannot contain empty value
+    return TestUtils.getRandomValue(random, columnName, dataType, false);
+  }
+
+  @Override
+  protected Value<?> getMinValue(String columnName, DataType dataType) {
+    if (dataType == DataType.DOUBLE) {
+      return DynamoTestUtils.getMinDynamoDoubleValue(columnName);
+    }
+    // don't allow empty value since secondary index cannot contain empty value
+    return TestUtils.getMinValue(columnName, dataType, false);
+  }
+
+  @Override
+  protected Value<?> getMaxValue(String columnName, DataType dataType) {
+    if (dataType == DataType.DOUBLE) {
+      return DynamoTestUtils.getMaxDynamoDoubleValue(columnName);
+    }
+    return super.getMaxValue(columnName, dataType);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSecondaryIndexIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Value;
+import com.scalar.db.storage.StorageSecondaryIndexIntegrationTestBase;
+import com.scalar.db.storage.TestUtils;
+import java.util.Random;
+
+public class JdbcSecondaryIndexIntegrationTest extends StorageSecondaryIndexIntegrationTestBase {
+
+  private static RdbEngine rdbEngine;
+
+  @Override
+  protected DatabaseConfig getDatabaseConfig() {
+    JdbcConfig jdbcConfig = JdbcEnv.getJdbcConfig();
+    rdbEngine = JdbcUtils.getRdbEngine(jdbcConfig.getContactPoints().get(0));
+    return jdbcConfig;
+  }
+
+  @Override
+  protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
+    if (rdbEngine == RdbEngine.ORACLE) {
+      if (dataType == DataType.DOUBLE) {
+        return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
+      }
+      // don't allow empty value since Oracle treats empty value as NULL
+      return TestUtils.getRandomValue(random, columnName, dataType, false);
+    }
+    return super.getRandomValue(random, columnName, dataType);
+  }
+
+  @Override
+  protected Value<?> getMinValue(String columnName, DataType dataType) {
+    if (rdbEngine == RdbEngine.ORACLE) {
+      if (dataType == DataType.DOUBLE) {
+        return JdbcTestUtils.getMinOracleDoubleValue(columnName);
+      }
+      // don't allow empty value since Oracle treats empty value as NULL
+      return TestUtils.getMinValue(columnName, dataType, false);
+    }
+    return super.getMinValue(columnName, dataType);
+  }
+
+  @Override
+  protected Value<?> getMaxValue(String columnName, DataType dataType) {
+    if (rdbEngine == RdbEngine.ORACLE) {
+      if (dataType == DataType.DOUBLE) {
+        return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
+      }
+    }
+    if (rdbEngine == RdbEngine.SQL_SERVER) {
+      if (dataType == DataType.TEXT) {
+        return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
+      }
+    }
+    return super.getMaxValue(columnName, dataType);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
@@ -36,7 +36,7 @@ public class OperationChecker {
     checkProjections(get, metadata);
 
     if (Utility.isSecondaryIndexSpecified(get, metadata)) {
-      if (!new ColumnChecker(metadata, true).check(get.getPartitionKey().get().get(0))) {
+      if (!new ColumnChecker(metadata, false).check(get.getPartitionKey().get().get(0))) {
         throw new IllegalArgumentException(
             "The partition key is not properly specified. Operation: " + get);
       }
@@ -57,7 +57,7 @@ public class OperationChecker {
     checkProjections(scan, metadata);
 
     if (Utility.isSecondaryIndexSpecified(scan, metadata)) {
-      if (!new ColumnChecker(metadata, true).check(scan.getPartitionKey().get().get(0))) {
+      if (!new ColumnChecker(metadata, false).check(scan.getPartitionKey().get().get(0))) {
         throw new IllegalArgumentException(
             "The partition key is not properly specified. Operation: " + scan);
       }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ValueBinder.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ValueBinder.java
@@ -8,7 +8,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.ValueVisitor;
-import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -95,12 +95,6 @@ public final class ValueBinder implements ValueVisitor {
    */
   @Override
   public void visit(BlobValue value) {
-    value
-        .get()
-        .ifPresent(
-            b -> {
-              ByteBuffer buffer = (ByteBuffer) ByteBuffer.allocate(b.length).put(b).flip();
-              consumer.accept(buffer.array());
-            });
+    value.get().ifPresent(b -> consumer.accept(Base64.getEncoder().encodeToString(b)));
   }
 }


### PR DESCRIPTION
This PR adds secondary index related integration tests. The integration tests check if all data types for secondary indexes are handled correctly. Please take a look!

