### PR TITLE
Support async commit/rollback in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -32,6 +32,9 @@ public class ConsensusCommitConfig {
   public static final String PARALLEL_COMMIT_ENABLED = PREFIX + "parallel_commit.enabled";
   public static final String PARALLEL_ROLLBACK_ENABLED = PREFIX + "parallel_rollback.enabled";
 
+  public static final String ASYNC_COMMIT_ENABLED = PREFIX + "async_commit.enabled";
+  public static final String ASYNC_ROLLBACK_ENABLED = PREFIX + "async_rollback.enabled";
+
   public static final int DEFAULT_PARALLEL_EXECUTOR_COUNT = 30;
 
   private final Properties props;
@@ -44,6 +47,8 @@ public class ConsensusCommitConfig {
   private boolean parallelPreparationEnabled;
   private boolean parallelCommitEnabled;
   private boolean parallelRollbackEnabled;
+  private boolean asyncCommitEnabled;
+  private boolean asyncRollbackEnabled;
 
   // for two-phase consensus commit
   public static final String TWO_PHASE_CONSENSUS_COMMIT_PREFIX = PREFIX + "2pcc.";
@@ -109,6 +114,9 @@ public class ConsensusCommitConfig {
     parallelCommitEnabled = getBoolean(getProperties(), PARALLEL_COMMIT_ENABLED, false);
     parallelRollbackEnabled =
         getBoolean(getProperties(), PARALLEL_ROLLBACK_ENABLED, parallelCommitEnabled);
+
+    asyncCommitEnabled = getBoolean(getProperties(), ASYNC_COMMIT_ENABLED, false);
+    asyncRollbackEnabled = getBoolean(getProperties(), ASYNC_ROLLBACK_ENABLED, asyncCommitEnabled);
   }
 
   public Isolation getIsolation() {
@@ -141,5 +149,13 @@ public class ConsensusCommitConfig {
 
   public boolean isParallelRollbackEnabled() {
     return parallelRollbackEnabled;
+  }
+
+  public boolean isAsyncCommitEnabled() {
+    return asyncCommitEnabled;
+  }
+
+  public boolean isAsyncRollbackEnabled() {
+    return asyncRollbackEnabled;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -33,17 +34,24 @@ public class ParallelExecutor {
     }
   }
 
+  @VisibleForTesting
+  ParallelExecutor(
+      ConsensusCommitConfig config, @Nullable ExecutorService parallelExecutorService) {
+    this.config = config;
+    this.parallelExecutorService = parallelExecutorService;
+  }
+
   public void prepare(List<ThrowableRunnable<ExecutionException>> tasks) throws ExecutionException {
     executeTasks(tasks, config.isParallelPreparationEnabled(), false);
   }
 
   public void commit(List<ThrowableRunnable<ExecutionException>> tasks) throws ExecutionException {
-    executeTasks(tasks, config.isParallelCommitEnabled(), false);
+    executeTasks(tasks, config.isParallelCommitEnabled(), config.isAsyncCommitEnabled());
   }
 
   public void rollback(List<ThrowableRunnable<ExecutionException>> tasks)
       throws ExecutionException {
-    executeTasks(tasks, config.isParallelRollbackEnabled(), false);
+    executeTasks(tasks, config.isParallelRollbackEnabled(), config.isAsyncRollbackEnabled());
   }
 
   private void executeTasks(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -3,13 +3,10 @@ package com.scalar.db.transaction.consensuscommit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.scalar.db.config.DatabaseConfig;
 import java.util.Properties;
 import org.junit.Test;
 
 public class ConsensusCommitConfigTest {
-
-  private static final String ANY_HOST = "localhost";
 
   @Test
   public void constructor_NoPropertiesGiven_ShouldLoadAsDefaultValues() {
@@ -29,6 +26,8 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isParallelPreparationEnabled()).isEqualTo(false);
     assertThat(config.isParallelCommitEnabled()).isEqualTo(false);
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(false);
+    assertThat(config.isAsyncCommitEnabled()).isEqualTo(false);
+    assertThat(config.isAsyncRollbackEnabled()).isEqualTo(false);
   }
 
   @Test
@@ -124,7 +123,6 @@ public class ConsensusCommitConfigTest {
   public void constructor_PropertiesWithCoordinatorNamespaceGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
     props.setProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, "changed_coordinator");
 
     // Act
@@ -139,7 +137,6 @@ public class ConsensusCommitConfigTest {
   public void constructor_ParallelExecutionRelatedPropertiesGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
     props.setProperty(ConsensusCommitConfig.PARALLEL_EXECUTOR_COUNT, "100");
     props.setProperty(ConsensusCommitConfig.PARALLEL_PREPARATION_ENABLED, "true");
     props.setProperty(ConsensusCommitConfig.PARALLEL_COMMIT_ENABLED, "true");
@@ -160,7 +157,6 @@ public class ConsensusCommitConfigTest {
       constructor_ParallelExecutionRelatedPropertiesWithoutParallelRollbackPropertyGiven_ShouldUseParallelCommitValueForParallelRollback() {
     // Arrange
     Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
     props.setProperty(ConsensusCommitConfig.PARALLEL_EXECUTOR_COUNT, "100");
     props.setProperty(ConsensusCommitConfig.PARALLEL_PREPARATION_ENABLED, "false");
     props.setProperty(ConsensusCommitConfig.PARALLEL_COMMIT_ENABLED, "true");
@@ -173,5 +169,35 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isParallelPreparationEnabled()).isEqualTo(false);
     assertThat(config.isParallelCommitEnabled()).isEqualTo(true);
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(true); // use the parallel commit value
+  }
+
+  @Test
+  public void constructor_AsyncExecutionRelatedPropertiesGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "true");
+    props.setProperty(ConsensusCommitConfig.ASYNC_ROLLBACK_ENABLED, "true");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.isAsyncCommitEnabled()).isEqualTo(true);
+    assertThat(config.isAsyncRollbackEnabled()).isEqualTo(true);
+  }
+
+  @Test
+  public void
+      constructor_AsyncExecutionRelatedPropertiesWithoutAsyncRollbackPropertyGiven_ShouldUseAsyncCommitValueForAsyncRollback() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "true");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.isAsyncCommitEnabled()).isEqualTo(true);
+    assertThat(config.isAsyncRollbackEnabled()).isEqualTo(true); // use the async commit value
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ParallelExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ParallelExecutorTest.java
@@ -1,0 +1,171 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.ThrowableRunnable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+public class ParallelExecutorTest {
+
+  @Mock private ConsensusCommitConfig config;
+  @Mock private ExecutorService parallelExecutorService;
+  @Mock private Future<Void> future;
+  @Mock private ThrowableRunnable<ExecutionException> task;
+
+  private ParallelExecutor parallelExecutor;
+  private List<ThrowableRunnable<ExecutionException>> tasks;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    // Arrange
+    when(parallelExecutorService.submit(ArgumentMatchers.<Callable<Void>>any())).thenReturn(future);
+    parallelExecutor = new ParallelExecutor(config, parallelExecutorService);
+    tasks = Arrays.asList(task, task, task);
+  }
+
+  @Test
+  public void prepare_ParallelPreparationNotEnabled_ShouldExecuteTasksSerially()
+      throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelPreparationEnabled()).thenReturn(false);
+
+    // Act
+    parallelExecutor.prepare(tasks);
+
+    // Assert
+    verify(task, times(tasks.size())).run();
+    verify(parallelExecutorService, never()).submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, never()).get();
+  }
+
+  @Test
+  public void prepare_ParallelPreparationEnabled_ShouldExecuteTasksInParallel()
+      throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelPreparationEnabled()).thenReturn(true);
+
+    // Act
+    parallelExecutor.prepare(tasks);
+
+    // Assert
+    verify(task, never()).run();
+    verify(parallelExecutorService, times(tasks.size()))
+        .submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, times(tasks.size())).get();
+  }
+
+  @Test
+  public void commit_ParallelCommitNotEnabled_ShouldExecuteTasksSerially()
+      throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelCommitEnabled()).thenReturn(false);
+
+    // Act
+    parallelExecutor.commit(tasks);
+
+    // Assert
+    verify(task, times(tasks.size())).run();
+    verify(parallelExecutorService, never()).submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, never()).get();
+  }
+
+  @Test
+  public void commit_ParallelCommitEnabled_ShouldExecuteTasksInParallel()
+      throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelCommitEnabled()).thenReturn(true);
+
+    // Act
+    parallelExecutor.commit(tasks);
+
+    // Assert
+    verify(task, never()).run();
+    verify(parallelExecutorService, times(tasks.size()))
+        .submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, times(tasks.size())).get();
+  }
+
+  @Test
+  public void
+      commit_ParallelCommitEnabledAndAsyncCommitEnabled_ShouldExecuteTasksInParallelAndAsynchronously()
+          throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelCommitEnabled()).thenReturn(true);
+    when(config.isAsyncCommitEnabled()).thenReturn(true);
+
+    // Act
+    parallelExecutor.commit(tasks);
+
+    // Assert
+    verify(task, never()).run();
+    verify(parallelExecutorService, times(tasks.size()))
+        .submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, never()).get();
+  }
+
+  @Test
+  public void rollback_ParallelRollbackNotEnabled_ShouldExecuteTasksSerially()
+      throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelRollbackEnabled()).thenReturn(false);
+
+    // Act
+    parallelExecutor.rollback(tasks);
+
+    // Assert
+    verify(task, times(tasks.size())).run();
+    verify(parallelExecutorService, never()).submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, never()).get();
+  }
+
+  @Test
+  public void rollback_ParallelRollbackEnabled_ShouldExecuteTasksInParallel()
+      throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelRollbackEnabled()).thenReturn(true);
+
+    // Act
+    parallelExecutor.rollback(tasks);
+
+    // Assert
+    verify(task, never()).run();
+    verify(parallelExecutorService, times(tasks.size()))
+        .submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, times(tasks.size())).get();
+  }
+
+  @Test
+  public void
+      rollback_ParallelRollbackEnabledAndAsyncRollbackEnabled_ShouldExecuteTasksInParallelAndAsynchronously()
+          throws ExecutionException, java.util.concurrent.ExecutionException, InterruptedException {
+    // Arrange
+    when(config.isParallelRollbackEnabled()).thenReturn(true);
+    when(config.isAsyncRollbackEnabled()).thenReturn(true);
+
+    // Act
+    parallelExecutor.rollback(tasks);
+
+    // Assert
+    verify(task, never()).run();
+    verify(parallelExecutorService, times(tasks.size()))
+        .submit(ArgumentMatchers.<Callable<Void>>any());
+    verify(future, never()).get();
+  }
+}


### PR DESCRIPTION
This PR introduces the following parameters:
```
scalar.db.consensus_commit.async_commit.enabled
scalar.db.consensus_commit.async_rollback.enabled
```

When we set `async_commit.enabled` to `true`, the record commit will be done asynchronously. Similarly, when we set `async_rollback.enabled` to `true`, the record rollback will be done asynchronously. Please take a look!