### PR TITLE
Fix unit test method names for GraphQL data fetchers

### DIFF
--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
@@ -111,7 +111,7 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_DeleteInputListGiven_ShouldRunScalarDbDelete() throws Exception {
+  public void get_DeleteArgumentGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
     MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcherTest.java
@@ -115,7 +115,7 @@ public class MutationBulkPutDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_PutInputListGiven_ShouldRunScalarDbPut() throws Exception {
+  public void get_PutArgumentGiven_ShouldRunScalarDbPut() throws Exception {
     // Arrange
     preparePutInputAndExpectedPut();
     MutationBulkPutDataFetcher dataFetcher = spy(dataFetcherForStorageTable);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
@@ -101,7 +101,7 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_PutInputGiven_ShouldRunScalarDbDelete() throws Exception {
+  public void get_DeleteArgumentGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
     MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
@@ -116,7 +116,7 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_WhenPutSucceeds_ShouldReturnTrue() throws Exception {
+  public void get_WhenDeleteSucceeds_ShouldReturnTrue() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
     MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
@@ -131,7 +131,7 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_WhenPutFails_ShouldReturnFalseWithErrors() throws Exception {
+  public void get_WhenDeleteFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
     MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcherTest.java
@@ -129,7 +129,7 @@ public class MutationMutateDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_PutAndDeleteInputListGiven_ShouldRunScalarDbMutate() throws Exception {
+  public void get_PutAndDeleteArgumentsGiven_ShouldRunScalarDbMutate() throws Exception {
     // Arrange
     preparePutAndDelete();
     MutationMutateDataFetcher dataFetcher = spy(dataFetcherForStorageTable);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcherTest.java
@@ -109,7 +109,7 @@ public class MutationPutDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_PutInputGiven_ShouldRunScalarDbDelete() throws Exception {
+  public void get_PutArgumentGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     preparePutInputAndExpectedPut();
     MutationPutDataFetcher dataFetcher = spy(dataFetcherForStorageTable);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -122,7 +122,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_GetArgumentGiven_ShouldReturnResultAsMap() throws Exception {
+  public void get_WhenGetSucceeds_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
     QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -107,7 +107,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_GetInputGiven_ShouldRunScalarDbGet() throws Exception {
+  public void get_GetArgumentGiven_ShouldRunScalarDbGet() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
     QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
@@ -122,7 +122,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_GetInputGiven_ShouldReturnResultAsMap() throws Exception {
+  public void get_GetArgumentGiven_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
     QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);


### PR DESCRIPTION
This fixes the unit test names for GraphQL data fetchers. (Especially `PutXXX` was mistakenly used for tests of Delete operations).
