### PR TITLE
Use only one of transaction or storage method regardless of the table type in one GraphQL operation

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -43,6 +43,10 @@ public class DataFetcherHelper {
     this.tableGraphQlModel = tableGraphQlModel;
   }
 
+  static DistributedTransaction getCurrentTransaction(DataFetchingEnvironment environment) {
+    return environment.getGraphQlContext().get(Constants.CONTEXT_TRANSACTION_KEY);
+  }
+
   static Value<?> createValueFromMap(String name, Map<String, Object> map) {
     Object v = getOneScalarValue(map);
     Value<?> value;
@@ -133,14 +137,6 @@ public class DataFetcherHelper {
                     createValueFromMap("", ex),
                     ConditionalExpression.Operator.valueOf((String) ex.get("operator"))))
         .collect(toList());
-  }
-
-  DistributedTransaction getTransactionIfEnabled(DataFetchingEnvironment environment) {
-    DistributedTransaction transaction = null;
-    if (tableGraphQlModel.getTransactionEnabled()) {
-      transaction = environment.getGraphQlContext().get(Constants.CONTEXT_TRANSACTION_KEY);
-    }
-    return transaction;
   }
 
   @SuppressWarnings("unchecked")

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
@@ -43,7 +43,7 @@ public class MutationBulkDeleteDataFetcher implements DataFetcher<DataFetcherRes
   @VisibleForTesting
   void performDelete(DataFetchingEnvironment environment, List<Delete> deletes)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.delete(deletes);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
@@ -42,7 +42,7 @@ public class MutationBulkPutDataFetcher implements DataFetcher<DataFetcherResult
   @VisibleForTesting
   void performPut(DataFetchingEnvironment environment, List<Put> puts)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.put(puts);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
@@ -40,7 +40,7 @@ public class MutationDeleteDataFetcher implements DataFetcher<DataFetcherResult<
   @VisibleForTesting
   void performDelete(DataFetchingEnvironment environment, Delete delete)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.delete(delete);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
@@ -50,7 +50,7 @@ public class MutationMutateDataFetcher implements DataFetcher<DataFetcherResult<
   @VisibleForTesting
   void performMutate(DataFetchingEnvironment environment, List<Mutation> mutations)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.mutate(mutations);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
