### PR TITLE
Move Isolation to the consensuscommit package

### DIFF
--- a/conf/database.properties
+++ b/conf/database.properties
@@ -14,8 +14,8 @@ scalar.db.password=cassandra
 # The type of the transaction manager. "consensus-commit" or "jdbc" or "grpc" can be set. The default is "consensus-commit"
 #scalar.db.transaction_manager=consensus-commit
 
-# Default isolation level. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
-#scalar.db.isolation_level=
+# Default isolation level for ConsensusCommit. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
+#scalar.db.consensus_commit.isolation_level=
 
 # Default serializable strategy for ConsensusCommit transaction manager.
 # Either EXTRA_READ or EXTRA_WRITE can be specified. EXTRA_READ is used by default.

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -16,7 +16,6 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
@@ -10,7 +10,6 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;

--- a/core/src/main/java/com/scalar/db/api/Isolation.java
+++ b/core/src/main/java/com/scalar/db/api/Isolation.java
@@ -1,5 +1,7 @@
 package com.scalar.db.api;
 
+/** @deprecated As of release 3.5.0. Will be removed in release 4.0.0. */
+@Deprecated
 public enum Isolation {
   SNAPSHOT,
   SERIALIZABLE,

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -8,7 +8,6 @@ import static com.scalar.db.config.ConfigUtils.getString;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.cassandra.CassandraAdmin;
@@ -52,7 +51,6 @@ public class DatabaseConfig {
   private Class<? extends DistributedStorageAdmin> adminClass;
   private Class<? extends DistributedTransactionManager> transactionManagerClass;
   private Class<? extends TwoPhaseCommitTransactionManager> twoPhaseCommitTransactionManagerClass;
-  private Isolation isolation;
   private long tableMetadataCacheExpirationTimeSecs;
 
   public static final String PREFIX = "scalar.db.";
@@ -62,7 +60,6 @@ public class DatabaseConfig {
   public static final String PASSWORD = PREFIX + "password";
   public static final String STORAGE = PREFIX + "storage";
   public static final String TRANSACTION_MANAGER = PREFIX + "transaction_manager";
-  public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
   public static final String TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS =
       PREFIX + "table_metadata.cache_expiration_time_secs";
 
@@ -162,11 +159,6 @@ public class DatabaseConfig {
             "transaction manager '" + transactionManager + "' isn't supported");
     }
 
-    isolation =
-        Isolation.valueOf(
-            getString(getProperties(), ISOLATION_LEVEL, Isolation.SNAPSHOT.toString())
-                .toUpperCase());
-
     tableMetadataCacheExpirationTimeSecs =
         getLong(getProperties(), TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, -1);
   }
@@ -202,10 +194,6 @@ public class DatabaseConfig {
 
   public Class<? extends DistributedTransactionManager> getTransactionManagerClass() {
     return transactionManagerClass;
-  }
-
-  public Isolation getIsolation() {
-    return isolation;
   }
 
   public long getTableMetadataCacheExpirationTimeSecs() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -6,20 +6,29 @@ import static com.scalar.db.config.ConfigUtils.getString;
 import com.scalar.db.config.DatabaseConfig;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Immutable
 @SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
-public class ConsensusCommitConfig extends DatabaseConfig {
+public class ConsensusCommitConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusCommitConfig.class);
+
   public static final String PREFIX = DatabaseConfig.PREFIX + "consensus_commit.";
+  public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
   public static final String SERIALIZABLE_STRATEGY = PREFIX + "serializable_strategy";
   public static final String COORDINATOR_NAMESPACE = PREFIX + "coordinator.namespace";
 
+  private final Properties props;
+
+  private Isolation isolation;
   private SerializableStrategy strategy;
   @Nullable private String coordinatorNamespace;
 
@@ -31,27 +40,43 @@ public class ConsensusCommitConfig extends DatabaseConfig {
   private boolean activeTransactionsManagementEnabled;
 
   public ConsensusCommitConfig(File propertiesFile) throws IOException {
-    super(propertiesFile);
+    this(new FileInputStream(propertiesFile));
   }
 
   public ConsensusCommitConfig(InputStream stream) throws IOException {
-    super(stream);
+    props = new Properties();
+    props.load(stream);
+    load();
   }
 
   public ConsensusCommitConfig(Properties properties) {
-    super(properties);
+    props = new Properties();
+    props.putAll(properties);
+    load();
   }
 
-  @Override
+  public Properties getProperties() {
+    return props;
+  }
+
   protected void load() {
-    String transactionManager = getProperties().getProperty(DatabaseConfig.TRANSACTION_MANAGER);
-    if (transactionManager != null && !transactionManager.equals("consensus-commit")) {
-      throw new IllegalArgumentException(
-          DatabaseConfig.TRANSACTION_MANAGER + " should be 'consensus-commit'");
+    if (getProperties().containsValue("scalar.db.isolation_level")) {
+      LOGGER.warn(
+          "The property \"scalar.db.isolation_level\" is deprecated and will be removed. "
+              + "Please use \""
+              + ISOLATION_LEVEL
+              + "\" instead.");
     }
-
-    super.load();
-
+    isolation =
+        Isolation.valueOf(
+            getString(
+                    getProperties(),
+                    ISOLATION_LEVEL,
+                    getString(
+                        getProperties(),
+                        "scalar.db.isolation_level", // for backward compatibility
+                        Isolation.SNAPSHOT.toString()))
+                .toUpperCase());
     strategy =
         SerializableStrategy.valueOf(
             getString(
@@ -62,6 +87,10 @@ public class ConsensusCommitConfig extends DatabaseConfig {
     activeTransactionsManagementEnabled =
         getBoolean(getProperties(), ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, true);
     coordinatorNamespace = getString(getProperties(), COORDINATOR_NAMESPACE, null);
+  }
+
+  public Isolation getIsolation() {
+    return isolation;
   }
 
   public SerializableStrategy getSerializableStrategy() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Isolation.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Isolation.java
@@ -1,0 +1,6 @@
+package com.scalar.db.transaction.consensuscommit;
+
+public enum Isolation {
+  SNAPSHOT,
+  SERIALIZABLE,
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -7,7 +7,6 @@ import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.CoordinatorException;

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -3,7 +3,6 @@ package com.scalar.db.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.scalar.db.api.Isolation;
 import com.scalar.db.storage.cassandra.Cassandra;
 import com.scalar.db.storage.cassandra.CassandraAdmin;
 import com.scalar.db.storage.cosmos.Cosmos;
@@ -50,7 +49,6 @@ public class DatabaseConfigTest {
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
-    assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -74,7 +72,6 @@ public class DatabaseConfigTest {
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
-    assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -98,7 +95,6 @@ public class DatabaseConfigTest {
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
-    assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -124,7 +120,6 @@ public class DatabaseConfigTest {
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
-    assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -401,42 +396,6 @@ public class DatabaseConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "cassandra");
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "grpc");
-
-    // Act Assert
-    assertThatThrownBy(() -> new DatabaseConfig(props))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void constructor_PropertiesWithIsolationLevelGiven_ShouldLoadProperly() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
-    props.setProperty(DatabaseConfig.ISOLATION_LEVEL, Isolation.SERIALIZABLE.toString());
-
-    // Act
-    DatabaseConfig config = new DatabaseConfig(props);
-
-    // Assert
-    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
-    assertThat(config.getIsolation()).isEqualTo(Isolation.SERIALIZABLE);
-  }
-
-  @Test
-  public void constructor_UnsupportedIsolationGiven_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
-    props.setProperty(DatabaseConfig.ISOLATION_LEVEL, "READ_COMMITTED");
 
     // Act Assert
     assertThatThrownBy(() -> new DatabaseConfig(props))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -57,7 +56,7 @@ public class ConsensusCommitManagerTest {
     // Arrange
 
     // Act
-    ConsensusCommit transaction = manager.start(Isolation.SERIALIZABLE);
+    ConsensusCommit transaction = manager.start(com.scalar.db.api.Isolation.SERIALIZABLE);
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -66,12 +65,12 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void start_NullIsolationGiven_ThrowIllegalArgumentException() {
+  public void start_NullIsolationGiven_ThrowNullPointerExceptionException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.start((Isolation) null))
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> manager.start((com.scalar.db.api.Isolation) null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -18,7 +18,6 @@ import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.TransactionException;

--- a/server/conf/database.properties.tmpl
+++ b/server/conf/database.properties.tmpl
@@ -14,7 +14,10 @@ scalar.db.storage={{ default .Env.SCALAR_DB_STORAGE "cassandra" }}
 # The type of the transaction manager. "consensus-commit" or "jdbc" or "grpc" can be set. The default is "consensus-commit"
 scalar.db.transaction_manager={{ default .Env.SCALAR_DB_TRANSACTION_MANAGER "consensus-commit" }}
 
-# Default isolation level. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
+# Default isolation level for ConsensusCommit. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
+scalar.db.consensus_commit.isolation_level={{ default .Env.SCALAR_DB_CONSENSUSCOMMIT_ISOLATION_LEVEL "" }}
+
+# For backward compatibility
 scalar.db.isolation_level={{ default .Env.SCALAR_DB_ISOLATION_LEVEL "" }}
 
 # Default serializable strategy for ConsensusCommit transaction manager.

--- a/server/src/integration-test/java/com/scalar/db/server/ServerEnv.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ServerEnv.java
@@ -72,7 +72,7 @@ public final class ServerEnv {
     properties.setProperty(DatabaseConfig.PASSWORD, password);
     properties.setProperty(DatabaseConfig.STORAGE, storage);
     if (isolation != null) {
-      properties.setProperty(DatabaseConfig.ISOLATION_LEVEL, isolation.name());
+      properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, isolation.name());
     }
     if (serializableStrategy != null) {
       properties.setProperty(


### PR DESCRIPTION
This PR moves the `Isolation` class to the `consensuscommit` package. Also, the property name is changed to `scalar.db.consensus_commit.isolation_level`. But we can still use the old property name `scalar.db.isolation_level` for backward compatibility.