### PR TITLE
Add mergeServiceFiles for shadowJar in Schema Loader

### DIFF
--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -41,6 +41,7 @@ shadowJar {
     manifest {
         attributes 'Main-Class': 'com.scalar.db.schemaloader.SchemaLoader'
     }
+    mergeServiceFiles()
 }
 
 spotless {


### PR DESCRIPTION
I faced the similar issue to the issue mentioned in the following article when using Schema Loader with Scalar DB server:
https://stackoverflow.com/questions/55484043/how-to-fix-could-not-find-policy-pick-first-with-google-tts-java-client

As this article says, after adding `mergeServiceFiles` for `shadowJar` in `build.gradle` for `schema-loader`, the issue is fixed.

Please take a look!