### PR TITLE
Add TransactionalTableMetadataManager

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionalTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionalTableMetadata.java
@@ -1,0 +1,84 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import com.scalar.db.util.ImmutableLinkedHashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class TransactionalTableMetadata {
+
+  private final TableMetadata tableMetadata;
+  private final LinkedHashSet<String> transactionalMetaColumnNames;
+  private final LinkedHashSet<String> beforeImageColumnNames;
+  private final LinkedHashSet<String> afterImageColumnNames;
+
+  public TransactionalTableMetadata(TableMetadata tableMetadata) {
+    this.tableMetadata = tableMetadata;
+    transactionalMetaColumnNames =
+        new ImmutableLinkedHashSet<>(
+            tableMetadata.getColumnNames().stream()
+                .filter(c -> ConsensusCommitUtils.isTransactionalMetaColumn(c, tableMetadata))
+                .collect(Collectors.toList()));
+    beforeImageColumnNames =
+        new ImmutableLinkedHashSet<>(
+            tableMetadata.getColumnNames().stream()
+                .filter(c -> ConsensusCommitUtils.isBeforeImageColumn(c, tableMetadata))
+                .collect(Collectors.toList()));
+    afterImageColumnNames =
+        new ImmutableLinkedHashSet<>(
+            tableMetadata.getColumnNames().stream()
+                .filter(c -> ConsensusCommitUtils.isAfterImageColumn(c, tableMetadata))
+                .collect(Collectors.toList()));
+  }
+
+  public TableMetadata getTableMetadata() {
+    return tableMetadata;
+  }
+
+  public LinkedHashSet<String> getColumnNames() {
+    return tableMetadata.getColumnNames();
+  }
+
+  public DataType getColumnDataType(String columnName) {
+    return tableMetadata.getColumnDataType(columnName);
+  }
+
+  public LinkedHashSet<String> getPartitionKeyNames() {
+    return tableMetadata.getPartitionKeyNames();
+  }
+
+  public LinkedHashSet<String> getClusteringKeyNames() {
+    return tableMetadata.getClusteringKeyNames();
+  }
+
+  public Scan.Ordering.Order getClusteringOrder(String clusteringKeyName) {
+    return tableMetadata.getClusteringOrder(clusteringKeyName);
+  }
+
+  public Map<String, Order> getClusteringOrders() {
+    return tableMetadata.getClusteringOrders();
+  }
+
+  public Set<String> getSecondaryIndexNames() {
+    return tableMetadata.getSecondaryIndexNames();
+  }
+
+  public LinkedHashSet<String> getTransactionalMetaColumnNames() {
+    return transactionalMetaColumnNames;
+  }
+
+  public LinkedHashSet<String> getBeforeImageColumnNames() {
+    return beforeImageColumnNames;
+  }
+
+  public LinkedHashSet<String> getAfterImageColumnNames() {
+    return afterImageColumnNames;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionalTableMetadataManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionalTableMetadataManager.java
@@ -1,0 +1,87 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+
+public class TransactionalTableMetadataManager {
+
+  private final LoadingCache<TableKey, Optional<TransactionalTableMetadata>> tableMetadataCache;
+
+  public TransactionalTableMetadataManager(
+      DistributedStorageAdmin admin, long cacheExpirationTimeSecs) {
+
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    if (cacheExpirationTimeSecs > 0) {
+      builder.expireAfterWrite(cacheExpirationTimeSecs, TimeUnit.SECONDS);
+    }
+    tableMetadataCache =
+        builder.build(
+            new CacheLoader<TableKey, Optional<TransactionalTableMetadata>>() {
+              @Override
+              public Optional<TransactionalTableMetadata> load(@Nonnull TableKey key)
+                  throws ExecutionException {
+                TableMetadata tableMetadata = admin.getTableMetadata(key.namespace, key.table);
+                if (tableMetadata == null) {
+                  return Optional.empty();
+                }
+                return Optional.of(new TransactionalTableMetadata(tableMetadata));
+              }
+            });
+  }
+
+  /**
+   * Returns a transactional table metadata corresponding to the specified operation.
+   *
+   * @param operation an operation
+   * @return a table metadata. null if the table is not found.
+   * @throws ExecutionException if the operation failed
+   */
+  public TransactionalTableMetadata getTransactionalTableMetadata(Operation operation)
+      throws ExecutionException {
+    if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
+      throw new IllegalArgumentException("operation has no target namespace and table name");
+    }
+    try {
+      TableKey key = new TableKey(operation.forNamespace().get(), operation.forTable().get());
+      return tableMetadataCache.get(key).orElse(null);
+    } catch (java.util.concurrent.ExecutionException e) {
+      throw new ExecutionException("getting a table metadata failed", e);
+    }
+  }
+
+  private static class TableKey {
+    public final String namespace;
+    public final String table;
+
+    public TableKey(String namespace, String table) {
+      this.namespace = namespace;
+      this.table = table;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof TableKey)) {
+        return false;
+      }
+      TableKey tableKey = (TableKey) o;
+      return namespace.equals(tableKey.namespace) && table.equals(tableKey.table);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(namespace, table);
+    }
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
@@ -363,4 +363,115 @@ public class ConsensusCommitUtilsTest {
         .isTrue();
     assertThat(ConsensusCommitUtils.isTransactionalMetaColumn("aaa", allColumnNames)).isFalse();
   }
+
+  @Test
+  public void isBeforeImageColumn_ResultGiven_shouldReturnProperResult() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    Set<String> allColumnNames =
+        ImmutableSet.<String>builder()
+            .add(ACCOUNT_ID)
+            .add(ACCOUNT_TYPE)
+            .add(BALANCE)
+            .add(Attribute.ID)
+            .add(Attribute.STATE)
+            .add(Attribute.VERSION)
+            .add(Attribute.PREPARED_AT)
+            .add(Attribute.COMMITTED_AT)
+            .add(Attribute.BEFORE_PREFIX + BALANCE)
+            .add(Attribute.BEFORE_ID)
+            .add(Attribute.BEFORE_STATE)
+            .add(Attribute.BEFORE_VERSION)
+            .add(Attribute.BEFORE_PREPARED_AT)
+            .add(Attribute.BEFORE_COMMITTED_AT)
+            .build();
+
+    // Act Assert
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(ACCOUNT_ID, allColumnNames)).isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(ACCOUNT_TYPE, allColumnNames)).isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(BALANCE, allColumnNames)).isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.ID, allColumnNames)).isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.STATE, allColumnNames)).isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.VERSION, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.PREPARED_AT, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.COMMITTED_AT, allColumnNames))
+        .isFalse();
+    assertThat(
+            ConsensusCommitUtils.isBeforeImageColumn(
+                Attribute.BEFORE_PREFIX + BALANCE, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.BEFORE_ID, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.BEFORE_STATE, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn(Attribute.BEFORE_VERSION, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isBeforeImageColumn(Attribute.BEFORE_PREPARED_AT, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isBeforeImageColumn(Attribute.BEFORE_COMMITTED_AT, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isBeforeImageColumn("aaa", allColumnNames)).isFalse();
+  }
+
+  @Test
+  public void isAfterImageColumn_ResultGiven_shouldReturnProperResult() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    Set<String> allColumnNames =
+        ImmutableSet.<String>builder()
+            .add(ACCOUNT_ID)
+            .add(ACCOUNT_TYPE)
+            .add(BALANCE)
+            .add(Attribute.ID)
+            .add(Attribute.STATE)
+            .add(Attribute.VERSION)
+            .add(Attribute.PREPARED_AT)
+            .add(Attribute.COMMITTED_AT)
+            .add(Attribute.BEFORE_PREFIX + BALANCE)
+            .add(Attribute.BEFORE_ID)
+            .add(Attribute.BEFORE_STATE)
+            .add(Attribute.BEFORE_VERSION)
+            .add(Attribute.BEFORE_PREPARED_AT)
+            .add(Attribute.BEFORE_COMMITTED_AT)
+            .build();
+
+    // Act Assert
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(ACCOUNT_ID, allColumnNames)).isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(ACCOUNT_TYPE, allColumnNames)).isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(BALANCE, allColumnNames)).isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.ID, allColumnNames)).isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.STATE, allColumnNames)).isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.VERSION, allColumnNames)).isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.PREPARED_AT, allColumnNames))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.COMMITTED_AT, allColumnNames))
+        .isTrue();
+    assertThat(
+            ConsensusCommitUtils.isAfterImageColumn(
+                Attribute.BEFORE_PREFIX + BALANCE, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.BEFORE_ID, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.BEFORE_STATE, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn(Attribute.BEFORE_VERSION, allColumnNames))
+        .isFalse();
+    assertThat(
+            ConsensusCommitUtils.isAfterImageColumn(Attribute.BEFORE_PREPARED_AT, allColumnNames))
+        .isFalse();
+    assertThat(
+            ConsensusCommitUtils.isAfterImageColumn(Attribute.BEFORE_COMMITTED_AT, allColumnNames))
+        .isFalse();
+    assertThat(ConsensusCommitUtils.isAfterImageColumn("aaa", allColumnNames)).isFalse();
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionalTableMetadataManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionalTableMetadataManagerTest.java
@@ -1,0 +1,209 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class TransactionalTableMetadataManagerTest {
+
+  private static final String ACCOUNT_ID = "account_id";
+  private static final String ACCOUNT_TYPE = "account_type";
+  private static final String BALANCE = "balance";
+  private static final String BRANCH = "branch";
+
+  @Mock private DistributedStorageAdmin admin;
+  private TableMetadata tableMetadata;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    // Arrange
+    tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(BRANCH, DataType.TEXT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + BRANCH, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(BRANCH)
+            .build();
+    when(admin.getTableMetadata(anyString(), anyString())).thenReturn(tableMetadata);
+  }
+
+  @Test
+  public void getTransactionalTableMetadata_CalledOnce_ShouldCallDistributedStorageAdminOnce()
+      throws ExecutionException {
+    // Arrange
+    TransactionalTableMetadataManager tableMetadataManager =
+        new TransactionalTableMetadataManager(admin, -1);
+
+    // Act
+    TransactionalTableMetadata actual =
+        tableMetadataManager.getTransactionalTableMetadata(
+            new Get(new Key("c1", "aaa")).forNamespace("ns").forTable("tbl"));
+
+    // Assert
+    verify(admin).getTableMetadata(anyString(), anyString());
+    assertTransactionalMetadata(actual);
+  }
+
+  @Test
+  public void getTransactionalTableMetadata_CalledTwice_ShouldCallDistributedStorageAdminOnlyOnce()
+      throws ExecutionException {
+    // Arrange
+    TransactionalTableMetadataManager tableMetadataManager =
+        new TransactionalTableMetadataManager(admin, -1);
+
+    Get get = new Get(new Key("c1", "aaa")).forNamespace("ns").forTable("tbl");
+
+    // Act
+    tableMetadataManager.getTransactionalTableMetadata(get);
+    TransactionalTableMetadata actual = tableMetadataManager.getTransactionalTableMetadata(get);
+
+    // Assert
+    verify(admin).getTableMetadata(anyString(), anyString());
+    assertTransactionalMetadata(actual);
+  }
+
+  @Test
+  public void
+      getTransactionalTableMetadata_CalledAfterCacheExpiration_ShouldCallDistributedStorageAdminAgain()
+          throws ExecutionException {
+    // Arrange
+    TransactionalTableMetadataManager tableMetadataManager =
+        new TransactionalTableMetadataManager(admin, 1); // one second
+
+    Get get = new Get(new Key("c1", "aaa")).forNamespace("ns").forTable("tbl");
+
+    // Act
+    tableMetadataManager.getTransactionalTableMetadata(get);
+    // Wait for cache to be expired
+    Uninterruptibles.sleepUninterruptibly(1200, TimeUnit.MILLISECONDS);
+    TransactionalTableMetadata actual = tableMetadataManager.getTransactionalTableMetadata(get);
+
+    // Assert
+    verify(admin, times(2)).getTableMetadata(anyString(), anyString());
+    assertTransactionalMetadata(actual);
+  }
+
+  private void assertTransactionalMetadata(TransactionalTableMetadata actual) {
+    assertThat(actual.getTableMetadata()).isEqualTo(tableMetadata);
+    assertThat(actual.getPartitionKeyNames())
+        .isEqualTo(new LinkedHashSet<>(Collections.singletonList(ACCOUNT_ID)));
+    assertThat(actual.getClusteringKeyNames())
+        .isEqualTo(new LinkedHashSet<>(Collections.singletonList(ACCOUNT_TYPE)));
+    assertThat(actual.getClusteringOrder(ACCOUNT_TYPE)).isEqualTo(Order.ASC);
+    assertThat(actual.getColumnNames())
+        .isEqualTo(
+            new LinkedHashSet<>(
+                Arrays.asList(
+                    ACCOUNT_ID,
+                    ACCOUNT_TYPE,
+                    BALANCE,
+                    BRANCH,
+                    Attribute.ID,
+                    Attribute.STATE,
+                    Attribute.VERSION,
+                    Attribute.PREPARED_AT,
+                    Attribute.COMMITTED_AT,
+                    Attribute.BEFORE_PREFIX + BALANCE,
+                    Attribute.BEFORE_PREFIX + BRANCH,
+                    Attribute.BEFORE_ID,
+                    Attribute.BEFORE_STATE,
+                    Attribute.BEFORE_VERSION,
+                    Attribute.BEFORE_PREPARED_AT,
+                    Attribute.BEFORE_COMMITTED_AT)));
+    assertThat(actual.getColumnDataType(ACCOUNT_ID)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(ACCOUNT_TYPE)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(BALANCE)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(BRANCH)).isEqualTo(DataType.TEXT);
+    assertThat(actual.getColumnDataType(Attribute.ID)).isEqualTo(DataType.TEXT);
+    assertThat(actual.getColumnDataType(Attribute.STATE)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(Attribute.VERSION)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(Attribute.PREPARED_AT)).isEqualTo(DataType.BIGINT);
+    assertThat(actual.getColumnDataType(Attribute.COMMITTED_AT)).isEqualTo(DataType.BIGINT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_PREFIX + BALANCE)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_PREFIX + BRANCH)).isEqualTo(DataType.TEXT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_ID)).isEqualTo(DataType.TEXT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_STATE)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_VERSION)).isEqualTo(DataType.INT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_PREPARED_AT)).isEqualTo(DataType.BIGINT);
+    assertThat(actual.getColumnDataType(Attribute.BEFORE_COMMITTED_AT)).isEqualTo(DataType.BIGINT);
+    assertThat(actual.getSecondaryIndexNames())
+        .isEqualTo(new HashSet<>(Collections.singletonList(BRANCH)));
+    assertThat(actual.getTransactionalMetaColumnNames())
+        .isEqualTo(
+            new LinkedHashSet<>(
+                Arrays.asList(
+                    Attribute.ID,
+                    Attribute.STATE,
+                    Attribute.VERSION,
+                    Attribute.PREPARED_AT,
+                    Attribute.COMMITTED_AT,
+                    Attribute.BEFORE_PREFIX + BALANCE,
+                    Attribute.BEFORE_PREFIX + BRANCH,
+                    Attribute.BEFORE_ID,
+                    Attribute.BEFORE_STATE,
+                    Attribute.BEFORE_VERSION,
+                    Attribute.BEFORE_PREPARED_AT,
+                    Attribute.BEFORE_COMMITTED_AT)));
+    assertThat(actual.getBeforeImageColumnNames())
+        .isEqualTo(
+            new LinkedHashSet<>(
+                Arrays.asList(
+                    Attribute.BEFORE_PREFIX + BALANCE,
+                    Attribute.BEFORE_PREFIX + BRANCH,
+                    Attribute.BEFORE_ID,
+                    Attribute.BEFORE_STATE,
+                    Attribute.BEFORE_VERSION,
+                    Attribute.BEFORE_PREPARED_AT,
+                    Attribute.BEFORE_COMMITTED_AT)));
+    assertThat(actual.getAfterImageColumnNames())
+        .isEqualTo(
+            new LinkedHashSet<>(
+                Arrays.asList(
+                    ACCOUNT_ID,
+                    ACCOUNT_TYPE,
+                    BALANCE,
+                    BRANCH,
+                    Attribute.ID,
+                    Attribute.STATE,
+                    Attribute.VERSION,
+                    Attribute.PREPARED_AT,
+                    Attribute.COMMITTED_AT)));
+  }
+}


### PR DESCRIPTION
This PR adds `TransactionalTableMetadataManager` that retrieves and caches `TransactionalTableMetadata` instances with table metadata and transactional meta info for transactional tables. We don't use these classes yet but will use them in another PR. Please take a look!