### PR TITLE
Throw RetriableExecutionException in mutate operations when conflicts happen in the JDBC adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -12,6 +12,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.storage.common.TableMetadataManager;
 import com.scalar.db.storage.common.checker.OperationChecker;
 import com.scalar.db.storage.jdbc.query.QueryBuilder;
@@ -37,6 +38,7 @@ public class JdbcDatabase implements DistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcDatabase.class);
 
   private final BasicDataSource dataSource;
+  private final RdbEngine rdbEngine;
   private final JdbcService jdbcService;
   private Optional<String> namespace;
   private Optional<String> tableName;
@@ -44,7 +46,7 @@ public class JdbcDatabase implements DistributedStorage {
   @Inject
   public JdbcDatabase(JdbcConfig config) {
     dataSource = JdbcUtils.initDataSource(config);
-    RdbEngine rdbEngine = JdbcUtils.getRdbEngine(config.getContactPoints().get(0));
+    rdbEngine = JdbcUtils.getRdbEngine(config.getContactPoints().get(0));
     TableMetadataManager tableMetadataManager =
         new TableMetadataManager(new JdbcDatabaseAdmin(dataSource, config), config);
     OperationChecker operationChecker = new OperationChecker(tableMetadataManager);
@@ -55,9 +57,10 @@ public class JdbcDatabase implements DistributedStorage {
   }
 
   @VisibleForTesting
-  JdbcDatabase(BasicDataSource dataSource, JdbcService jdbcService) {
+  JdbcDatabase(BasicDataSource dataSource, RdbEngine rdbEngine, JdbcService jdbcService) {
     this.dataSource = dataSource;
     this.jdbcService = jdbcService;
+    this.rdbEngine = rdbEngine;
   }
 
   @Override
@@ -188,6 +191,11 @@ public class JdbcDatabase implements DistributedStorage {
         connection.rollback();
       } catch (SQLException sqlException) {
         throw new ExecutionException("failed to rollback", sqlException);
+      }
+      if (JdbcUtils.isConflictError(e, rdbEngine)) {
+        // Since a mutate operation executes multiple put/delete operations in a transaction,
+        // conflicts can happen. Throw RetriableExecutionException in that case.
+        throw new RetriableExecutionException("conflict happened in a mutate operation", e);
       }
       throw new ExecutionException("mutate operation failed", e);
     } finally {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -77,4 +77,31 @@ public final class JdbcUtils {
         throw new AssertionError();
     }
   }
+
+  public static boolean isConflictError(SQLException e, RdbEngine rdbEngine) {
+    switch (rdbEngine) {
+      case MYSQL:
+        if (e.getErrorCode() == 1213 || e.getErrorCode() == 1205) {
+          // Deadlock found when trying to get lock or Lock wait timeout exceeded
+          return true;
+        }
+        break;
+      case POSTGRESQL:
+        if (e.getSQLState().equals("40001") || e.getSQLState().equals("40P01")) {
+          // Serialization error happened or Dead lock found
+          return true;
+        }
+        break;
+      case ORACLE:
+        if (e.getErrorCode() == 8177 || e.getErrorCode() == 60) {
+          // ORA-08177: can't serialize access for this transaction
+          // ORA-00060: deadlock detected while waiting for resource
+          return true;
+        }
+        break;
+      default:
+        break;
+    }
+    return false;
+  }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -17,6 +17,7 @@ import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.storage.jdbc.JdbcService;
+import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -212,43 +213,16 @@ public class JdbcTransaction implements DistributedTransaction {
   }
 
   private CrudException createCrudException(SQLException e, String message) {
-    if (isConflictError(e)) {
+    if (JdbcUtils.isConflictError(e, rdbEngine)) {
       return new CrudConflictException("conflict happened; try restarting transaction", e);
     }
     return new CrudException(message, e);
   }
 
   private CommitException createCommitException(SQLException e) {
-    if (isConflictError(e)) {
+    if (JdbcUtils.isConflictError(e, rdbEngine)) {
       return new CommitConflictException("conflict happened; try restarting transaction", e);
     }
     return new CommitException("failed to commit", e);
-  }
-
-  private boolean isConflictError(SQLException e) {
-    switch (rdbEngine) {
-      case MYSQL:
-        if (e.getErrorCode() == 1213 || e.getErrorCode() == 1205) {
-          // Deadlock found when trying to get lock or Lock wait timeout exceeded
-          return true;
-        }
-        break;
-      case POSTGRESQL:
-        if (e.getSQLState().equals("40001") || e.getSQLState().equals("40P01")) {
-          // Serialization error happened or Dead lock found
-          return true;
-        }
-        break;
-      case ORACLE:
-        if (e.getErrorCode() == 8177 || e.getErrorCode() == 60) {
-          // ORA-08177: can't serialize access for this transaction
-          // ORA-00060: deadlock detected while waiting for resource
-          return true;
-        }
-        break;
-      default:
-        break;
-    }
-    return false;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -96,7 +96,9 @@ public class JdbcTransaction implements DistributedTransaction {
   public Optional<Result> get(Get get) throws CrudException {
     try {
       return jdbcService.get(get, connection, namespace, tableName);
-    } catch (SQLException | ExecutionException e) {
+    } catch (SQLException e) {
+      throw createCrudException(e, "get operation failed");
+    } catch (ExecutionException e) {
       throw new CrudException("get operation failed", e);
     }
   }
@@ -105,7 +107,9 @@ public class JdbcTransaction implements DistributedTransaction {
   public List<Result> scan(Scan scan) throws CrudException {
     try {
       return jdbcService.scan(scan, connection, namespace, tableName);
-    } catch (SQLException | ExecutionException e) {
+    } catch (SQLException e) {
+      throw createCrudException(e, "scan operation failed");
+    } catch (ExecutionException e) {
       throw new CrudException("scan operation failed", e);
     }
   }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -42,7 +42,7 @@ public class JdbcDatabaseTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    jdbcDatabase = new JdbcDatabase(dataSource, jdbcService);
+    jdbcDatabase = new JdbcDatabase(dataSource, RdbEngine.MYSQL, jdbcService);
 
     when(dataSource.getConnection()).thenReturn(connection);
   }


### PR DESCRIPTION
Since a mutate operation in the JDBC adapter executes multiple put/delete operations in a transaction, conflicts can happen. This PR makes it throw `RetriableExecutionException` in that case. Please take a look!