@@ -40,7 +40,7 @@ public class MutationPutDataFetcher implements DataFetcher<DataFetcherResult<Boo
   @VisibleForTesting
   void performPut(DataFetchingEnvironment environment, Put put)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.put(put);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -62,7 +62,7 @@ public class QueryGetDataFetcher implements DataFetcher<Map<String, Map<String, 
   @VisibleForTesting
   Optional<Result> performGet(DataFetchingEnvironment environment, Get get)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       return transaction.get(get);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -117,7 +117,7 @@ public class QueryScanDataFetcher implements DataFetcher<Map<String, List<Map<St
   @VisibleForTesting
   List<Result> performScan(DataFetchingEnvironment environment, Scan scan)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       return transaction.scan(scan);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -34,7 +34,6 @@ public class TableGraphQlModel {
   private final String namespaceName;
   private final String tableName;
   private final TableMetadata tableMetadata;
-  private final boolean transactionEnabled;
   private final LinkedHashSet<String> fieldNames;
   private final Map<String, GraphQLScalarType> fieldNameGraphQLScalarTypeMap;
 
@@ -65,7 +64,6 @@ public class TableGraphQlModel {
     this.tableName = Objects.requireNonNull(tableName);
     this.tableMetadata = Objects.requireNonNull(tableMetadata);
 
-    this.transactionEnabled = ConsensusCommitUtils.isTransactionalTableMetadata(tableMetadata);
     this.fieldNames =
         ConsensusCommitUtils.removeTransactionalMetaColumns(tableMetadata).getColumnNames();
     this.fieldNameGraphQLScalarTypeMap =
@@ -365,10 +363,6 @@ public class TableGraphQlModel {
 
   public TableMetadata getTableMetadata() {
     return tableMetadata;
-  }
-
-  public boolean getTransactionEnabled() {
-    return transactionEnabled;
   }
 
   public LinkedHashSet<String> getFieldNames() {

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
@@ -26,10 +26,13 @@ public abstract class DataFetcherTestBase {
 
     // Arrange
     when(environment.getGraphQlContext()).thenReturn(graphQlContext);
-    when(graphQlContext.get(Constants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
 
     doSetUp();
   }
 
   protected abstract void doSetUp() throws Exception;
+
+  protected void setTransactionStarted() {
+    when(graphQlContext.get(Constants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
+  }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
@@ -20,7 +20,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.List;
@@ -37,15 +36,14 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   private static final String COL5 = "c5";
   private static final String COL6 = "c5";
 
-  private MutationBulkDeleteDataFetcher dataFetcherForStorageTable;
-  private MutationBulkDeleteDataFetcher dataFetcherForTransactionalTable;
+  private MutationBulkDeleteDataFetcher dataFetcher;
   private Delete expectedDelete;
   @Captor private ArgumentCaptor<List<Delete>> deleteListCaptor;
 
   @Override
   public void doSetUp() {
     // Arrange
-    TableMetadata storageTableMetadata =
+    TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(COL1, DataType.INT)
             .addColumn(COL2, DataType.TEXT)
@@ -57,16 +55,11 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
             .addClusteringKey(COL2)
             .build();
     TableGraphQlModel storageTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new MutationBulkDeleteDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new MutationBulkDeleteDataFetcher(
-            storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, tableMetadata);
+    dataFetcher =
+        spy(
+            new MutationBulkDeleteDataFetcher(
+                storage, new DataFetcherHelper(storageTableGraphQlModel)));
   }
 
   private void prepareDeleteAndExpectedDelete() {
@@ -83,12 +76,12 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
 
     // Act
-    dataFetcherForStorageTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, times(1)).delete(deleteListCaptor.capture());
@@ -97,12 +90,13 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
+    setTransactionStarted();
 
     // Act
-    dataFetcherForTransactionalTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, never()).get(any());
@@ -114,7 +108,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_DeleteInputListGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), anyList());
 
     // Act
@@ -129,7 +122,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenDeleteSucceeds_ShouldReturnTrue() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), anyList());
 
     // Act
@@ -144,7 +136,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenDeleteFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     TransactionException exception = new TransactionException("error");
     doThrow(exception).when(dataFetcher).performDelete(eq(environment), anyList());
 

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
@@ -18,7 +18,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.Map;
@@ -31,13 +30,12 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   private static final String COL2 = "c2";
   private static final String COL3 = "c3";
 
-  private MutationDeleteDataFetcher dataFetcherForStorageTable;
-  private MutationDeleteDataFetcher dataFetcherForTransactionalTable;
+  private MutationDeleteDataFetcher dataFetcher;
   private Delete expectedDelete;
   @Captor private ArgumentCaptor<Delete> deleteCaptor;
 
   @Override
-  public void doSetUp() throws Exception {
+  public void doSetUp() {
     // Arrange
     TableMetadata storageTableMetadata =
         TableMetadata.newBuilder()
@@ -47,17 +45,10 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
             .addPartitionKey(COL1)
             .addClusteringKey(COL2)
             .build();
-    TableGraphQlModel storageTableGraphQlModel =
+    TableGraphQlModel tableGraphQlModel =
         new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new MutationDeleteDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new MutationDeleteDataFetcher(
-            storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+    dataFetcher =
+        spy(new MutationDeleteDataFetcher(storage, new DataFetcherHelper(tableGraphQlModel)));
   }
 
   private void prepareDeleteInputAndExpectedDelete() {
@@ -75,12 +66,12 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
 
     // Act
-    dataFetcherForStorageTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, times(1)).delete(expectedDelete);
@@ -88,12 +79,13 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
+    setTransactionStarted();
 
     // Act
-    dataFetcherForTransactionalTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, never()).get(any());
@@ -104,7 +96,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_PutInputGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 
     // Act
@@ -119,7 +110,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutSucceeds_ShouldReturnTrue() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 
     // Act
@@ -134,7 +124,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     TransactionException exception = new TransactionException("error");
     doThrow(exception).when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -23,7 +23,6 @@ import com.scalar.db.io.DoubleValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -35,16 +34,15 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   private static final String COL2 = "c2";
   private static final String COL3 = "c3";
 
-  private TableGraphQlModel storageTableGraphQlModel;
-  private QueryGetDataFetcher dataFetcherForStorageTable;
-  private QueryGetDataFetcher dataFetcherForTransactionalTable;
+  private TableGraphQlModel tableGraphQlModel;
+  private QueryGetDataFetcher dataFetcher;
   private Map<String, Object> getInput;
   private Get expectedGet;
 
   @Override
   public void doSetUp() {
     // Arrange
-    TableMetadata storageTableMetadata =
+    TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(COL1, DataType.INT)
             .addColumn(COL2, DataType.TEXT)
@@ -52,16 +50,8 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
             .addPartitionKey(COL1)
             .addClusteringKey(COL2)
             .build();
-    storageTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new QueryGetDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new QueryGetDataFetcher(storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+    tableGraphQlModel = new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, tableMetadata);
+    dataFetcher = spy(new QueryGetDataFetcher(storage, new DataFetcherHelper(tableGraphQlModel)));
   }
 
   private void prepareGetInputAndExpectedGet() {
@@ -79,10 +69,9 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
 
     // Act
     dataFetcher.get(environment);
@@ -93,10 +82,10 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForTransactionalTable);
+    setTransactionStarted();
 
     // Act
     dataFetcher.get(environment);
@@ -110,7 +99,6 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   public void get_GetInputGiven_ShouldRunScalarDbGet() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
 
     // Act
     dataFetcher.get(environment);
@@ -125,7 +113,6 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   public void get_GetInputGiven_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     Result mockResult = mock(Result.class);
     when(mockResult.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
@@ -136,7 +123,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     Map<String, Map<String, Object>> result = dataFetcher.get(environment);
 
     // Assert
-    Map<String, Object> object = result.get(storageTableGraphQlModel.getObjectType().getName());
+    Map<String, Object> object = result.get(tableGraphQlModel.getObjectType().getName());
     assertThat(object)
         .containsOnly(entry(COL1, 1), entry(COL2, Optional.of("A")), entry(COL3, 2.0));
   }
@@ -147,7 +134,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     prepareGetInputAndExpectedGet();
 
     // Act
-    Get actual = dataFetcherForStorageTable.createGet(getInput);
+    Get actual = dataFetcher.createGet(getInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedGet);
@@ -161,7 +148,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     expectedGet.withConsistency(Consistency.EVENTUAL);
 
     // Act
-    Get actual = dataFetcherForStorageTable.createGet(getInput);
+    Get actual = dataFetcher.createGet(getInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedGet);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
@@ -25,7 +25,6 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,16 +42,15 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   private static final String COL5 = "c5";
   private static final String COL6 = "c5";
 
-  private TableGraphQlModel storageTableGraphQlModel;
-  private QueryScanDataFetcher dataFetcherForStorageTable;
-  private QueryScanDataFetcher dataFetcherForTransactionalTable;
+  private TableGraphQlModel tableGraphQlModel;
+  private QueryScanDataFetcher dataFetcher;
   private Map<String, Object> scanInput;
   private Scan expectedScan;
 
   @Override
   protected void doSetUp() throws Exception {
     // Arrange
-    TableMetadata storageTableMetadata =
+    TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(COL1, DataType.INT)
             .addColumn(COL2, DataType.TEXT)
@@ -66,16 +64,8 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
             .addClusteringKey(COL4)
             .addClusteringKey(COL5)
             .build();
-    storageTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new QueryScanDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new QueryScanDataFetcher(storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+    tableGraphQlModel = new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, tableMetadata);
+    dataFetcher = spy(new QueryScanDataFetcher(storage, new DataFetcherHelper(tableGraphQlModel)));
 
     // Mock scanner for storage
     Scanner mockScanner = mock(Scanner.class);
@@ -98,12 +88,12 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
 
     // Act
-    dataFetcherForStorageTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, times(1)).scan(expectedScan);
@@ -111,12 +101,13 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
+    setTransactionStarted();
 
     // Act
-    dataFetcherForTransactionalTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, never()).get(any());
@@ -127,7 +118,6 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   public void get_ScanArgumentGiven_ShouldRunScalarDbScan() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
-    QueryScanDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
 
     // Act
     dataFetcher.get(environment);
@@ -142,7 +132,6 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   public void get_ScanArgumentGiven_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
-    QueryScanDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     Result mockResult1 = mock(Result.class);
     when(mockResult1.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult1.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
@@ -159,7 +148,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     Map<String, List<Map<String, Object>>> result = dataFetcher.get(environment);
 
     // Assert
-    List<Map<String, Object>> list = result.get(storageTableGraphQlModel.getObjectType().getName());
+    List<Map<String, Object>> list = result.get(tableGraphQlModel.getObjectType().getName());
     assertThat(list).hasSize(2);
     assertThat(list.get(0))
         .containsOnly(entry(COL1, 1), entry(COL2, Optional.of("A")), entry(COL3, 2L));
@@ -173,7 +162,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     prepareScanInputAndExpectedScan();
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -187,7 +176,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withConsistency(Consistency.EVENTUAL);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -204,7 +193,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withStart(new Key(new BigIntValue(COL3, 1L)), false);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -221,7 +210,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withEnd(new Key(new BigIntValue(COL3, 10L)), false);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -242,7 +231,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
         .withOrdering(new Scan.Ordering(COL3, Scan.Ordering.Order.DESC));
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -256,7 +245,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withLimit(100);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);


### PR DESCRIPTION
Before, in GraphQL operations, whether each table had transactional metadata or not was used to determine which method,  `transaction` or `storage`, was used for data access. This means that the `storage` method was used for tables without transactional metadata even if a `@transaction` directive was specified.

```graphql
query op1 @transaction {
  storage_table_get(get: {...}) {  # -> storage is used for this table
    ...
  }
  transactional_table_get(get: {...}) { # -> transaction is used for this table
    ...
  }
}
```

This PR changes this behavior. That is, only the `@transaction` directive determines whether `transaction` or `storage` is used in a whole operation. If the `@transaction` directive is specified in the input of a GraphQL operation (in which case the transaction object is kept in the `GraphQLContext` object), `transaction` will be used throughout the process regardless of the table type.