### PR TITLE
Support parallel preparation/commit/rollback in Consensus Commit

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -74,6 +74,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   protected static ConsensusCommitAdmin consensusCommitAdmin;
   protected static String namespace1;
   protected static String namespace2;
+  protected static ParallelExecutor parallelExecutor;
 
   protected ConsensusCommitManager manager;
   protected DistributedStorage storage;
@@ -93,15 +94,15 @@ public abstract class ConsensusCommitIntegrationTestBase {
       namespace2 = getNamespace2();
       createTables();
       originalStorage = factory.getStorage();
+      parallelExecutor = new ParallelExecutor(consensusCommitConfig);
       initialized = true;
     }
 
     truncateTables();
     storage = spy(originalStorage);
     coordinator = spy(new Coordinator(storage, consensusCommitConfig));
-    recovery = spy(new RecoveryHandler(storage, coordinator, consensusCommitConfig, null));
-    CommitHandler commit =
-        spy(new CommitHandler(storage, coordinator, recovery, consensusCommitConfig, null));
+    recovery = spy(new RecoveryHandler(storage, coordinator, parallelExecutor));
+    CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery, parallelExecutor));
     manager =
         new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
   }
@@ -152,6 +153,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     deleteTables();
     admin.close();
     originalStorage.close();
+    parallelExecutor.close();
   }
 
   private static void deleteTables() throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -1,6 +1,7 @@
 package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.config.ConfigUtils.getBoolean;
+import static com.scalar.db.config.ConfigUtils.getInt;
 import static com.scalar.db.config.ConfigUtils.getString;
 
 import com.scalar.db.config.DatabaseConfig;
@@ -26,11 +27,23 @@ public class ConsensusCommitConfig {
   public static final String SERIALIZABLE_STRATEGY = PREFIX + "serializable_strategy";
   public static final String COORDINATOR_NAMESPACE = PREFIX + "coordinator.namespace";
 
+  public static final String PARALLEL_EXECUTOR_COUNT = PREFIX + "parallel_executor_count";
+  public static final String PARALLEL_PREPARATION_ENABLED = PREFIX + "parallel_preparation.enabled";
+  public static final String PARALLEL_COMMIT_ENABLED = PREFIX + "parallel_commit.enabled";
+  public static final String PARALLEL_ROLLBACK_ENABLED = PREFIX + "parallel_rollback.enabled";
+
+  public static final int DEFAULT_PARALLEL_EXECUTOR_COUNT = 30;
+
   private final Properties props;
 
   private Isolation isolation;
   private SerializableStrategy strategy;
   @Nullable private String coordinatorNamespace;
+
+  private int parallelExecutorCount;
+  private boolean parallelPreparationEnabled;
+  private boolean parallelCommitEnabled;
+  private boolean parallelRollbackEnabled;
 
   // for two-phase consensus commit
   public static final String TWO_PHASE_CONSENSUS_COMMIT_PREFIX = PREFIX + "2pcc.";
@@ -84,9 +97,18 @@ public class ConsensusCommitConfig {
                     SERIALIZABLE_STRATEGY,
                     SerializableStrategy.EXTRA_READ.toString())
                 .toUpperCase());
+
     activeTransactionsManagementEnabled =
         getBoolean(getProperties(), ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, true);
+
     coordinatorNamespace = getString(getProperties(), COORDINATOR_NAMESPACE, null);
