### PR TITLE
Add -XX:MaxRAMPercentage parameter to SCALARDB_SERVER_OPTS

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -49,7 +49,7 @@ COPY log4j2.properties .
 COPY database.properties.tmpl .
 COPY docker-entrypoint.sh .
 
-ENV JAVA_OPT_MAX_RAM_PERCENTAGE '50.0'
+ENV JAVA_OPT_MAX_RAM_PERCENTAGE '70.0'
 ENV SCALARDB_SERVER_OPTS -Dlog4j.configurationFile=file:log4j2.properties
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -47,8 +47,12 @@ WORKDIR /scalardb/server
 COPY log4j2.properties .
 # Support use cases where environment variables are used to configure the database
 COPY database.properties.tmpl .
+COPY docker-entrypoint.sh .
 
+ENV JAVA_OPT_MAX_RAM_PERCENTAGE '50.0'
 ENV SCALARDB_SERVER_OPTS -Dlog4j.configurationFile=file:log4j2.properties
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
 
 CMD ["./bin/scalardb-server", "--config", "database.properties"]
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -65,7 +65,7 @@ application {
 
 docker {
     name "ghcr.io/scalar-labs/scalardb-server:${project.version}"
-    files tasks.distTar.outputs, 'conf/log4j2.properties', 'conf/database.properties.tmpl'
+    files tasks.distTar.outputs, 'conf/log4j2.properties', 'conf/database.properties.tmpl', 'docker-entrypoint.sh'
 }
 
 task integrationTestScalarDbServer(type: Test) {

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export SCALARDB_SERVER_OPTS="${SCALARDB_SERVER_OPTS} -XX:MaxRAMPercentage=${JAVA_OPT_MAX_RAM_PERCENTAGE}"
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Added `-XX:MaxRAMPercentage` for optimizing the upper limit of `Heap Size`.
- Default -XX:MaxRAMPercentage `50.0`

## Detail
* -XX:MaxRAMPercentage `50.0`

```
resources:
  requests:
    cpu: 800m
    memory: 1Gi
  limits:
    cpu: 1200m
    memory: 1.5Gi
```
![scalardb](https://user-images.githubusercontent.com/301510/144001075-07a888c8-9504-40b8-90e6-5eb816d7d42b.png)

