### PR TITLE
Upgrade log4j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
         errorproneVersion = '2.10.0'
         errorproneJavacVersion = '9+181-r4173-1'
         gsonVersion = '2.8.7'
-        log4jVersion = '2.14.1'
+        log4jVersion = '2.15.0'
     }
 
     repositories {


### PR DESCRIPTION
We need to upgrade the log4j version because it has a vulnerability explained in the following article:
https://www.lunasec.io/docs/blog/log4j-zero-day/

In Scalar DB, only Scalar DB Server uses log4j for now.

Please take a look!