### PR TITLE
Handle GraphQL data fetching errors

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -139,7 +139,7 @@ public class GraphQlFactory {
 
     GraphQLSchema schema = schemaBuilder.build();
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("GraphQL schema generated: " + new SchemaPrinter().print(schema));
+      LOGGER.debug("GraphQL schema generated: {}", new SchemaPrinter().print(schema));
     }
 
     return GraphQL.newGraphQL(schema)
@@ -188,7 +188,7 @@ public class GraphQlFactory {
             new TableGraphQlModel(
                 namespace, table, storageAdmin.getTableMetadata(namespace, table));
         tableModelListBuilder.add(tableGraphQlModel);
-        LOGGER.debug("table added: " + namespace + "." + table);
+        LOGGER.debug("table added: {}.{}", namespace, table);
       }
 
       return new GraphQlFactory(

--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -26,14 +26,17 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaPrinter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Immutable
 public class GraphQlFactory {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(GraphQlFactory.class);
   private final DistributedStorage storage;
   private final DistributedTransactionManager transactionManager;
   private final List<TableGraphQlModel> tableModels;
@@ -122,16 +125,24 @@ public class GraphQlFactory {
   public GraphQL createGraphQL() {
     GraphQLObjectType queryObjectType = createQueryObjectType();
     GraphQLObjectType mutationObjectType = createMutationObjectType();
-    GraphQLSchema.Builder schema =
+    GraphQLSchema.Builder schemaBuilder =
         GraphQLSchema.newSchema()
             .query(queryObjectType)
             .mutation(mutationObjectType)
             .codeRegistry(createGraphQLCodeRegistry(queryObjectType, mutationObjectType));
-    CommonSchema.createCommonGraphQLTypes().forEach(schema::additionalType);
+    CommonSchema.createCommonGraphQLTypes().forEach(schemaBuilder::additionalType);
     if (transactionManager != null) {
-      schema.additionalDirective(CommonSchema.createTransactionDirective());
+      schemaBuilder.additionalDirective(CommonSchema.createTransactionDirective());
+    } else {
+      LOGGER.info("@transaction directive is disabled since transactionManager is not given");
     }
-    return GraphQL.newGraphQL(schema.build())
+
+    GraphQLSchema schema = schemaBuilder.build();
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("GraphQL schema generated: " + new SchemaPrinter().print(schema));
+    }
+
+    return GraphQL.newGraphQL(schema)
         // TODO: .instrumentation(new TransactionInstrumentation(transactionManager))
         .build();
   }
@@ -173,9 +184,11 @@ public class GraphQlFactory {
       for (int i = 0; i < tables.size(); i++) {
         String namespace = namespaces.get(i);
         String table = tables.get(i);
-        tableModelListBuilder.add(
+        TableGraphQlModel tableGraphQlModel =
             new TableGraphQlModel(
-                namespace, table, storageAdmin.getTableMetadata(namespace, table)));
+                namespace, table, storageAdmin.getTableMetadata(namespace, table));
+        tableModelListBuilder.add(tableGraphQlModel);
+        LOGGER.debug("table added: " + namespace + "." + table);
       }
 
       return new GraphQlFactory(

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -43,6 +43,10 @@ public class DataFetcherHelper {
     this.tableGraphQlModel = tableGraphQlModel;
   }
 
+  static DistributedTransaction getCurrentTransaction(DataFetchingEnvironment environment) {
+    return environment.getGraphQlContext().get(Constants.CONTEXT_TRANSACTION_KEY);
+  }
+
   static Value<?> createValueFromMap(String name, Map<String, Object> map) {
     Object v = getOneScalarValue(map);
     Value<?> value;
@@ -133,14 +137,6 @@ public class DataFetcherHelper {
                     createValueFromMap("", ex),
                     ConditionalExpression.Operator.valueOf((String) ex.get("operator"))))
         .collect(toList());
-  }
-
-  DistributedTransaction getTransactionIfEnabled(DataFetchingEnvironment environment) {
-    DistributedTransaction transaction = null;
-    if (tableGraphQlModel.getTransactionEnabled()) {
-      transaction = environment.getGraphQlContext().get(Constants.CONTEXT_TRANSACTION_KEY);
-    }
-    return transaction;
   }
 
   @SuppressWarnings("unchecked")

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -2,6 +2,7 @@ package com.scalar.db.graphql.datafetcher;
 
 import static java.util.stream.Collectors.toList;
 
+import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
@@ -25,6 +26,9 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
 import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLInputObjectField;
@@ -84,6 +88,15 @@ public class DataFetcherHelper {
           "One and only one of intValue, bigIntValue, floatValue, doubleValue, textValue, and booleanValue must be specified.");
     }
     return values.get(0);
+  }
+
+  static GraphQLError getGraphQLError(Exception exception, DataFetchingEnvironment environment) {
+    String exName = exception.getClass().getSimpleName();
+    return GraphqlErrorBuilder.newError(environment)
+        .message("Scalar DB %s happened while fetching data: %s", exName, exception.getMessage())
+        .extensions(ImmutableMap.of(Constants.ERRORS_EXTENSIONS_EXCEPTION_KEY, exName))
+        .errorType(ErrorType.DataFetchingException)
+        .build();
   }
 
   Key createPartitionKeyFromKeyArgument(Map<String, Object> keyArg) {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
@@ -28,7 +28,7 @@ public class MutationBulkDeleteDataFetcher implements DataFetcher<DataFetcherRes
   @Override
   public DataFetcherResult<Boolean> get(DataFetchingEnvironment environment) {
     List<Map<String, Object>> deleteInput = environment.getArgument("delete");
-    LOGGER.debug("got delete argument: " + deleteInput);
+    LOGGER.debug("got delete argument: {}", deleteInput);
     List<Delete> deletes =
         deleteInput.stream().map(helper::createDelete).collect(Collectors.toList());
 
@@ -49,10 +49,10 @@ public class MutationBulkDeleteDataFetcher implements DataFetcher<DataFetcherRes
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Delete operations with transaction: " + deletes);
+      LOGGER.debug("running Delete operations with transaction: {}", deletes);
       transaction.delete(deletes);
     } else {
-      LOGGER.debug("running Delete operations with storage: " + deletes);
+      LOGGER.debug("running Delete operations with storage: {}", deletes);
       storage.delete(deletes);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
@@ -43,7 +43,7 @@ public class MutationBulkDeleteDataFetcher implements DataFetcher<DataFetcherRes
   @VisibleForTesting
   void performDelete(DataFetchingEnvironment environment, List<Delete> deletes)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.delete(deletes);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
@@ -28,7 +28,7 @@ public class MutationBulkPutDataFetcher implements DataFetcher<DataFetcherResult
   @Override
   public DataFetcherResult<Boolean> get(DataFetchingEnvironment environment) {
     List<Map<String, Object>> putInput = environment.getArgument("put");
-    LOGGER.debug("got put argument: " + putInput);
+    LOGGER.debug("got put argument: {}", putInput);
     List<Put> puts = putInput.stream().map(helper::createPut).collect(Collectors.toList());
 
     DataFetcherResult.Builder<Boolean> result = DataFetcherResult.newResult();
@@ -48,10 +48,10 @@ public class MutationBulkPutDataFetcher implements DataFetcher<DataFetcherResult
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Put operations with transaction: " + puts);
+      LOGGER.debug("running Put operations with transaction: {}", puts);
       transaction.put(puts);
     } else {
-      LOGGER.debug("running Put operations with storage: " + puts);
+      LOGGER.debug("running Put operations with storage: {}", puts);
       storage.put(puts);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
@@ -42,7 +42,7 @@ public class MutationBulkPutDataFetcher implements DataFetcher<DataFetcherResult
   @VisibleForTesting
   void performPut(DataFetchingEnvironment environment, List<Put> puts)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.put(puts);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
@@ -40,7 +40,7 @@ public class MutationDeleteDataFetcher implements DataFetcher<DataFetcherResult<
   @VisibleForTesting
   void performDelete(DataFetchingEnvironment environment, Delete delete)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.delete(delete);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
@@ -26,7 +26,7 @@ public class MutationDeleteDataFetcher implements DataFetcher<DataFetcherResult<
   @Override
   public DataFetcherResult<Boolean> get(DataFetchingEnvironment environment) {
     Map<String, Object> deleteInput = environment.getArgument("delete");
-    LOGGER.debug("got delete argument: " + deleteInput);
+    LOGGER.debug("got delete argument: {}", deleteInput);
     Delete delete = helper.createDelete(deleteInput);
 
     DataFetcherResult.Builder<Boolean> result = DataFetcherResult.newResult();
@@ -46,10 +46,10 @@ public class MutationDeleteDataFetcher implements DataFetcher<DataFetcherResult<
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Delete operation with transaction: " + delete);
+      LOGGER.debug("running Delete operation with transaction: {}", delete);
       transaction.delete(delete);
     } else {
-      LOGGER.debug("running Delete operation with storage: " + delete);
+      LOGGER.debug("running Delete operation with storage: {}", delete);
       storage.delete(delete);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
@@ -50,7 +50,7 @@ public class MutationMutateDataFetcher implements DataFetcher<DataFetcherResult<
   @VisibleForTesting
   void performMutate(DataFetchingEnvironment environment, List<Mutation> mutations)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.mutate(mutations);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
@@ -32,11 +32,11 @@ public class MutationMutateDataFetcher implements DataFetcher<DataFetcherResult<
     List<Map<String, Object>> deleteInput = environment.getArgument("delete");
     List<Mutation> mutations = new ArrayList<>();
     if (putInput != null) {
-      LOGGER.debug("got put argument: " + putInput);
+      LOGGER.debug("got put argument: {}", putInput);
       mutations.addAll(putInput.stream().map(helper::createPut).collect(Collectors.toList()));
     }
     if (deleteInput != null) {
-      LOGGER.debug("got delete argument: " + deleteInput);
+      LOGGER.debug("got delete argument: {}", deleteInput);
       mutations.addAll(deleteInput.stream().map(helper::createDelete).collect(Collectors.toList()));
     }
 
@@ -57,10 +57,10 @@ public class MutationMutateDataFetcher implements DataFetcher<DataFetcherResult<
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Mutation operations with transaction: " + mutations);
+      LOGGER.debug("running Mutation operations with transaction: {}", mutations);
       transaction.mutate(mutations);
     } else {
-      LOGGER.debug("running Mutation operations with storage: " + mutations);
+      LOGGER.debug("running Mutation operations with storage: {}", mutations);
       storage.mutate(mutations);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
@@ -40,7 +40,7 @@ public class MutationPutDataFetcher implements DataFetcher<DataFetcherResult<Boo
   @VisibleForTesting
   void performPut(DataFetchingEnvironment environment, Put put)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       transaction.put(put);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
@@ -26,7 +26,7 @@ public class MutationPutDataFetcher implements DataFetcher<DataFetcherResult<Boo
   @Override
   public DataFetcherResult<Boolean> get(DataFetchingEnvironment environment) {
     Map<String, Object> putInput = environment.getArgument("put");
-    LOGGER.debug("got put argument: " + putInput);
+    LOGGER.debug("got put argument: {}", putInput);
     Put put = helper.createPut(putInput);
 
     DataFetcherResult.Builder<Boolean> result = DataFetcherResult.newResult();
@@ -46,10 +46,10 @@ public class MutationPutDataFetcher implements DataFetcher<DataFetcherResult<Boo
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Put operation with transaction: " + put);
+      LOGGER.debug("running Put operation with transaction: {}", put);
       transaction.put(put);
     } else {
-      LOGGER.debug("running Put operation with storage: " + put);
+      LOGGER.debug("running Put operation with storage: {}", put);
       storage.put(put);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -62,7 +62,7 @@ public class QueryGetDataFetcher implements DataFetcher<Map<String, Map<String, 
   @VisibleForTesting
   Optional<Result> performGet(DataFetchingEnvironment environment, Get get)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       return transaction.get(get);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -32,7 +32,7 @@ public class QueryGetDataFetcher
   public DataFetcherResult<Map<String, Map<String, Object>>> get(
       DataFetchingEnvironment environment) {
     Map<String, Object> getInput = environment.getArgument("get");
-    LOGGER.debug("got get argument: " + getInput);
+    LOGGER.debug("got get argument: {}", getInput);
     Get get = createGet(getInput);
 
     DataFetcherResult.Builder<Map<String, Map<String, Object>>> result =
@@ -78,10 +78,10 @@ public class QueryGetDataFetcher
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Get operation with transaction: " + get);
+      LOGGER.debug("running Get operation with transaction: {}", get);
       return transaction.get(get);
     } else {
-      LOGGER.debug("running Get operation with storage: " + get);
+      LOGGER.debug("running Get operation with storage: {}", get);
       return storage.get(get);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -117,7 +117,7 @@ public class QueryScanDataFetcher implements DataFetcher<Map<String, List<Map<St
   @VisibleForTesting
   List<Result> performScan(DataFetchingEnvironment environment, Scan scan)
       throws TransactionException, ExecutionException {
-    DistributedTransaction transaction = helper.getTransactionIfEnabled(environment);
+    DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
       return transaction.scan(scan);
     } else {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -39,7 +39,7 @@ public class QueryScanDataFetcher
   public DataFetcherResult<Map<String, List<Map<String, Object>>>> get(
       DataFetchingEnvironment environment) {
     Map<String, Object> scanInput = environment.getArgument("scan");
-    LOGGER.debug("got scan argument: " + scanInput);
+    LOGGER.debug("got scan argument: {}", scanInput);
     Scan scan = createScan(scanInput);
 
     // TODO: scan.withProjections()
@@ -134,10 +134,10 @@ public class QueryScanDataFetcher
       throws CrudException, ExecutionException {
     DistributedTransaction transaction = DataFetcherHelper.getCurrentTransaction(environment);
     if (transaction != null) {
-      LOGGER.debug("running Scan operation with transaction: " + scan);
+      LOGGER.debug("running Scan operation with transaction: {}", scan);
       return transaction.scan(scan);
     } else {
-      LOGGER.debug("running Scan operation with storage: " + scan);
+      LOGGER.debug("running Scan operation with storage: {}", scan);
       return ImmutableList.copyOf(storage.scan(scan));
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/Constants.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/Constants.java
@@ -4,6 +4,7 @@ public class Constants {
   public static final String TRANSACTION_DIRECTIVE_NAME = "transaction";
   public static final String TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME = "txId";
   public static final String CONTEXT_TRANSACTION_KEY = "transaction";
+  public static final String ERRORS_EXTENSIONS_EXCEPTION_KEY = "exception";
 
   private Constants() {}
 }

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -34,7 +34,6 @@ public class TableGraphQlModel {
   private final String namespaceName;
   private final String tableName;
   private final TableMetadata tableMetadata;
-  private final boolean transactionEnabled;
   private final LinkedHashSet<String> fieldNames;
   private final Map<String, GraphQLScalarType> fieldNameGraphQLScalarTypeMap;
 
@@ -65,7 +64,6 @@ public class TableGraphQlModel {
     this.tableName = Objects.requireNonNull(tableName);
     this.tableMetadata = Objects.requireNonNull(tableMetadata);
 
-    this.transactionEnabled = ConsensusCommitUtils.isTransactionalTableMetadata(tableMetadata);
     this.fieldNames =
         ConsensusCommitUtils.removeTransactionalMetaColumns(tableMetadata).getColumnNames();
     this.fieldNameGraphQLScalarTypeMap =
@@ -365,10 +363,6 @@ public class TableGraphQlModel {
 
   public TableMetadata getTableMetadata() {
     return tableMetadata;
-  }
-
-  public boolean getTransactionEnabled() {
-    return transactionEnabled;
   }
 
   public LinkedHashSet<String> getFieldNames() {

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
@@ -26,10 +26,13 @@ public abstract class DataFetcherTestBase {
 
     // Arrange
     when(environment.getGraphQlContext()).thenReturn(graphQlContext);
-    when(graphQlContext.get(Constants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
 
     doSetUp();
   }
 
   protected abstract void doSetUp() throws Exception;
+
+  protected void setTransactionStarted() {
+    when(graphQlContext.get(Constants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
+  }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
@@ -1,11 +1,19 @@
 package com.scalar.db.graphql.datafetcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.graphql.schema.Constants;
 import graphql.GraphQLContext;
+import graphql.GraphQLError;
+import graphql.Scalars;
+import graphql.execution.DataFetcherResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.language.Field;
+import graphql.language.SourceLocation;
 import graphql.schema.DataFetchingEnvironment;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -26,6 +34,15 @@ public abstract class DataFetcherTestBase {
 
     // Arrange
     when(environment.getGraphQlContext()).thenReturn(graphQlContext);
+    // Stub environment methods for errors
+    when(environment.getField())
+        .thenReturn(Field.newField("test").sourceLocation(SourceLocation.EMPTY).build());
+    when(environment.getExecutionStepInfo())
+        .thenReturn(
+            ExecutionStepInfo.newExecutionStepInfo()
+                .type(Scalars.GraphQLString)
+                .path(ResultPath.parse(""))
+                .build());
 
     doSetUp();
   }
@@ -34,5 +51,20 @@ public abstract class DataFetcherTestBase {
 
   protected void setTransactionStarted() {
     when(graphQlContext.get(Constants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
+  }
+
+  protected void assertThatDataFetcherResultHasErrorForException(
+      DataFetcherResult<?> result, Exception exception) {
+    String exName = exception.getClass().getSimpleName();
+    GraphQLError error =
+        result.getErrors().stream()
+            .filter(
+                e ->
+                    exName.equals(e.getExtensions().get(Constants.ERRORS_EXTENSIONS_EXCEPTION_KEY)))
+            .findFirst()
+            .orElse(null);
+    assertThat(error).isNotNull();
+    assertThat(error.getMessage()).contains(exception.getMessage());
+    assertThat(error.getMessage()).contains(exName);
   }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
@@ -16,11 +16,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +135,7 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenDeleteFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    TransactionException exception = new TransactionException("error");
+    ExecutionException exception = new ExecutionException("error");
     doThrow(exception).when(dataFetcher).performDelete(eq(environment), anyList());
 
     // Act
@@ -144,11 +143,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
 
     // Assert
     assertThat(result.getData()).isFalse();
-    assertThat(result.getErrors())
-        .hasSize(1)
-        .element(0)
-        .isInstanceOf(AbortExecutionException.class);
-    assertThat(((AbortExecutionException) result.getErrors().get(0)).getCause())
-        .isSameAs(exception);
+    assertThatDataFetcherResultHasErrorForException(result, exception);
   }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcherTest.java
@@ -20,7 +20,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.List;
@@ -37,15 +36,14 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   private static final String COL5 = "c5";
   private static final String COL6 = "c5";
 
-  private MutationBulkDeleteDataFetcher dataFetcherForStorageTable;
-  private MutationBulkDeleteDataFetcher dataFetcherForTransactionalTable;
+  private MutationBulkDeleteDataFetcher dataFetcher;
   private Delete expectedDelete;
   @Captor private ArgumentCaptor<List<Delete>> deleteListCaptor;
 
   @Override
   public void doSetUp() {
     // Arrange
-    TableMetadata storageTableMetadata =
+    TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(COL1, DataType.INT)
             .addColumn(COL2, DataType.TEXT)
@@ -57,16 +55,11 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
             .addClusteringKey(COL2)
             .build();
     TableGraphQlModel storageTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new MutationBulkDeleteDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new MutationBulkDeleteDataFetcher(
-            storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, tableMetadata);
+    dataFetcher =
+        spy(
+            new MutationBulkDeleteDataFetcher(
+                storage, new DataFetcherHelper(storageTableGraphQlModel)));
   }
 
   private void prepareDeleteAndExpectedDelete() {
@@ -83,12 +76,12 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
 
     // Act
-    dataFetcherForStorageTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, times(1)).delete(deleteListCaptor.capture());
@@ -97,12 +90,13 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
+    setTransactionStarted();
 
     // Act
-    dataFetcherForTransactionalTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, never()).get(any());
@@ -114,7 +108,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_DeleteInputListGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), anyList());
 
     // Act
@@ -129,7 +122,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenDeleteSucceeds_ShouldReturnTrue() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), anyList());
 
     // Act
@@ -144,7 +136,6 @@ public class MutationBulkDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenDeleteFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteAndExpectedDelete();
-    MutationBulkDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     TransactionException exception = new TransactionException("error");
     doThrow(exception).when(dataFetcher).performDelete(eq(environment), anyList());
 

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcherTest.java
@@ -16,11 +16,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +137,7 @@ public class MutationBulkPutDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     preparePutInputAndExpectedPut();
-    TransactionException exception = new TransactionException("error");
+    ExecutionException exception = new ExecutionException("error");
     doThrow(exception).when(dataFetcher).performPut(eq(environment), anyList());
 
     // Act
@@ -146,11 +145,6 @@ public class MutationBulkPutDataFetcherTest extends DataFetcherTestBase {
 
     // Assert
     assertThat(result.getData()).isFalse();
-    assertThat(result.getErrors())
-        .hasSize(1)
-        .element(0)
-        .isInstanceOf(AbortExecutionException.class);
-    assertThat(((AbortExecutionException) result.getErrors().get(0)).getCause())
-        .isSameAs(exception);
+    assertThatDataFetcherResultHasErrorForException(result, exception);
   }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
@@ -14,11 +14,10 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.Map;
 import org.junit.Test;
@@ -124,7 +123,7 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    TransactionException exception = new TransactionException("error");
+    ExecutionException exception = new ExecutionException("error");
     doThrow(exception).when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 
     // Act
@@ -132,11 +131,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
 
     // Assert
     assertThat(result.getData()).isFalse();
-    assertThat(result.getErrors())
-        .hasSize(1)
-        .element(0)
-        .isInstanceOf(AbortExecutionException.class);
-    assertThat(((AbortExecutionException) result.getErrors().get(0)).getCause())
-        .isSameAs(exception);
+    assertThatDataFetcherResultHasErrorForException(result, exception);
   }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcherTest.java
@@ -18,7 +18,6 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.Map;
@@ -31,13 +30,12 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   private static final String COL2 = "c2";
   private static final String COL3 = "c3";
 
-  private MutationDeleteDataFetcher dataFetcherForStorageTable;
-  private MutationDeleteDataFetcher dataFetcherForTransactionalTable;
+  private MutationDeleteDataFetcher dataFetcher;
   private Delete expectedDelete;
   @Captor private ArgumentCaptor<Delete> deleteCaptor;
 
   @Override
-  public void doSetUp() throws Exception {
+  public void doSetUp() {
     // Arrange
     TableMetadata storageTableMetadata =
         TableMetadata.newBuilder()
@@ -47,17 +45,10 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
             .addPartitionKey(COL1)
             .addClusteringKey(COL2)
             .build();
-    TableGraphQlModel storageTableGraphQlModel =
+    TableGraphQlModel tableGraphQlModel =
         new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new MutationDeleteDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new MutationDeleteDataFetcher(
-            storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+    dataFetcher =
+        spy(new MutationDeleteDataFetcher(storage, new DataFetcherHelper(tableGraphQlModel)));
   }
 
   private void prepareDeleteInputAndExpectedDelete() {
@@ -75,12 +66,12 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
 
     // Act
-    dataFetcherForStorageTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, times(1)).delete(expectedDelete);
@@ -88,12 +79,13 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
+    setTransactionStarted();
 
     // Act
-    dataFetcherForTransactionalTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, never()).get(any());
@@ -104,7 +96,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_PutInputGiven_ShouldRunScalarDbDelete() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 
     // Act
@@ -119,7 +110,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutSucceeds_ShouldReturnTrue() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     doNothing().when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 
     // Act
@@ -134,7 +124,6 @@ public class MutationDeleteDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     prepareDeleteInputAndExpectedDelete();
-    MutationDeleteDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     TransactionException exception = new TransactionException("error");
     doThrow(exception).when(dataFetcher).performDelete(eq(environment), any(Delete.class));
 

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcherTest.java
@@ -18,11 +18,10 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.List;
 import java.util.Map;
@@ -152,7 +151,7 @@ public class MutationMutateDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenMutateFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     preparePutAndDelete();
-    TransactionException exception = new TransactionException("error");
+    ExecutionException exception = new ExecutionException("error");
     doThrow(exception).when(dataFetcher).performMutate(eq(environment), anyList());
 
     // Act
@@ -160,11 +159,6 @@ public class MutationMutateDataFetcherTest extends DataFetcherTestBase {
 
     // Assert
     assertThat(result.getData()).isFalse();
-    assertThat(result.getErrors())
-        .hasSize(1)
-        .element(0)
-        .isInstanceOf(AbortExecutionException.class);
-    assertThat(((AbortExecutionException) result.getErrors().get(0)).getCause())
-        .isSameAs(exception);
+    assertThatDataFetcherResultHasErrorForException(result, exception);
   }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcherTest.java
@@ -14,11 +14,10 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
-import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
 import java.util.Map;
 import org.junit.Test;
@@ -133,7 +132,7 @@ public class MutationPutDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenPutFails_ShouldReturnFalseWithErrors() throws Exception {
     // Arrange
     preparePutInputAndExpectedPut();
-    TransactionException exception = new TransactionException("error");
+    ExecutionException exception = new ExecutionException("error");
     doThrow(exception).when(dataFetcher).performPut(eq(environment), any(Put.class));
 
     // Act
@@ -141,11 +140,6 @@ public class MutationPutDataFetcherTest extends DataFetcherTestBase {
 
     // Assert
     assertThat(result.getData()).isFalse();
-    assertThat(result.getErrors())
-        .hasSize(1)
-        .element(0)
-        .isInstanceOf(AbortExecutionException.class);
-    assertThat(((AbortExecutionException) result.getErrors().get(0)).getCause())
-        .isSameAs(exception);
+    assertThatDataFetcherResultHasErrorForException(result, exception);
   }
 }

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -17,12 +18,14 @@ import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.schema.TableGraphQlModel;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.DoubleValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
+import graphql.execution.DataFetcherResult;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -110,7 +113,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_GetInputGiven_ShouldReturnResultAsMap() throws Exception {
+  public void get_WhenGetSucceeds_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
     Result mockResult = mock(Result.class);
@@ -120,12 +123,27 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     doReturn(Optional.of(mockResult)).when(dataFetcher).performGet(eq(environment), any(Get.class));
 
     // Act
-    Map<String, Map<String, Object>> result = dataFetcher.get(environment);
+    DataFetcherResult<Map<String, Map<String, Object>>> result = dataFetcher.get(environment);
 
     // Assert
-    Map<String, Object> object = result.get(tableGraphQlModel.getObjectType().getName());
+    Map<String, Object> object = result.getData().get(tableGraphQlModel.getObjectType().getName());
     assertThat(object)
         .containsOnly(entry(COL1, 1), entry(COL2, Optional.of("A")), entry(COL3, 2.0));
+  }
+
+  @Test
+  public void get_WhenGetFails_ShouldReturnNullWithErrors() throws Exception {
+    // Arrange
+    prepareGetInputAndExpectedGet();
+    ExecutionException exception = new ExecutionException("error");
+    doThrow(exception).when(dataFetcher).performGet(eq(environment), any(Get.class));
+
+    // Act
+    DataFetcherResult<Map<String, Map<String, Object>>> result = dataFetcher.get(environment);
+
+    // Assert
+    assertThat(result.getData()).isNull();
+    assertThatDataFetcherResultHasErrorForException(result, exception);
   }
 
   @Test

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -23,7 +23,6 @@ import com.scalar.db.io.DoubleValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -35,16 +34,15 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   private static final String COL2 = "c2";
   private static final String COL3 = "c3";
 
-  private TableGraphQlModel storageTableGraphQlModel;
-  private QueryGetDataFetcher dataFetcherForStorageTable;
-  private QueryGetDataFetcher dataFetcherForTransactionalTable;
+  private TableGraphQlModel tableGraphQlModel;
+  private QueryGetDataFetcher dataFetcher;
   private Map<String, Object> getInput;
   private Get expectedGet;
 
   @Override
   public void doSetUp() {
     // Arrange
-    TableMetadata storageTableMetadata =
+    TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(COL1, DataType.INT)
             .addColumn(COL2, DataType.TEXT)
@@ -52,16 +50,8 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
             .addPartitionKey(COL1)
             .addClusteringKey(COL2)
             .build();
-    storageTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new QueryGetDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new QueryGetDataFetcher(storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+    tableGraphQlModel = new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, tableMetadata);
+    dataFetcher = spy(new QueryGetDataFetcher(storage, new DataFetcherHelper(tableGraphQlModel)));
   }
 
   private void prepareGetInputAndExpectedGet() {
@@ -79,10 +69,9 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
 
     // Act
     dataFetcher.get(environment);
@@ -93,10 +82,10 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForTransactionalTable);
+    setTransactionStarted();
 
     // Act
     dataFetcher.get(environment);
@@ -110,7 +99,6 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   public void get_GetInputGiven_ShouldRunScalarDbGet() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
 
     // Act
     dataFetcher.get(environment);
@@ -125,7 +113,6 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   public void get_GetInputGiven_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
-    QueryGetDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     Result mockResult = mock(Result.class);
     when(mockResult.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
@@ -136,7 +123,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     Map<String, Map<String, Object>> result = dataFetcher.get(environment);
 
     // Assert
-    Map<String, Object> object = result.get(storageTableGraphQlModel.getObjectType().getName());
+    Map<String, Object> object = result.get(tableGraphQlModel.getObjectType().getName());
     assertThat(object)
         .containsOnly(entry(COL1, 1), entry(COL2, Optional.of("A")), entry(COL3, 2.0));
   }
@@ -147,7 +134,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     prepareGetInputAndExpectedGet();
 
     // Act
-    Get actual = dataFetcherForStorageTable.createGet(getInput);
+    Get actual = dataFetcher.createGet(getInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedGet);
@@ -161,7 +148,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     expectedGet.withConsistency(Consistency.EVENTUAL);
 
     // Act
-    Get actual = dataFetcherForStorageTable.createGet(getInput);
+    Get actual = dataFetcher.createGet(getInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedGet);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
@@ -25,7 +25,6 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,16 +42,15 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   private static final String COL5 = "c5";
   private static final String COL6 = "c5";
 
-  private TableGraphQlModel storageTableGraphQlModel;
-  private QueryScanDataFetcher dataFetcherForStorageTable;
-  private QueryScanDataFetcher dataFetcherForTransactionalTable;
+  private TableGraphQlModel tableGraphQlModel;
+  private QueryScanDataFetcher dataFetcher;
   private Map<String, Object> scanInput;
   private Scan expectedScan;
 
   @Override
   protected void doSetUp() throws Exception {
     // Arrange
-    TableMetadata storageTableMetadata =
+    TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(COL1, DataType.INT)
             .addColumn(COL2, DataType.TEXT)
@@ -66,16 +64,8 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
             .addClusteringKey(COL4)
             .addClusteringKey(COL5)
             .build();
-    storageTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, storageTableMetadata);
-    dataFetcherForStorageTable =
-        new QueryScanDataFetcher(storage, new DataFetcherHelper(storageTableGraphQlModel));
-    TableMetadata transactionalTableMetadata =
-        ConsensusCommitUtils.buildTransactionalTableMetadata(storageTableMetadata);
-    TableGraphQlModel transactionalTableGraphQlModel =
-        new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, transactionalTableMetadata);
-    dataFetcherForTransactionalTable =
-        new QueryScanDataFetcher(storage, new DataFetcherHelper(transactionalTableGraphQlModel));
+    tableGraphQlModel = new TableGraphQlModel(ANY_NAMESPACE, ANY_TABLE, tableMetadata);
+    dataFetcher = spy(new QueryScanDataFetcher(storage, new DataFetcherHelper(tableGraphQlModel)));
 
     // Mock scanner for storage
     Scanner mockScanner = mock(Scanner.class);
@@ -98,12 +88,12 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForStorageTable_ShouldUseStorage() throws Exception {
+  public void get_WhenTransactionNotStarted_ShouldUseStorage() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
 
     // Act
-    dataFetcherForStorageTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, times(1)).scan(expectedScan);
@@ -111,12 +101,13 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   }
 
   @Test
-  public void get_ForTransactionalTable_ShouldUseTransaction() throws Exception {
+  public void get_WhenTransactionStarted_ShouldUseTransaction() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
+    setTransactionStarted();
 
     // Act
-    dataFetcherForTransactionalTable.get(environment);
+    dataFetcher.get(environment);
 
     // Assert
     verify(storage, never()).get(any());
@@ -127,7 +118,6 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   public void get_ScanArgumentGiven_ShouldRunScalarDbScan() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
-    QueryScanDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
 
     // Act
     dataFetcher.get(environment);
@@ -142,7 +132,6 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   public void get_ScanArgumentGiven_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
-    QueryScanDataFetcher dataFetcher = spy(dataFetcherForStorageTable);
     Result mockResult1 = mock(Result.class);
     when(mockResult1.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult1.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
@@ -159,7 +148,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     Map<String, List<Map<String, Object>>> result = dataFetcher.get(environment);
 
     // Assert
-    List<Map<String, Object>> list = result.get(storageTableGraphQlModel.getObjectType().getName());
+    List<Map<String, Object>> list = result.get(tableGraphQlModel.getObjectType().getName());
     assertThat(list).hasSize(2);
     assertThat(list.get(0))
         .containsOnly(entry(COL1, 1), entry(COL2, Optional.of("A")), entry(COL3, 2L));
@@ -173,7 +162,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     prepareScanInputAndExpectedScan();
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -187,7 +176,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withConsistency(Consistency.EVENTUAL);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -204,7 +193,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withStart(new Key(new BigIntValue(COL3, 1L)), false);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -221,7 +210,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withEnd(new Key(new BigIntValue(COL3, 10L)), false);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -242,7 +231,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
         .withOrdering(new Scan.Ordering(COL3, Scan.Ordering.Order.DESC));
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);
@@ -256,7 +245,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     expectedScan.withLimit(100);
 
     // Act
-    Scan actual = dataFetcherForStorageTable.createScan(scanInput);
+    Scan actual = dataFetcher.createScan(scanInput);
 
     // Assert
     assertThat(actual).isEqualTo(expectedScan);


### PR DESCRIPTION
(Once #460 is merged, I will update this PR.)

This PR adds the exception names to the results of data fetchers that are thrown while running Scalar DB operations.
When a Scalar DB storage throws `ExecutionException` or a transaction throws `CrudException` (or `CrudConflictException`), they should be handled in the `get` method of `DataFetcher` objects and the name should be included in the `"errors"` -> `"extensions"` key of the result JSON.

Here are the example query and response.

```graphql
query @transaction(commit: true, txId: "9a04e41e-364d-4ee3-b77a-8f7b560ea4c0") {
  book1: books_by_isbn_tx_get(get: {key: {isbn: "978-4-09-386620-0", version: 1}}) {
    books_by_isbn_tx {
      isbn
    }
  }
}
```

If the above query encounters a `CrudConflictException`, the response should be returned like the following:

```json
{
  "errors": [
    {
      "message": "Scalar DB CrudConflictException happened while fetching data: conflict happened; try restarting transaction",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "book1"
      ],
      "extensions": {
        "exception": "CrudConflictException",
        "classification": "DataFetchingException"
      }
    }
  ],
  "data": {
    "book1": null
  }
}
```

Also, loggers have been added to data fetchers in this PR.
