### PR TITLE
Remove synchronized from ConsensusCommitManager

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -94,39 +94,38 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
 
   @Deprecated
   @Override
-  public synchronized ConsensusCommit start(com.scalar.db.api.Isolation isolation) {
+  public ConsensusCommit start(com.scalar.db.api.Isolation isolation) {
     return start(Isolation.valueOf(isolation.name()), config.getSerializableStrategy());
   }
 
   @Deprecated
   @Override
-  public synchronized ConsensusCommit start(String txId, com.scalar.db.api.Isolation isolation) {
+  public ConsensusCommit start(String txId, com.scalar.db.api.Isolation isolation) {
     return start(txId, Isolation.valueOf(isolation.name()), config.getSerializableStrategy());
   }
 
   @Deprecated
   @Override
-  public synchronized ConsensusCommit start(
+  public ConsensusCommit start(
       com.scalar.db.api.Isolation isolation, com.scalar.db.api.SerializableStrategy strategy) {
     return start(Isolation.valueOf(isolation.name()), (SerializableStrategy) strategy);
   }
 
   @Deprecated
   @Override
-  public synchronized ConsensusCommit start(com.scalar.db.api.SerializableStrategy strategy) {
+  public ConsensusCommit start(com.scalar.db.api.SerializableStrategy strategy) {
     return start(Isolation.SERIALIZABLE, (SerializableStrategy) strategy);
   }
 
   @Deprecated
   @Override
-  public synchronized ConsensusCommit start(
-      String txId, com.scalar.db.api.SerializableStrategy strategy) {
+  public ConsensusCommit start(String txId, com.scalar.db.api.SerializableStrategy strategy) {
     return start(txId, Isolation.SERIALIZABLE, (SerializableStrategy) strategy);
   }
 
   @Deprecated
   @Override
-  public synchronized ConsensusCommit start(
+  public ConsensusCommit start(
       String txId,
       com.scalar.db.api.Isolation isolation,
       com.scalar.db.api.SerializableStrategy strategy) {
@@ -134,14 +133,13 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   }
 
   @VisibleForTesting
-  synchronized ConsensusCommit start(Isolation isolation, SerializableStrategy strategy) {
+  ConsensusCommit start(Isolation isolation, SerializableStrategy strategy) {
     String txId = UUID.randomUUID().toString();
     return start(txId, isolation, strategy);
   }
 
   @VisibleForTesting
-  synchronized ConsensusCommit start(
-      String txId, Isolation isolation, SerializableStrategy strategy) {
+  ConsensusCommit start(String txId, Isolation isolation, SerializableStrategy strategy) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     checkNotNull(isolation);
     if (!config.getIsolation().equals(isolation)


### PR DESCRIPTION
I don't think we need the `synchronized` in `ConsensusCommitManager`. This PR removes them. Please take a look!