### PR TITLE
Use different datasource for table metadata in JDBC adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -25,8 +25,16 @@ public class JdbcConfig extends DatabaseConfig {
       PREFIX + "prepared_statements_pool.enabled";
   public static final String PREPARED_STATEMENTS_POOL_MAX_OPEN =
       PREFIX + "prepared_statements_pool.max_open";
-  public static final String TABLE_METADATA_SCHEMA = PREFIX + "table_metadata.schema";
+
   public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
+
+  public static final String TABLE_METADATA_SCHEMA = PREFIX + "table_metadata.schema";
+  public static final String TABLE_METADATA_CONNECTION_POOL_MIN_IDLE =
+      PREFIX + "table_metadata.connection_pool.min_idle";
+  public static final String TABLE_METADATA_CONNECTION_POOL_MAX_IDLE =
+      PREFIX + "table_metadata.connection_pool.max_idle";
+  public static final String TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL =
+      PREFIX + "table_metadata.connection_pool.max_total";
 
   public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 20;
   public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 50;
@@ -34,13 +42,22 @@ public class JdbcConfig extends DatabaseConfig {
   public static final boolean DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED = false;
   public static final int DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN = -1;
 
+  public static final int DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE = 5;
+  public static final int DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE = 10;
+  public static final int DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL = 25;
+
   private int connectionPoolMinIdle;
   private int connectionPoolMaxIdle;
   private int connectionPoolMaxTotal;
   private boolean preparedStatementsPoolEnabled;
   private int preparedStatementsPoolMaxOpen;
-  @Nullable private String tableMetadataSchema;
+
   @Nullable private Isolation isolation;
+
+  @Nullable private String tableMetadataSchema;
+  private int tableMetadataConnectionPoolMinIdle;
+  private int tableMetadataConnectionPoolMaxIdle;
+  private int tableMetadataConnectionPoolMaxTotal;
 
   public JdbcConfig(File propertiesFile) throws IOException {
     super(propertiesFile);
@@ -80,12 +97,27 @@ public class JdbcConfig extends DatabaseConfig {
             PREPARED_STATEMENTS_POOL_MAX_OPEN,
             DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
 
-    tableMetadataSchema = getString(getProperties(), TABLE_METADATA_SCHEMA, null);
-
     String isolationLevel = getString(getProperties(), ISOLATION_LEVEL, null);
     if (isolationLevel != null) {
       isolation = Isolation.valueOf(isolationLevel);
     }
+
+    tableMetadataSchema = getString(getProperties(), TABLE_METADATA_SCHEMA, null);
+    tableMetadataConnectionPoolMinIdle =
+        getInt(
+            getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_MIN_IDLE,
+            DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE);
+    tableMetadataConnectionPoolMaxIdle =
+        getInt(
+            getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_MAX_IDLE,
+            DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE);
+    tableMetadataConnectionPoolMaxTotal =
+        getInt(
+            getProperties(),
+            TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL,
+            DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL);
   }
 
   public int getConnectionPoolMinIdle() {
@@ -108,12 +140,23 @@ public class JdbcConfig extends DatabaseConfig {
     return preparedStatementsPoolMaxOpen;
   }
 
+  public Optional<Isolation> getIsolation() {
+    return Optional.ofNullable(isolation);
+  }
+
   public Optional<String> getTableMetadataSchema() {
     return Optional.ofNullable(tableMetadataSchema);
   }
 
-  @Nullable
-  public Isolation getIsolation() {
-    return isolation;
+  public int getTableMetadataConnectionPoolMinIdle() {
+    return tableMetadataConnectionPoolMinIdle;
+  }
+
+  public int getTableMetadataConnectionPoolMaxIdle() {
+    return tableMetadataConnectionPoolMaxIdle;
+  }
+
+  public int getTableMetadataConnectionPoolMaxTotal() {
+    return tableMetadataConnectionPoolMaxTotal;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabaseAdmin.java
@@ -126,7 +126,7 @@ public class JdbcDatabaseAdmin implements DistributedStorageAdmin {
 
   @Inject
   public JdbcDatabaseAdmin(JdbcConfig config) {
-    dataSource = JdbcUtils.initDataSource(config, config.getIsolation());
+    dataSource = JdbcUtils.initDataSource(config);
     rdbEngine = JdbcUtils.getRdbEngine(config.getContactPoints().get(0));
     metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);
   }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -26,11 +26,14 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
     props.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "1");
     props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "100");
-    props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "200");
+    props.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "500");
     props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
     props.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "300");
-    props.setProperty(JdbcConfig.TABLE_METADATA_SCHEMA, ANY_TABLE_METADATA_SCHEMA);
     props.setProperty(JdbcConfig.ISOLATION_LEVEL, Isolation.SERIALIZABLE.name());
+    props.setProperty(JdbcConfig.TABLE_METADATA_SCHEMA, ANY_TABLE_METADATA_SCHEMA);
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "100");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_IDLE, "200");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
 
     // Act
     JdbcConfig config = new JdbcConfig(props);
