### PR TITLE
Support parallel validation for EXTRA_READ in Consensus Commit

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -103,7 +103,8 @@ public abstract class ConsensusCommitIntegrationTestBase {
     recovery = spy(new RecoveryHandler(storage, coordinator, parallelExecutor));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery, parallelExecutor));
     manager =
-        new ConsensusCommitManager(storage, consensusCommitConfig, coordinator, recovery, commit);
+        new ConsensusCommitManager(
+            storage, consensusCommitConfig, coordinator, parallelExecutor, recovery, commit);
   }
 
   protected void initialize() throws Exception {}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -11,7 +11,7 @@ import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.util.ThrowableRunnable;
+import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -76,7 +76,7 @@ public class CommitHandler {
     PartitionedMutations mutations = new PartitionedMutations(composer.get());
 
     ImmutableList<PartitionedMutations.Key> orderedKeys = mutations.getOrderedKeys();
-    List<ThrowableRunnable<ExecutionException>> tasks = new ArrayList<>(orderedKeys.size());
+    List<ParallelExecutorTask> tasks = new ArrayList<>(orderedKeys.size());
     for (PartitionedMutations.Key key : orderedKeys) {
       tasks.add(() -> storage.mutate(mutations.get(key)));
     }
@@ -129,7 +129,7 @@ public class CommitHandler {
       PartitionedMutations mutations = new PartitionedMutations(composer.get());
 
       ImmutableList<PartitionedMutations.Key> orderedKeys = mutations.getOrderedKeys();
-      List<ThrowableRunnable<ExecutionException>> tasks = new ArrayList<>(orderedKeys.size());
+      List<ParallelExecutorTask> tasks = new ArrayList<>(orderedKeys.size());
       for (PartitionedMutations.Key key : orderedKeys) {
         tasks.add(() -> storage.mutate(mutations.get(key)));
       }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -29,6 +29,7 @@ public class ConsensusCommitConfig {
 
   public static final String PARALLEL_EXECUTOR_COUNT = PREFIX + "parallel_executor_count";
   public static final String PARALLEL_PREPARATION_ENABLED = PREFIX + "parallel_preparation.enabled";
+  public static final String PARALLEL_VALIDATION_ENABLED = PREFIX + "parallel_validation.enabled";
   public static final String PARALLEL_COMMIT_ENABLED = PREFIX + "parallel_commit.enabled";
   public static final String PARALLEL_ROLLBACK_ENABLED = PREFIX + "parallel_rollback.enabled";
 
@@ -45,6 +46,7 @@ public class ConsensusCommitConfig {
 
   private int parallelExecutorCount;
   private boolean parallelPreparationEnabled;
+  private boolean parallelValidationEnabled;
   private boolean parallelCommitEnabled;
   private boolean parallelRollbackEnabled;
   private boolean asyncCommitEnabled;
@@ -116,6 +118,11 @@ public class ConsensusCommitConfig {
         getInt(getProperties(), PARALLEL_EXECUTOR_COUNT, DEFAULT_PARALLEL_EXECUTOR_COUNT);
     parallelPreparationEnabled = getBoolean(getProperties(), PARALLEL_PREPARATION_ENABLED, false);
     parallelCommitEnabled = getBoolean(getProperties(), PARALLEL_COMMIT_ENABLED, false);
+
+    // Use the value of parallel commit for parallel validation and parallel rollback as default
+    // value
+    parallelValidationEnabled =
+        getBoolean(getProperties(), PARALLEL_VALIDATION_ENABLED, parallelCommitEnabled);
     parallelRollbackEnabled =
         getBoolean(getProperties(), PARALLEL_ROLLBACK_ENABLED, parallelCommitEnabled);
 
@@ -145,6 +152,10 @@ public class ConsensusCommitConfig {
 
   public boolean isParallelPreparationEnabled() {
     return parallelPreparationEnabled;
+  }
+
+  public boolean isParallelValidationEnabled() {
+    return parallelValidationEnabled;
   }
 
   public boolean isParallelCommitEnabled() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -46,12 +46,13 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
       DistributedStorage storage,
       ConsensusCommitConfig config,
       Coordinator coordinator,
+      ParallelExecutor parallelExecutor,
       RecoveryHandler recovery,
       CommitHandler commit) {
     this.storage = storage;
     this.config = config;
     this.coordinator = coordinator;
-    parallelExecutor = null;
+    this.parallelExecutor = parallelExecutor;
     this.recovery = recovery;
     this.commit = commit;
     this.namespace = storage.getNamespace();
@@ -150,7 +151,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
           "Setting different isolation level or serializable strategy from the ones"
               + "in DatabaseConfig might cause unexpected anomalies.");
     }
-    Snapshot snapshot = new Snapshot(txId, isolation, strategy);
+    Snapshot snapshot = new Snapshot(txId, isolation, strategy, parallelExecutor);
     CrudHandler crud = new CrudHandler(storage, snapshot);
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
     namespace.ifPresent(consensus::withNamespace);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -92,7 +92,7 @@ public class CrudHandler {
         }
       }
     }
-    snapshot.put(scan, Optional.of(keys));
+    snapshot.put(scan, keys);
 
     return results;
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.util.ThrowableRunnable;
 import java.util.Collections;
 import java.util.List;
@@ -17,12 +18,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class ParallelExecutor {
 
+  @FunctionalInterface
+  public interface ValidationTask {
+    void run() throws ExecutionException, CommitConflictException;
+  }
+
   private final ConsensusCommitConfig config;
   @Nullable private final ExecutorService parallelExecutorService;
 
   public ParallelExecutor(ConsensusCommitConfig config) {
     this.config = config;
     if (config.isParallelPreparationEnabled()
+        || config.isParallelValidationEnabled()
         || config.isParallelCommitEnabled()
         || config.isParallelRollbackEnabled()) {
       parallelExecutorService =
@@ -45,6 +52,49 @@ public class ParallelExecutor {
     executeTasks(tasks, config.isParallelPreparationEnabled(), false);
   }
 
+  public void validate(List<ValidationTask> tasks)
+      throws ExecutionException, CommitConflictException {
+    List<Future<?>> futures;
+    if (config.isParallelValidationEnabled()) {
+      assert parallelExecutorService != null;
+      futures =
+          tasks.stream()
+              .map(
+                  t ->
+                      parallelExecutorService.submit(
+                          () -> {
+                            t.run();
+                            return null;
+                          }))
+              .collect(Collectors.toList());
+    } else {
+      futures = Collections.emptyList();
+      for (ValidationTask task : tasks) {
+        task.run();
+      }
+    }
+
+    for (Future<?> future : futures) {
+      try {
+        Uninterruptibles.getUninterruptibly(future);
+      } catch (java.util.concurrent.ExecutionException e) {
+        if (e.getCause() instanceof ExecutionException) {
+          throw (ExecutionException) e.getCause();
+        }
+        if (e.getCause() instanceof CommitConflictException) {
+          throw (CommitConflictException) e.getCause();
+        }
+        if (e.getCause() instanceof RuntimeException) {
+          throw (RuntimeException) e.getCause();
+        }
+        if (e.getCause() instanceof Error) {
+          throw (Error) e.getCause();
+        }
+        throw new AssertionError("Can't reach here. Maybe a bug", e);
+      }
+    }
+  }
+
   public void commit(List<ThrowableRunnable<ExecutionException>> tasks) throws ExecutionException {
     executeTasks(tasks, config.isParallelCommitEnabled(), config.isAsyncCommitEnabled());
   }
@@ -57,7 +107,6 @@ public class ParallelExecutor {
   private void executeTasks(
       List<ThrowableRunnable<ExecutionException>> tasks, boolean parallel, boolean noWait)
       throws ExecutionException {
-
     List<Future<?>> futures;
     if (parallel) {
       assert parallelExecutorService != null;
@@ -73,8 +122,8 @@ public class ParallelExecutor {
               .collect(Collectors.toList());
     } else {
       futures = Collections.emptyList();
-      for (ThrowableRunnable<ExecutionException> runnable : tasks) {
-        runnable.run();
+      for (ThrowableRunnable<ExecutionException> task : tasks) {
+        task.run();
       }
     }
 
@@ -92,7 +141,7 @@ public class ParallelExecutor {
           if (e.getCause() instanceof Error) {
             throw (Error) e.getCause();
           }
-          throw new ExecutionException("an error occurred during executing the tasks", e);
+          throw new AssertionError("Can't reach here. Maybe a bug", e);
         }
       }
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -9,7 +9,7 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.util.ThrowableRunnable;
+import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +62,7 @@ public class RecoveryHandler {
       PartitionedMutations mutations = new PartitionedMutations(composer.get());
 
       ImmutableList<PartitionedMutations.Key> orderedKeys = mutations.getOrderedKeys();
-      List<ThrowableRunnable<ExecutionException>> tasks = new ArrayList<>(orderedKeys.size());
+      List<ParallelExecutorTask> tasks = new ArrayList<>(orderedKeys.size());
       for (PartitionedMutations.Key key : orderedKeys) {
         tasks.add(() -> storage.mutate(mutations.get(key)));
       }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -14,7 +14,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
-import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ValidationTask;
+import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -252,11 +252,11 @@ public class Snapshot {
       return;
     }
 
-    List<ValidationTask> validationTasks = new ArrayList<>();
+    List<ParallelExecutorTask> tasks = new ArrayList<>();
 
     // Read set by scan is re-validated to check if there is no anti-dependency
     for (Map.Entry<Scan, List<Key>> entry : scanSet.entrySet()) {
-      validationTasks.add(
+      tasks.add(
           () -> {
             Set<TransactionResult> currentReadSet = new HashSet<>();
             Set<Key> validatedReadSet = new HashSet<>();
@@ -315,7 +315,7 @@ public class Snapshot {
         continue;
       }
 
-      validationTasks.add(
+      tasks.add(
           () -> {
             Get get =
                 new Get(key.getPartitionKey(), key.getClusteringKey().orElse(null))
@@ -331,7 +331,7 @@ public class Snapshot {
           });
     }
 
-    parallelExecutor.validate(validationTasks);
+    parallelExecutor.validate(tasks);
   }
 
   private void throwExceptionDueToPotentialAntiDependency() throws CommitConflictException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -73,12 +73,13 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
       DistributedStorage storage,
       ConsensusCommitConfig config,
       Coordinator coordinator,
+      ParallelExecutor parallelExecutor,
       RecoveryHandler recovery,
       CommitHandler commit) {
     this.storage = storage;
     this.config = config;
     this.coordinator = coordinator;
-    parallelExecutor = null;
+    this.parallelExecutor = parallelExecutor;
     this.recovery = recovery;
     this.commit = commit;
     if (config.isActiveTransactionsManagementEnabled()) {
@@ -159,7 +160,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
 
   private TwoPhaseConsensusCommit createNewTransaction(
       String txId, boolean isCoordinator, Isolation isolation, SerializableStrategy strategy) {
-    Snapshot snapshot = new Snapshot(txId, isolation, strategy);
+    Snapshot snapshot = new Snapshot(txId, isolation, strategy, parallelExecutor);
     CrudHandler crud = new CrudHandler(storage, snapshot);
 
     TwoPhaseConsensusCommit transaction =

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -83,7 +83,12 @@ public class CommitHandlerTest {
   }
 
   private Snapshot prepareSnapshotWithDifferentPartitionPut() {
-    Snapshot snapshot = new Snapshot(ANY_ID);
+    Snapshot snapshot =
+        new Snapshot(
+            ANY_ID,
+            Isolation.SNAPSHOT,
+            SerializableStrategy.EXTRA_WRITE,
+            new ParallelExecutor(config));
 
     // different partition
     Put put1 = preparePut1();
@@ -95,7 +100,12 @@ public class CommitHandlerTest {
   }
 
   private Snapshot prepareSnapshotWithSamePartitionPut() {
-    Snapshot snapshot = new Snapshot(ANY_ID);
+    Snapshot snapshot =
+        new Snapshot(
+            ANY_ID,
+            Isolation.SNAPSHOT,
+            SerializableStrategy.EXTRA_WRITE,
+            new ParallelExecutor(config));
 
     // same partition
     Put put1 = preparePut1();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -24,6 +24,7 @@ public class ConsensusCommitConfigTest {
     assertThat(config.getParallelExecutorCount())
         .isEqualTo(ConsensusCommitConfig.DEFAULT_PARALLEL_EXECUTOR_COUNT);
     assertThat(config.isParallelPreparationEnabled()).isEqualTo(false);
+    assertThat(config.isParallelValidationEnabled()).isEqualTo(false);
     assertThat(config.isParallelCommitEnabled()).isEqualTo(false);
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(false);
     assertThat(config.isAsyncCommitEnabled()).isEqualTo(false);
@@ -139,6 +140,7 @@ public class ConsensusCommitConfigTest {
     Properties props = new Properties();
     props.setProperty(ConsensusCommitConfig.PARALLEL_EXECUTOR_COUNT, "100");
     props.setProperty(ConsensusCommitConfig.PARALLEL_PREPARATION_ENABLED, "true");
+    props.setProperty(ConsensusCommitConfig.PARALLEL_VALIDATION_ENABLED, "true");
     props.setProperty(ConsensusCommitConfig.PARALLEL_COMMIT_ENABLED, "true");
     props.setProperty(ConsensusCommitConfig.PARALLEL_ROLLBACK_ENABLED, "true");
 
@@ -148,13 +150,14 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.getParallelExecutorCount()).isEqualTo(100);
     assertThat(config.isParallelPreparationEnabled()).isEqualTo(true);
+    assertThat(config.isParallelValidationEnabled()).isEqualTo(true);
     assertThat(config.isParallelCommitEnabled()).isEqualTo(true);
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(true);
   }
 
   @Test
   public void
-      constructor_ParallelExecutionRelatedPropertiesWithoutParallelRollbackPropertyGiven_ShouldUseParallelCommitValueForParallelRollback() {
+      constructor_ParallelExecutionRelatedPropertiesWithoutParallelValidationAndParallelRollbackPropertyGiven_ShouldUseParallelCommitValueForParallelValidationAndParallelRollback() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(ConsensusCommitConfig.PARALLEL_EXECUTOR_COUNT, "100");
@@ -167,6 +170,8 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.getParallelExecutorCount()).isEqualTo(100);
     assertThat(config.isParallelPreparationEnabled()).isEqualTo(false);
+    assertThat(config.isParallelValidationEnabled())
+        .isEqualTo(true); // use the parallel commit value
     assertThat(config.isParallelCommitEnabled()).isEqualTo(true);
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(true); // use the parallel commit value
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -45,6 +45,7 @@ public class CrudHandlerTest {
   @InjectMocks private CrudHandler handler;
   @Mock private DistributedStorage storage;
   @Mock private Snapshot snapshot;
+  @Mock private ParallelExecutor parallelExecutor;
   @Mock private Scanner scanner;
   @Mock private Result result;
 
@@ -267,6 +268,7 @@ public class CrudHandlerTest {
             ANY_TX_ID,
             Isolation.SNAPSHOT,
             null,
+            parallelExecutor,
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),
@@ -327,6 +329,7 @@ public class CrudHandlerTest {
             ANY_TX_ID,
             Isolation.SNAPSHOT,
             null,
+            parallelExecutor,
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -22,6 +22,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   @Mock private DistributedStorage storage;
   @Mock private ConsensusCommitConfig config;
   @Mock private Coordinator coordinator;
+  @Mock private ParallelExecutor parallelExecutor;
   @Mock private RecoveryHandler recovery;
   @Mock private CommitHandler commit;
 
@@ -36,7 +37,9 @@ public class TwoPhaseConsensusCommitManagerTest {
     when(config.getSerializableStrategy()).thenReturn(SerializableStrategy.EXTRA_READ);
     when(config.isActiveTransactionsManagementEnabled()).thenReturn(true);
 
-    manager = new TwoPhaseConsensusCommitManager(storage, config, coordinator, recovery, commit);
+    manager =
+        new TwoPhaseConsensusCommitManager(
+            storage, config, coordinator, parallelExecutor, recovery, commit);
   }
 
   @Test
@@ -133,7 +136,9 @@ public class TwoPhaseConsensusCommitManagerTest {
       resume_WhenActiveTransactionsManagementEnabledIsFalse_ShouldThrowUnsupportedOperationException() {
     // Arrange
     when(config.isActiveTransactionsManagementEnabled()).thenReturn(false);
-    manager = new TwoPhaseConsensusCommitManager(storage, config, coordinator, recovery, commit);
+    manager =
+        new TwoPhaseConsensusCommitManager(
+            storage, config, coordinator, parallelExecutor, recovery, commit);
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_TX_ID))


### PR DESCRIPTION
This PR introduces a parameter `scalar.db.consensus_commit.async_commit.enabled`. After this change, when we set the parameter to `true`, the validation for `EXTRA_READ` is done in parallel. Please take a look!