### PR TITLE
Transactions that have multiple scans are always rejected in EXTRA_READ

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -2111,6 +2111,20 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   @Test
+  public void scanAndCommit_MultipleScansGivenInTransactionWithExtraRead_ShouldCommitProperly()
+      throws CrudException, CommitException, UnknownTransactionStatusException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+
+    // Act Assert
+    ConsensusCommit transaction =
+        manager.start(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    transaction.scan(prepareScan(0, namespace1, TABLE_1));
+    transaction.scan(prepareScan(1, namespace1, TABLE_1));
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
   public void putAndCommit_DeleteGivenInBetweenTransactions_ShouldProduceSerializableResults()
       throws CrudException, CommitException, UnknownTransactionStatusException {
     // Arrange
@@ -2534,6 +2548,14 @@ public abstract class ConsensusCommitIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE)
         .withStart(new Key(ACCOUNT_TYPE, fromType))
         .withEnd(new Key(ACCOUNT_TYPE, toType));
+  }
+
+  private Scan prepareScan(int id, String namespace, String table) {
+    Key partitionKey = new Key(ACCOUNT_ID, id);
+    return new Scan(partitionKey)
+        .forNamespace(namespace)
+        .forTable(table)
+        .withConsistency(Consistency.LINEARIZABLE);
   }
 
   private Put preparePut(int id, int type, String namespace, String table) {


### PR DESCRIPTION
It looks like the current EXTRA_READ validation always rejects transactions that have multiple scans. This PR fixes this issue. Please take a look!