@@ -46,12 +49,16 @@ public class JdbcConfigTest {
     assertThat(config.getAdminClass()).isEqualTo(JdbcDatabaseAdmin.class);
     assertThat(config.getConnectionPoolMinIdle()).isEqualTo(1);
     assertThat(config.getConnectionPoolMaxIdle()).isEqualTo(100);
-    assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(200);
+    assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(500);
     assertThat(config.isPreparedStatementsPoolEnabled()).isEqualTo(true);
     assertThat(config.getPreparedStatementsPoolMaxOpen()).isEqualTo(300);
+    assertThat(config.getIsolation()).isPresent();
+    assertThat(config.getIsolation().get()).isEqualTo(Isolation.SERIALIZABLE);
     assertThat(config.getTableMetadataSchema()).isPresent();
     assertThat(config.getTableMetadataSchema().get()).isEqualTo(ANY_TABLE_METADATA_SCHEMA);
-    assertThat(config.getIsolation()).isEqualTo(Isolation.SERIALIZABLE);
+    assertThat(config.getTableMetadataConnectionPoolMinIdle()).isEqualTo(100);
+    assertThat(config.getTableMetadataConnectionPoolMaxIdle()).isEqualTo(200);
+    assertThat(config.getTableMetadataConnectionPoolMaxTotal()).isEqualTo(300);
   }
 
   @Test
@@ -86,8 +93,14 @@ public class JdbcConfigTest {
         .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     assertThat(config.getPreparedStatementsPoolMaxOpen())
         .isEqualTo(JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
+    assertThat(config.getIsolation()).isNotPresent();
     assertThat(config.getTableMetadataSchema()).isNotPresent();
-    assertThat(config.getIsolation()).isNull();
+    assertThat(config.getTableMetadataConnectionPoolMinIdle())
+        .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MIN_IDLE);
+    assertThat(config.getTableMetadataConnectionPoolMaxIdle())
+        .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE);
+    assertThat(config.getTableMetadataConnectionPoolMaxTotal())
+        .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL);
   }
 
   @Test
@@ -148,6 +161,23 @@ public class JdbcConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
     props.setProperty(JdbcConfig.ISOLATION_LEVEL, "aaa");
+
+    // Act Assert
+    assertThatThrownBy(() -> new JdbcConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_PropertiesWithInvalidTableMetadataConnectionPoolPropertiesGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_JDBC_URL);
+    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+    props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "aaa");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_IDLE, "bbb");
+    props.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "ccc");
 
     // Act Assert
     assertThatThrownBy(() -> new JdbcConfig(props)).isInstanceOf(IllegalArgumentException.class);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -30,6 +30,7 @@ import org.mockito.MockitoAnnotations;
 public class JdbcDatabaseTest {
 
   @Mock private BasicDataSource dataSource;
+  @Mock private BasicDataSource tableMetadataDataSource;
   @Mock private JdbcService jdbcService;
 
   @Mock private ResultInterpreter resultInterpreter;
@@ -43,7 +44,8 @@ public class JdbcDatabaseTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    jdbcDatabase = new JdbcDatabase(dataSource, RdbEngine.MYSQL, jdbcService);
+    jdbcDatabase =
+        new JdbcDatabase(dataSource, tableMetadataDataSource, RdbEngine.MYSQL, jdbcService);
 
     when(dataSource.getConnection()).thenReturn(connection);
   }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -1,0 +1,126 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.Test;
