### PR TITLE
Filter transactional columns and support projection for get/scan in Consensus Commit

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -176,7 +176,8 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     // Assert
     assertThat(result.isPresent()).isTrue();
-    Assertions.assertThat(((TransactionResult) result.get()).getState())
+    Assertions.assertThat(
+            ((TransactionResult) ((FilteredResult) result.get()).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
 
@@ -193,7 +194,8 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     // Assert
     assertThat(results.size()).isEqualTo(1);
-    Assertions.assertThat(((TransactionResult) results.get(0)).getState())
+    Assertions.assertThat(
+            ((TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
 
@@ -294,11 +296,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_2);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -346,11 +348,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -444,11 +446,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -518,11 +520,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_2);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -589,11 +591,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -694,11 +696,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -792,11 +794,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -929,11 +931,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) r.get();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) results.get(0);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -1003,7 +1005,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     Optional<Result> r = another.get(get);
     assertThat(r).isPresent();
-    TransactionResult result = (TransactionResult) r.get();
+    TransactionResult result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(result)).isEqualTo(expected);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
@@ -1029,7 +1031,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     ConsensusCommit another = manager.start();
     Optional<Result> r = another.get(get);
     assertThat(r).isPresent();
-    TransactionResult actual = (TransactionResult) r.get();
+    TransactionResult actual = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(actual)).isEqualTo(expected);
     Assertions.assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(actual.getVersion()).isEqualTo(2);

