### PR TITLE
Add integration tests to clustering order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ jobs:
 
       - run:
           name: Run integration test
+          no_output_timeout: 20m
           command: gradle integrationTestCosmos -Dscalardb.cosmos.uri=${COSMOS_URI} -Dscalardb.cosmos.password=${COSMOS_PASSWORD} -Dscalardb.cosmos.database_prefix="${CIRCLE_BUILD_NUM}_"
 
       - run:
@@ -191,6 +192,7 @@ jobs:
 
       - run:
           name: Run integration test
+          no_output_timeout: 20m
           command: gradle integrationTestDynamo
 
       - run:

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageColumnValueIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageColumnValueIntegrationTestBase.java
@@ -65,8 +65,7 @@ public abstract class StorageColumnValueIntegrationTestBase {
       createTable();
       storage = factory.getStorage();
       seed = System.currentTimeMillis();
-      System.out.println(
-          "The seed used in the single clustering key scan integration test is " + seed);
+      System.out.println("The seed used in the column value integration test is " + seed);
       initialized = true;
     }
     admin.truncateTable(namespace, TABLE);

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -120,8 +120,16 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             admin.createNamespace(getNamespaceName(firstClusteringKeyType), true, options);
             for (DataType secondClusteringKeyType :
                 clusteringKeyTypes.get(firstClusteringKeyType)) {
-              createTable(
-                  firstClusteringKeyType, Order.ASC, secondClusteringKeyType, Order.ASC, options);
+              for (Order firstClusteringOrder : Order.values()) {
+                for (Order secondClusteringOrder : Order.values()) {
+                  createTable(
+                      firstClusteringKeyType,
+                      firstClusteringOrder,
+                      secondClusteringKeyType,
+                      secondClusteringOrder,
+                      options);
+                }
+              }
             }
             return null;
           };