+
+public class JdbcUtilsTest {
+
+  @Test
+  public void initDataSource_NonTransactional_ShouldReturnProperDataSource() throws SQLException {
+    // Arrange
+    Properties properties = new Properties();
+    properties.setProperty(DatabaseConfig.CONTACT_POINTS, "jdbc:mysql://localhost:3306/");
+    properties.setProperty(DatabaseConfig.USERNAME, "root");
+    properties.setProperty(DatabaseConfig.PASSWORD, "mysql");
+    properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
+    properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "SERIALIZABLE");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "10");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "20");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "30");
+    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
+    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "100");
+
+    JdbcConfig config = new JdbcConfig(properties);
+
+    // Act
+    BasicDataSource dataSource = JdbcUtils.initDataSource(config);
+
+    // Assert
+    assertThat(dataSource.getUrl()).isEqualTo("jdbc:mysql://localhost:3306/");
+    assertThat(dataSource.getDriver().getClass().getName()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(dataSource.getUsername()).isEqualTo("root");
+    assertThat(dataSource.getPassword()).isEqualTo("mysql");
+
+    assertThat(dataSource.getDefaultAutoCommit()).isEqualTo(null);
+    assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(true);
+    assertThat(dataSource.getDefaultTransactionIsolation())
+        .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
+
+    assertThat(dataSource.getMinIdle()).isEqualTo(10);
+    assertThat(dataSource.getMaxIdle()).isEqualTo(20);
+    assertThat(dataSource.getMaxTotal()).isEqualTo(30);
+    assertThat(dataSource.isPoolPreparedStatements()).isEqualTo(true);
+    assertThat(dataSource.getMaxOpenPreparedStatements()).isEqualTo(100);
+
+    dataSource.close();
+  }
+
+  @Test
+  public void initDataSource_Transactional_ShouldReturnProperDataSource() throws SQLException {
+    // Arrange
+    Properties properties = new Properties();
+    properties.setProperty(DatabaseConfig.CONTACT_POINTS, "jdbc:postgresql://localhost:5432/");
+    properties.setProperty(DatabaseConfig.USERNAME, "user");
+    properties.setProperty(DatabaseConfig.PASSWORD, "postgres");
+    properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
+    properties.setProperty(JdbcConfig.ISOLATION_LEVEL, "READ_COMMITTED");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MIN_IDLE, "30");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_IDLE, "40");
+    properties.setProperty(JdbcConfig.CONNECTION_POOL_MAX_TOTAL, "50");
+    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED, "true");
+    properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "200");
+
+    JdbcConfig config = new JdbcConfig(properties);
+
+    // Act
+    BasicDataSource dataSource = JdbcUtils.initDataSource(config, true);
+
+    // Assert
+    assertThat(dataSource.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/");
+    assertThat(dataSource.getDriver().getClass().getName()).isEqualTo("org.postgresql.Driver");
+    assertThat(dataSource.getUsername()).isEqualTo("user");
+    assertThat(dataSource.getPassword()).isEqualTo("postgres");
+
+    assertThat(dataSource.getDefaultAutoCommit()).isEqualTo(false);
+    assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(false);
+    assertThat(dataSource.getDefaultTransactionIsolation())
+        .isEqualTo(Connection.TRANSACTION_READ_COMMITTED);
+
+    assertThat(dataSource.getMinIdle()).isEqualTo(30);
+    assertThat(dataSource.getMaxIdle()).isEqualTo(40);
+    assertThat(dataSource.getMaxTotal()).isEqualTo(50);
+    assertThat(dataSource.isPoolPreparedStatements()).isEqualTo(true);
+    assertThat(dataSource.getMaxOpenPreparedStatements()).isEqualTo(200);
+
+    dataSource.close();
+  }
+
+  @Test
+  public void initDataSourceForTableMetadata_ShouldReturnProperDataSource() throws SQLException {
+    // Arrange
+    Properties properties = new Properties();
+    properties.setProperty(
+        DatabaseConfig.CONTACT_POINTS, "jdbc:oracle:thin:@localhost:1521/XEPDB1");
+    properties.setProperty(DatabaseConfig.USERNAME, "user");
+    properties.setProperty(DatabaseConfig.PASSWORD, "oracle");
+    properties.setProperty(DatabaseConfig.STORAGE, "jdbc");
+    properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MIN_IDLE, "100");
+    properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_IDLE, "200");
+    properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
+
+    JdbcConfig config = new JdbcConfig(properties);
+
+    // Act
+    BasicDataSource tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config);
+
+    // Assert
+    assertThat(tableMetadataDataSource.getUrl())
+        .isEqualTo("jdbc:oracle:thin:@localhost:1521/XEPDB1");
+    assertThat(tableMetadataDataSource.getDriver().getClass().getName())
+        .isEqualTo("oracle.jdbc.OracleDriver");
+    assertThat(tableMetadataDataSource.getUsername()).isEqualTo("user");
+    assertThat(tableMetadataDataSource.getPassword()).isEqualTo("oracle");
+
+    assertThat(tableMetadataDataSource.getMinIdle()).isEqualTo(100);
+    assertThat(tableMetadataDataSource.getMaxIdle()).isEqualTo(200);
+    assertThat(tableMetadataDataSource.getMaxTotal()).isEqualTo(300);
+
+    tableMetadataDataSource.close();
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -33,6 +33,7 @@ import org.mockito.MockitoAnnotations;
 public class JdbcTransactionManagerTest {
 
   @Mock private BasicDataSource dataSource;
+  @Mock private BasicDataSource tableMetadataDataSource;
   @Mock private JdbcService jdbcService;
   @Mock private Connection connection;
   @Mock private SQLException sqlException;
@@ -42,7 +43,9 @@ public class JdbcTransactionManagerTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    manager = new JdbcTransactionManager(dataSource, RdbEngine.MYSQL, jdbcService);
+    manager =
+        new JdbcTransactionManager(
+            dataSource, tableMetadataDataSource, RdbEngine.MYSQL, jdbcService);
 
     when(dataSource.getConnection()).thenReturn(connection);
   }

