### PR TITLE
Adjust integration test concurrency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -150,7 +150,6 @@ task integrationTestCassandra(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 5
 }
 
 task integrationTestCosmos(type: Test) {
@@ -162,7 +161,7 @@ task integrationTestCosmos(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 5
+    maxParallelForks = 3
 }
 
 task integrationTestDynamo(type: Test) {
@@ -174,7 +173,7 @@ task integrationTestDynamo(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 5
+    maxParallelForks = 10
 }
 
 task integrationTestJdbc(type: Test) {
@@ -186,7 +185,6 @@ task integrationTestJdbc(type: Test) {
     options {
         systemProperties(System.getProperties())
     }
-    maxParallelForks = 5
 }
 
 task integrationTestMultiStorage(type: Test) {

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -58,7 +58,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
 
   private static final Random RANDOM = new Random();
 
-  private static final int THREAD_NUM = 5;
+  private static final int THREAD_NUM = 10;
 
   private static boolean initialized;
   protected static DistributedStorageAdmin admin;
@@ -80,7 +80,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
       admin = factory.getAdmin();
       namespaceBaseName = getNamespaceBaseName();
       clusteringKeyTypes = getClusteringKeyTypes();
-      executorService = Executors.newFixedThreadPool(THREAD_NUM);
+      executorService = Executors.newFixedThreadPool(getThreadNum());
       createTables();
       storage = factory.getStorage();
       seed = System.currentTimeMillis();
@@ -104,6 +104,10 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
       }
     }
     return clusteringKeyTypes;
+  }
+
+  protected int getThreadNum() {
+    return THREAD_NUM;
   }
 
   protected Map<String, String> getCreateOptions() {

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultiplePartitionKeyIntegrationTestBase.java
@@ -49,7 +49,7 @@ public abstract class StorageMultiplePartitionKeyIntegrationTestBase {
 
   private static final Random RANDOM = new Random();
 
-  private static final int THREAD_NUM = 5;
+  private static final int THREAD_NUM = 10;
 
   private static boolean initialized;
   protected static DistributedStorageAdmin admin;
@@ -71,7 +71,7 @@ public abstract class StorageMultiplePartitionKeyIntegrationTestBase {
       admin = factory.getAdmin();
       namespaceBaseName = getNamespaceBaseName();
       partitionKeyTypes = getPartitionKeyTypes();
-      executorService = Executors.newFixedThreadPool(THREAD_NUM);
+      executorService = Executors.newFixedThreadPool(getThreadNum());
       createTables();
       storage = factory.getStorage();
       seed = System.currentTimeMillis();
@@ -94,6 +94,10 @@ public abstract class StorageMultiplePartitionKeyIntegrationTestBase {
       }
     }
     return partitionKeyTypes;
+  }
+
+  protected int getThreadNum() {
+    return THREAD_NUM;
   }
 
   protected Map<String, String> getCreateOptions() {

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
@@ -41,6 +41,11 @@ public class CosmosMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
+  protected int getThreadNum() {
+    return 3;
+  }
+
+  @Override
   protected Map<String, String> getCreateOptions() {
     return CosmosEnv.getCreateOptions();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
@@ -19,6 +19,11 @@ public class CosmosMultiplePartitionKeyIntegrationTest
   }
 
   @Override
+  protected int getThreadNum() {
+    return 3;
+  }
+
+  @Override
   protected Map<String, String> getCreateOptions() {
     return CosmosEnv.getCreateOptions();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMultipleClusteringKeyScanIntegrationTest.java
@@ -19,6 +19,14 @@ public class JdbcMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
+  protected int getThreadNum() {
+    if (rdbEngine == RdbEngine.ORACLE) {
+      return 1;
+    }
+    return super.getThreadNum();
+  }
+
+  @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
     if (rdbEngine == RdbEngine.ORACLE) {
       if (dataType == DataType.DOUBLE) {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcMultiplePartitionKeyIntegrationTest.java
@@ -18,6 +18,14 @@ public class JdbcMultiplePartitionKeyIntegrationTest
   }
 
   @Override
+  protected int getThreadNum() {
+    if (rdbEngine == RdbEngine.ORACLE) {
+      return 1;
+    }
+    return super.getThreadNum();
+  }
+
+  @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
     if (rdbEngine == RdbEngine.ORACLE) {
       if (dataType == DataType.DOUBLE) {


### PR DESCRIPTION
It looks like the integration tests are still failing sometimes after reducing the concurrency in #397. This PR further adjusts the integration test concurrency to resolve the issue. Please take a look!