### PR TITLE
Restore JdbcUtils.initDataSource(JdbcConfig config)

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -25,6 +25,17 @@ public final class JdbcUtils {
     }
   }
 
+  /**
+   * @param config a jdbc config
+   * @return the data source
+   * @deprecated As of release 3.5.0. Will be removed in release 4.0.0.
+   */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  public static BasicDataSource initDataSource(JdbcConfig config) {
+    return initDataSource(config, false, null);
+  }
+
   public static BasicDataSource initDataSource(JdbcConfig config, @Nullable Isolation isolation) {
     return initDataSource(config, false, isolation);
   }


### PR DESCRIPTION
This PR restores the method `initDataSource(JdbcConfig config)` in `JdbcUtils` that was removed in #412 to keep the backward compatibility. Please take a look!