### PR TITLE
Upgrade log4j to 2.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
         errorproneVersion = '2.10.0'
         errorproneJavacVersion = '9+181-r4173-1'
         gsonVersion = '2.8.7'
-        log4jVersion = '2.17.0'
+        log4jVersion = '2.17.1'
     }
 
     repositories {


### PR DESCRIPTION
It looks like `2.17.0` have another vulnerability according to the following article:
https://www.bleepingcomputer.com/news/security/log4j-2171-out-now-fixes-new-remote-code-execution-bug/

This PR upgrades `log4j` to `2.17.1`. Please take a look!