### PR TITLE
Move CoordinatorException to the consensuscommit package

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -27,7 +27,6 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
@@ -18,7 +18,6 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
@@ -224,7 +223,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   }
 
   private void selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-      boolean isGet) throws ExecutionException, TransactionException {
+      boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -261,18 +260,18 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   @Test
   public void get_GetGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(true);
   }
 
   @Test
   public void scan_ScanGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(false);
   }
 
   private void selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
-      boolean isGet) throws ExecutionException, TransactionException {
+      boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -309,13 +308,13 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   @Test
   public void get_GetGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(true);
   }
 
   @Test
   public void scan_ScanGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(false);
   }
 
@@ -362,7 +361,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   private void
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          boolean isGet) throws ExecutionException, TransactionException {
+          boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS;
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -402,7 +401,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   @Test
   public void get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
         true);
   }
@@ -410,14 +409,14 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
         false);
   }
 
   private void
       selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          boolean isGet) throws ExecutionException, TransactionException {
+          boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -469,7 +468,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       get_GetGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
         true);
   }
@@ -477,14 +476,14 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       scan_ScanGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
         false);
   }
 
   private void
       selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          boolean isGet) throws ExecutionException, TransactionException {
+          boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -536,7 +535,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       get_GetGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
         true);
   }
@@ -544,13 +543,13 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       scan_ScanGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
         false);
   }
 
   private void selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-      boolean isGet) throws ExecutionException, TransactionException {
+      boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -581,18 +580,18 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   @Test
   public void get_GetGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(true);
   }
 
   @Test
   public void scan_ScanGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(false);
   }
 
   private void selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
-      boolean isGet) throws ExecutionException, TransactionException {
+      boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -629,13 +628,13 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   @Test
   public void get_GetGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(true);
   }
 
   @Test
   public void scan_ScanGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(false);
   }
 
@@ -682,7 +681,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   private void
       selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          boolean isGet) throws ExecutionException, TransactionException {
+          boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS;
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -722,7 +721,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   @Test
   public void get_GetGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
         true);
   }
@@ -730,14 +729,14 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       scan_ScanGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
         false);
   }
 
   private void
       selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          boolean isGet) throws ExecutionException, TransactionException {
+          boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -783,7 +782,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       get_GetGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
         true);
   }
@@ -791,14 +790,14 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       scan_ScanGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
         false);
   }
 
   private void
       selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          boolean isGet) throws ExecutionException, TransactionException {
+          boolean isGet) throws ExecutionException, TransactionException, CoordinatorException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -850,7 +849,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       get_GetGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
         true);
   }
@@ -858,7 +857,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       scan_ScanGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, TransactionException {
+          throws ExecutionException, TransactionException, CoordinatorException {
     selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
         false);
   }
@@ -1747,7 +1746,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   @Test
   public void
       commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly()
-          throws TransactionException {
+          throws TransactionException, CoordinatorException {
     // Arrange
     State state = new State(ANY_ID_1, TransactionState.ABORTED);
     coordinator.putState(state);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -9,7 +9,6 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -9,7 +9,6 @@ import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -14,7 +14,6 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import java.util.Objects;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorException.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorException.java
@@ -1,6 +1,6 @@
-package com.scalar.db.exception.transaction;
+package com.scalar.db.transaction.consensuscommit;
 
-public class CoordinatorException extends TransactionException {
+public class CoordinatorException extends Exception {
 
   public CoordinatorException(String message) {
     super(message);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -9,7 +9,6 @@ import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -7,7 +7,6 @@ import com.google.common.base.Strings;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -19,7 +19,6 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
 import java.util.Optional;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -18,7 +18,6 @@ import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.io.BigIntValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -12,7 +12,6 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.io.Value;
 import java.util.Optional;
 import org.junit.Before;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.transaction.CoordinatorException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;


### PR DESCRIPTION
Since `CoordinatorException` is Consensus Commit specific, we should move it to the `consensuscommit` package. Please take a look!