### PR TITLE
Result.getClusteringKey() should return empty when there is no clustering key

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/common/ResultImpl.java
+++ b/core/src/main/java/com/scalar/db/storage/common/ResultImpl.java
@@ -38,6 +38,9 @@ public class ResultImpl implements Result {
   }
 
   private Optional<Key> getKey(LinkedHashSet<String> names) {
+    if (names.isEmpty()) {
+      return Optional.empty();
+    }
     Key.Builder builder = Key.newBuilder();
     for (String name : names) {
       Value<?> value = values.get(name);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -129,7 +129,7 @@ public class CrudHandler {
   private Optional<Snapshot.Key> getSnapshotKey(Result result, Scan scan) {
     Optional<Key> partitionKey = result.getPartitionKey();
     Optional<Key> clusteringKey = result.getClusteringKey();
-    if (!partitionKey.isPresent() || !clusteringKey.isPresent()) {
+    if (!partitionKey.isPresent()) {
       return Optional.empty();
     }
 
@@ -138,7 +138,7 @@ public class CrudHandler {
             scan.forNamespace().get(),
             scan.forTable().get(),
             partitionKey.get(),
-            clusteringKey.get()));
+            clusteringKey.orElse(null)));
   }
 
   public Snapshot getSnapshot() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
@@ -357,7 +358,7 @@ public class Snapshot {
         String namespace,
         String table,
         com.scalar.db.io.Key partitionKey,
-        com.scalar.db.io.Key clusteringKey) {
+        @Nullable com.scalar.db.io.Key clusteringKey) {
       this.namespace = namespace;
       this.table = table;
       this.partitionKey = partitionKey;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -19,7 +19,6 @@ import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
-import com.scalar.db.exception.transaction.CrudRuntimeException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
@@ -221,21 +220,6 @@ public class CrudHandlerTest {
     // Assert
     verify(snapshot, never())
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-  }
-
-  @Test
-  public void scan_ClusteringKeyNotGivenInResult_ShouldThrowRuntimeException()
-      throws ExecutionException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(false, TransactionState.COMMITTED);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    // this is needed for forEach
-    // doCallRealMethod().when(scanner).forEach(any(Consumer.class));
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(CrudRuntimeException.class);
   }
 
   @Test


### PR DESCRIPTION
Currently, `Result.getClusteringKey()` returns a `Key` object with no `Value` objects when there is no clustering key, but it should return `Optional.empty()` in that case. This PR fixes this issue. Please take a look!