+
+    parallelExecutorCount =
+        getInt(getProperties(), PARALLEL_EXECUTOR_COUNT, DEFAULT_PARALLEL_EXECUTOR_COUNT);
+    parallelPreparationEnabled = getBoolean(getProperties(), PARALLEL_PREPARATION_ENABLED, false);
+    parallelCommitEnabled = getBoolean(getProperties(), PARALLEL_COMMIT_ENABLED, false);
+    parallelRollbackEnabled =
+        getBoolean(getProperties(), PARALLEL_ROLLBACK_ENABLED, parallelCommitEnabled);
   }
 
   public Isolation getIsolation() {
@@ -103,5 +125,21 @@ public class ConsensusCommitConfig {
 
   public Optional<String> getCoordinatorNamespace() {
     return Optional.ofNullable(coordinatorNamespace);
+  }
+
+  public int getParallelExecutorCount() {
+    return parallelExecutorCount;
+  }
+
+  public boolean isParallelPreparationEnabled() {
+    return parallelPreparationEnabled;
+  }
+
+  public boolean isParallelCommitEnabled() {
+    return parallelCommitEnabled;
+  }
+
+  public boolean isParallelRollbackEnabled() {
+    return parallelRollbackEnabled;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
@@ -1,0 +1,98 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.ThrowableRunnable;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+public class ParallelExecutor {
+
+  private final ConsensusCommitConfig config;
+  @Nullable private final ExecutorService parallelExecutorService;
+
+  public ParallelExecutor(ConsensusCommitConfig config) {
+    this.config = config;
+    if (config.isParallelPreparationEnabled()
+        || config.isParallelCommitEnabled()
+        || config.isParallelRollbackEnabled()) {
+      parallelExecutorService =
+          Executors.newFixedThreadPool(
+              config.getParallelExecutorCount(),
+              new ThreadFactoryBuilder().setNameFormat("parallel-executor-%d").build());
+    } else {
+      parallelExecutorService = null;
+    }
+  }
+
+  public void prepare(List<ThrowableRunnable<ExecutionException>> tasks) throws ExecutionException {
+    executeTasks(tasks, config.isParallelPreparationEnabled(), false);
+  }
+
+  public void commit(List<ThrowableRunnable<ExecutionException>> tasks) throws ExecutionException {
+    executeTasks(tasks, config.isParallelCommitEnabled(), false);
+  }
+
+  public void rollback(List<ThrowableRunnable<ExecutionException>> tasks)
+      throws ExecutionException {
+    executeTasks(tasks, config.isParallelRollbackEnabled(), false);
+  }
+
+  private void executeTasks(
+      List<ThrowableRunnable<ExecutionException>> tasks, boolean parallel, boolean noWait)
+      throws ExecutionException {
+
+    List<Future<?>> futures;
+    if (parallel) {
+      assert parallelExecutorService != null;
+      futures =
+          tasks.stream()
+              .map(
+                  t ->
+                      parallelExecutorService.submit(
+                          () -> {
+                            t.run();
+                            return null;
+                          }))
+              .collect(Collectors.toList());
+    } else {
+      futures = Collections.emptyList();
+      for (ThrowableRunnable<ExecutionException> runnable : tasks) {
+        runnable.run();
+      }
+    }
+
+    if (!noWait) {
+      for (Future<?> future : futures) {
+        try {
+          Uninterruptibles.getUninterruptibly(future);
+        } catch (java.util.concurrent.ExecutionException e) {
+          if (e.getCause() instanceof ExecutionException) {
+            throw (ExecutionException) e.getCause();
+          }
+          if (e.getCause() instanceof RuntimeException) {
+            throw (RuntimeException) e.getCause();
+          }
+          if (e.getCause() instanceof Error) {
+            throw (Error) e.getCause();
+          }
+          throw new ExecutionException("an error occurred during executing the tasks", e);
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  public void close() {
+    if (parallelExecutorService != null) {
+      parallelExecutorService.shutdown();
+      Uninterruptibles.awaitTerminationUninterruptibly(parallelExecutorService);
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
@@ -11,7 +11,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class ParallelExecutor {
 
   private final ConsensusCommitConfig config;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -3,14 +3,19 @@ package com.scalar.db.transaction.consensuscommit;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.db.util.ThrowableRunnable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,10 +26,18 @@ public class RecoveryHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(RecoveryHandler.class);
   private final DistributedStorage storage;
   private final Coordinator coordinator;
+  private final ConsensusCommitConfig config;
+  @Nullable private final ExecutorService parallelExecutorService;
 
-  public RecoveryHandler(DistributedStorage storage, Coordinator coordinator) {
+  public RecoveryHandler(
+      DistributedStorage storage,
+      Coordinator coordinator,
+      ConsensusCommitConfig config,
+      @Nullable ExecutorService parallelExecutorService) {
     this.storage = checkNotNull(storage);
     this.coordinator = checkNotNull(coordinator);
+    this.config = config;
+    this.parallelExecutorService = parallelExecutorService;
   }
 
   // lazy recovery in read phase
@@ -40,28 +53,37 @@ public class RecoveryHandler {
 
     if (state.isPresent()) {
       if (state.get().getState().equals(TransactionState.COMMITTED)) {
-        rollforward(selection, result);
+        rollforwardRecord(selection, result);
       } else {
-        rollback(selection, result);
+        rollbackRecord(selection, result);
       }
     } else {
       abortIfExpired(selection, result);
     }
   }
 
-  public void rollback(Snapshot snapshot) throws CommitConflictException {
+  public void rollbackRecords(Snapshot snapshot) {
     LOGGER.debug("rollback from snapshot for {}", snapshot.getId());
-    RollbackMutationComposer composer = new RollbackMutationComposer(snapshot.getId(), storage);
-    snapshot.to(composer);
-    PartitionedMutations mutations = new PartitionedMutations(composer.get());
+    try {
+      RollbackMutationComposer composer = new RollbackMutationComposer(snapshot.getId(), storage);
+      snapshot.to(composer);
+      PartitionedMutations mutations = new PartitionedMutations(composer.get());
 
-    for (PartitionedMutations.Key key : mutations.getOrderedKeys()) {
-      mutate(mutations.get(key));
+      ImmutableList<PartitionedMutations.Key> orderedKeys = mutations.getOrderedKeys();
+      List<ThrowableRunnable<ExecutionException>> tasks = new ArrayList<>(orderedKeys.size());
+      for (PartitionedMutations.Key key : orderedKeys) {
+        tasks.add(() -> storage.mutate(mutations.get(key)));
+      }
+      ScalarDbUtils.executeTasks(
+          tasks, parallelExecutorService, config.isParallelRollbackEnabled(), false);
+    } catch (Exception e) {
+      LOGGER.warn("rolling back records failed", e);
+      // ignore since records are recovered lazily
     }
   }
 
   @VisibleForTesting
-  void rollback(Selection selection, TransactionResult result) {
+  void rollbackRecord(Selection selection, TransactionResult result) {
     LOGGER.debug(
         "rollback for {}, {} mutated by {}",
         selection.getPartitionKey(),
@@ -73,7 +95,7 @@ public class RecoveryHandler {
   }
 
   @VisibleForTesting
-  void rollforward(Selection selection, TransactionResult result) {
+  void rollforwardRecord(Selection selection, TransactionResult result) {
     LOGGER.debug(
         "rollforward for {}, {} mutated by {}",
         selection.getPartitionKey(),
@@ -92,7 +114,7 @@ public class RecoveryHandler {
 
     try {
       coordinator.putState(new Coordinator.State(result.getId(), TransactionState.ABORTED));
-      rollback(selection, result);
+      rollbackRecord(selection, result);
     } catch (CoordinatorException e) {
       LOGGER.warn("coordinator tries to abort {}, but failed", result.getId(), e);
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
@@ -13,6 +15,8 @@ import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.util.ActiveExpiringMap;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -30,6 +34,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   private final DistributedStorage storage;
   private final ConsensusCommitConfig config;
   private final Coordinator coordinator;
+  @Nullable private final ExecutorService parallelExecutorService;
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
 
@@ -44,8 +49,20 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
     this.config = config;
 
     coordinator = new Coordinator(storage, config);
-    recovery = new RecoveryHandler(storage, coordinator);
-    commit = new CommitHandler(storage, coordinator, recovery);
+
+    if (config.isParallelPreparationEnabled()
+        || config.isParallelCommitEnabled()
+        || config.isParallelRollbackEnabled()) {
+      parallelExecutorService =
+          Executors.newFixedThreadPool(
+              config.getParallelExecutorCount(),
+              new ThreadFactoryBuilder().setNameFormat("parallel-executor-%d").build());
+    } else {
+      parallelExecutorService = null;
+    }
+    recovery = new RecoveryHandler(storage, coordinator, config, parallelExecutorService);
+    commit = new CommitHandler(storage, coordinator, recovery, config, parallelExecutorService);
+
     if (config.isActiveTransactionsManagementEnabled()) {
       activeTransactions =
           new ActiveExpiringMap<>(
@@ -67,6 +84,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
     this.storage = storage;
     this.config = config;
     this.coordinator = coordinator;
+    parallelExecutorService = null;
     this.recovery = recovery;
     this.commit = commit;
     if (config.isActiveTransactionsManagementEnabled()) {
@@ -201,9 +219,15 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
     }
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   @Override
   public void close() {
     storage.close();
+
+    if (parallelExecutorService != null) {
+      parallelExecutorService.shutdown();
+      Uninterruptibles.awaitTerminationUninterruptibly(parallelExecutorService);
+    }
   }
 
   void removeTransaction(String txId) {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -1,21 +1,14 @@
 package com.scalar.db.util;
 
 import com.google.common.collect.Streams;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Value;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 public final class ScalarDbUtils {
 
@@ -89,52 +82,5 @@ public final class ScalarDbUtils {
    */
   public static String getFullTableName(String namespace, String table) {
     return namespace + "." + table;
-  }
-
-  public static void executeTasks(
-      List<ThrowableRunnable<ExecutionException>> tasks,
-      @Nullable ExecutorService executorService,
-      boolean parallel,
-      boolean noWait)
-      throws ExecutionException {
-
-    List<Future<?>> futures;
-    if (parallel) {
-      assert executorService != null;
-      futures =
-          tasks.stream()
-              .map(
-                  t ->
-                      executorService.submit(
-                          () -> {
-                            t.run();
-                            return null;
-                          }))
-              .collect(Collectors.toList());
-    } else {
-      futures = Collections.emptyList();
-      for (ThrowableRunnable<ExecutionException> runnable : tasks) {
-        runnable.run();
-      }
-    }
-
-    if (!noWait) {
-      for (Future<?> future : futures) {
-        try {
-          Uninterruptibles.getUninterruptibly(future);
-        } catch (java.util.concurrent.ExecutionException e) {
-          if (e.getCause() instanceof ExecutionException) {
-            throw (ExecutionException) e.getCause();
-          }
-          if (e.getCause() instanceof RuntimeException) {
-            throw (RuntimeException) e.getCause();
-          }
-          if (e.getCause() instanceof Error) {
-            throw (Error) e.getCause();
-          }
-          throw new ExecutionException("an error occurred during executing the tasks", e);
-        }
-      }
-    }
   }
 }

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -1,14 +1,21 @@
 package com.scalar.db.util;
 
 import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Value;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 public final class ScalarDbUtils {
 
@@ -82,5 +89,52 @@ public final class ScalarDbUtils {
    */
   public static String getFullTableName(String namespace, String table) {
     return namespace + "." + table;
+  }
+
+  public static void executeTasks(
+      List<ThrowableRunnable<ExecutionException>> tasks,
+      @Nullable ExecutorService executorService,
+      boolean parallel,
+      boolean noWait)
+      throws ExecutionException {
+
+    List<Future<?>> futures;
+    if (parallel) {
+      assert executorService != null;
+      futures =
+          tasks.stream()
+              .map(
+                  t ->
+                      executorService.submit(
+                          () -> {
+                            t.run();
+                            return null;
+                          }))
+              .collect(Collectors.toList());
+    } else {
+      futures = Collections.emptyList();
+      for (ThrowableRunnable<ExecutionException> runnable : tasks) {
+        runnable.run();
+      }
+    }
+
+    if (!noWait) {
+      for (Future<?> future : futures) {
+        try {
+          Uninterruptibles.getUninterruptibly(future);
+        } catch (java.util.concurrent.ExecutionException e) {
+          if (e.getCause() instanceof ExecutionException) {
+            throw (ExecutionException) e.getCause();
+          }
+          if (e.getCause() instanceof RuntimeException) {
+            throw (RuntimeException) e.getCause();
+          }
+          if (e.getCause() instanceof Error) {
+            throw (Error) e.getCause();
+          }
+          throw new ExecutionException("an error occurred during executing the tasks", e);
+        }
+      }
+    }
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -52,7 +52,7 @@ public class CommitHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new CommitHandler(storage, coordinator, recovery, config, null);
+    handler = new CommitHandler(storage, coordinator, recovery, new ParallelExecutor(config));
   }
 
   private Put preparePut1() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -35,7 +35,7 @@ public class RecoveryHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = spy(new RecoveryHandler(storage, coordinator, config, null));
+    handler = spy(new RecoveryHandler(storage, coordinator, new ParallelExecutor(config)));
   }
 
   private void configureResult(Result mock, long preparedAt) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,21 +18,24 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 public class RecoveryHandlerTest {
   private static final String ANY_ID_1 = "id1";
   private static final long ANY_TIME_1 = 100;
-  private RecoveryHandler handler;
+
   @Mock private DistributedStorage storage;
   @Mock private Coordinator coordinator;
   @Mock private Selection selection;
+  @Mock private ConsensusCommitConfig config;
+
+  private RecoveryHandler handler;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    handler = Mockito.spy(new RecoveryHandler(storage, coordinator));
+
+    handler = spy(new RecoveryHandler(storage, coordinator, config, null));
   }
 
   private void configureResult(Result mock, long preparedAt) {
@@ -59,13 +63,13 @@ public class RecoveryHandlerTest {
     TransactionResult result = prepareResult(ANY_TIME_1);
     when(coordinator.getState(ANY_ID_1))
         .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED)));
-    doNothing().when(handler).rollforward(any(Selection.class), any(TransactionResult.class));
+    doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
     handler.recover(selection, result);
 
     // Assert
-    verify(handler).rollforward(selection, result);
+    verify(handler).rollforwardRecord(selection, result);
   }
 
   @Test
@@ -75,13 +79,13 @@ public class RecoveryHandlerTest {
     TransactionResult result = prepareResult(ANY_TIME_1);
     when(coordinator.getState(ANY_ID_1))
         .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED)));
-    doNothing().when(handler).rollback(any(Selection.class), any(TransactionResult.class));
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
     handler.recover(selection, result);
 
     // Assert
-    verify(handler).rollback(selection, result);
+    verify(handler).rollbackRecord(selection, result);
   }
 
   @Test
@@ -91,7 +95,7 @@ public class RecoveryHandlerTest {
     // Arrange
     TransactionResult result = prepareResult(System.currentTimeMillis());
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
-    doNothing().when(handler).rollback(any(Selection.class), any(TransactionResult.class));
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
     handler.recover(selection, result);
@@ -99,7 +103,7 @@ public class RecoveryHandlerTest {
     // Assert
     verify(coordinator, never())
         .putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
-    verify(handler, never()).rollback(selection, result);
+    verify(handler, never()).rollbackRecord(selection, result);
   }
 
   @Test
@@ -110,13 +114,13 @@ public class RecoveryHandlerTest {
         prepareResult(System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(handler).rollback(any(Selection.class), any(TransactionResult.class));
+    doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
     // Act
     handler.recover(selection, result);
 
     // Assert
     verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
-    verify(handler).rollback(selection, result);
+    verify(handler).rollbackRecord(selection, result);
   }
 }


### PR DESCRIPTION
This PR introduces the following parameters:
```
scalar.db.consensus_commit.parallel_preparation.enabled
scalar.db.consensus_commit.parallel_commit.enabled
scalar.db.consensus_commit.parallel_rollback.enabled
scalar.db.consensus_commit.parallel_executor_count
```

When we set `parallel_preparation.enabled` to `true`, the record preparation will be done in parallel. Also, when we the `parallel_commit.enabled` and `parallel_rollback.enabled` parameter to `true`, the record commit/rollback will be done in parallel. The `parallel_executor_count` determines the number of threads for the parallel execution. 

Please take a look!