### PR TITLE
Use the internal JRE Docker image to avoid CVE fixing commands

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,9 +1,4 @@
-FROM openjdk:8u275-jre-slim
-
-# Fix CVE-2021-3520, CVE-2021-33560, CVE-2021-20231, CVE-2021-20232, CVE-2020-24659, CVE-2021-20305, and CVE-2021-3711
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends liblz4-1=1.8.3-1+deb10u1 libgcrypt20=1.8.4-5+deb10u1 libgnutls30=3.6.7-4+deb10u7 libhogweed4=3.4.1-1+deb10u1 libssl1.1=1.1.1d-0+deb10u7 openssl=1.1.1d-0+deb10u7 && \
-    rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/scalar-labs/jre8:1.0.0
 
 ADD scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,15 +16,10 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM openjdk:8u292-jre-slim
+FROM ghcr.io/scalar-labs/jre8:1.0.0
 
 COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/
-
-# Fix CVE-2021-3520, CVE-2021-33560, CVE-2021-20231, CVE-2021-20232, CVE-2020-24659, CVE-2021-20305, and CVE-2021-3711
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends liblz4-1=1.8.3-1+deb10u1 libgcrypt20=1.8.4-5+deb10u1 libgnutls30=3.6.7-4+deb10u7 libhogweed4=3.4.1-1+deb10u1 libssl1.1=1.1.1d-0+deb10u7 openssl=1.1.1d-0+deb10u7 && \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /scalardb
 


### PR DESCRIPTION
This PR uses a self-maintained JRE Docker image to avoid adding CVE patches through Dockerfile.

The Docker file is maintained in 
https://github.com/scalar-labs/docker/blob/main/jre/8/Dockerfile