### PR TITLE
Reduce integration test concurrency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -150,7 +150,7 @@ task integrationTestCassandra(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 10
+    maxParallelForks = 5
 }
 
 task integrationTestCosmos(type: Test) {
@@ -162,7 +162,7 @@ task integrationTestCosmos(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 10
+    maxParallelForks = 5
 }
 
 task integrationTestDynamo(type: Test) {
@@ -174,7 +174,7 @@ task integrationTestDynamo(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 10
+    maxParallelForks = 5
 }
 
 task integrationTestJdbc(type: Test) {
@@ -186,7 +186,7 @@ task integrationTestJdbc(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 10
+    maxParallelForks = 5
 }
 
 task integrationTestMultiStorage(type: Test) {

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -58,7 +58,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
 
   private static final Random RANDOM = new Random();
 
-  private static final int THREAD_NUM = 10;
+  private static final int THREAD_NUM = 5;
 
   private static boolean initialized;
   protected static DistributedStorageAdmin admin;

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultiplePartitionKeyIntegrationTestBase.java
@@ -49,7 +49,7 @@ public abstract class StorageMultiplePartitionKeyIntegrationTestBase {
 
   private static final Random RANDOM = new Random();
 
-  private static final int THREAD_NUM = 10;
+  private static final int THREAD_NUM = 5;
 
   private static boolean initialized;
   protected static DistributedStorageAdmin admin;


### PR DESCRIPTION
It looks like the current integration test concurrency is too aggressive, causing the integration test failures sometimes. This PR reduces the integration test concurrency. Please take a look!