### PR TITLE
Log in GitHub Container Registry first

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,15 +33,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Create containers
-        run: gradle docker
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
+
+      - name: Create containers
+        run: gradle docker
 
       - name: Push containers
         run: |


### PR DESCRIPTION
This PR changes the ordering of commands in the release CI workflow to log in to GitHub Container Registry first before building the Docker image.
(Sorry, I forgot about the internal JRE image is a private image)