### PR TITLE
Rename stringValue GraphQL field name to textValue

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/schema/CommonSchema.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/CommonSchema.java
@@ -36,7 +36,7 @@ public final class CommonSchema {
             .field(newInputObjectField().name("bigIntValue").type(BIG_INT_SCALAR))
             .field(newInputObjectField().name("floatValue").type(FLOAT_32_SCALAR))
             .field(newInputObjectField().name("doubleValue").type(Scalars.GraphQLFloat))
-            .field(newInputObjectField().name("stringValue").type(Scalars.GraphQLString))
+            .field(newInputObjectField().name("textValue").type(Scalars.GraphQLString))
             .field(newInputObjectField().name("booleanValue").type(Scalars.GraphQLBoolean))
             .field(
                 newInputObjectField()

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -197,7 +197,7 @@ public class TableGraphQlModel {
         .field(newInputObjectField().name("bigIntValue").type(CommonSchema.BIG_INT_SCALAR))
         .field(newInputObjectField().name("floatValue").type(CommonSchema.FLOAT_32_SCALAR))
         .field(newInputObjectField().name("doubleValue").type(Scalars.GraphQLFloat))
-        .field(newInputObjectField().name("stringValue").type(Scalars.GraphQLString))
+        .field(newInputObjectField().name("textValue").type(Scalars.GraphQLString))
         .field(newInputObjectField().name("booleanValue").type(Scalars.GraphQLBoolean))
         .build();
   }

--- a/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
@@ -361,7 +361,7 @@ public class TableGraphQlModelTest {
     //   bigIntValue: BigInt
     //   floatValue: Float32
     //   doubleValue: Float
-    //   stringValue: String
+    //   textValue: String
     //   booleanValue: Boolean
     // }
     GraphQLInputObjectType inputObjectType = model.getClusteringKeyInputObjectType();
@@ -373,7 +373,7 @@ public class TableGraphQlModelTest {
     assertNullableInputObjectField(fields.get(2), "bigIntValue", CommonSchema.BIG_INT_SCALAR);
     assertNullableInputObjectField(fields.get(3), "floatValue", CommonSchema.FLOAT_32_SCALAR);
     assertNullableInputObjectField(fields.get(4), "doubleValue", Scalars.GraphQLFloat);
-    assertNullableInputObjectField(fields.get(5), "stringValue", Scalars.GraphQLString);
+    assertNullableInputObjectField(fields.get(5), "textValue", Scalars.GraphQLString);
     assertNullableInputObjectField(fields.get(6), "booleanValue", Scalars.GraphQLBoolean);
   }
 


### PR DESCRIPTION
This PR aims to align the GraphQL argument vocabulary with Scalar DB. Only `stringValue` was different.