### PR TITLE
Rename JdbcDatabaseAdmin to JdbcAdmin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/TestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/TestUtils.java
@@ -15,8 +15,8 @@ import com.scalar.db.storage.cosmos.CosmosAdmin;
 import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.storage.dynamo.DynamoAdmin;
 import com.scalar.db.storage.dynamo.DynamoConfig;
+import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
-import com.scalar.db.storage.jdbc.JdbcDatabaseAdmin;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Arrays;
@@ -179,7 +179,7 @@ public final class TestUtils {
     // for JDBC
     String tableMetadataSchema = properties.getProperty(JdbcConfig.TABLE_METADATA_SCHEMA);
     if (tableMetadataSchema == null) {
-      tableMetadataSchema = JdbcDatabaseAdmin.METADATA_SCHEMA;
+      tableMetadataSchema = JdbcAdmin.METADATA_SCHEMA;
     }
     properties.setProperty(JdbcConfig.TABLE_METADATA_SCHEMA, tableMetadataSchema + "_" + testName);
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -3,7 +3,7 @@ package com.scalar.db.storage.jdbc;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.AdminIntegrationTestBase;
 
-public class JdbcDatabaseAdminIntegrationTest extends AdminIntegrationTestBase {
+public class JdbcAdminIntegrationTest extends AdminIntegrationTestBase {
 
   @Override
   protected DatabaseConfig getDatabaseConfig() {

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -15,8 +15,8 @@ import com.scalar.db.storage.cosmos.Cosmos;
 import com.scalar.db.storage.cosmos.CosmosAdmin;
 import com.scalar.db.storage.dynamo.Dynamo;
 import com.scalar.db.storage.dynamo.DynamoAdmin;
+import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcDatabase;
-import com.scalar.db.storage.jdbc.JdbcDatabaseAdmin;
 import com.scalar.db.storage.multistorage.MultiStorage;
 import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import com.scalar.db.storage.rpc.GrpcAdmin;
@@ -104,7 +104,7 @@ public class DatabaseConfig {
         break;
       case "jdbc":
         storageClass = JdbcDatabase.class;
-        adminClass = JdbcDatabaseAdmin.class;
+        adminClass = JdbcAdmin.class;
         break;
       case "multi-storage":
         storageClass = MultiStorage.class;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -36,9 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class JdbcDatabaseAdmin implements DistributedStorageAdmin {
+public class JdbcAdmin implements DistributedStorageAdmin {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(JdbcDatabaseAdmin.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(JdbcAdmin.class);
   private static final ImmutableMap<RdbEngine, ImmutableMap<DataType, String>> DATA_TYPE_MAPPING =
       ImmutableMap.<RdbEngine, ImmutableMap<DataType, String>>builder()
           .put(
@@ -125,20 +125,20 @@ public class JdbcDatabaseAdmin implements DistributedStorageAdmin {
   private final String metadataSchema;
 
   @Inject
-  public JdbcDatabaseAdmin(JdbcConfig config) {
+  public JdbcAdmin(JdbcConfig config) {
     dataSource = JdbcUtils.initDataSource(config);
     rdbEngine = JdbcUtils.getRdbEngine(config.getContactPoints().get(0));
     metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);
   }
 
-  public JdbcDatabaseAdmin(BasicDataSource dataSource, JdbcConfig config) {
+  public JdbcAdmin(BasicDataSource dataSource, JdbcConfig config) {
     this.dataSource = dataSource;
     rdbEngine = JdbcUtils.getRdbEngine(config.getContactPoints().get(0));
     metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);
   }
 
   @VisibleForTesting
-  JdbcDatabaseAdmin(BasicDataSource dataSource, RdbEngine rdbEngine, JdbcConfig config) {
+  JdbcAdmin(BasicDataSource dataSource, RdbEngine rdbEngine, JdbcConfig config) {
     this.dataSource = dataSource;
     this.rdbEngine = rdbEngine;
     metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -51,7 +51,7 @@ public class JdbcDatabase implements DistributedStorage {
 
     tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config);
     TableMetadataManager tableMetadataManager =
-        new TableMetadataManager(new JdbcDatabaseAdmin(tableMetadataDataSource, config), config);
+        new TableMetadataManager(new JdbcAdmin(tableMetadataDataSource, config), config);
 
     OperationChecker operationChecker = new OperationChecker(tableMetadataManager);
     QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -9,8 +9,8 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.storage.common.TableMetadataManager;
 import com.scalar.db.storage.common.checker.OperationChecker;
+import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
-import com.scalar.db.storage.jdbc.JdbcDatabaseAdmin;
 import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
@@ -41,7 +41,7 @@ public class JdbcTransactionManager implements DistributedTransactionManager {
 
     tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config);
     TableMetadataManager tableMetadataManager =
-        new TableMetadataManager(new JdbcDatabaseAdmin(tableMetadataDataSource, config), config);
+        new TableMetadataManager(new JdbcAdmin(tableMetadataDataSource, config), config);
 
     OperationChecker operationChecker = new OperationChecker(tableMetadataManager);
     QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -9,8 +9,8 @@ import com.scalar.db.storage.cosmos.Cosmos;
 import com.scalar.db.storage.cosmos.CosmosAdmin;
 import com.scalar.db.storage.dynamo.Dynamo;
 import com.scalar.db.storage.dynamo.DynamoAdmin;
+import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcDatabase;
-import com.scalar.db.storage.jdbc.JdbcDatabaseAdmin;
 import com.scalar.db.storage.multistorage.MultiStorage;
 import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import com.scalar.db.storage.rpc.GrpcAdmin;
@@ -235,7 +235,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcDatabaseAdmin.class);
+    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
   }
 
   @Test
@@ -340,7 +340,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcDatabaseAdmin.class);
+    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(JdbcTransactionManager.class);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -32,7 +32,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 
 @SuppressFBWarnings({"OBL_UNSATISFIED_OBLIGATION", "ODR_OPEN_DATABASE_RESOURCE"})
-public class JdbcDatabaseAdminTest {
+public class JdbcAdminTest {
 
   @Mock private BasicDataSource dataSource;
   @Mock private Connection connection;
@@ -148,7 +148,7 @@ public class JdbcDatabaseAdminTest {
     if (tableMetadataSchema.isPresent()) {
       when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
     }
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     TableMetadata actualMetadata = admin.getTableMetadata(namespace, table);
@@ -215,7 +215,7 @@ public class JdbcDatabaseAdminTest {
       throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
     List<Statement> mockedStatements = new ArrayList<>();
 
     for (int i = 0; i < expectedSqlStatements.length; i++) {
@@ -371,7 +371,7 @@ public class JdbcDatabaseAdminTest {
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
 
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.createTable(namespace, table, metadata, new HashMap<>());
@@ -638,7 +638,7 @@ public class JdbcDatabaseAdminTest {
     if (tableMetadataSchema.isPresent()) {
       when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
     }
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.createTable(namespace, table, metadata, new HashMap<>());
@@ -683,7 +683,7 @@ public class JdbcDatabaseAdminTest {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     Statement truncateTableStatement = mock(Statement.class);
     when(connection.createStatement()).thenReturn(truncateTableStatement);
@@ -835,7 +835,7 @@ public class JdbcDatabaseAdminTest {
     if (tableMetadataSchema.isPresent()) {
       when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
     }
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.dropTable(namespace, table);
@@ -978,7 +978,7 @@ public class JdbcDatabaseAdminTest {
     if (tableMetadataSchema.isPresent()) {
       when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
     }
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.dropTable(namespace, table);
@@ -1017,7 +1017,7 @@ public class JdbcDatabaseAdminTest {
       RdbEngine rdbEngine, String expectedDropSchemaStatement) throws Exception {
     // Arrange
     String namespace = "my_ns";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     Connection connection = mock(Connection.class);
     Statement dropSchemaStatement = mock(Statement.class);
@@ -1127,7 +1127,7 @@ public class JdbcDatabaseAdminTest {
     if (tableMetadataSchema.isPresent()) {
       when(config.getTableMetadataSchema()).thenReturn(tableMetadataSchema);
     }
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     Set<String> actualTableNames = admin.getNamespaceTableNames(namespace);
@@ -1170,7 +1170,7 @@ public class JdbcDatabaseAdminTest {
       RdbEngine rdbEngine, String expectedSelectStatement) throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
-    JdbcDatabaseAdmin admin = new JdbcDatabaseAdmin(dataSource, rdbEngine, config);
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     Connection connection = mock(Connection.class);
     PreparedStatement selectStatement = mock(PreparedStatement.class);
@@ -1207,14 +1207,12 @@ public class JdbcDatabaseAdminTest {
       }
       GetColumnsResultSetMocker.Row currentRow = rows.get(row);
       ResultSet mock = (ResultSet) invocation.getMock();
-      when(mock.getString(JdbcDatabaseAdmin.METADATA_COL_COLUMN_NAME))
-          .thenReturn(currentRow.columnName);
-      when(mock.getString(JdbcDatabaseAdmin.METADATA_COL_DATA_TYPE))
-          .thenReturn(currentRow.dataType);
-      when(mock.getString(JdbcDatabaseAdmin.METADATA_COL_KEY_TYPE)).thenReturn(currentRow.keyType);
-      when(mock.getString(JdbcDatabaseAdmin.METADATA_COL_CLUSTERING_ORDER))
+      when(mock.getString(JdbcAdmin.METADATA_COL_COLUMN_NAME)).thenReturn(currentRow.columnName);
+      when(mock.getString(JdbcAdmin.METADATA_COL_DATA_TYPE)).thenReturn(currentRow.dataType);
+      when(mock.getString(JdbcAdmin.METADATA_COL_KEY_TYPE)).thenReturn(currentRow.keyType);
+      when(mock.getString(JdbcAdmin.METADATA_COL_CLUSTERING_ORDER))
           .thenReturn(currentRow.clusteringOrder);
-      when(mock.getBoolean(JdbcDatabaseAdmin.METADATA_COL_INDEXED)).thenReturn(currentRow.indexed);
+      when(mock.getBoolean(JdbcAdmin.METADATA_COL_INDEXED)).thenReturn(currentRow.indexed);
       return true;
     }
 
@@ -1257,7 +1255,7 @@ public class JdbcDatabaseAdminTest {
       }
       GetTablesNamesResultSetMocker.Row currentRow = rows.get(row);
       ResultSet mock = (ResultSet) invocation.getMock();
-      when(mock.getString(JdbcDatabaseAdmin.METADATA_COL_FULL_TABLE_NAME))
+      when(mock.getString(JdbcAdmin.METADATA_COL_FULL_TABLE_NAME))
           .thenReturn(currentRow.fullTableName);
       return true;
     }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -46,7 +46,7 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcDatabaseAdmin.class);
+    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getConnectionPoolMinIdle()).isEqualTo(1);
     assertThat(config.getConnectionPoolMaxIdle()).isEqualTo(100);
     assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(500);
@@ -82,7 +82,7 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcDatabaseAdmin.class);
+    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getConnectionPoolMinIdle())
         .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MIN_IDLE);
     assertThat(config.getConnectionPoolMaxIdle())


### PR DESCRIPTION
This PR renames `JdbcDatabaseAdmin` to `JdbcAdmin` because I think `JdbcAdmin` is a more proper name. Please take a look!