@@ -178,10 +186,17 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
           () -> {
             for (DataType secondClusteringKeyType :
                 clusteringKeyTypes.get(firstClusteringKeyType)) {
-              admin.dropTable(
-                  getNamespaceName(firstClusteringKeyType),
-                  getTableName(
-                      firstClusteringKeyType, Order.ASC, secondClusteringKeyType, Order.ASC));
+              for (Order firstClusteringOrder : Order.values()) {
+                for (Order secondClusteringOrder : Order.values()) {
+                  admin.dropTable(
+                      getNamespaceName(firstClusteringKeyType),
+                      getTableName(
+                          firstClusteringKeyType,
+                          firstClusteringOrder,
+                          secondClusteringKeyType,
+                          secondClusteringOrder));
+                }
+              }
             }
             admin.dropNamespace(getNamespaceName(firstClusteringKeyType));
             return null;
@@ -271,11 +286,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -354,7 +371,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -433,7 +450,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -508,7 +525,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -582,7 +599,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -644,7 +661,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -712,7 +729,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -768,7 +785,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(new Ordering(SECOND_CLUSTERING_KEY, reverse ? Order.DESC : Order.ASC))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
@@ -863,11 +880,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -975,11 +994,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -1079,11 +1100,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -1159,7 +1182,6 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
               .filter(c -> c.first.equals(firstClusteringKeyValue))
               .collect(Collectors.toList());
     } else {
-
       Value<?> firstClusteringKeyValue =
           clusteringKeys.get(getFirstClusteringKeyIndex(2, secondClusteringKeyType)).first;
       clusteringKeys =
@@ -1183,11 +1205,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -1266,11 +1290,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -1363,11 +1389,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -1446,11 +1474,13 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
             .withOrdering(
                 new Ordering(
                     FIRST_CLUSTERING_KEY,
-                    reverse ? reverseOrder(firstClusteringOrder) : firstClusteringOrder))
+                    reverse ? TestUtils.reverseOrder(firstClusteringOrder) : firstClusteringOrder))
             .withOrdering(
                 new Ordering(
                     SECOND_CLUSTERING_KEY,
-                    reverse ? reverseOrder(secondClusteringOrder) : secondClusteringOrder))
+                    reverse
+                        ? TestUtils.reverseOrder(secondClusteringOrder)
+                        : secondClusteringOrder))
             .forNamespace(getNamespaceName(firstClusteringKeyType))
             .forTable(
                 getTableName(
@@ -1587,9 +1617,38 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
                         secondClusteringKeyValue));
               });
     } else {
-      List<Value<?>> secondClusteringKeyValues =
-          getSecondClusteringKeyValues(secondClusteringKeyType);
-      for (Value<?> secondClusteringKeyValue : secondClusteringKeyValues) {
+      Set<Value<?>> valueSet = new HashSet<>();
+
+      // min and max second clustering key values
+      Arrays.asList(
+              getMinValue(SECOND_CLUSTERING_KEY, secondClusteringKeyType),
+              getMaxValue(SECOND_CLUSTERING_KEY, secondClusteringKeyType))
+          .forEach(
+              secondClusteringKeyValue -> {
+                ret.add(new ClusteringKey(firstClusteringKeyValue, secondClusteringKeyValue));
+                puts.add(
+                    preparePut(
+                        firstClusteringKeyType,
+                        firstClusteringOrder,
+                        firstClusteringKeyValue,
+                        secondClusteringKeyType,
+                        secondClusteringOrder,
+                        secondClusteringKeyValue));
+                valueSet.add(secondClusteringKeyValue);
+              });
+
+      for (int i = 0; i < SECOND_CLUSTERING_KEY_NUM - 2; i++) {
+        Value<?> secondClusteringKeyValue;
+        while (true) {
+          secondClusteringKeyValue =
+              getRandomValue(RANDOM, SECOND_CLUSTERING_KEY, secondClusteringKeyType);
+          // reject duplication
+          if (!valueSet.contains(secondClusteringKeyValue)) {
+            valueSet.add(secondClusteringKeyValue);
+            break;
+          }
+        }
+
         ret.add(new ClusteringKey(firstClusteringKeyValue, secondClusteringKeyValue));
         puts.add(
             preparePut(
@@ -1654,52 +1713,12 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
     return builder.toString();
   }
 
-  private Order reverseOrder(Order order) {
-    switch (order) {
-      case ASC:
-        return Order.DESC;
-      case DESC:
-        return Order.ASC;
-      default:
-        throw new AssertionError();
-    }
-  }
-
   private Key getPartitionKey() {
     return new Key(PARTITION_KEY, 1);
   }
 
   private Value<?> getFirstClusteringKeyValue(DataType dataType) {
     return getRandomValue(RANDOM, FIRST_CLUSTERING_KEY, dataType);
-  }
-
-  private List<Value<?>> getSecondClusteringKeyValues(DataType dataType) {
-    Set<Value<?>> valueSet = new HashSet<>();
-    List<Value<?>> ret = new ArrayList<>();
-
-    // min and max second clustering key values
-    Arrays.asList(
-            getMinValue(SECOND_CLUSTERING_KEY, dataType),
-            getMaxValue(SECOND_CLUSTERING_KEY, dataType))
-        .forEach(
-            value -> {
-              ret.add(value);
-              valueSet.add(value);
-            });
-
-    for (int i = 0; i < SECOND_CLUSTERING_KEY_NUM - 2; i++) {
-      while (true) {
-        Value<?> value = getRandomValue(RANDOM, SECOND_CLUSTERING_KEY, dataType);
-        // reject duplication
-        if (!valueSet.contains(value)) {
-          ret.add(value);
-          valueSet.add(value);
-          break;
-        }
-      }
-    }
-
-    return ret;
   }
 
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
@@ -1792,16 +1811,19 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
       throws java.util.concurrent.ExecutionException, InterruptedException {
     List<Callable<Void>> testCallables = new ArrayList<>();
     for (DataType firstClusteringKeyType : clusteringKeyTypes.keySet()) {
-      testCallables.add(
-          () -> {
-            truncateTable(firstClusteringKeyType, Order.ASC, DataType.INT, Order.ASC);
+      for (Order firstClusteringOrder : Order.values()) {
+        testCallables.add(
+            () -> {
+              truncateTable(firstClusteringKeyType, firstClusteringOrder, DataType.INT, Order.ASC);
 
-            List<ClusteringKey> clusteringKeys =
-                prepareRecords(firstClusteringKeyType, Order.ASC, DataType.INT, Order.ASC);
+              List<ClusteringKey> clusteringKeys =
+                  prepareRecords(
+                      firstClusteringKeyType, firstClusteringOrder, DataType.INT, Order.ASC);
 
-            test.execute(clusteringKeys, firstClusteringKeyType, Order.ASC);
-            return null;
-          });
+              test.execute(clusteringKeys, firstClusteringKeyType, firstClusteringOrder);
+              return null;
+            });
+      }
     }
 
     execute(testCallables);
@@ -1812,22 +1834,33 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
     List<Callable<Void>> testCallables = new ArrayList<>();
     for (DataType firstClusteringKeyType : clusteringKeyTypes.keySet()) {
       for (DataType secondClusteringKeyType : clusteringKeyTypes.get(firstClusteringKeyType)) {
-        testCallables.add(
-            () -> {
-              truncateTable(firstClusteringKeyType, Order.ASC, secondClusteringKeyType, Order.ASC);
+        for (Order firstClusteringOrder : Order.values()) {
+          for (Order secondClusteringOrder : Order.values()) {
+            testCallables.add(
+                () -> {
+                  truncateTable(
+                      firstClusteringKeyType,
+                      firstClusteringOrder,
+                      secondClusteringKeyType,
+                      secondClusteringOrder);
 
-              List<ClusteringKey> clusteringKeys =
-                  prepareRecords(
-                      firstClusteringKeyType, Order.ASC, secondClusteringKeyType, Order.ASC);
+                  List<ClusteringKey> clusteringKeys =
+                      prepareRecords(
+                          firstClusteringKeyType,
+                          firstClusteringOrder,
+                          secondClusteringKeyType,
+                          secondClusteringOrder);
 
-              test.execute(
-                  clusteringKeys,
-                  firstClusteringKeyType,
-                  Order.ASC,
-                  secondClusteringKeyType,
-                  Order.ASC);
-              return null;
-            });
+                  test.execute(
+                      clusteringKeys,
+                      firstClusteringKeyType,
+                      firstClusteringOrder,
+                      secondClusteringKeyType,
+                      secondClusteringOrder);
+                  return null;
+                });
+          }
+        }
       }
     }
     execute(testCallables);

--- a/core/src/integration-test/java/com/scalar/db/storage/TestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/TestUtils.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage;
 
+import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.BlobValue;
@@ -192,5 +193,16 @@ public final class TestUtils {
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
     return new DatabaseConfig(properties);
+  }
+
+  public static Order reverseOrder(Order order) {
+    switch (order) {
+      case ASC:
+        return Order.DESC;
+      case DESC:
+        return Order.ASC;
+      default:
+        throw new AssertionError();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
@@ -15,7 +15,7 @@ public final class CosmosEnv {
   private static final String PROP_COSMOS_CREATE_OPTIONS = "scalardb.cosmos.create_options";
 
   private static final ImmutableMap<String, String> DEFAULT_COSMOS_CREATE_OPTIONS =
-      ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "4000");
+      ImmutableMap.of(CosmosAdmin.REQUEST_UNIT, "10000");
 
   private CosmosEnv() {}
 


### PR DESCRIPTION
This PR extends `StorageSingleClusteringKeyScanIntegrationTestBase` and `StorageMultipleClusteringKeyScanIntegrationTestBase` to add integration tests to the clustering order feature. Please take a look!