### PR TITLE
Move ReadRepairableExecutionException to the Cassandra package

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cassandra/MutateStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/MutateStatementHandler.java
@@ -11,7 +11,6 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.ReadRepairableExecutionException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;

--- a/core/src/main/java/com/scalar/db/storage/cassandra/ReadRepairableExecutionException.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ReadRepairableExecutionException.java
@@ -1,4 +1,6 @@
-package com.scalar.db.exception.storage;
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.exception.storage.ExecutionException;
 
 public class ReadRepairableExecutionException extends ExecutionException {
 

--- a/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
@@ -28,7 +28,6 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.ReadRepairableExecutionException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.Key;
 import org.junit.Before;


### PR DESCRIPTION
Since `ReadRepairableExecutionException` is a Cassandra specific exception, we should have it in the Cassandra package. This PR moves `ReadRepairableExecutionException` to the Cassandra package. Please take a look!