### PR TITLE
Add `SCALAR_DB_SERVER_PORT` to database.properties.tmpl

### DIFF
--- a/server/conf/database.properties.tmpl
+++ b/server/conf/database.properties.tmpl
@@ -24,3 +24,6 @@ scalar.db.isolation_level={{ default .Env.SCALAR_DB_ISOLATION_LEVEL "" }}
 # Either EXTRA_READ or EXTRA_WRITE can be specified. EXTRA_READ is used by default.
 # If SNAPSHOT is specified, this is ignored.
 scalar.db.consensus_commit.serializable_strategy={{ default .Env.SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY "" }}
+
+# Port number for grpc server. Default port number is 60051.
+scalar.db.server.port={{ default .Env.SCALAR_DB_SERVER_PORT "" }}


### PR DESCRIPTION
## Summary
- Added support for configuring the server port, as there are some use cases that run on ports other than the default server port (60051).
