### PR TITLE
GraphQL schema change of Mutation type

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -60,7 +60,8 @@ public class GraphQlFactory {
           .field(tableModel.getMutationPutField())
           .field(tableModel.getMutationBulkPutField())
           .field(tableModel.getMutationDeleteField())
-          .field(tableModel.getMutationBulkDeleteField());
+          .field(tableModel.getMutationBulkDeleteField())
+          .field(tableModel.getMutationMutateField());
     }
     builder
         .field(

--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -55,8 +55,8 @@ public class GraphQlFactory {
   private GraphQLObjectType createMutationObjectType() {
     GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name("Mutation");
     for (TableGraphQlModel tableModel : tableModels) {
-      builder.field(tableModel.getMutationPutField());
-      builder.field(tableModel.getMutationDeleteField());
+      builder.field(tableModel.getMutationBulkPutField());
+      builder.field(tableModel.getMutationBulkDeleteField());
     }
     builder.field(
         GraphQLFieldDefinition.newFieldDefinition().name("commit").type(Scalars.GraphQLBoolean));

--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -55,8 +55,11 @@ public class GraphQlFactory {
   private GraphQLObjectType createMutationObjectType() {
     GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name("Mutation");
     for (TableGraphQlModel tableModel : tableModels) {
-      builder.field(tableModel.getMutationBulkPutField());
-      builder.field(tableModel.getMutationBulkDeleteField());
+      builder
+          .field(tableModel.getMutationPutField())
+          .field(tableModel.getMutationBulkPutField())
+          .field(tableModel.getMutationDeleteField())
+          .field(tableModel.getMutationBulkDeleteField());
     }
     builder.field(
         GraphQLFieldDefinition.newFieldDefinition().name("commit").type(Scalars.GraphQLBoolean));

--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -13,6 +13,7 @@ import graphql.GraphQL;
 import graphql.Scalars;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import java.util.ArrayList;
@@ -61,10 +62,15 @@ public class GraphQlFactory {
           .field(tableModel.getMutationDeleteField())
           .field(tableModel.getMutationBulkDeleteField());
     }
-    builder.field(
-        GraphQLFieldDefinition.newFieldDefinition().name("commit").type(Scalars.GraphQLBoolean));
-    builder.field(
-        GraphQLFieldDefinition.newFieldDefinition().name("abort").type(Scalars.GraphQLBoolean));
+    builder
+        .field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name("commit")
+                .type(GraphQLNonNull.nonNull(Scalars.GraphQLBoolean)))
+        .field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name("abort")
+                .type(GraphQLNonNull.nonNull(Scalars.GraphQLBoolean)));
 
     return builder.build();
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -58,6 +58,7 @@ public class TableGraphQlModel {
   private final GraphQLInputObjectType deleteInputObjectType;
   private final GraphQLFieldDefinition mutationDeleteField;
   private final GraphQLFieldDefinition mutationBulkDeleteField;
+  private final GraphQLFieldDefinition mutationMutateField;
 
   public TableGraphQlModel(String namespaceName, String tableName, TableMetadata tableMetadata) {
     this.namespaceName = Objects.requireNonNull(namespaceName);
@@ -109,6 +110,8 @@ public class TableGraphQlModel {
     this.deleteInputObjectType = createDeleteInputObjectType();
     this.mutationDeleteField = createMutationDeleteField();
     this.mutationBulkDeleteField = createMutationBulkDeleteField();
+
+    this.mutationMutateField = createMutationMutateField();
   }
 
   public LinkedHashSet<String> getPartitionKeyNames() {
@@ -343,6 +346,15 @@ public class TableGraphQlModel {
         .build();
   }
 
+  private GraphQLFieldDefinition createMutationMutateField() {
+    return newFieldDefinition()
+        .name(objectType.getName() + "_mutate")
+        .type(nonNull(Scalars.GraphQLBoolean))
+        .argument(newArgument().name("put").type(list(nonNull(putInputObjectType))))
+        .argument(newArgument().name("delete").type(list(nonNull(deleteInputObjectType))))
+        .build();
+  }
+
   public String getNamespaceName() {
     return namespaceName;
   }
@@ -441,5 +453,9 @@ public class TableGraphQlModel {
 
   public GraphQLInputObjectType getDeleteInputObjectType() {
     return deleteInputObjectType;
+  }
+
+  public GraphQLFieldDefinition getMutationMutateField() {
+    return mutationMutateField;
   }
 }

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -51,7 +51,6 @@ public class TableGraphQlModel {
   private final GraphQLObjectType scanPayloadObjectType;
   private final GraphQLFieldDefinition queryScanField;
   private final GraphQLObjectType primaryKeyOutputObjectType;
-  private final GraphQLObjectType mutationResultObjectType;
   private final GraphQLInputObjectType putValuesObjectType;
   private final GraphQLInputObjectType putInputObjectType;
   private final GraphQLFieldDefinition mutationPutField;
@@ -99,7 +98,6 @@ public class TableGraphQlModel {
     }
 
     this.primaryKeyOutputObjectType = createPrimaryKeyOutputObjectType();
-    this.mutationResultObjectType = createMutationResultObjectType();
 
     this.putValuesObjectType = createPutValuesObjectType();
     this.putInputObjectType = createPutInputObjectType();
@@ -268,14 +266,6 @@ public class TableGraphQlModel {
     return builder.build();
   }
 
-  private GraphQLObjectType createMutationResultObjectType() {
-    return newObject()
-        .name(objectType.getName() + "_MutationResult")
-        .field(newFieldDefinition().name("applied").type(nonNull(Scalars.GraphQLBoolean)))
-        .field(newFieldDefinition().name("key").type(nonNull(primaryKeyOutputObjectType)))
-        .build();
-  }
-
   private GraphQLInputObjectType createPutValuesObjectType() {
     LinkedHashSet<String> keyNames = new LinkedHashSet<>();
     keyNames.addAll(getPartitionKeyNames());
@@ -321,7 +311,7 @@ public class TableGraphQlModel {
   private GraphQLFieldDefinition createMutationPutField() {
     return newFieldDefinition()
         .name(objectType.getName() + "_put")
-        .type(nonNull(list(nonNull(mutationResultObjectType))))
+        .type(nonNull(Scalars.GraphQLBoolean))
         .argument(newArgument().name("put").type(nonNull(list(nonNull(putInputObjectType)))))
         .build();
   }
@@ -348,7 +338,7 @@ public class TableGraphQlModel {
   private GraphQLFieldDefinition createMutationDeleteField() {
     return newFieldDefinition()
         .name(objectType.getName() + "_delete")
-        .type(nonNull(list(nonNull(mutationResultObjectType))))
+        .type(nonNull(Scalars.GraphQLBoolean))
         .argument(newArgument().name("delete").type(nonNull(list(nonNull(deleteInputObjectType)))))
         .build();
   }
@@ -423,10 +413,6 @@ public class TableGraphQlModel {
 
   public GraphQLObjectType getPrimaryKeyOutputObjectType() {
     return primaryKeyOutputObjectType;
-  }
-
-  public GraphQLObjectType getMutationResultObjectType() {
-    return mutationResultObjectType;
   }
 
   public GraphQLFieldDefinition getMutationPutField() {

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -53,9 +53,9 @@ public class TableGraphQlModel {
   private final GraphQLObjectType primaryKeyOutputObjectType;
   private final GraphQLInputObjectType putValuesObjectType;
   private final GraphQLInputObjectType putInputObjectType;
-  private final GraphQLFieldDefinition mutationPutField;
+  private final GraphQLFieldDefinition mutationBulkPutField;
   private final GraphQLInputObjectType deleteInputObjectType;
-  private final GraphQLFieldDefinition mutationDeleteField;
+  private final GraphQLFieldDefinition mutationBulkDeleteField;
 
   public TableGraphQlModel(String namespaceName, String tableName, TableMetadata tableMetadata) {
     this.namespaceName = Objects.requireNonNull(namespaceName);
@@ -101,10 +101,10 @@ public class TableGraphQlModel {
 
     this.putValuesObjectType = createPutValuesObjectType();
     this.putInputObjectType = createPutInputObjectType();
-    this.mutationPutField = createMutationPutField();
+    this.mutationBulkPutField = createMutationBulkPutField();
 
     this.deleteInputObjectType = createDeleteInputObjectType();
-    this.mutationDeleteField = createMutationDeleteField();
+    this.mutationBulkDeleteField = createMutationBulkDeleteField();
   }
 
   public LinkedHashSet<String> getPartitionKeyNames() {
@@ -298,9 +298,9 @@ public class TableGraphQlModel {
         .build();
   }
 
-  private GraphQLFieldDefinition createMutationPutField() {
+  private GraphQLFieldDefinition createMutationBulkPutField() {
     return newFieldDefinition()
-        .name(objectType.getName() + "_put")
+        .name(objectType.getName() + "_bulkPut")
         .type(nonNull(Scalars.GraphQLBoolean))
         .argument(newArgument().name("put").type(nonNull(list(nonNull(putInputObjectType)))))
         .build();
@@ -315,9 +315,9 @@ public class TableGraphQlModel {
         .build();
   }
 
-  private GraphQLFieldDefinition createMutationDeleteField() {
+  private GraphQLFieldDefinition createMutationBulkDeleteField() {
     return newFieldDefinition()
-        .name(objectType.getName() + "_delete")
+        .name(objectType.getName() + "_bulkDelete")
         .type(nonNull(Scalars.GraphQLBoolean))
         .argument(newArgument().name("delete").type(nonNull(list(nonNull(deleteInputObjectType)))))
         .build();
@@ -395,8 +395,8 @@ public class TableGraphQlModel {
     return primaryKeyOutputObjectType;
   }
 
-  public GraphQLFieldDefinition getMutationPutField() {
-    return mutationPutField;
+  public GraphQLFieldDefinition getMutationBulkPutField() {
+    return mutationBulkPutField;
   }
 
   public GraphQLInputObjectType getPutInputObjectType() {
@@ -407,8 +407,8 @@ public class TableGraphQlModel {
     return putValuesObjectType;
   }
 
-  public GraphQLFieldDefinition getMutationDeleteField() {
-    return mutationDeleteField;
+  public GraphQLFieldDefinition getMutationBulkDeleteField() {
+    return mutationBulkDeleteField;
   }
 
   public GraphQLInputObjectType getDeleteInputObjectType() {

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -298,16 +298,6 @@ public class TableGraphQlModel {
         .build();
   }
 
-  private GraphQLObjectType createPutPayloadObjectType() {
-    return newObject()
-        .name(objectType.getName() + "_PutPayload")
-        .field(
-            newFieldDefinition()
-                .name(objectType.getName())
-                .type(nonNull(list(nonNull(objectType)))))
-        .build();
-  }
-
   private GraphQLFieldDefinition createMutationPutField() {
     return newFieldDefinition()
         .name(objectType.getName() + "_put")
@@ -322,16 +312,6 @@ public class TableGraphQlModel {
         .field(newInputObjectField().name("key").type(nonNull(primaryKeyInputObjectType)))
         .field(newInputObjectField().name("condition").type(typeRef("DeleteCondition")))
         .field(newInputObjectField().name("consistency").type(typeRef("Consistency")))
-        .build();
-  }
-
-  private GraphQLObjectType createDeletePayloadObjectType() {
-    return newObject()
-        .name(objectType.getName() + "_DeletePayload")
-        .field(
-            newFieldDefinition()
-                .name(objectType.getName())
-                .type(nonNull(list(nonNull(objectType)))))
         .build();
   }
 

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -53,8 +53,10 @@ public class TableGraphQlModel {
   private final GraphQLObjectType primaryKeyOutputObjectType;
   private final GraphQLInputObjectType putValuesObjectType;
   private final GraphQLInputObjectType putInputObjectType;
+  private final GraphQLFieldDefinition mutationPutField;
   private final GraphQLFieldDefinition mutationBulkPutField;
   private final GraphQLInputObjectType deleteInputObjectType;
+  private final GraphQLFieldDefinition mutationDeleteField;
   private final GraphQLFieldDefinition mutationBulkDeleteField;
 
   public TableGraphQlModel(String namespaceName, String tableName, TableMetadata tableMetadata) {
@@ -101,9 +103,11 @@ public class TableGraphQlModel {
 
     this.putValuesObjectType = createPutValuesObjectType();
     this.putInputObjectType = createPutInputObjectType();
+    this.mutationPutField = createMutationPutField();
     this.mutationBulkPutField = createMutationBulkPutField();
 
     this.deleteInputObjectType = createDeleteInputObjectType();
+    this.mutationDeleteField = createMutationDeleteField();
     this.mutationBulkDeleteField = createMutationBulkDeleteField();
   }
 
@@ -298,6 +302,14 @@ public class TableGraphQlModel {
         .build();
   }
 
+  private GraphQLFieldDefinition createMutationPutField() {
+    return newFieldDefinition()
+        .name(objectType.getName() + "_put")
+        .type(nonNull(Scalars.GraphQLBoolean))
+        .argument(newArgument().name("put").type(nonNull(putInputObjectType)))
+        .build();
+  }
+
   private GraphQLFieldDefinition createMutationBulkPutField() {
     return newFieldDefinition()
         .name(objectType.getName() + "_bulkPut")
@@ -312,6 +324,14 @@ public class TableGraphQlModel {
         .field(newInputObjectField().name("key").type(nonNull(primaryKeyInputObjectType)))
         .field(newInputObjectField().name("condition").type(typeRef("DeleteCondition")))
         .field(newInputObjectField().name("consistency").type(typeRef("Consistency")))
+        .build();
+  }
+
+  private GraphQLFieldDefinition createMutationDeleteField() {
+    return newFieldDefinition()
+        .name(objectType.getName() + "_delete")
+        .type(nonNull(Scalars.GraphQLBoolean))
+        .argument(newArgument().name("delete").type(nonNull(deleteInputObjectType)))
         .build();
   }
 
@@ -395,6 +415,10 @@ public class TableGraphQlModel {
     return primaryKeyOutputObjectType;
   }
 
+  public GraphQLFieldDefinition getMutationPutField() {
+    return mutationPutField;
+  }
+
   public GraphQLFieldDefinition getMutationBulkPutField() {
     return mutationBulkPutField;
   }
@@ -405,6 +429,10 @@ public class TableGraphQlModel {
 
   public GraphQLInputObjectType getPutValuesObjectType() {
     return putValuesObjectType;
+  }
+
+  public GraphQLFieldDefinition getMutationDeleteField() {
+    return mutationDeleteField;
   }
 
   public GraphQLFieldDefinition getMutationBulkDeleteField() {

--- a/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
@@ -489,17 +489,17 @@ public class TableGraphQlModelTest {
   }
 
   @Test
-  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationPutField() {
+  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationBulkPutField() {
     // Act
     TableGraphQlModel model =
         new TableGraphQlModel(NAMESPACE_NAME, TABLE_NAME, createTableMetadata());
 
     // Assert
     // type Mutation {
-    //   table_1_put(put: [table1_PutInput!]!): Boolean!
+    //   table_1_bulkPut(put: [table1_PutInput!]!): Boolean!
     // }
-    GraphQLFieldDefinition field = model.getMutationPutField();
-    assertNonNullFieldDefinition(field, TABLE_NAME + "_put", Scalars.GraphQLBoolean);
+    GraphQLFieldDefinition field = model.getMutationBulkPutField();
+    assertNonNullFieldDefinition(field, TABLE_NAME + "_bulkPut", Scalars.GraphQLBoolean);
     assertThat(field.getArguments().size()).isEqualTo(1);
     GraphQLArgument argument = field.getArguments().get(0);
     assertNonNullListOfNonNullObjectArgument(argument, "put", model.getPutInputObjectType());
@@ -531,17 +531,17 @@ public class TableGraphQlModelTest {
   }
 
   @Test
-  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationDeleteField() {
+  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationBulkDeleteField() {
     // Act
     TableGraphQlModel model =
         new TableGraphQlModel(NAMESPACE_NAME, TABLE_NAME, createTableMetadata());
 
     // Assert
     // type Mutation {
-    //   table_1_delete(delete: [table_1_DeleteInput!]!): Boolean!
+    //   table_1_bulkDelete(delete: [table_1_DeleteInput!]!): Boolean!
     // }
-    GraphQLFieldDefinition field = model.getMutationDeleteField();
-    assertNonNullFieldDefinition(field, TABLE_NAME + "_delete", Scalars.GraphQLBoolean);
+    GraphQLFieldDefinition field = model.getMutationBulkDeleteField();
+    assertNonNullFieldDefinition(field, TABLE_NAME + "_bulkDelete", Scalars.GraphQLBoolean);
     assertThat(field.getArguments().size()).isEqualTo(1);
     assertNonNullListOfNonNullObjectArgument(
         field.getArguments().get(0), "delete", model.getDeleteInputObjectType());

--- a/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
@@ -38,6 +38,13 @@ public class TableGraphQlModelTest {
     assertThat(field.getType()).isEqualTo(type);
   }
 
+  private void assertNonNullFieldDefinition(
+      GraphQLFieldDefinition field, String name, GraphQLType type) {
+    assertThat(field.getName()).isEqualTo(name);
+    assertThat(field.getType()).isInstanceOf(GraphQLNonNull.class);
+    assertThat(((GraphQLNonNull) field.getType()).getWrappedType()).isEqualTo(type);
+  }
+
   private void assertNonNullInputObjectField(
       GraphQLInputObjectField field, String name, GraphQLType type) {
     assertThat(field.getName()).isEqualTo(name);
@@ -436,35 +443,6 @@ public class TableGraphQlModelTest {
   }
 
   @Test
-  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationResultObjectType() {
-    // Act
-    TableGraphQlModel model =
-        new TableGraphQlModel(NAMESPACE_NAME, TABLE_NAME, createTableMetadata());
-
-    // Assert
-    // type table_1_MutationResult {
-    //   applied: Boolean!
-    //   key: table_1_KeyOutput!
-    // }
-    GraphQLObjectType objectType = model.getMutationResultObjectType();
-    assertThat(objectType.getName()).isEqualTo(TABLE_NAME + "_MutationResult");
-    List<GraphQLFieldDefinition> fields = objectType.getFieldDefinitions();
-    assertThat(fields.size()).isEqualTo(2);
-
-    GraphQLFieldDefinition field = fields.get(0);
-    assertThat(field.getName()).isEqualTo("applied");
-    assertThat(field.getType()).isInstanceOf(GraphQLNonNull.class);
-    assertThat(((GraphQLNonNull) field.getType()).getWrappedType())
-        .isEqualTo(Scalars.GraphQLBoolean);
-
-    field = fields.get(1);
-    assertThat(field.getName()).isEqualTo("key");
-    assertThat(field.getType()).isInstanceOf(GraphQLNonNull.class);
-    assertThat(((GraphQLNonNull) field.getType()).getWrappedType())
-        .isEqualTo(model.getPrimaryKeyOutputObjectType());
-  }
-
-  @Test
   public void constructor_NonNullArgumentsGiven_ShouldCreatePutValuesObjectType() {
     // Act
     TableGraphQlModel model =
@@ -518,12 +496,10 @@ public class TableGraphQlModelTest {
 
     // Assert
     // type Mutation {
-    //   table_1_put(put: [table1_PutInput!]!): [table_1_MutationResult!]!
+    //   table_1_put(put: [table1_PutInput!]!): Boolean!
     // }
     GraphQLFieldDefinition field = model.getMutationPutField();
-    assertThat(field.getName()).isEqualTo(TABLE_NAME + "_put");
-    assertNonNullListOfNonNullObject(model.getMutationResultObjectType(), field.getType());
-
+    assertNonNullFieldDefinition(field, TABLE_NAME + "_put", Scalars.GraphQLBoolean);
     assertThat(field.getArguments().size()).isEqualTo(1);
     GraphQLArgument argument = field.getArguments().get(0);
     assertNonNullListOfNonNullObjectArgument(argument, "put", model.getPutInputObjectType());
@@ -562,11 +538,10 @@ public class TableGraphQlModelTest {
 
     // Assert
     // type Mutation {
-    //   table_1_delete(delete: [table_1_DeleteInput!]!): [table_1_MutationResult!]!
+    //   table_1_delete(delete: [table_1_DeleteInput!]!): Boolean!
     // }
     GraphQLFieldDefinition field = model.getMutationDeleteField();
-    assertThat(field.getName()).isEqualTo(TABLE_NAME + "_delete");
-    assertNonNullListOfNonNullObject(model.getMutationResultObjectType(), field.getType());
+    assertNonNullFieldDefinition(field, TABLE_NAME + "_delete", Scalars.GraphQLBoolean);
     assertThat(field.getArguments().size()).isEqualTo(1);
     assertNonNullListOfNonNullObjectArgument(
         field.getArguments().get(0), "delete", model.getDeleteInputObjectType());

--- a/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
@@ -555,7 +555,7 @@ public class TableGraphQlModelTest {
 
     // Assert
     // type Mutation {
-    //   table_1_delete(put: table1_DeleteInput!): Boolean!
+    //   table_1_delete(delete: table1_DeleteInput!): Boolean!
     // }
     GraphQLFieldDefinition field = model.getMutationPutField();
     assertNonNullFieldDefinition(field, TABLE_NAME + "_put", Scalars.GraphQLBoolean);

--- a/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
@@ -489,6 +489,23 @@ public class TableGraphQlModelTest {
   }
 
   @Test
+  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationPutField() {
+    // Act
+    TableGraphQlModel model =
+        new TableGraphQlModel(NAMESPACE_NAME, TABLE_NAME, createTableMetadata());
+
+    // Assert
+    // type Mutation {
+    //   table_1_put(put: table1_PutInput!): Boolean!
+    // }
+    GraphQLFieldDefinition field = model.getMutationPutField();
+    assertNonNullFieldDefinition(field, TABLE_NAME + "_put", Scalars.GraphQLBoolean);
+    assertThat(field.getArguments().size()).isEqualTo(1);
+    GraphQLArgument argument = field.getArguments().get(0);
+    assertNonNullArgument(argument, "put", model.getPutInputObjectType());
+  }
+
+  @Test
   public void constructor_NonNullArgumentsGiven_ShouldCreateMutationBulkPutField() {
     // Act
     TableGraphQlModel model =
@@ -528,6 +545,23 @@ public class TableGraphQlModelTest {
     GraphQLInputType consistencyType = fields.get(2).getType();
     assertThat(consistencyType).isInstanceOf(GraphQLTypeReference.class);
     assertThat(((GraphQLTypeReference) consistencyType).getName()).isEqualTo("Consistency");
+  }
+
+  @Test
+  public void constructor_NonNullArgumentsGiven_ShouldCreateMutationDeleteField() {
+    // Act
+    TableGraphQlModel model =
+        new TableGraphQlModel(NAMESPACE_NAME, TABLE_NAME, createTableMetadata());
+
+    // Assert
+    // type Mutation {
+    //   table_1_delete(put: table1_DeleteInput!): Boolean!
+    // }
+    GraphQLFieldDefinition field = model.getMutationPutField();
+    assertNonNullFieldDefinition(field, TABLE_NAME + "_put", Scalars.GraphQLBoolean);
+    assertThat(field.getArguments().size()).isEqualTo(1);
+    GraphQLArgument argument = field.getArguments().get(0);
+    assertNonNullArgument(argument, "put", model.getPutInputObjectType());
   }
 
   @Test

--- a/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/schema/TableGraphQlModelTest.java
@@ -64,18 +64,6 @@ public class TableGraphQlModelTest {
     assertThat(((GraphQLNonNull) argument.getType()).getWrappedType()).isEqualTo(type);
   }
 
-  private void assertNonNullListOfNonNullObjectField(
-      GraphQLFieldDefinition field, String name, GraphQLType listElementType) {
-    assertThat(field.getName()).isEqualTo(name);
-    assertNonNullListOfNonNullObject(listElementType, field.getType());
-  }
-
-  private void assertNonNullListOfNonNullObjectArgument(
-      GraphQLArgument argument, String name, GraphQLType objectType) {
-    assertThat(argument.getName()).isEqualTo(name);
-    assertNonNullListOfNonNullObject(objectType, argument.getType());
-  }
-
   private void assertNonNullListOfNonNullObject(
       GraphQLType listElementType, GraphQLType outerType) {
     assertThat(outerType).isInstanceOf(GraphQLNonNull.class);
@@ -83,8 +71,7 @@ public class TableGraphQlModelTest {
     assertListOfNonNullObject(listElementType, wrappedType1);
   }
 
-  private void assertListOfNonNullObject(
-      GraphQLType listElementType, GraphQLType outerType) {
+  private void assertListOfNonNullObject(GraphQLType listElementType, GraphQLType outerType) {
     assertThat(outerType).isInstanceOf(GraphQLList.class);
     GraphQLType wrappedType = ((GraphQLList) outerType).getWrappedType();
     assertThat(wrappedType).isInstanceOf(GraphQLNonNull.class);
@@ -428,7 +415,9 @@ public class TableGraphQlModelTest {
     assertThat(objectType.getName()).isEqualTo(TABLE_NAME + "_ScanPayload");
     List<GraphQLFieldDefinition> fields = objectType.getFieldDefinitions();
     assertThat(fields.size()).isEqualTo(1);
-    assertNonNullListOfNonNullObjectField(fields.get(0), TABLE_NAME, model.getObjectType());
+    GraphQLFieldDefinition field = fields.get(0);
+    assertThat(field.getName()).isEqualTo(TABLE_NAME);
+    assertNonNullListOfNonNullObject(model.getObjectType(), field.getType());
   }
 
   @Test
@@ -524,7 +513,8 @@ public class TableGraphQlModelTest {
     assertNonNullFieldDefinition(field, TABLE_NAME + "_bulkPut", Scalars.GraphQLBoolean);
     assertThat(field.getArguments().size()).isEqualTo(1);
     GraphQLArgument argument = field.getArguments().get(0);
-    assertNonNullListOfNonNullObjectArgument(argument, "put", model.getPutInputObjectType());
+    assertThat(argument.getName()).isEqualTo("put");
+    assertNonNullListOfNonNullObject(model.getPutInputObjectType(), argument.getType());
   }
 
   @Test
@@ -582,8 +572,9 @@ public class TableGraphQlModelTest {
     GraphQLFieldDefinition field = model.getMutationBulkDeleteField();
     assertNonNullFieldDefinition(field, TABLE_NAME + "_bulkDelete", Scalars.GraphQLBoolean);
     assertThat(field.getArguments().size()).isEqualTo(1);
-    assertNonNullListOfNonNullObjectArgument(
-        field.getArguments().get(0), "delete", model.getDeleteInputObjectType());
+    GraphQLArgument argument = field.getArguments().get(0);
+    assertThat(argument.getName()).isEqualTo("delete");
+    assertNonNullListOfNonNullObject(model.getDeleteInputObjectType(), argument.getType());
   }
 
   @Test


### PR DESCRIPTION
This PR changes the schema generation as follows, for example, for a table named `table_1`.

Before:

```graphql
type Mutation {
  abort: Boolean
  commit: Boolean
  table_1_delete(delete: [table_1_DeleteInput!]!): table_1_DeletePayload
  table_1_put(put: [table_1_PutInput!]!): table_1_PutPayload
}
```

After:

```graphql
type Mutation {
  abort: Boolean!
  commit: Boolean!
  table_1_bulkDelete(delete: [table_1_DeleteInput!]!): Boolean!
  table_1_bulkPut(put: [table_1_PutInput!]!): Boolean!
  table_1_delete(delete: table_1_DeleteInput!): Boolean!
  table_1_mutate(delete: [table_1_DeleteInput!], put: [table_1_PutInput!]): Boolean!
  table_1_put(put: table_1_PutInput!): Boolean!
}
```

1. Make the type of `commit` and `abort` non-null.
2. Add `put` and `delete` mutations that accept a single input object. The previous `put` and `delete` have been renamed to `bulkPut` and `bulkDelete`. (The naming of bulk- is following Stargate. It generates operations like `insertbooks()` and `bulkInsertbooks()` if we have a `books` table.)

    The `put` operation should translate and pass the argument to Scalar DB's `put(Put)` method, and `bulkPut` operation should do that to `put(List<Put>)`. The same applies to `delete` and `bulkDelete`.
    Previously we made a decision that the put operation receives a list of `PutInput` because I misunderstood that it is not allowed to run multiple mutations with the same name in a single execution. Actually, it's possible to send the same operation multiple times using aliases like the example below.

    ```graphql
    mutation put2mountains {
      mt_fuji: mountain_put(put: { key: { name: "Mt. Fuji" }, values: { elevation: 3776 }})
      takaosan: mountain_put(put: { key: { name: "Takaosan" }, values: { elevation: 599 }})
    }
    ```

    Additionally `table_1_mutate()` field that accepts both lists of `put` and `delete` is added to the `Mutation` type. It should map to Scalar DB's `mutate` operation.

3. Remove the result type of mutations `<table_name>_MutationResult`, since the mutations in Scalar DB API are void methods. The response type used to have an `applied` boolean field, but it doesn't make sense for `put(List<Put>)` and `delete(List<Delete>)` since the mutations in the list either all succeed or all fail.