### PR TITLE
Revisit Key construction

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/AdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/AdminIntegrationTestBase.java
@@ -353,8 +353,8 @@ public abstract class AdminIntegrationTestBase {
   @Test
   public void truncateTable_ShouldTruncateProperly() throws ExecutionException, IOException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addText(COL_NAME2, "aaa").addInt(COL_NAME1, 1).build();
-    Key clusteringKey = Key.newBuilder().addInt(COL_NAME4, 2).addText(COL_NAME3, "bbb").build();
+    Key partitionKey = new Key(COL_NAME2, "aaa", COL_NAME1, 1);
+    Key clusteringKey = new Key(COL_NAME4, 2, COL_NAME3, "bbb");
     storage.put(
         new Put(partitionKey, clusteringKey)
             .withValue(COL_NAME5, 3)

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageIntegrationTestBase.java
@@ -1153,10 +1153,10 @@ public abstract class StorageIntegrationTestBase {
   public void scan_ScanLargeData_ShouldRetrieveExpectedValues()
       throws ExecutionException, IOException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(COL_NAME1, 1).build();
+    Key partitionKey = new Key(COL_NAME1, 1);
     List<Integer> expectedValues = new ArrayList<>();
     for (int i = 0; i < 345; i++) {
-      Key clusteringKey = Key.newBuilder().addInt(COL_NAME4, i).build();
+      Key clusteringKey = new Key(COL_NAME4, i);
       storage.put(new Put(partitionKey, clusteringKey));
       expectedValues.add(i);
     }
@@ -1174,9 +1174,9 @@ public abstract class StorageIntegrationTestBase {
   public void scan_ScanLargeDataWithOrdering_ShouldRetrieveExpectedValues()
       throws ExecutionException, IOException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(COL_NAME1, 1).build();
+    Key partitionKey = new Key(COL_NAME1, 1);
     for (int i = 0; i < 345; i++) {
-      Key clusteringKey = Key.newBuilder().addInt(COL_NAME4, i).build();
+      Key clusteringKey = new Key(COL_NAME4, i);
       storage.put(new Put(partitionKey, clusteringKey));
     }
     Scan scan = new Scan(partitionKey).withOrdering(new Ordering(COL_NAME4, Order.ASC));

--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -13,7 +13,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -103,7 +102,7 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param name name of the {@code Value}
    * @param value content of the {@code Value}
    */
-  public Key(String name, @Nullable String value) {
+  public Key(String name, String value) {
     values = Collections.singletonList(new TextValue(name, value));
   }
 
@@ -113,8 +112,102 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param name name of the {@code Value}
    * @param value content of the {@code Value}
    */
-  public Key(String name, @Nullable byte[] value) {
+  public Key(String name, byte[] value) {
     values = Collections.singletonList(new BlobValue(name, value));
+  }
+
+  /**
+   * Constructs a {@code Key} with multiple {@link Value}s
+   *
+   * @param n1 name of the 1st {@code Value}
+   * @param v1 content of the 1st {@code Value}
+   * @param n2 name of the 2nd {@code Value}
+   * @param v2 content of the 2nd {@code Value}
+   */
+  public Key(String n1, Object v1, String n2, Object v2) {
+    values = Arrays.asList(toValue(n1, v1), toValue(n2, v2));
+  }
+
+  /**
+   * Constructs a {@code Key} with multiple {@link Value}s
+   *
+   * @param n1 name of the 1st {@code Value}
+   * @param v1 content of the 1st {@code Value}
+   * @param n2 name of the 2nd {@code Value}
+   * @param v2 content of the 2nd {@code Value}
+   * @param n3 name of the 3rd {@code Value}
+   * @param v3 content of the 3rd {@code Value}
+   */
+  public Key(String n1, Object v1, String n2, Object v2, String n3, Object v3) {
+    values = Arrays.asList(toValue(n1, v1), toValue(n2, v2), toValue(n3, v3));
+  }
+
+  /**
+   * Constructs a {@code Key} with multiple {@link Value}s
+   *
+   * @param n1 name of the 1st {@code Value}
+   * @param v1 content of the 1st {@code Value}
+   * @param n2 name of the 2nd {@code Value}
+   * @param v2 content of the 2nd {@code Value}
+   * @param n3 name of the 3rd {@code Value}
+   * @param v3 content of the 3rd {@code Value}
+   * @param n4 name of the 4th {@code Value}
+   * @param v4 content of the 4th {@code Value}
+   */
+  public Key(
+      String n1, Object v1, String n2, Object v2, String n3, Object v3, String n4, Object v4) {
+    values = Arrays.asList(toValue(n1, v1), toValue(n2, v2), toValue(n3, v3), toValue(n4, v4));
+  }
+
+  /**
+   * Constructs a {@code Key} with multiple {@link Value}s
+   *
+   * @param n1 name of the 1st {@code Value}
+   * @param v1 content of the 1st {@code Value}
+   * @param n2 name of the 2nd {@code Value}
+   * @param v2 content of the 2nd {@code Value}
+   * @param n3 name of the 3rd {@code Value}
+   * @param v3 content of the 3rd {@code Value}
+   * @param n4 name of the 4th {@code Value}
+   * @param v4 content of the 4th {@code Value}
+   * @param n5 name of the 5th {@code Value}
+   * @param v5 content of the 5th {@code Value}
+   */
+  public Key(
+      String n1,
+      Object v1,
+      String n2,
+      Object v2,
+      String n3,
+      Object v3,
+      String n4,
+      Object v4,
+      String n5,
+      Object v5) {
+    values =
+        Arrays.asList(
+            toValue(n1, v1), toValue(n2, v2), toValue(n3, v3), toValue(n4, v4), toValue(n5, v5));
+  }
+
+  private Value<?> toValue(String name, Object value) {
+    if (value instanceof Boolean) {
+      return new BooleanValue(name, (Boolean) value);
+    } else if (value instanceof Integer) {
+      return new IntValue(name, (Integer) value);
+    } else if (value instanceof Long) {
+      return new BigIntValue(name, (Long) value);
+    } else if (value instanceof Float) {
+      return new FloatValue(name, (Float) value);
+    } else if (value instanceof Double) {
+      return new DoubleValue(name, (Double) value);
+    } else if (value instanceof String) {
+      return new TextValue(name, (String) value);
+    } else if (value instanceof byte[]) {
+      return new BlobValue(name, (byte[]) value);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported type, name: " + name + ", type: " + value.getClass().getName());
+    }
   }
 
   /**
@@ -201,37 +294,128 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
 
     private Builder() {}
 
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
+     *     boolean)} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
     public Builder addBoolean(String name, boolean value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, boolean value) {
       values.add(new BooleanValue(name, value));
       return this;
     }
 
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
+     *     int)} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
     public Builder addInt(String name, int value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, int value) {
       values.add(new IntValue(name, value));
       return this;
     }
 
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
+     *     long)} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
     public Builder addBigInt(String name, long value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, long value) {
       values.add(new BigIntValue(name, value));
       return this;
     }
 
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
+     *     float)} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
     public Builder addFloat(String name, float value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, float value) {
       values.add(new FloatValue(name, value));
       return this;
     }
 
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
+     *     double)} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
     public Builder addDouble(String name, double value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, double value) {
       values.add(new DoubleValue(name, value));
       return this;
     }
 
-    public Builder addText(String name, @Nullable String value) {
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use @{@link #add(String,
+     *     String)} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
+    public Builder addText(String name, String value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, String value) {
       values.add(new TextValue(name, value));
       return this;
     }
 
-    public Builder addBlob(String name, @Nullable byte[] value) {
+    /**
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
+     *     byte[])} instead
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
+    public Builder addBlob(String name, byte[] value) {
+      return add(name, value);
+    }
+
+    public Builder add(String name, byte[] value) {
       values.add(new BlobValue(name, value));
       return this;
     }

--- a/core/src/test/java/com/scalar/db/io/KeyTest.java
+++ b/core/src/test/java/com/scalar/db/io/KeyTest.java
@@ -133,6 +133,54 @@ public class KeyTest {
   }
 
   @Test
+  public void constructor_WithMultipleNamesAndValues_ShouldReturnWhatsSet() {
+    // Arrange
+    Key key1 = new Key("key1", true, "key2", 5678);
+    Key key2 = new Key("key3", 1234L, "key4", 4.56f, "key5", 1.23);
+    Key key3 =
+        new Key(
+            "key6",
+            "string_key",
+            "key7",
+            "blob_key".getBytes(StandardCharsets.UTF_8),
+            "key8",
+            1357,
+            "key9",
+            2468);
+    Key key4 = new Key("key1", true, "key2", 5678, "key3", 1234L, "key4", 4.56f, "key5", 1.23);
+
+    // Act
+    List<Value<?>> values1 = key1.get();
+    List<Value<?>> values2 = key2.get();
+    List<Value<?>> values3 = key3.get();
+    List<Value<?>> values4 = key4.get();
+
+    // Assert
+    assertThat(values1.size()).isEqualTo(2);
+    assertThat(values1.get(0)).isEqualTo(new BooleanValue("key1", true));
+    assertThat(values1.get(1)).isEqualTo(new IntValue("key2", 5678));
+
+    assertThat(values2.size()).isEqualTo(3);
+    assertThat(values2.get(0)).isEqualTo(new BigIntValue("key3", 1234L));
+    assertThat(values2.get(1)).isEqualTo(new FloatValue("key4", 4.56f));
+    assertThat(values2.get(2)).isEqualTo(new DoubleValue("key5", 1.23));
+
+    assertThat(values3.size()).isEqualTo(4);
+    assertThat(values3.get(0)).isEqualTo(new TextValue("key6", "string_key"));
+    assertThat(values3.get(1))
+        .isEqualTo(new BlobValue("key7", "blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(values3.get(2)).isEqualTo(new IntValue("key8", 1357));
+    assertThat(values3.get(3)).isEqualTo(new IntValue("key9", 2468));
+
+    assertThat(values4.size()).isEqualTo(5);
+    assertThat(values4.get(0)).isEqualTo(new BooleanValue("key1", true));
+    assertThat(values4.get(1)).isEqualTo(new IntValue("key2", 5678));
+    assertThat(values4.get(2)).isEqualTo(new BigIntValue("key3", 1234L));
+    assertThat(values4.get(3)).isEqualTo(new FloatValue("key4", 4.56f));
+    assertThat(values4.get(4)).isEqualTo(new DoubleValue("key5", 1.23));
+  }
+
+  @Test
   public void get_ProperKeysGivenInConstructor_ShouldReturnWhatsSet() {
     // Arrange
     TextValue key1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
@@ -151,13 +199,13 @@ public class KeyTest {
     // Arrange
     Key key =
         Key.newBuilder()
-            .addBoolean("key1", true)
-            .addInt("key2", 5678)
-            .addBigInt("key3", 1234L)
-            .addFloat("key4", 4.56f)
-            .addDouble("key5", 1.23)
-            .addText("key6", "string_key")
-            .addBlob("key7", "blob_key".getBytes(StandardCharsets.UTF_8))
+            .add("key1", true)
+            .add("key2", 5678)
+            .add("key3", 1234L)
+            .add("key4", 4.56f)
+            .add("key5", 1.23)
+            .add("key6", "string_key")
+            .add("key7", "blob_key".getBytes(StandardCharsets.UTF_8))
             .add(new IntValue("key8", 1357))
             .addAll(Arrays.asList(new IntValue("key9", 2468), new BigIntValue("key10", 1111L)))
             .build();

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -231,16 +231,8 @@ public class SelectStatementHandlerTest {
                 });
     configureBehavior(expected);
     scan = prepareScan();
-    scan.withStart(
-            Key.newBuilder()
-                .addText(ANY_NAME_2, ANY_TEXT_2)
-                .addText(ANY_NAME_3, ANY_TEXT_3)
-                .build())
-        .withEnd(
-            Key.newBuilder()
-                .addText(ANY_NAME_2, ANY_TEXT_2)
-                .addText(ANY_NAME_3, ANY_TEXT_4)
-                .build());
+    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+        .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
 
     // Act
     handler.prepare(scan);
@@ -365,16 +357,8 @@ public class SelectStatementHandlerTest {
     // Arrange
     configureBehavior(null);
     scan = prepareScan();
-    scan.withStart(
-            Key.newBuilder()
-                .addText(ANY_NAME_2, ANY_TEXT_2)
-                .addText(ANY_NAME_3, ANY_TEXT_3)
-                .build())
-        .withEnd(
-            Key.newBuilder()
-                .addText(ANY_NAME_2, ANY_TEXT_2)
-                .addText(ANY_NAME_3, ANY_TEXT_4)
-                .build());
+    scan.withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+        .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
 
     // Act
     handler.bind(prepared, scan);

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -80,8 +80,8 @@ public class OperationCheckerTest {
   public void whenCheckingOperationWithWrongTable_shouldThrowIllegalArgumentException()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -97,8 +97,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingGetOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -110,8 +110,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingGetOperationWithInvalidProjections_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -125,8 +125,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText("p3", "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -140,8 +140,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidPartitionKeyType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addText(PKEY1, "1").addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, "1", PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -155,8 +155,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, "c3", "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -170,8 +170,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithInvalidClusteringKeyType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addText(CKEY1, "2").addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, "2", CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -185,7 +185,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingGetOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
@@ -199,9 +199,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -221,7 +221,7 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithoutAnyClusteringKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key startClusteringKey = null;
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
@@ -243,7 +243,7 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithPartialClusteringKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key startClusteringKey = new Key(CKEY1, 1);
     Key endClusteringKey = new Key(CKEY1, 9);
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
@@ -265,8 +265,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithoutAnyEndClusteringKey_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     Key endClusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
@@ -287,9 +287,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithReverseOrderings_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -309,9 +309,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithPartialOrdering_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -330,9 +330,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithEmptyOrdering_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -351,9 +351,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidProjections_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
     int limit = 10;
     Scan scan =
@@ -375,9 +375,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText("p3", "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -399,9 +399,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, "c3", "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, "c3", "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =
@@ -423,8 +423,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidClusteringKeyRange_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     Key endClusteringKey = new Key(CKEY1, 2);
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
@@ -447,9 +447,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithNegativeLimitNumber_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = -10;
     Scan scan =
@@ -470,9 +470,9 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingScanOperationWithInvalidOrderings_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = -10;
     Scan scan =
@@ -494,9 +494,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingScanOperationWithInvalidPartialOrdering_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val9").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = -10;
     Scan scan =
@@ -516,8 +516,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -532,8 +532,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithoutAnyCondition_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -549,8 +549,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText("c3", "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, "c3", "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -567,8 +567,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, "c3", "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -585,7 +585,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     List<Value<?>> values =
         Arrays.asList(
@@ -602,8 +602,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithInvalidValues_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue("v4", true));
@@ -619,8 +619,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithInvalidValueType_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new TextValue(COL1, "1"), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -637,8 +637,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithInvalidPutIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -657,8 +657,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithDeleteIfExistsCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -674,8 +674,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingPutOperationWithDeleteIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -692,8 +692,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithPartitionKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, null).build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = Key.newBuilder().add(PKEY1, 1).add(PKEY2, (String) null).build();
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -709,8 +709,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithPartitionKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -726,8 +726,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithClusteringKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, null).build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.newBuilder().add(CKEY1, 2).add(CKEY2, (String) null).build();
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -743,8 +743,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithClusteringKeyWithEmptyTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "");
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
@@ -871,8 +871,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingDeleteOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new IntValue(1), ConditionalExpression.Operator.EQ));
@@ -886,8 +886,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingDeleteOperationWithoutAnyCondition_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = null;
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
@@ -900,8 +900,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidPartitionKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText("p3", "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new DeleteIfExists();
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
@@ -915,8 +915,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, "c3", "val1");
     MutationCondition condition = new DeleteIfExists();
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
@@ -930,7 +930,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithoutAnyClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     MutationCondition condition = new DeleteIfExists();
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
@@ -944,8 +944,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingDeleteOperationWithPutIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIf();
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
@@ -959,8 +959,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithPutIfExistsCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfExists();
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
@@ -974,8 +974,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithPutIfNotExistsCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfNotExists();
     Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
@@ -989,8 +989,8 @@ public class OperationCheckerTest {
   public void
       whenCheckingDeleteOperationWithInvalidDeleteIfCondition_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
@@ -1005,8 +1005,8 @@ public class OperationCheckerTest {
   @Test
   public void whenCheckingMutateOperationWithAllValidArguments_shouldNotThrowAnyException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val1").build();
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     Put put = new Put(partitionKey, clusteringKey).withValue(COL1, 1);
     ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
     Delete delete = new Delete(partitionKey, clusteringKey);
@@ -1030,9 +1030,9 @@ public class OperationCheckerTest {
   public void
       whenCheckingMutateOperationWithMutationsWithDifferentPartitionKeysWithNotAllowPartitions_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, "val1").build();
-    Key partitionKey2 = Key.newBuilder().addInt(PKEY1, 2).addText(PKEY2, "val2").build();
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val3").build();
+    Key partitionKey1 = new Key(PKEY1, 1, PKEY2, "val1");
+    Key partitionKey2 = new Key(PKEY1, 2, PKEY2, "val2");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
     Put put = new Put(partitionKey1, clusteringKey).withValue(COL1, 1);
     ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
     Delete delete = new Delete(partitionKey2, clusteringKey);
@@ -1091,7 +1091,7 @@ public class OperationCheckerTest {
       whenCheckingGetOperationWithIndexedColumnAsPartitionKeyWithClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = new Key(COL1, 1);
-    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, "val2").build();
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
     ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
@@ -1171,8 +1171,8 @@ public class OperationCheckerTest {
       whenCheckingScanOperationWithIndexedColumnAsPartitionKeyWithClusteringKey_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = new Key(COL1, 1);
-    Key startClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val1").build();
-    Key endClusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText("c3", "val9").build();
+    Key startClusteringKey = new Key(CKEY1, 2, "c3", "val1");
+    Key endClusteringKey = new Key(CKEY1, 2, "c3", "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
     int limit = 10;
     Scan scan =

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationTest.java
@@ -53,8 +53,7 @@ public class CosmosOperationTest {
     // Arrange
     when(metadata.getClusteringKeyNames()).thenReturn(new LinkedHashSet<>());
 
-    Key partitionKey =
-        Key.newBuilder().addText(ANY_NAME_1, ANY_TEXT_1).addInt(ANY_NAME_3, ANY_INT_1).build();
+    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
@@ -71,8 +70,7 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey =
-        Key.newBuilder().addText(ANY_NAME_1, ANY_TEXT_1).addInt(ANY_NAME_3, ANY_INT_1).build();
+    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
     Get get =
         new Get(partitionKey, clusteringKey)
@@ -93,8 +91,7 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey =
-        Key.newBuilder().addText(ANY_NAME_1, ANY_TEXT_1).addInt(ANY_NAME_3, ANY_INT_1).build();
+    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Delete delete =
         new Delete(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(delete, metadata);
@@ -113,11 +110,7 @@ public class CosmosOperationTest {
         .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3)));
 
     Key partitionKey =
-        Key.newBuilder()
-            .addText(ANY_NAME_1, ANY_TEXT_1)
-            .addText(ANY_NAME_2, ANY_TEXT_2)
-            .addInt(ANY_NAME_3, ANY_INT_1)
-            .build();
+        new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
     Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
@@ -135,11 +128,7 @@ public class CosmosOperationTest {
         .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_1, ANY_NAME_2, ANY_NAME_3)));
 
     Key partitionKey =
-        Key.newBuilder()
-            .addText(ANY_NAME_1, ANY_TEXT_1)
-            .addText(ANY_NAME_2, ANY_TEXT_2)
-            .addInt(ANY_NAME_3, ANY_INT_1)
-            .build();
+        new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_INT_1);
     Get get = new Get(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
     CosmosOperation cosmosOperation = new CosmosOperation(get, metadata);
 
@@ -158,8 +147,7 @@ public class CosmosOperationTest {
     when(metadata.getClusteringKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_2)));
 
-    Key partitionKey =
-        Key.newBuilder().addText(ANY_NAME_1, ANY_TEXT_1).addInt(ANY_NAME_3, ANY_INT_1).build();
+    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_3, ANY_INT_1);
     Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
     Get get =
         new Get(partitionKey, clusteringKey)

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -259,16 +259,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build())
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_4)
-                    .build());
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3))
+            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4));
 
     String query =
         "select * from Record r where (r.concatenatedPartitionKey = '"

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -553,18 +553,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                true)
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_4)
-                    .build(),
-                true);
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true)
+            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -591,10 +581,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_3)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -604,10 +591,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_4)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -640,18 +624,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                true)
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_4)
-                    .build(),
-                true);
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true)
+            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -678,10 +652,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_4)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -691,10 +662,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_3)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -726,18 +694,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                false)
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_4)
-                    .build(),
-                false);
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false)
+            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -765,10 +723,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_3)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -780,10 +735,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_4)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -817,18 +769,8 @@ public class SelectStatementHandlerTest {
 
     Scan scan =
         prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                false)
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_4)
-                    .build(),
-                false);
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false)
+            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -856,10 +798,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_4)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_4),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -871,10 +810,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_3)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1046,13 +982,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                true);
+        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1079,10 +1009,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_3)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -1126,13 +1053,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                true);
+        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1167,10 +1088,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_3)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -1201,13 +1119,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                false);
+        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1235,10 +1147,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_3)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1283,13 +1192,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withStart(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                false);
+        prepareScan().withStart(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1325,10 +1228,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_3)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1470,13 +1370,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                true);
+        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1511,10 +1405,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_3)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
 
@@ -1546,13 +1437,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                true);
+        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), true);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1579,10 +1464,7 @@ public class SelectStatementHandlerTest {
                 SdkBytes.fromByteBuffer(
                     new KeyBytesEncoder()
                         .encode(
-                            Key.newBuilder()
-                                .addText(ANY_NAME_2, ANY_TEXT_2)
-                                .addText(ANY_NAME_3, ANY_TEXT_3)
-                                .build(),
+                            new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                             metadata.getClusteringOrders())))
             .build());
     expectedBindMap.put(
@@ -1625,13 +1507,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                false);
+        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1667,10 +1543,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestPreviousBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_3)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());
@@ -1703,13 +1576,7 @@ public class SelectStatementHandlerTest {
     when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
 
     Scan scan =
-        prepareScan()
-            .withEnd(
-                Key.newBuilder()
-                    .addText(ANY_NAME_2, ANY_TEXT_2)
-                    .addText(ANY_NAME_3, ANY_TEXT_3)
-                    .build(),
-                false);
+        prepareScan().withEnd(new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3), false);
 
     String expectedCondition =
         DynamoOperation.PARTITION_KEY
@@ -1737,10 +1604,7 @@ public class SelectStatementHandlerTest {
                     BytesUtils.getClosestNextBytes(
                             new KeyBytesEncoder()
                                 .encode(
-                                    Key.newBuilder()
-                                        .addText(ANY_NAME_2, ANY_TEXT_2)
-                                        .addText(ANY_NAME_3, ANY_TEXT_3)
-                                        .build(),
+                                    new Key(ANY_NAME_2, ANY_TEXT_2, ANY_NAME_3, ANY_TEXT_3),
                                     metadata.getClusteringOrders()))
                         .get()))
             .build());

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -89,9 +89,7 @@ public class QueryBuilderTest {
             queryBuilder
                 .select(Collections.emptyList())
                 .from(NAMESPACE, TABLE, TABLE_METADATA)
-                .where(
-                    Key.newBuilder().addText("p1", "aaa").addText("p2", "bbb").build(),
-                    Optional.empty())
+                .where(new Key("p1", "aaa", "p2", "bbb"), Optional.empty())
                 .build()
                 .toString())
         .isEqualTo(encloseSql("SELECT * FROM n1.t1 WHERE p1=? AND p2=?"));
@@ -109,9 +107,7 @@ public class QueryBuilderTest {
             queryBuilder
                 .select(Arrays.asList("c1", "c2"))
                 .from(NAMESPACE, TABLE, TABLE_METADATA)
-                .where(
-                    new Key("p1", "aaa"),
-                    Optional.of(Key.newBuilder().addText("c1", "aaa").addText("c2", "bbb").build()))
+                .where(new Key("p1", "aaa"), Optional.of(new Key("c1", "aaa", "c2", "bbb")))
                 .build()
                 .toString())
         .isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE p1=? AND c1=? AND c2=?"));
@@ -153,9 +149,9 @@ public class QueryBuilderTest {
                 .from(NAMESPACE, TABLE, TABLE_METADATA)
                 .where(
                     new Key("p1", "aaa"),
-                    Optional.of(Key.newBuilder().addText("c1", "aaa").addText("c2", "aaa").build()),
+                    Optional.of(new Key("c1", "aaa", "c2", "aaa")),
                     true,
-                    Optional.of(Key.newBuilder().addText("c1", "aaa").addText("c2", "bbb").build()),
+                    Optional.of(new Key("c1", "aaa", "c2", "bbb")),
                     false)
                 .build()
                 .toString())
@@ -344,8 +340,8 @@ public class QueryBuilderTest {
             queryBuilder
                 .insertInto(NAMESPACE, TABLE)
                 .values(
-                    Key.newBuilder().addText("p1", "aaa").addText("p2", "ccc").build(),
-                    Optional.of(Key.newBuilder().addText("c1", "bbb").addText("c2", "ddd").build()),
+                    new Key("p1", "aaa", "p2", "ccc"),
+                    Optional.of(new Key("c1", "bbb", "c2", "ddd")),
                     values)
                 .build()
                 .toString())
@@ -383,8 +379,8 @@ public class QueryBuilderTest {
                 .update(NAMESPACE, TABLE)
                 .set(values)
                 .where(
-                    Key.newBuilder().addText("p1", "aaa").addText("p2", "ccc").build(),
-                    Optional.of(Key.newBuilder().addText("c1", "bbb").addText("c2", "ddd").build()))
+                    new Key("p1", "aaa", "p2", "ccc"),
+                    Optional.of(new Key("c1", "bbb", "c2", "ddd")))
                 .build()
                 .toString())
         .isEqualTo(
@@ -443,8 +439,8 @@ public class QueryBuilderTest {
             queryBuilder
                 .deleteFrom(NAMESPACE, TABLE)
                 .where(
-                    Key.newBuilder().addText("p1", "aaa").addText("p2", "ccc").build(),
-                    Optional.of(Key.newBuilder().addText("c1", "bbb").addText("c2", "ddd").build()))
+                    new Key("p1", "aaa", "p2", "ccc"),
+                    Optional.of(new Key("c1", "bbb", "c2", "ddd")))
                 .build()
                 .toString())
         .isEqualTo(encloseSql("DELETE FROM n1.t1 WHERE p1=? AND p2=? AND c1=? AND c2=?"));
@@ -588,8 +584,8 @@ public class QueryBuilderTest {
             queryBuilder
                 .upsertInto(NAMESPACE, TABLE)
                 .values(
-                    Key.newBuilder().addText("p1", "aaa").addText("p2", "ccc").build(),
-                    Optional.of(Key.newBuilder().addText("c1", "bbb").addText("c2", "ddd").build()),
+                    new Key("p1", "aaa", "p2", "ccc"),
+                    Optional.of(new Key("c1", "bbb", "c2", "ddd")),
                     values)
                 .build()
                 .toString())
@@ -684,8 +680,8 @@ public class QueryBuilderTest {
             queryBuilder
                 .upsertInto(NAMESPACE, TABLE)
                 .values(
-                    Key.newBuilder().addText("p1", "aaa").addText("p2", "ccc").build(),
-                    Optional.of(Key.newBuilder().addText("c1", "bbb").addText("c2", "ddd").build()),
+                    new Key("p1", "aaa", "p2", "ccc"),
+                    Optional.of(new Key("c1", "bbb", "c2", "ddd")),
                     Collections.emptyMap())
                 .build()
                 .toString())

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcStorageTest.java
@@ -48,7 +48,7 @@ public class GrpcStorageTest {
   public void get_isCalledWithProperArguments_StubShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Get get = new Get(partitionKey);
     when(blockingStub.get(any())).thenReturn(GetResponse.newBuilder().build());
 
@@ -62,7 +62,7 @@ public class GrpcStorageTest {
   @Test
   public void get_StubThrowInvalidArgumentError_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Get get = new Get(partitionKey);
     when(blockingStub.get(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
 
@@ -73,7 +73,7 @@ public class GrpcStorageTest {
   @Test
   public void get_StubThrowInternalError_ShouldThrowExecutionException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Get get = new Get(partitionKey);
     when(blockingStub.get(any())).thenThrow(Status.INTERNAL.asRuntimeException());
 
@@ -85,7 +85,7 @@ public class GrpcStorageTest {
   public void put_isCalledWithProperArguments_StubShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Put put = new Put(partitionKey);
 
     // Act
@@ -98,7 +98,7 @@ public class GrpcStorageTest {
   @Test
   public void put_StubThrowInvalidArgumentError_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Put put = new Put(partitionKey);
     when(blockingStub.mutate(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
 
@@ -109,7 +109,7 @@ public class GrpcStorageTest {
   @Test
   public void put_StubThrowFailedPreconditionError_ShouldThrowNoMutationException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Put put = new Put(partitionKey);
     when(blockingStub.mutate(any())).thenThrow(Status.FAILED_PRECONDITION.asRuntimeException());
 
@@ -120,7 +120,7 @@ public class GrpcStorageTest {
   @Test
   public void put_StubThrowInternalError_ShouldThrowExecutionException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Put put = new Put(partitionKey);
     when(blockingStub.mutate(any())).thenThrow(Status.INTERNAL.asRuntimeException());
 
@@ -132,8 +132,8 @@ public class GrpcStorageTest {
   public void puts_isCalledWithProperArguments_StubShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Put> puts = Arrays.asList(new Put(partitionKey2), new Put(partitionKey1));
 
     // Act
@@ -146,8 +146,8 @@ public class GrpcStorageTest {
   @Test
   public void puts_StubThrowInvalidArgumentError_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Put> puts = Arrays.asList(new Put(partitionKey2), new Put(partitionKey1));
     when(blockingStub.mutate(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
 
@@ -158,8 +158,8 @@ public class GrpcStorageTest {
   @Test
   public void puts_StubThrowFailedPreconditionError_ShouldThrowNoMutationException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Put> puts = Arrays.asList(new Put(partitionKey2), new Put(partitionKey1));
     when(blockingStub.mutate(any())).thenThrow(Status.FAILED_PRECONDITION.asRuntimeException());
 
@@ -170,8 +170,8 @@ public class GrpcStorageTest {
   @Test
   public void puts_StubThrowInternalError_ShouldThrowExecutionException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Put> puts = Arrays.asList(new Put(partitionKey2), new Put(partitionKey1));
     when(blockingStub.mutate(any())).thenThrow(Status.INTERNAL.asRuntimeException());
 
@@ -183,7 +183,7 @@ public class GrpcStorageTest {
   public void delete_isCalledWithProperArguments_StubShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Delete delete = new Delete(partitionKey);
 
     // Act
@@ -196,7 +196,7 @@ public class GrpcStorageTest {
   @Test
   public void delete_StubThrowInvalidArgumentError_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Delete delete = new Delete(partitionKey);
     when(blockingStub.mutate(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
 
@@ -207,7 +207,7 @@ public class GrpcStorageTest {
   @Test
   public void delete_StubThrowFailedPreconditionError_ShouldThrowNoMutationException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Delete delete = new Delete(partitionKey);
     when(blockingStub.mutate(any())).thenThrow(Status.FAILED_PRECONDITION.asRuntimeException());
 
@@ -218,7 +218,7 @@ public class GrpcStorageTest {
   @Test
   public void delete_StubThrowInternalError_ShouldThrowExecutionException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     Delete delete = new Delete(partitionKey);
     when(blockingStub.mutate(any())).thenThrow(Status.INTERNAL.asRuntimeException());
 
@@ -230,8 +230,8 @@ public class GrpcStorageTest {
   public void deletes_isCalledWithProperArguments_StubShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Delete> deletes = Arrays.asList(new Delete(partitionKey2), new Delete(partitionKey1));
 
     // Act
@@ -244,8 +244,8 @@ public class GrpcStorageTest {
   @Test
   public void deletes_StubThrowInvalidArgumentError_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Delete> deletes = Arrays.asList(new Delete(partitionKey2), new Delete(partitionKey1));
     when(blockingStub.mutate(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
 
@@ -256,8 +256,8 @@ public class GrpcStorageTest {
   @Test
   public void deletes_StubThrowFailedPreconditionError_ShouldThrowNoMutationException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Delete> deletes = Arrays.asList(new Delete(partitionKey2), new Delete(partitionKey1));
     when(blockingStub.mutate(any())).thenThrow(Status.FAILED_PRECONDITION.asRuntimeException());
 
@@ -268,8 +268,8 @@ public class GrpcStorageTest {
   @Test
   public void deletes_StubThrowInternalError_ShouldThrowExecutionException() {
     // Arrange
-    Key partitionKey1 = Key.newBuilder().addInt("col1", 1).build();
-    Key partitionKey2 = Key.newBuilder().addInt("col1", 2).build();
+    Key partitionKey1 = new Key("col1", 1);
+    Key partitionKey2 = new Key("col1", 2);
     List<Delete> deletes = Arrays.asList(new Delete(partitionKey2), new Delete(partitionKey1));
     when(blockingStub.mutate(any())).thenThrow(Status.INTERNAL.asRuntimeException());
 
@@ -281,7 +281,7 @@ public class GrpcStorageTest {
   public void mutate_isCalledWithProperArguments_StubShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     List<Mutation> mutations = Arrays.asList(new Put(partitionKey), new Delete(partitionKey));
 
     // Act
@@ -294,7 +294,7 @@ public class GrpcStorageTest {
   @Test
   public void mutate_StubThrowInvalidArgumentError_ShouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     List<Mutation> mutations = Arrays.asList(new Put(partitionKey), new Delete(partitionKey));
     when(blockingStub.mutate(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
 
@@ -306,7 +306,7 @@ public class GrpcStorageTest {
   @Test
   public void mutate_StubThrowFailedPreconditionError_ShouldThrowNoMutationException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     List<Mutation> mutations = Arrays.asList(new Put(partitionKey), new Delete(partitionKey));
     when(blockingStub.mutate(any())).thenThrow(Status.FAILED_PRECONDITION.asRuntimeException());
 
@@ -317,7 +317,7 @@ public class GrpcStorageTest {
   @Test
   public void mutate_StubThrowInternalError_ShouldThrowExecutionException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     List<Mutation> mutations = Arrays.asList(new Put(partitionKey), new Delete(partitionKey));
     when(blockingStub.mutate(any())).thenThrow(Status.INTERNAL.asRuntimeException());
 

--- a/server/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
+++ b/server/src/test/java/com/scalar/db/server/DistributedStorageServiceTest.java
@@ -120,7 +120,7 @@ public class DistributedStorageServiceTest {
   public void mutate_IsCalledWithSinglePut_StorageShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addMutation(ProtoUtils.toMutation(new Put(partitionKey)))
@@ -141,7 +141,7 @@ public class DistributedStorageServiceTest {
   public void mutate_IsCalledWithMultiplePuts_StorageShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addAllMutation(
@@ -165,7 +165,7 @@ public class DistributedStorageServiceTest {
   public void mutate_IsCalledWithSingleDelete_StorageShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addMutation(ProtoUtils.toMutation(new Delete(partitionKey)))
@@ -186,7 +186,7 @@ public class DistributedStorageServiceTest {
   public void mutate_IsCalledWithMultipleDeletes_StorageShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addAllMutation(
@@ -210,7 +210,7 @@ public class DistributedStorageServiceTest {
   public void mutate_IsCalledWithMixedPutAndDelete_StorageShouldBeCalledProperly()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addAllMutation(
@@ -234,7 +234,7 @@ public class DistributedStorageServiceTest {
   public void mutate_StorageThrowsIllegalArgumentException_ShouldThrowInvalidArgumentError()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addMutation(ProtoUtils.toMutation(new Put(partitionKey)))
@@ -256,7 +256,7 @@ public class DistributedStorageServiceTest {
   public void mutate_StorageThrowsNoMutationException_ShouldThrowFailedPreconditionError()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addMutation(ProtoUtils.toMutation(new Put(partitionKey)))
@@ -278,7 +278,7 @@ public class DistributedStorageServiceTest {
   public void mutate_StorageThrowsExecutionException_ShouldThrowInternalError()
       throws ExecutionException {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addMutation(ProtoUtils.toMutation(new Put(partitionKey)))
@@ -298,7 +298,7 @@ public class DistributedStorageServiceTest {
   @Test
   public void mutate_GateKeeperReturnsFalse_ShouldThrowUnavailableError() {
     // Arrange
-    Key partitionKey = Key.newBuilder().addInt("col1", 1).build();
+    Key partitionKey = new Key("col1", 1);
     MutateRequest request =
         MutateRequest.newBuilder()
             .addMutation(ProtoUtils.toMutation(new Put(partitionKey)))


### PR DESCRIPTION
This PR revisits the `Key` construction. After this change, we can follow the following guideline to construct `Key` objects:

1. If the key consists of a single value (column), use the constructors for a single value (column) as follows:
```
Key key1 = new Key("col1", 1);
Key key2 = new Key("col1", 100L);
Key key3 = new Key("col1", 1.3d);
Key key4 = new Key("col1", "value");
```
2. If the key consists of 2 - 5 values (columns), use the constructors for multiple values (columns) as follows:
```
Key key1 = new Key("col1", 1, "col2", 100L);
Key key2 = new Key("col1", 1, "col2", 100L, "col3", 1.3d);
Key key3 = new Key("col1", 1, "col2", 100L, "col3", 1.3d, "col4", "value");
Key key4 = new Key("col1", 1, "col2", 100L, "col3", 1.3d, "col4", "value", "col5", false);
```
3. If the key consists of more than 5 values (columns), use the builder as follows:
```
Key key = Key.newBuilder()
            .add("col1", 1)
            .add("col2", 100L)
            .add("col3", 1.3d)
            .add("col4", "value")
            .add("col5", false)
            .add("col6", 100)
            .build();
```

Please take a look!