--- a/docs/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/getting-started-with-scalardb-on-jdbc.md
@@ -21,21 +21,21 @@ The **scalardb.properties** (getting-started/scalardb.properties) file holds the
 # The JDBC URL
 scalar.db.contact_points=jdbc:mysql://localhost:3306/
 
-# Credential information to access the database
+# The username and password
 scalar.db.username=root
 scalar.db.password=mysql
 
-# Storage implementation. Either cassandra or cosmos or dynamo or jdbc can be set. Default storage is cassandra.
+# JDBC storage implementation
 scalar.db.storage=jdbc
 
-# The minimum number of idle connections in the connection pool. The default is 5
-#scalar.db.jdbc.connection_pool.min_idle=5
+# The minimum number of idle connections in the connection pool. The default is 20
+#scalar.db.jdbc.connection_pool.min_idle=20
 
-# The maximum number of connections that can remain idle in the connection pool. The default is 10
-#scalar.db.jdbc.connection_pool.max_idle=10
+# The maximum number of connections that can remain idle in the connection pool. The default is 50
+#scalar.db.jdbc.connection_pool.max_idle=50
 
-# The maximum total number of idle and borrowed connections that can be active at the same time. Use a negative value for no limit. The default is 25
-#scalar.db.jdbc.connection_pool.max_total=25
+# The maximum total number of idle and borrowed connections that can be active at the same time for the connection pool. Use a negative value for no limit. The default is 100
+#scalar.db.jdbc.connection_pool.max_total=100
 
 # Setting true to this property enables prepared statement pooling. The default is false
 #scalar.db.jdbc.prepared_statements_pool.enabled=false
@@ -45,6 +45,18 @@ scalar.db.storage=jdbc
 
 # Isolation level for JDBC. Either READ_UNCOMMITTED or READ_COMMITTED or REPEATABLE_READ or SERIALIZABLE can be specified
 #scalar.db.jdbc.isolation_level=
+
+# The schema name of the table metadata. If not specified, the default name ("scalardb") is used
+#scalar.db.jdbc.table_metadata.schema=
+
+# The minimum number of idle connections in the connection pool for the table metadata. The default is 5
+#scalar.db.jdbc.table_metadata.connection_pool.min_idle=5
+
+# The maximum number of connections that can remain idle in the connection pool for the table metadata. The default is 10
+#scalar.db.jdbc.table_metadata.connection_pool.max_idle=10
+
+# The maximum total number of idle and borrowed connections that can be active at the same time for the connection pool for the table metadata. Use a negative value for no limit. The default is 25
+#scalar.db.jdbc.table_metadata.connection_pool.max_total=25
 ```
 
 Please follow [Getting Started with Scalar DB](getting-started-with-scalardb.md) to run the application.


### PR DESCRIPTION
Currently, since using the same datasource (connection pool) in Crud (Get/Scan/Put/Delete/Mutate) operations and the table metadata operation, something like a deadlock could happen (it's a very rare case, though). This PR makes the table metadata operation use a different datasource (connection pool) from Crud operations to avoid the deadlock. Please take a look!