--- a/core/src/main/java/com/scalar/db/storage/common/ResultImpl.java
+++ b/core/src/main/java/com/scalar/db/storage/common/ResultImpl.java
@@ -1,11 +1,11 @@
 package com.scalar.db.storage.common;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -61,7 +61,7 @@ public class ResultImpl implements Result {
   @Override
   @Nonnull
   public Map<String, Value<?>> getValues() {
-    return Collections.unmodifiableMap(values);
+    return ImmutableMap.copyOf(values);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -17,8 +17,10 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.util.ScalarDbUtils;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,9 +92,7 @@ public class ConsensusCommit implements DistributedTransaction {
 
   /**
    * Retrieves a result from the storage through a transaction with the specified {@link Get}
-   * command with a primary key and returns the result. Note that the current implementation clears
-   * the specified projections in {@link Get} to project all the values including metadata properly,
-   * but the behavior might be changed at some point.
+   * command with a primary key and returns the result.
    *
    * @param get a {@code Get} command
    * @return an {@code Optional} with the returned result
@@ -101,9 +101,10 @@ public class ConsensusCommit implements DistributedTransaction {
   @Override
   public Optional<Result> get(Get get) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    List<String> projections = new ArrayList<>(get.getProjections());
     get.clearProjections(); // project all
     try {
-      return crud.get(get);
+      return crud.get(get).map(r -> new FilteredResult(r, projections));
     } catch (UncommittedRecordException e) {
       lazyRecovery(get, e.getResults());
       throw e;
@@ -113,9 +114,7 @@ public class ConsensusCommit implements DistributedTransaction {
   /**
    * Retrieves results from the storage through a transaction with the specified {@link Scan}
    * command with a partition key and returns a list of {@link Result}. Results can be filtered by
-   * specifying a range of clustering keys. Note that the current implementation clears the
-   * specified projections in {@link Scan} to project all the values including metadata properly,
-   * but the behavior might be changed at some point.
+   * specifying a range of clustering keys.
    *
    * @param scan a {@code Scan} command
    * @return a list of {@link Result}
@@ -124,9 +123,12 @@ public class ConsensusCommit implements DistributedTransaction {
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    List<String> projections = new ArrayList<>(scan.getProjections());
     scan.clearProjections(); // project all
     try {
-      return crud.scan(scan);
+      return crud.scan(scan).stream()
+          .map(r -> new FilteredResult(r, projections))
+          .collect(Collectors.toList());
     } catch (UncommittedRecordException e) {
       lazyRecovery(scan, e.getResults());
       throw e;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -139,4 +139,33 @@ public final class ConsensusCommitUtils {
     tableMetadata.getSecondaryIndexNames().forEach(builder::addSecondaryIndex);
     return builder.build();
   }
+
+  /**
+   * Returns whether the specified column is transactional or not.
+   *
+   * @param columnName a column name
+   * @param tableMetadata a transactional table metadata
+   * @return whether the specified column is transactional or not
+   */
+  public static boolean isTransactionalMetaColumn(String columnName, TableMetadata tableMetadata) {
+    return isTransactionalMetaColumn(columnName, tableMetadata.getColumnNames());
+  }
+
+  /**
+   * Returns whether the specified column is transactional or not.
+   *
+   * @param columnName a column name
+   * @param allColumnNames a set of all the column names
+   * @return whether the specified column is transactional or not
+   */
+  public static boolean isTransactionalMetaColumn(String columnName, Set<String> allColumnNames) {
+    if (TRANSACTION_META_COLUMNS.containsKey(columnName)) {
+      return true;
+    }
+    if (columnName.startsWith(Attribute.BEFORE_PREFIX)) {
+      // if the column name without the "before_" prefix exists, it's a transactional meta column
+      return allColumnNames.contains(columnName.substring(Attribute.BEFORE_PREFIX.length()));
+    }
+    return false;
+  }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
@@ -18,7 +18,9 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** An implementation of {@code Result} to filter projected columns and transactional columns. */
+/**
+ * An implementation of {@code Result} to filter out unprojected columns and transactional columns.
+ */
 public class FilteredResult implements Result {
   private static final Logger LOGGER = LoggerFactory.getLogger(FilteredResult.class);
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
@@ -1,0 +1,108 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Result;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.Value;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** An implementation of {@code Result} to filter projected columns and transactional columns. */
+public class FilteredResult implements Result {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FilteredResult.class);
+
+  private final Result result;
+  private final Set<String> projections;
+  private final Supplier<Map<String, Value<?>>> values;
+
+  public FilteredResult(Result result, List<String> projections) {
+    // assume that all the values are projected to the original result
+    this.result = Objects.requireNonNull(result);
+    this.projections = new HashSet<>(Objects.requireNonNull(projections));
+    values = Suppliers.memoize(this::filterValues); // lazy loading
+  }
+
+  private Map<String, Value<?>> filterValues() {
+    return result.getValues().entrySet().stream()
+        .filter(e -> projections.isEmpty() || projections.contains(e.getKey()))
+        .filter(
+            e ->
+                !ConsensusCommitUtils.isTransactionalMetaColumn(
+                    e.getKey(), result.getValues().keySet()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Optional<Key> getPartitionKey() {
+    return getKey(result.getPartitionKey());
+  }
+
+  @Override
+  public Optional<Key> getClusteringKey() {
+    return getKey(result.getClusteringKey());
+  }
+
+  private Optional<Key> getKey(Optional<Key> key) {
+    if (!key.isPresent()) {
+      return Optional.empty();
+    }
+    if (projections.isEmpty()) {
+      return key;
+    }
+    for (Value<?> value : key.get()) {
+      if (!projections.contains(value.getName())) {
+        LOGGER.warn("full key doesn't seem to be projected into the result");
+        return Optional.empty();
+      }
+    }
+    return key;
+  }
+
+  @Override
+  public Optional<Value<?>> getValue(String name) {
+    return Optional.ofNullable(values.get().get(name));
+  }
+
+  @Override
+  public Map<String, Value<?>> getValues() {
+    return ImmutableMap.copyOf(values.get());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof FilteredResult)) {
+      return false;
+    }
+    FilteredResult that = (FilteredResult) o;
+    return values.get().equals(that.values.get());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(values.get());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("values", values.get()).toString();
+  }
+
+  @VisibleForTesting
+  Result getOriginalResult() {
+    return result;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -23,9 +23,11 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.util.ScalarDbUtils;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
@@ -110,9 +112,7 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
 
   /**
    * Retrieves a result from the storage through a transaction with the specified {@link Get}
-   * command with a primary key and returns the result. Note that the current implementation clears
-   * the specified projections in {@link Get} to project all the values including metadata properly,
-   * but the behavior might be changed at some point.
+   * command with a primary key and returns the result.
    *
    * @param get a {@code Get} command
    * @return an {@code Optional} with the returned result
@@ -123,9 +123,10 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
     checkStatus("The transaction is not active", Status.ACTIVE);
     updateTransactionExpirationTime();
     setTargetToIfNot(get);
+    List<String> projections = new ArrayList<>(get.getProjections());
     get.clearProjections(); // project all
     try {
-      return crud.get(get);
+      return crud.get(get).map(r -> new FilteredResult(r, projections));
     } catch (UncommittedRecordException e) {
       lazyRecovery(get, e.getResults());
       throw e;
@@ -135,9 +136,7 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
   /**
    * Retrieves results from the storage through a transaction with the specified {@link Scan}
    * command with a partition key and returns a list of {@link Result}. Results can be filtered by
-   * specifying a range of clustering keys. Note that the current implementation clears the
-   * specified projections in {@link Scan} to project all the values including metadata properly,
-   * but the behavior might be changed at some point.
+   * specifying a range of clustering keys.
    *
    * @param scan a {@code Scan} command
    * @return a list of {@link Result}
@@ -148,9 +147,12 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
     checkStatus("The transaction is not active", Status.ACTIVE);
     updateTransactionExpirationTime();
     setTargetToIfNot(scan);
+    List<String> projections = new ArrayList<>(scan.getProjections());
     scan.clearProjections(); // project all
     try {
-      return crud.scan(scan);
+      return crud.scan(scan).stream()
+          .map(r -> new FilteredResult(r, projections))
+          .collect(Collectors.toList());
     } catch (UncommittedRecordException e) {
       lazyRecovery(scan, e.getResults());
       throw e;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -66,7 +66,7 @@ public class ConsensusCommitTest {
     Optional<Result> actual = consensus.get(get);
 
     // Assert
-    assertThat(actual.get()).isEqualTo(result);
+    assertThat(actual).isPresent();
     verify(recovery, never()).recover(get, result);
     verify(crud).get(get);
   }
@@ -97,7 +97,7 @@ public class ConsensusCommitTest {
     List<Result> actual = consensus.scan(scan);
 
     // Assert
-    assertThat(actual).isEqualTo(results);
+    assertThat(actual.size()).isEqualTo(1);
     verify(crud).scan(scan);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
@@ -3,8 +3,10 @@ package com.scalar.db.transaction.consensuscommit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
+import java.util.Set;
 import org.junit.Test;
 
 public class ConsensusCommitUtilsTest {
@@ -235,5 +237,130 @@ public class ConsensusCommitUtilsTest {
                 .addPartitionKey(ACCOUNT_ID)
                 .addClusteringKey(ACCOUNT_TYPE)
                 .build());
+  }
+
+  @Test
+  public void isTransactionalMetaColumn_TableMetadataGiven_shouldReturnProperResult() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .build();
+
+    // Act Assert
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_ID, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_TYPE, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(BALANCE, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.ID, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.STATE, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.VERSION, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.PREPARED_AT, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.COMMITTED_AT, metadata))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(
+                Attribute.BEFORE_PREFIX + BALANCE, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_ID, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_STATE, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_VERSION, metadata))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_PREPARED_AT, metadata))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_COMMITTED_AT, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn("aaa", metadata)).isFalse();
+  }
+
+  @Test
+  public void isTransactionalMetaColumn_ResultGiven_shouldReturnProperResult() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    Set<String> allColumnNames =
+        ImmutableSet.<String>builder()
+            .add(ACCOUNT_ID)
+            .add(ACCOUNT_TYPE)
+            .add(BALANCE)
+            .add(Attribute.ID)
+            .add(Attribute.STATE)
+            .add(Attribute.VERSION)
+            .add(Attribute.PREPARED_AT)
+            .add(Attribute.COMMITTED_AT)
+            .add(Attribute.BEFORE_PREFIX + BALANCE)
+            .add(Attribute.BEFORE_ID)
+            .add(Attribute.BEFORE_STATE)
+            .add(Attribute.BEFORE_VERSION)
+            .add(Attribute.BEFORE_PREPARED_AT)
+            .add(Attribute.BEFORE_COMMITTED_AT)
+            .build();
+
+    // Act Assert
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_ID, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_TYPE, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(BALANCE, allColumnNames)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.ID, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.STATE, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.VERSION, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.PREPARED_AT, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.COMMITTED_AT, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(
+                Attribute.BEFORE_PREFIX + BALANCE, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_ID, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_STATE, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(
+                Attribute.BEFORE_VERSION, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(
+                Attribute.BEFORE_PREPARED_AT, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isTransactionalMetaColumn(
+                Attribute.BEFORE_COMMITTED_AT, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn("aaa", allColumnNames)).isFalse();
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
@@ -1,0 +1,244 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.TextValue;
+import com.scalar.db.io.Value;
+import com.scalar.db.storage.common.ResultImpl;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FilteredResultTest {
+
+  private static final String ACCOUNT_ID = "account_id";
+  private static final String ACCOUNT_TYPE = "account_type";
+  private static final String BALANCE = "balance";
+
+  private static final IntValue ACCOUNT_ID_VALUE = new IntValue(ACCOUNT_ID, 0);
+  private static final IntValue ACCOUNT_TYPE_VALUE = new IntValue(ACCOUNT_TYPE, 1);
+  private static final IntValue BALANCE_VALUE = new IntValue(BALANCE, 2);
+  private static final TextValue ID_VALUE = new TextValue(Attribute.ID, "aaa");
+  private static final IntValue STATE_VALUE = new IntValue(Attribute.STATE, 3);
+  private static final IntValue VERSION_VALUE = new IntValue(Attribute.VERSION, 4);
+  private static final BigIntValue PREPARED_AT_VALUE = new BigIntValue(Attribute.PREPARED_AT, 5);
+  private static final BigIntValue COMMITTED_AT_VALUE = new BigIntValue(Attribute.COMMITTED_AT, 6);
+  private static final IntValue BEFORE_BALANCE_VALUE =
+      new IntValue(Attribute.BEFORE_PREFIX + BALANCE, 7);
+  private static final TextValue BEFORE_ID_VALUE = new TextValue(Attribute.BEFORE_ID, "bbb");
+  private static final IntValue BEFORE_STATE_VALUE = new IntValue(Attribute.BEFORE_STATE, 8);
+  private static final IntValue BEFORE_VERSION_VALUE = new IntValue(Attribute.BEFORE_VERSION, 9);
+  private static final BigIntValue BEFORE_PREPARED_AT_VALUE =
+      new BigIntValue(Attribute.BEFORE_PREPARED_AT, 10);
+  private static final BigIntValue BEFORE_COMMITTED_AT_VALUE =
+      new BigIntValue(Attribute.BEFORE_COMMITTED_AT, 11);
+
+  private Result result;
+
+  @Before
+  public void setUp() throws Exception {
+    // Arrange
+    Map<String, Value<?>> values =
+        ImmutableMap.<String, Value<?>>builder()
+            .put(ACCOUNT_ID, ACCOUNT_ID_VALUE)
+            .put(ACCOUNT_TYPE, ACCOUNT_TYPE_VALUE)
+            .put(BALANCE, BALANCE_VALUE)
+            .put(Attribute.ID, ID_VALUE)
+            .put(Attribute.STATE, STATE_VALUE)
+            .put(Attribute.VERSION, VERSION_VALUE)
+            .put(Attribute.PREPARED_AT, PREPARED_AT_VALUE)
+            .put(Attribute.COMMITTED_AT, COMMITTED_AT_VALUE)
+            .put(Attribute.BEFORE_PREFIX + BALANCE, BEFORE_BALANCE_VALUE)
+            .put(Attribute.BEFORE_ID, BEFORE_ID_VALUE)
+            .put(Attribute.BEFORE_STATE, BEFORE_STATE_VALUE)
+            .put(Attribute.BEFORE_VERSION, BEFORE_VERSION_VALUE)
+            .put(Attribute.BEFORE_PREPARED_AT, BEFORE_PREPARED_AT_VALUE)
+            .put(Attribute.BEFORE_COMMITTED_AT, BEFORE_COMMITTED_AT_VALUE)
+            .build();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .build();
+    result = new ResultImpl(values, metadata);
+  }
+
+  @Test
+  public void WithoutProjections_ShouldFilterTransactionMetaColumns() {
+    // Arrange
+    FilteredResult filteredResult = new FilteredResult(result, Collections.emptyList());
+
+    // Act Assert
+    assertThat(filteredResult.getPartitionKey()).isPresent();
+    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+
+    assertThat(filteredResult.getClusteringKey()).isPresent();
+    assertThat(filteredResult.getClusteringKey().get().size()).isEqualTo(1);
+    assertThat(filteredResult.getClusteringKey().get().get().get(0)).isEqualTo(ACCOUNT_TYPE_VALUE);
+
+    assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get()).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+
+    assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT)).isNotPresent();
+  }
+
+  @Test
+  public void WithProjections_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+    // Arrange
+    FilteredResult filteredResult = new FilteredResult(result, Arrays.asList(ACCOUNT_ID, BALANCE));
+
+    // Act Assert
+    assertThat(filteredResult.getPartitionKey()).isPresent();
+    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+
+    assertThat(filteredResult.getClusteringKey()).isNotPresent();
+
+    assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
+    assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+
+    assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT)).isNotPresent();
+  }
+
+  @Test
+  public void
+      WithProjectionsForPartitionKey_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+    // Arrange
+    FilteredResult filteredResult =
+        new FilteredResult(result, Collections.singletonList(ACCOUNT_ID));
+
+    // Act Assert
+    assertThat(filteredResult.getPartitionKey()).isPresent();
+    assertThat(filteredResult.getPartitionKey().get().size()).isEqualTo(1);
+    assertThat(filteredResult.getPartitionKey().get().get().get(0)).isEqualTo(ACCOUNT_ID_VALUE);
+
+    assertThat(filteredResult.getClusteringKey()).isNotPresent();
+
+    assertThat(filteredResult.getValue(ACCOUNT_ID).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(ACCOUNT_ID).get()).isEqualTo(ACCOUNT_ID_VALUE);
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
+    assertThat(filteredResult.getValue(BALANCE)).isNotPresent();
+
+    assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT)).isNotPresent();
+  }
+
+  @Test
+  public void
+      WithProjectionsForClusteringKey_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+    // Arrange
+    FilteredResult filteredResult =
+        new FilteredResult(result, Collections.singletonList(ACCOUNT_TYPE));
+
+    // Act Assert
+    assertThat(filteredResult.getPartitionKey()).isNotPresent();
+
+    assertThat(filteredResult.getClusteringKey()).isPresent();
+    assertThat(filteredResult.getClusteringKey().get().size()).isEqualTo(1);
+    assertThat(filteredResult.getClusteringKey().get().get().get(0)).isEqualTo(ACCOUNT_TYPE_VALUE);
+
+    assertThat(filteredResult.getValue(ACCOUNT_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE).get()).isEqualTo(ACCOUNT_TYPE_VALUE);
+    assertThat(filteredResult.getValue(BALANCE)).isNotPresent();
+
+    assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT)).isNotPresent();
+  }
+
+  @Test
+  public void
+      WithProjectionsForNonPrimaryKey_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+    // Arrange
+    FilteredResult filteredResult = new FilteredResult(result, Collections.singletonList(BALANCE));
+
+    // Act Assert
+    assertThat(filteredResult.getPartitionKey()).isNotPresent();
+    assertThat(filteredResult.getClusteringKey()).isNotPresent();
+
+    assertThat(filteredResult.getValue(ACCOUNT_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(ACCOUNT_TYPE)).isNotPresent();
+    assertThat(filteredResult.getValue(BALANCE).isPresent()).isTrue();
+    assertThat(filteredResult.getValue(BALANCE).get()).isEqualTo(BALANCE_VALUE);
+
+    assertThat(filteredResult.getValue(Attribute.ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.COMMITTED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREFIX + BALANCE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_ID)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_STATE)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_VERSION)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_PREPARED_AT)).isNotPresent();
+    assertThat(filteredResult.getValue(Attribute.BEFORE_COMMITTED_AT)).isNotPresent();
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
@@ -86,7 +86,7 @@ public class FilteredResultTest {
   }
 
   @Test
-  public void WithoutProjections_ShouldFilterTransactionMetaColumns() {
+  public void WithoutProjections_ShouldFilterOutTransactionMetaColumns() {
     // Arrange
     FilteredResult filteredResult = new FilteredResult(result, Collections.emptyList());
 
@@ -120,7 +120,7 @@ public class FilteredResultTest {
   }
 
   @Test
-  public void WithProjections_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+  public void WithProjections_ShouldFilterOutUnprojectedColumnsAndTransactionMetaColumns() {
     // Arrange
     FilteredResult filteredResult = new FilteredResult(result, Arrays.asList(ACCOUNT_ID, BALANCE));
 
@@ -152,7 +152,7 @@ public class FilteredResultTest {
 
   @Test
   public void
-      WithProjectionsForPartitionKey_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+      WithProjectionsForPartitionKey_ShouldFilterOutUnprojectedColumnsAndTransactionMetaColumns() {
     // Arrange
     FilteredResult filteredResult =
         new FilteredResult(result, Collections.singletonList(ACCOUNT_ID));
@@ -184,7 +184,7 @@ public class FilteredResultTest {
 
   @Test
   public void
-      WithProjectionsForClusteringKey_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+      WithProjectionsForClusteringKey_ShouldFilterOutUnprojectedColumnsAndTransactionMetaColumns() {
     // Arrange
     FilteredResult filteredResult =
         new FilteredResult(result, Collections.singletonList(ACCOUNT_TYPE));
@@ -216,7 +216,7 @@ public class FilteredResultTest {
 
   @Test
   public void
-      WithProjectionsForNonPrimaryKey_ShouldFilterNonProjectedColumnsAndTransactionMetaColumns() {
+      WithProjectionsForNonPrimaryKey_ShouldFilterOutUnprojectedColumnsAndTransactionMetaColumns() {
     // Arrange
     FilteredResult filteredResult = new FilteredResult(result, Collections.singletonList(BALANCE));
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -75,7 +75,6 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     assertThat(actual).isPresent();
-    assertThat(actual.get()).isEqualTo(result);
     verify(recovery, never()).recover(get, result);
     verify(crud).get(get);
   }
@@ -112,7 +111,7 @@ public class TwoPhaseConsensusCommitTest {
     List<Result> actual = transaction.scan(scan);
 
     // Assert
-    assertThat(actual).isEqualTo(results);
+    assertThat(actual.size()).isEqualTo(1);
     verify(crud).scan(scan);
   }
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitIntegrationTest.java
@@ -28,7 +28,6 @@ import com.scalar.db.service.StorageFactory;
 import com.scalar.db.storage.rpc.GrpcConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdmin;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.TransactionResult;
 import com.scalar.db.transaction.rpc.GrpcTransaction;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
 import java.io.IOException;
@@ -137,8 +136,6 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
 
     // Assert
     assertThat(result.isPresent()).isTrue();
-    assertThat(new TransactionResult(result.get()).getState())
-        .isEqualTo(TransactionState.COMMITTED);
   }
 
   @Test
@@ -154,8 +151,6 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
 
     // Assert
     assertThat(results.size()).isEqualTo(1);
-    assertThat(new TransactionResult(results.get(0)).getState())
-        .isEqualTo(TransactionState.COMMITTED);
   }
 
   @Test
@@ -229,13 +224,10 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
     // Assert
     Get get = prepareGet(0, 0, TABLE_1);
     GrpcTransaction another = manager.start();
-    Optional<Result> r = another.get(get);
-    assertThat(r).isPresent();
-    TransactionResult result = new TransactionResult(r.get());
+    Optional<Result> result = another.get(get);
     another.commit();
-    assertThat(getBalance(result)).isEqualTo(expected);
-    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(1);
+    assertThat(result).isPresent();
+    assertThat(getBalance(result.get())).isEqualTo(expected);
   }
 
   @Test
@@ -256,13 +248,10 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
 
     // Assert
     GrpcTransaction another = manager.start();
-    Optional<Result> r = another.get(get);
-    assertThat(r).isPresent();
-    TransactionResult actual = new TransactionResult(r.get());
+    Optional<Result> actual = another.get(get);
+    assertThat(actual).isPresent();
     another.commit();
-    assertThat(getBalance(actual)).isEqualTo(expected);
-    assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(actual.getVersion()).isEqualTo(2);
+    assertThat(getBalance(actual.get())).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
Currently, Get/Scan operations results include the transactional columns and non-projected columns in Consensus Commit. After this change, we will get the Get/Scan operations results without the transactional columns, and it also adds a Projection function support. Please take a look!