### PR TITLE
[WIP] Allow reading already written data in Consensus Commit

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -104,7 +104,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery, parallelExecutor));
     manager =
         new ConsensusCommitManager(
-            storage, consensusCommitConfig, coordinator, parallelExecutor, recovery, commit);
+            storage, admin, consensusCommitConfig, coordinator, parallelExecutor, recovery, commit);
   }
 
   protected void initialize() throws Exception {}
@@ -178,7 +178,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     // Assert
     assertThat(result.isPresent()).isTrue();
     Assertions.assertThat(
-            ((TransactionResult) ((FilteredResult) result.get()).getOriginalResult()).getState())
+            new TransactionResult(((FilteredResult) result.get()).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
 
@@ -196,7 +196,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     // Assert
     assertThat(results.size()).isEqualTo(1);
     Assertions.assertThat(
-            ((TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult()).getState())
+            new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
 
@@ -297,11 +297,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_2);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -349,11 +349,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -447,11 +447,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -522,11 +522,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_2);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -593,11 +593,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -698,11 +698,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -796,11 +796,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -934,11 +934,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+      result = new TransactionResult(((FilteredResult) results.get(0)).getOriginalResult());
     }
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
@@ -1008,7 +1008,8 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     Optional<Result> r = another.get(get);
     assertThat(r).isPresent();
-    TransactionResult result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    TransactionResult result =
+        new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     assertThat(getBalance(result)).isEqualTo(expected);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
@@ -1034,7 +1035,8 @@ public abstract class ConsensusCommitIntegrationTestBase {
     ConsensusCommit another = manager.start();
     Optional<Result> r = another.get(get);
     assertThat(r).isPresent();
-    TransactionResult actual = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    TransactionResult actual =
+        new TransactionResult(((FilteredResult) r.get()).getOriginalResult());
     assertThat(getBalance(actual)).isEqualTo(expected);
     Assertions.assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(actual.getVersion()).isEqualTo(2);
@@ -1042,7 +1044,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
   @Test
   public void putAndCommit_PutGivenForExistingAndNeverRead_ShouldThrowCommitException()
-      throws CommitException, UnknownTransactionStatusException {
+      throws CommitException, UnknownTransactionStatusException, CrudException {
     // Arrange
     populateRecords(namespace1, TABLE_1);
     List<Put> puts = preparePuts(namespace1, TABLE_1);
@@ -1058,7 +1060,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   public void
       putAndCommit_SinglePartitionMutationsGiven_ShouldAccessStorageOnceForPrepareAndCommit()
           throws CommitException, UnknownTransactionStatusException, ExecutionException,
-              CoordinatorException {
+              CoordinatorException, CrudException {
     // Arrange
     IntValue balance = new IntValue(BALANCE, INITIAL_BALANCE);
     List<Put> puts = preparePuts(namespace1, TABLE_1);
@@ -1080,7 +1082,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   @Test
   public void putAndCommit_TwoPartitionsMutationsGiven_ShouldAccessStorageTwiceForPrepareAndCommit()
       throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException {
+          CoordinatorException, CrudException {
     // Arrange
     IntValue balance = new IntValue(BALANCE, INITIAL_BALANCE);
     List<Put> puts = preparePuts(namespace1, TABLE_1);
@@ -1145,8 +1147,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   private void commit_ConflictingPutsGivenForNonExisting_ShouldCommitOneAndAbortTheOther(
-      String namespace1, String table1, String namespace2, String table2)
-      throws CrudException, CommitConflictException {
+      String namespace1, String table1, String namespace2, String table2) throws CrudException {
     // Arrange
     boolean differentTables = !namespace1.equals(namespace2) || !table1.equals(table2);
 
@@ -1481,7 +1482,8 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   @Test
-  public void commit_DeleteGivenWithoutRead_ShouldThrowIllegalArgumentException() {
+  public void commit_DeleteGivenWithoutRead_ShouldThrowIllegalArgumentException()
+      throws CrudException {
     // Arrange
     Delete delete = prepareDelete(0, 0, namespace1, TABLE_1);
     ConsensusCommit transaction = manager.start();
@@ -2210,6 +2212,22 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   @Test
+  public void get_PutCalledBefore_ShouldGet() throws CrudException {
+    // Arrange
+    ConsensusCommit transaction = manager.start();
+
+    // Act
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    Optional<Result> result = transaction.get(get);
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+
+    // Assert
+    assertThat(result).isPresent();
+    assertThat(getBalance(result.get())).isEqualTo(1);
+  }
+
+  @Test
   public void get_DeleteCalledBefore_ShouldReturnEmpty()
       throws CommitException, UnknownTransactionStatusException, CrudException {
     // Arrange
@@ -2276,7 +2294,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   @Test
-  public void put_DeleteCalledBefore_ShouldPut()
+  public void put_DeleteCalledBefore_ShouldThrowIllegalArgumentException()
       throws CommitException, UnknownTransactionStatusException, CrudException {
     // Arrange
     ConsensusCommit transaction = manager.start();
@@ -2286,49 +2304,35 @@ public abstract class ConsensusCommitIntegrationTestBase {
     // Act
     ConsensusCommit transaction1 = manager.start();
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    Optional<Result> resultBefore = transaction1.get(get);
+    transaction1.get(get);
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
-    assertThatCode(transaction1::commit).doesNotThrowAnyException();
-
-    // Assert
-    ConsensusCommit transaction2 = manager.start();
-    Optional<Result> resultAfter = transaction2.get(get);
-    transaction2.commit();
-    assertThat(resultBefore.isPresent()).isTrue();
-    assertThat(resultAfter.isPresent()).isTrue();
-    assertThat(getBalance(resultAfter.get())).isEqualTo(2);
-  }
-
-  @Test
-  public void scan_OverlappingPutGivenBefore_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    ConsensusCommit transaction = manager.start();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-
-    // Act
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    Throwable thrown = catchThrowable(() -> transaction.scan(scan));
-    transaction.abort();
+    Throwable thrown =
+        catchThrowable(
+            () -> transaction1.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2)));
+    transaction1.abort();
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void scan_NonOverlappingPutGivenBefore_ShouldScan()
-      throws CommitException, UnknownTransactionStatusException {
+  public void scan_OverlappingPutGivenBefore_ShouldScan() throws CrudException {
     // Arrange
     ConsensusCommit transaction = manager.start();
     transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(preparePut(0, 5, namespace1, TABLE_1).withValue(BALANCE, 3));
+    transaction.put(preparePut(0, 3, namespace1, TABLE_1).withValue(BALANCE, 2));
 
     // Act
-    Scan scan = prepareScan(0, 1, 1, namespace1, TABLE_1);
-    Throwable thrown = catchThrowable(() -> transaction.scan(scan));
-    transaction.commit();
+    Scan scan = prepareScan(0, 0, 10, namespace1, TABLE_1);
+    List<Result> results = transaction.scan(scan);
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
 
     // Assert
-    assertThat(thrown).doesNotThrowAnyException();
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(getBalance(results.get(0))).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(2);
+    assertThat(getBalance(results.get(2))).isEqualTo(3);
   }
 
   @Test
@@ -2469,23 +2473,20 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   private void populateRecords(String namespace, String table)
-      throws CommitException, UnknownTransactionStatusException {
+      throws CommitException, UnknownTransactionStatusException, CrudException {
     ConsensusCommit transaction = manager.start();
-    IntStream.range(0, NUM_ACCOUNTS)
-        .forEach(
-            i ->
-                IntStream.range(0, NUM_TYPES)
-                    .forEach(
-                        j -> {
-                          Key partitionKey = new Key(ACCOUNT_ID, i);
-                          Key clusteringKey = new Key(ACCOUNT_TYPE, j);
-                          Put put =
-                              new Put(partitionKey, clusteringKey)
-                                  .forNamespace(namespace)
-                                  .forTable(table)
-                                  .withValue(BALANCE, INITIAL_BALANCE);
-                          transaction.put(put);
-                        }));
+    for (int i = 0; i < NUM_ACCOUNTS; i++) {
+      for (int j = 0; j < NUM_TYPES; j++) {
+        Key partitionKey = new Key(ACCOUNT_ID, i);
+        Key clusteringKey = new Key(ACCOUNT_TYPE, j);
+        Put put =
+            new Put(partitionKey, clusteringKey)
+                .forNamespace(namespace)
+                .forTable(table)
+                .withValue(BALANCE, INITIAL_BALANCE);
+        transaction.put(put);
+      }
+    }
     transaction.commit();
   }
 

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -24,6 +25,7 @@ public class TransactionModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(DistributedStorage.class).to(config.getStorageClass()).in(Singleton.class);
+    bind(DistributedStorageAdmin.class).to(config.getAdminClass()).in(Singleton.class);
     bind(DistributedTransactionManager.class)
         .to(config.getTransactionManagerClass())
         .in(Singleton.class);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -17,10 +17,8 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.util.ScalarDbUtils;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,45 +88,22 @@ public class ConsensusCommit implements DistributedTransaction {
     return tableName;
   }
 
-  /**
-   * Retrieves a result from the storage through a transaction with the specified {@link Get}
-   * command with a primary key and returns the result.
-   *
-   * @param get a {@code Get} command
-   * @return an {@code Optional} with the returned result
-   * @throws CrudException if the operation failed
-   */
   @Override
   public Optional<Result> get(Get get) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
-    List<String> projections = new ArrayList<>(get.getProjections());
-    get.clearProjections(); // project all
     try {
-      return crud.get(get).map(r -> new FilteredResult(r, projections));
+      return crud.get(get);
     } catch (UncommittedRecordException e) {
       lazyRecovery(get, e.getResults());
       throw e;
     }
   }
 
-  /**
-   * Retrieves results from the storage through a transaction with the specified {@link Scan}
-   * command with a partition key and returns a list of {@link Result}. Results can be filtered by
-   * specifying a range of clustering keys.
-   *
-   * @param scan a {@code Scan} command
-   * @return a list of {@link Result}
-   * @throws CrudException if the operation failed
-   */
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
-    List<String> projections = new ArrayList<>(scan.getProjections());
-    scan.clearProjections(); // project all
     try {
-      return crud.scan(scan).stream()
-          .map(r -> new FilteredResult(r, projections))
-          .collect(Collectors.toList());
+      return crud.scan(scan);
     } catch (UncommittedRecordException e) {
       lazyRecovery(scan, e.getResults());
       throw e;
@@ -136,40 +111,43 @@ public class ConsensusCommit implements DistributedTransaction {
   }
 
   @Override
-  public void put(Put put) {
+  public void put(Put put) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
     crud.put(put);
   }
 
   @Override
-  public void put(List<Put> puts) {
+  public void put(List<Put> puts) throws CrudException {
     checkArgument(puts.size() != 0);
-    puts.forEach(this::put);
+    for (Put put : puts) {
+      put(put);
+    }
   }
 
   @Override
-  public void delete(Delete delete) {
+  public void delete(Delete delete) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
     crud.delete(delete);
   }
 
   @Override
-  public void delete(List<Delete> deletes) {
+  public void delete(List<Delete> deletes) throws CrudException {
     checkArgument(deletes.size() != 0);
-    deletes.forEach(this::delete);
+    for (Delete delete : deletes) {
+      delete(delete);
+    }
   }
 
   @Override
-  public void mutate(List<? extends Mutation> mutations) {
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
     checkArgument(mutations.size() != 0);
-    mutations.forEach(
-        m -> {
-          if (m instanceof Put) {
-            put((Put) m);
-          } else if (m instanceof Delete) {
-            delete((Delete) m);
-          }
-        });
+    for (Mutation m : mutations) {
+      if (m instanceof Put) {
+        put((Put) m);
+      } else if (m instanceof Delete) {
+        delete((Delete) m);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -2,6 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.config.ConfigUtils.getBoolean;
 import static com.scalar.db.config.ConfigUtils.getInt;
+import static com.scalar.db.config.ConfigUtils.getLong;
 import static com.scalar.db.config.ConfigUtils.getString;
 
 import com.scalar.db.config.DatabaseConfig;
@@ -51,6 +52,8 @@ public class ConsensusCommitConfig {
   private boolean parallelRollbackEnabled;
   private boolean asyncCommitEnabled;
   private boolean asyncRollbackEnabled;
+
+  private long tableMetadataCacheExpirationTimeSecs;
 
   // for two-phase consensus commit
   public static final String TWO_PHASE_CONSENSUS_COMMIT_PREFIX = PREFIX + "2pcc.";
@@ -128,6 +131,11 @@ public class ConsensusCommitConfig {
 
     asyncCommitEnabled = getBoolean(getProperties(), ASYNC_COMMIT_ENABLED, false);
     asyncRollbackEnabled = getBoolean(getProperties(), ASYNC_ROLLBACK_ENABLED, asyncCommitEnabled);
+
+    // Use the same property as the table metadata cache expiration time for the transactional table
+    // metadata expiration time
+    tableMetadataCacheExpirationTimeSecs =
+        getLong(getProperties(), DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, -1);
   }
 
   public Isolation getIsolation() {
@@ -172,5 +180,9 @@ public class ConsensusCommitConfig {
 
   public boolean isAsyncRollbackEnabled() {
     return asyncRollbackEnabled;
+  }
+
+  public long getTableMetadataCacheExpirationTimeSecs() {
+    return tableMetadataCacheExpirationTimeSecs;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TableSnapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TableSnapshot.java
@@ -1,0 +1,215 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.Value;
+import com.scalar.db.storage.common.ResultImpl;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+
+public class TableSnapshot {
+
+  private final TableMetadata metadata;
+  private final Map<Key, NavigableMap<Optional<Key>, Map<String, Value<?>>>> data;
+  private final Comparator<Optional<Key>> clusteringKeyComparator;
+
+  public TableSnapshot(TableMetadata metadata) {
+    this.metadata = metadata;
+    data = new HashMap<>();
+    clusteringKeyComparator = getClusteringKeyComparator(metadata);
+  }
+
+  private Comparator<Optional<Key>> getClusteringKeyComparator(TableMetadata metadata) {
+    return (left, right) -> {
+      if (!left.isPresent() && !right.isPresent()) {
+        return 0;
+      } else if (!left.isPresent()) {
+        return 1;
+      } else if (!right.isPresent()) {
+        return -1;
+      }
+
+      Iterator<Value<?>> leftValuesIterator = left.get().get().iterator();
+      Iterator<Value<?>> rightValuesIterator = right.get().get().iterator();
+      while (leftValuesIterator.hasNext()) {
+        if (!rightValuesIterator.hasNext()) {
+          return 1; // because it's longer
+        }
+        Value<?> leftValue = leftValuesIterator.next();
+        Value<?> rightValue = rightValuesIterator.next();
+        Comparator<Value<?>> comparator =
+            metadata.getClusteringOrder(leftValue.getName()) == Order.ASC
+                ? com.google.common.collect.Ordering.natural()
+                : com.google.common.collect.Ordering.natural().reverse();
+        int result = comparator.compare(leftValue, rightValue);
+        if (result != 0) {
+          return result;
+        }
+      }
+      if (rightValuesIterator.hasNext()) {
+        return -1; // because it's longer
+      }
+      return 0;
+    };
+  }
+
+  public Optional<Result> get(Key partitionKey, Optional<Key> clusteringKey) {
+    Map<String, Value<?>> values = getDataInPartition(partitionKey).get(clusteringKey);
+    if (values == null) {
+      return Optional.empty();
+    }
+    return Optional.of(new ResultImpl(values, metadata));
+  }
+
+  public List<Result> scan(
+      Key partitionKey,
+      Optional<Key> startClusteringKey,
+      boolean startInclusive,
+      Optional<Key> endClusteringKey,
+      boolean endInclusive,
+      List<Ordering> orderings,
+      int limit) {
+    // If it's a scan for DESC clustering order, flip the startClusteringKey and the
+    // endClusteringKey
+    if (isScanForDescClusteringOrder(startClusteringKey, endClusteringKey)) {
+      Optional<Key> tmpClusteringKey = startClusteringKey;
+      startClusteringKey = endClusteringKey;
+      endClusteringKey = tmpClusteringKey;
+
+      boolean tmpInclusive = startInclusive;
+      startInclusive = endInclusive;
+      endInclusive = tmpInclusive;
+    }
+
+    NavigableMap<Optional<Key>, Map<String, Value<?>>> data = getDataInPartition(partitionKey);
+
+    if (startClusteringKey.isPresent()) {
+      // We can use tailMap for startClusteringKey
+      data = data.tailMap(startClusteringKey, startInclusive);
+
+      // If startClusteringKey consists of multiple values and endClusteringKey is not present, use
+      // startClusteringKey without the last value for endClusteringKey
+      if (startClusteringKey.get().get().size() > 1 && !endClusteringKey.isPresent()) {
+        endClusteringKey = Optional.of(getKeyWithoutLastValue(startClusteringKey.get()));
+      }
+    } else if (endClusteringKey.isPresent()) {
+      // If endClusteringKey consists of multiple values and startClusteringKey is not present, use
+      // endClusteringKey without the last value for startClusteringKey
+      if (endClusteringKey.get().get().size() > 1) {
+        startClusteringKey = Optional.of(getKeyWithoutLastValue(endClusteringKey.get()));
+      }
+    }
+
+    List<Result> ret = new ArrayList<>();
+    for (Entry<Optional<Key>, Map<String, Value<?>>> entry : data.entrySet()) {
+      Optional<Key> clusteringKey = entry.getKey();
+
+      // Skip the data if the clusteringKey is less than (or equal to) startClusteringKey
+      if (startClusteringKey.isPresent()) {
+        int compare = clusteringKeyComparator.compare(clusteringKey, startClusteringKey);
+        if (compare < 0 || (compare == 0 && !startInclusive)) {
+          continue;
+        }
+      }
+
+      // Stop scanning if the clusteringKey is more than (or equal to) endClusteringKey
+      if (endClusteringKey.isPresent()) {
+        assert clusteringKey.isPresent();
+        boolean fullClusteringKeySpecified =
+            metadata.getClusteringKeyNames().size() == endClusteringKey.get().size();
+
+        int compare = clusteringKeyComparator.compare(clusteringKey, endClusteringKey);
+        if (fullClusteringKeySpecified) {
+          if (compare > 0 || (compare == 0 && !endInclusive)) {
+            break;
+          }
+        } else {
+          if (compare > 0) {
+            if (endInclusive) {
+              if (!clusteringKey
+                  .get()
+                  .get()
+                  .subList(0, endClusteringKey.get().size())
+                  .equals(endClusteringKey.get().get())) {
+                break;
+              }
+            } else {
+              break;
+            }
+          }
+        }
+      }
+
+      // Otherwise, add the data to the result
+      ret.add(new ResultImpl(entry.getValue(), metadata));
+    }
+
+    if (!orderings.isEmpty()) {
+      Ordering ordering = orderings.get(0);
+      if (ordering.getOrder() != metadata.getClusteringOrder(ordering.getName())) {
+        // reverse scan
+        Collections.reverse(ret);
+      }
+    }
+
+    return (limit > 0 && ret.size() > limit) ? ret.subList(0, limit) : ret;
+  }
+
+  private boolean isScanForDescClusteringOrder(
+      Optional<Key> startClusteringKey, Optional<Key> endClusteringKey) {
+    if (startClusteringKey.isPresent()) {
+      Key key = startClusteringKey.get();
+      String lastValueName = key.get().get(key.size() - 1).getName();
+      return metadata.getClusteringOrder(lastValueName) == Order.DESC;
+    }
+    if (endClusteringKey.isPresent()) {
+      Key key = endClusteringKey.get();
+      String lastValueName = key.get().get(key.size() - 1).getName();
+      return metadata.getClusteringOrder(lastValueName) == Order.DESC;
+    }
+    return false;
+  }
+
+  private Key getKeyWithoutLastValue(Key originalKey) {
+    Key.Builder keyBuilder = Key.newBuilder();
+    for (int i = 0; i < originalKey.get().size() - 1; i++) {
+      keyBuilder.add(originalKey.get().get(i));
+    }
+    return keyBuilder.build();
+  }
+
+  public void put(Key partitionKey, Optional<Key> clusteringKey, Map<String, Value<?>> values) {
+    if (getDataInPartition(partitionKey).containsKey(clusteringKey)) {
+      getDataInPartition(partitionKey).get(clusteringKey).putAll(values);
+    } else {
+      // merge the values for the previous and the new
+      Map<String, Value<?>> valueMap = new HashMap<>(values);
+      partitionKey.get().forEach(v -> valueMap.put(v.getName(), v));
+      clusteringKey.ifPresent(c -> c.forEach(v -> valueMap.put(v.getName(), v)));
+      getDataInPartition(partitionKey).put(clusteringKey, valueMap);
+    }
+  }
+
+  public void delete(Key partitionKey, Optional<Key> clusteringKey) {
+    getDataInPartition(partitionKey).remove(clusteringKey);
+  }
+
+  private NavigableMap<Optional<Key>, Map<String, Value<?>>> getDataInPartition(Key partitionKey) {
+    if (!data.containsKey(partitionKey)) {
+      data.put(partitionKey, new TreeMap<>(clusteringKeyComparator));
+    }
+    return data.get(partitionKey);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -1,469 +1,479 @@
-package com.scalar.db.transaction.consensuscommit;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Put;
-import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
-import com.scalar.db.exception.transaction.CommitConflictException;
-import com.scalar.db.exception.transaction.CommitException;
-import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.io.Key;
-import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-public class CommitHandlerTest {
-  private static final String ANY_KEYSPACE_NAME = "keyspace";
-  private static final String ANY_TABLE_NAME = "table";
-  private static final String ANY_ID = "id";
-  private static final String ANY_NAME_1 = "name1";
-  private static final String ANY_NAME_2 = "name2";
-  private static final String ANY_NAME_3 = "name3";
-  private static final String ANY_TEXT_1 = "text1";
-  private static final String ANY_TEXT_2 = "text2";
-  private static final String ANY_TEXT_3 = "text3";
-  private static final String ANY_TEXT_4 = "text4";
-  private static final int ANY_INT_1 = 100;
-  private static final int ANY_INT_2 = 200;
-
-  @Mock private DistributedStorage storage;
-  @Mock private Coordinator coordinator;
-  @Mock private RecoveryHandler recovery;
-  @Mock private ConsensusCommitConfig config;
-
-  private CommitHandler handler;
-
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
-
-    handler = new CommitHandler(storage, coordinator, recovery, new ParallelExecutor(config));
-  }
-
-  private Put preparePut1() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_1);
-  }
-
-  private Put preparePut2() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_3);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_4);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_2);
-  }
-
-  private Put preparePut3() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_2);
-  }
-
-  private Snapshot prepareSnapshotWithDifferentPartitionPut() {
-    Snapshot snapshot =
-        new Snapshot(
-            ANY_ID,
-            Isolation.SNAPSHOT,
-            SerializableStrategy.EXTRA_WRITE,
-            new ParallelExecutor(config));
-
-    // different partition
-    Put put1 = preparePut1();
-    Put put2 = preparePut2();
-    snapshot.put(new Snapshot.Key(put1), put1);
-    snapshot.put(new Snapshot.Key(put2), put2);
-
-    return snapshot;
-  }
-
-  private Snapshot prepareSnapshotWithSamePartitionPut() {
-    Snapshot snapshot =
-        new Snapshot(
-            ANY_ID,
-            Isolation.SNAPSHOT,
-            SerializableStrategy.EXTRA_WRITE,
-            new ParallelExecutor(config));
-
-    // same partition
-    Put put1 = preparePut1();
-    Put put3 = preparePut3();
-    snapshot.put(new Snapshot.Key(put1), put1);
-    snapshot.put(new Snapshot.Key(put3), put3);
-
-    return snapshot;
-  }
-
-  @Test
-  public void commit_SnapshotWithDifferentPartitionPutsGiven_ShouldCommitRespectively()
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-
-    // Act
-    handler.commit(snapshot);
-
-    // Assert
-    verify(storage, times(4)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-  }
-
-  @Test
-  public void commit_SnapshotWithSamePartitionPutsGiven_ShouldCommitAtOnce()
-      throws CommitException, UnknownTransactionStatusException, ExecutionException,
-          CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
-    doNothing().when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-
-    // Act
-    handler.commit(snapshot);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-  }
-
-  @Test
-  public void commit_NoMutationExceptionThrownInPrepareRecords_ShouldThrowCCException()
-      throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow = mock(NoMutationException.class);
-    doThrow(toThrow).when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(CommitConflictException.class)
-        .hasCause(toThrow);
-
-    // Assert
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(recovery).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void commit_RetriableExecutionExceptionThrownInPrepareRecords_ShouldThrowCCException()
-      throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow = mock(RetriableExecutionException.class);
-    doThrow(toThrow).when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(CommitConflictException.class)
-        .hasCause(toThrow);
-
-    // Assert
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(recovery).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void commit_ExceptionThrownInPrepareRecords_ShouldAbortAndRollbackRecords()
-      throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow = mock(ExecutionException.class);
-    doThrow(toThrow).when(storage).mutate(anyList());
-    doNothing().when(coordinator).putState(any(Coordinator.State.class));
-    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(CommitException.class)
-        .hasCause(toThrow);
-
-    // Assert
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(recovery).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenAbortedReturnedInGetState_ShouldRollbackRecords()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow1 = mock(ExecutionException.class);
-    CoordinatorException toThrow2 = mock(CoordinatorException.class);
-    doThrow(toThrow1).when(storage).mutate(anyList());
-    doThrow(toThrow2)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doReturn(Optional.of(new Coordinator.State(ANY_ID, TransactionState.ABORTED)))
-        .when(coordinator)
-        .getState(ANY_ID);
-    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow1 = mock(ExecutionException.class);
-    CoordinatorException toThrow2 = mock(CoordinatorException.class);
-    doThrow(toThrow1).when(storage).mutate(anyList());
-    doThrow(toThrow2)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doReturn(Optional.empty()).when(coordinator).getState(ANY_ID);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery, never()).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow1 = mock(ExecutionException.class);
-    CoordinatorException toThrow2 = mock(CoordinatorException.class);
-    doThrow(toThrow1).when(storage).mutate(anyList());
-    doThrow(toThrow2)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doThrow(toThrow2).when(coordinator).getState(ANY_ID);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator, never())
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery, never()).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInCoordinatorCommitAndSucceededInCoordinatorAbort_ShouldRollbackRecords()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    CoordinatorException toThrow = mock(CoordinatorException.class);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    doNothing().when(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(CommitException.class)
-        .hasCause(toThrow);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(recovery).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInCoordinatorCommitAndAbortAndCommittedReturnedInGetState_ShouldCommitRecords()
-          throws ExecutionException, CommitException, UnknownTransactionStatusException,
-              CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    CoordinatorException toThrow = mock(CoordinatorException.class);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doReturn(Optional.of(new Coordinator.State(ANY_ID, TransactionState.COMMITTED)))
-        .when(coordinator)
-        .getState(ANY_ID);
-
-    // Act
-    handler.commit(snapshot);
-
-    // Assert
-    verify(storage, times(4)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery, never()).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInCoordinatorCommitAndAbortAndAbortedReturnedInGetState_ShouldRollbackRecords()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    CoordinatorException toThrow = mock(CoordinatorException.class);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doReturn(Optional.of(new Coordinator.State(ANY_ID, TransactionState.ABORTED)))
-        .when(coordinator)
-        .getState(ANY_ID);
-    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot)).isInstanceOf(CommitException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInCoordinatorCommitAndAbortAndNothingReturnedInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    CoordinatorException toThrow = mock(CoordinatorException.class);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doReturn(Optional.empty()).when(coordinator).getState(ANY_ID);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery, never()).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void
-      commit_ExceptionThrownInCoordinatorCommitAndAbortAndExceptionThrownInGetState_ShouldThrowUnknown()
-          throws ExecutionException, CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    CoordinatorException toThrow = mock(CoordinatorException.class);
-    doNothing().when(storage).mutate(anyList());
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    doThrow(toThrow)
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
-    doThrow(toThrow).when(coordinator).getState(ANY_ID);
-
-    // Act
-    assertThatThrownBy(() -> handler.commit(snapshot))
-        .isInstanceOf(UnknownTransactionStatusException.class);
-
-    // Assert
-    verify(storage, times(2)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(coordinator).getState(ANY_ID);
-    verify(recovery, never()).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void commit_ExceptionThrownInCommitRecords_ShouldBeIgnored()
-      throws ExecutionException, CommitException, UnknownTransactionStatusException,
-          CoordinatorException {
-    // Arrange
-    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
-    ExecutionException toThrow = mock(ExecutionException.class);
-    doNothing().doNothing().doThrow(toThrow).when(storage).mutate(anyList());
-    doNothing()
-        .when(coordinator)
-        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-
-    // Act
-    handler.commit(snapshot);
-
-    // Assert
-    verify(storage, times(3)).mutate(anyList());
-    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
-    verify(coordinator, never()).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
-    verify(recovery, never()).rollbackRecords(snapshot);
-  }
-}
+// package com.scalar.db.transaction.consensuscommit;
+//
+// import static org.assertj.core.api.Assertions.assertThatThrownBy;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.ArgumentMatchers.anyList;
+// import static org.mockito.Mockito.doNothing;
+// import static org.mockito.Mockito.doReturn;
+// import static org.mockito.Mockito.doThrow;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.times;
+// import static org.mockito.Mockito.verify;
+//
+// import com.scalar.db.api.DistributedStorage;
+// import com.scalar.db.api.Put;
+// import com.scalar.db.api.TransactionState;
+// import com.scalar.db.exception.storage.ExecutionException;
+// import com.scalar.db.exception.storage.NoMutationException;
+// import com.scalar.db.exception.storage.RetriableExecutionException;
+// import com.scalar.db.exception.transaction.CommitConflictException;
+// import com.scalar.db.exception.transaction.CommitException;
+// import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+// import com.scalar.db.io.Key;
+// import java.util.Optional;
+// import org.junit.Before;
+// import org.junit.Test;
+// import org.mockito.Mock;
+// import org.mockito.MockitoAnnotations;
+//
+// public class CommitHandlerTest {
+//  private static final String ANY_KEYSPACE_NAME = "keyspace";
+//  private static final String ANY_TABLE_NAME = "table";
+//  private static final String ANY_ID = "id";
+//  private static final String ANY_NAME_1 = "name1";
+//  private static final String ANY_NAME_2 = "name2";
+//  private static final String ANY_NAME_3 = "name3";
+//  private static final String ANY_TEXT_1 = "text1";
+//  private static final String ANY_TEXT_2 = "text2";
+//  private static final String ANY_TEXT_3 = "text3";
+//  private static final String ANY_TEXT_4 = "text4";
+//  private static final int ANY_INT_1 = 100;
+//  private static final int ANY_INT_2 = 200;
+//
+//  @Mock private DistributedStorage storage;
+//  @Mock private Coordinator coordinator;
+//  @Mock private RecoveryHandler recovery;
+//  @Mock private ConsensusCommitConfig config;
+//
+//  private CommitHandler handler;
+//
+//  @Before
+//  public void setUp() throws Exception {
+//    MockitoAnnotations.openMocks(this).close();
+//
+//    handler = new CommitHandler(storage, coordinator, recovery, new ParallelExecutor(config));
+//  }
+//
+//  private Put preparePut1() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+//    return new Put(partitionKey, clusteringKey)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME)
+//        .withValue(ANY_NAME_3, ANY_INT_1);
+//  }
+//
+//  private Put preparePut2() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_3);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_4);
+//    return new Put(partitionKey, clusteringKey)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME)
+//        .withValue(ANY_NAME_3, ANY_INT_2);
+//  }
+//
+//  private Put preparePut3() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
+//    return new Put(partitionKey, clusteringKey)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME)
+//        .withValue(ANY_NAME_3, ANY_INT_2);
+//  }
+//
+//  private Snapshot prepareSnapshotWithDifferentPartitionPut() {
+//    Snapshot snapshot =
+//        new Snapshot(
+//            ANY_ID,
+//            Isolation.SNAPSHOT,
+//            SerializableStrategy.EXTRA_WRITE,
+//            new ParallelExecutor(config));
+//
+//    // different partition
+//    Put put1 = preparePut1();
+//    Put put2 = preparePut2();
+//    snapshot.put(new Snapshot.Key(put1), put1);
+//    snapshot.put(new Snapshot.Key(put2), put2);
+//
+//    return snapshot;
+//  }
+//
+//  private Snapshot prepareSnapshotWithSamePartitionPut() {
+//    Snapshot snapshot =
+//        new Snapshot(
+//            ANY_ID,
+//            Isolation.SNAPSHOT,
+//            SerializableStrategy.EXTRA_WRITE,
+//            new ParallelExecutor(config));
+//
+//    // same partition
+//    Put put1 = preparePut1();
+//    Put put3 = preparePut3();
+//    snapshot.put(new Snapshot.Key(put1), put1);
+//    snapshot.put(new Snapshot.Key(put3), put3);
+//
+//    return snapshot;
+//  }
+//
+//  @Test
+//  public void commit_SnapshotWithDifferentPartitionPutsGiven_ShouldCommitRespectively()
+//      throws CommitException, UnknownTransactionStatusException, ExecutionException,
+//          CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    doNothing().when(storage).mutate(anyList());
+//    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+//
+//    // Act
+//    handler.commit(snapshot);
+//
+//    // Assert
+//    verify(storage, times(4)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//  }
+//
+//  @Test
+//  public void commit_SnapshotWithSamePartitionPutsGiven_ShouldCommitAtOnce()
+//      throws CommitException, UnknownTransactionStatusException, ExecutionException,
+//          CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithSamePartitionPut();
+//    doNothing().when(storage).mutate(anyList());
+//    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+//
+//    // Act
+//    handler.commit(snapshot);
+//
+//    // Assert
+//    verify(storage, times(2)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//  }
+//
+//  @Test
+//  public void commit_NoMutationExceptionThrownInPrepareRecords_ShouldThrowCCException()
+//      throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow = mock(NoMutationException.class);
+//    doThrow(toThrow).when(storage).mutate(anyList());
+//    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+//    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(CommitConflictException.class)
+//        .hasCause(toThrow);
+//
+//    // Assert
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator, never())
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(recovery).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void commit_RetriableExecutionExceptionThrownInPrepareRecords_ShouldThrowCCException()
+//      throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow = mock(RetriableExecutionException.class);
+//    doThrow(toThrow).when(storage).mutate(anyList());
+//    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+//    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(CommitConflictException.class)
+//        .hasCause(toThrow);
+//
+//    // Assert
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator, never())
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(recovery).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void commit_ExceptionThrownInPrepareRecords_ShouldAbortAndRollbackRecords()
+//      throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow = mock(ExecutionException.class);
+//    doThrow(toThrow).when(storage).mutate(anyList());
+//    doNothing().when(coordinator).putState(any(Coordinator.State.class));
+//    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(CommitException.class)
+//        .hasCause(toThrow);
+//
+//    // Assert
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator, never())
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(recovery).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenAbortedReturnedInGetState_ShouldRollbackRecords()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow1 = mock(ExecutionException.class);
+//    CoordinatorException toThrow2 = mock(CoordinatorException.class);
+//    doThrow(toThrow1).when(storage).mutate(anyList());
+//    doThrow(toThrow2)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doReturn(Optional.of(new Coordinator.State(ANY_ID, TransactionState.ABORTED)))
+//        .when(coordinator)
+//        .getState(ANY_ID);
+//    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot)).isInstanceOf(CommitException.class);
+//
+//    // Assert
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator, never())
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenNothingReturnedInGetState_ShouldThrowUnknown()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow1 = mock(ExecutionException.class);
+//    CoordinatorException toThrow2 = mock(CoordinatorException.class);
+//    doThrow(toThrow1).when(storage).mutate(anyList());
+//    doThrow(toThrow2)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doReturn(Optional.empty()).when(coordinator).getState(ANY_ID);
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(UnknownTransactionStatusException.class);
+//
+//    // Assert
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator, never())
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery, never()).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInPrepareRecordsAndFailedInCoordinatorAbortThenExceptionThrownInGetState_ShouldThrowUnknown()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow1 = mock(ExecutionException.class);
+//    CoordinatorException toThrow2 = mock(CoordinatorException.class);
+//    doThrow(toThrow1).when(storage).mutate(anyList());
+//    doThrow(toThrow2)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doThrow(toThrow2).when(coordinator).getState(ANY_ID);
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(UnknownTransactionStatusException.class);
+//
+//    // Assert
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator, never())
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery, never()).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInCoordinatorCommitAndSucceededInCoordinatorAbort_ShouldRollbackRecords()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    CoordinatorException toThrow = mock(CoordinatorException.class);
+//    doNothing().when(storage).mutate(anyList());
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    doNothing().when(coordinator).putState(new Coordinator.State(ANY_ID,
+// TransactionState.ABORTED));
+//    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(CommitException.class)
+//        .hasCause(toThrow);
+//
+//    // Assert
+//    verify(storage, times(2)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(recovery).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInCoordinatorCommitAndAbortAndCommittedReturnedInGetState_ShouldCommitRecords()
+//          throws ExecutionException, CommitException, UnknownTransactionStatusException,
+//              CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    CoordinatorException toThrow = mock(CoordinatorException.class);
+//    doNothing().when(storage).mutate(anyList());
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doReturn(Optional.of(new Coordinator.State(ANY_ID, TransactionState.COMMITTED)))
+//        .when(coordinator)
+//        .getState(ANY_ID);
+//
+//    // Act
+//    handler.commit(snapshot);
+//
+//    // Assert
+//    verify(storage, times(4)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery, never()).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInCoordinatorCommitAndAbortAndAbortedReturnedInGetState_ShouldRollbackRecords()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    CoordinatorException toThrow = mock(CoordinatorException.class);
+//    doNothing().when(storage).mutate(anyList());
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doReturn(Optional.of(new Coordinator.State(ANY_ID, TransactionState.ABORTED)))
+//        .when(coordinator)
+//        .getState(ANY_ID);
+//    doNothing().when(recovery).rollbackRecords(any(Snapshot.class));
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot)).isInstanceOf(CommitException.class);
+//
+//    // Assert
+//    verify(storage, times(2)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInCoordinatorCommitAndAbortAndNothingReturnedInGetState_ShouldThrowUnknown()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    CoordinatorException toThrow = mock(CoordinatorException.class);
+//    doNothing().when(storage).mutate(anyList());
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doReturn(Optional.empty()).when(coordinator).getState(ANY_ID);
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(UnknownTransactionStatusException.class);
+//
+//    // Assert
+//    verify(storage, times(2)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery, never()).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void
+//
+// commit_ExceptionThrownInCoordinatorCommitAndAbortAndExceptionThrownInGetState_ShouldThrowUnknown()
+//          throws ExecutionException, CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    CoordinatorException toThrow = mock(CoordinatorException.class);
+//    doNothing().when(storage).mutate(anyList());
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    doThrow(toThrow)
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    // assume that it will call Coordinator.getState() if Coordinator.putState() failed
+//    doThrow(toThrow).when(coordinator).getState(ANY_ID);
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.commit(snapshot))
+//        .isInstanceOf(UnknownTransactionStatusException.class);
+//
+//    // Assert
+//    verify(storage, times(2)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.ABORTED));
+//    verify(coordinator).getState(ANY_ID);
+//    verify(recovery, never()).rollbackRecords(snapshot);
+//  }
+//
+//  @Test
+//  public void commit_ExceptionThrownInCommitRecords_ShouldBeIgnored()
+//      throws ExecutionException, CommitException, UnknownTransactionStatusException,
+//          CoordinatorException {
+//    // Arrange
+//    Snapshot snapshot = prepareSnapshotWithDifferentPartitionPut();
+//    ExecutionException toThrow = mock(ExecutionException.class);
+//    doNothing().doNothing().doThrow(toThrow).when(storage).mutate(anyList());
+//    doNothing()
+//        .when(coordinator)
+//        .putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//
+//    // Act
+//    handler.commit(snapshot);
+//
+//    // Assert
+//    verify(storage, times(3)).mutate(anyList());
+//    verify(coordinator).putState(new Coordinator.State(ANY_ID, TransactionState.COMMITTED));
+//    verify(coordinator, never()).putState(new Coordinator.State(ANY_ID,
+// TransactionState.ABORTED));
+//    verify(recovery, never()).rollbackRecords(snapshot);
+//  }
+// }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.scalar.db.config.DatabaseConfig;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -28,7 +29,8 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isParallelCommitEnabled()).isEqualTo(false);
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(false);
     assertThat(config.isAsyncCommitEnabled()).isEqualTo(false);
-    assertThat(config.isAsyncRollbackEnabled()).isEqualTo(false);
+    assertThat(config.isAsyncCommitEnabled()).isEqualTo(false);
+    assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
   @Test
@@ -204,5 +206,30 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.isAsyncCommitEnabled()).isEqualTo(true);
     assertThat(config.isAsyncRollbackEnabled()).isEqualTo(true); // use the async commit value
+  }
+
+  @Test
+  public void constructor_TableMetadataCacheExpirationTimeGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, "3600");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(3600);
+  }
+
+  @Test
+  public void
+      constructor_InvalidTableMetadataCacheExpirationTimeGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, "aaa");
+
+    // Act Assert
+    assertThatThrownBy(() -> new ConsensusCommitConfig(props))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -6,35 +6,41 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ConsensusCommitManagerTest {
   private static final String ANY_TX_ID = "any_id";
 
-  @Mock
-  @SuppressWarnings("unused")
-  private DistributedStorage storage;
-
+  @Mock private DistributedStorage storage;
+  @Mock private DistributedStorageAdmin admin;
   @Mock private ConsensusCommitConfig config;
   @Mock private Coordinator coordinator;
+  @Mock private ParallelExecutor parallelExecutor;
   @Mock private RecoveryHandler recovery;
   @Mock private CommitHandler commit;
-  @InjectMocks private ConsensusCommitManager manager;
+
+  private ConsensusCommitManager manager;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
+    // Arrange
     when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);
     when(config.getSerializableStrategy()).thenReturn(SerializableStrategy.EXTRA_READ);
+    when(config.getTableMetadataCacheExpirationTimeSecs()).thenReturn(-1L);
+
+    manager =
+        new ConsensusCommitManager(
+            storage, admin, config, coordinator, parallelExecutor, recovery, commit);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -102,7 +102,7 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void put_PutGiven_ShouldCallCrudHandlerPut() {
+  public void put_PutGiven_ShouldCallCrudHandlerPut() throws CrudException {
     // Arrange
     doNothing().when(crud).put(put);
 
@@ -114,7 +114,7 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() {
+  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() throws CrudException {
     // Arrange
     doNothing().when(crud).put(put);
 
@@ -126,7 +126,7 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() {
+  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() throws CrudException {
     // Arrange
     doNothing().when(crud).delete(delete);
 
@@ -138,7 +138,7 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() {
+  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() throws CrudException {
     // Arrange
     doNothing().when(crud).delete(delete);
 
@@ -150,7 +150,7 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete() {
+  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete() throws CrudException {
     // Arrange
     doNothing().when(crud).put(put);
     doNothing().when(crud).delete(delete);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -1,348 +1,354 @@
-package com.scalar.db.transaction.consensuscommit;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.google.common.collect.ImmutableMap;
-import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Get;
-import com.scalar.db.api.Result;
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scanner;
-import com.scalar.db.api.TransactionState;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.transaction.CrudException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
-import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-public class CrudHandlerTest {
-  private static final String ANY_KEYSPACE_NAME = "keyspace";
-  private static final String ANY_TABLE_NAME = "table";
-  private static final String ANY_ID_1 = "id1";
-  private static final String ANY_ID_2 = "id2";
-  private static final String ANY_NAME_1 = "name1";
-  private static final String ANY_NAME_2 = "name2";
-  private static final String ANY_TEXT_1 = "text1";
-  private static final String ANY_TEXT_2 = "text2";
-  private static final String ANY_TX_ID = "tx_id";
-  @InjectMocks private CrudHandler handler;
-  @Mock private DistributedStorage storage;
-  @Mock private Snapshot snapshot;
-  @Mock private ParallelExecutor parallelExecutor;
-  @Mock private Scanner scanner;
-  @Mock private Result result;
-
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
-  }
-
-  private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    return new Scan(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
-  }
-
-  private void configureResult(Result mock, boolean hasClusteringKey, TransactionState state) {
-    when(mock.getPartitionKey()).thenReturn(Optional.of(new Key(ANY_NAME_1, ANY_TEXT_1)));
-    if (hasClusteringKey) {
-      when(mock.getClusteringKey()).thenReturn(Optional.of(new Key(ANY_NAME_2, ANY_TEXT_2)));
-    } else {
-      when(mock.getClusteringKey()).thenReturn(Optional.empty());
-    }
-
-    ImmutableMap<String, Value<?>> values =
-        ImmutableMap.<String, Value<?>>builder()
-            .put(Attribute.ID, Attribute.toIdValue(ANY_ID_2))
-            .put(Attribute.STATE, Attribute.toStateValue(state))
-            .put(Attribute.VERSION, Attribute.toVersionValue(2))
-            .put(Attribute.BEFORE_ID, Attribute.toBeforeIdValue(ANY_ID_1))
-            .put(Attribute.BEFORE_STATE, Attribute.toBeforeStateValue(TransactionState.COMMITTED))
-            .put(Attribute.BEFORE_VERSION, Attribute.toBeforeVersionValue(1))
-            .build();
-
-    when(mock.getValues()).thenReturn(values);
-  }
-
-  private TransactionResult prepareResult(boolean hasClusteringKey, TransactionState state) {
-    Result result = mock(Result.class);
-    configureResult(result, hasClusteringKey, state);
-    return new TransactionResult(result);
-  }
-
-  @Test
-  public void get_KeyExistsInSnapshot_ShouldReturnFromSnapshot() throws CrudException {
-    // Arrange
-    Get get = prepareGet();
-    Optional<TransactionResult> expected =
-        Optional.of(prepareResult(true, TransactionState.COMMITTED));
-    when(snapshot.containsKey(new Snapshot.Key(get))).thenReturn(true);
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(expected);
-
-    // Act
-    Optional<Result> actual = handler.get(get);
-
-    // Assert
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  public void
-      get_KeyNotExistsInSnapshotAndRecordInStorageCommitted_ShouldReturnFromStorageAndUpdateSnapshot()
-          throws CrudException, ExecutionException {
-    // Arrange
-    Get get = prepareGet();
-    Optional<Result> expected = Optional.of(prepareResult(true, TransactionState.COMMITTED));
-    when(snapshot.containsKey(new Snapshot.Key(get))).thenReturn(false);
-    doNothing()
-        .when(snapshot)
-        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-    when(storage.get(get)).thenReturn(expected);
-
-    // Act
-    Optional<Result> result = handler.get(get);
-
-    // Assert
-    assertThat(result).isEqualTo(expected);
-    verify(storage).get(get);
-    verify(snapshot).put(new Snapshot.Key(get), Optional.of((TransactionResult) expected.get()));
-  }
-
-  @Test
-  public void
-      get_KeyNotExistsInSnapshotAndRecordInStorageNotCommitted_ShouldThrowUncommittedRecordException()
-          throws ExecutionException {
-    // Arrange
-    Get get = prepareGet();
-    Optional<Result> expected = Optional.of(prepareResult(true, TransactionState.PREPARED));
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
-    when(storage.get(get)).thenReturn(expected);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.get(get)).isInstanceOf(UncommittedRecordException.class);
-  }
-
-  @Test
-  public void get_KeyNeitherExistsInSnapshotNorInStorage_ShouldReturnEmpty()
-      throws CrudException, ExecutionException {
-    // Arrange
-    Get get = prepareGet();
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
-    when(storage.get(get)).thenReturn(Optional.empty());
-
-    // Act
-    Optional<Result> result = handler.get(get);
-
-    // Assert
-    assertThat(result.isPresent()).isFalse();
-  }
-
-  @Test
-  public void get_KeyNotExistsInCrudSetAndExceptionThrownInStorage_ShouldThrowCrudException()
-      throws ExecutionException {
-    // Arrange
-    Get get = prepareGet();
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
-    ExecutionException toThrow = mock(ExecutionException.class);
-    when(storage.get(get)).thenThrow(toThrow);
-
-    // Act Assert
-    assertThatThrownBy(() -> handler.get(get)).isInstanceOf(CrudException.class).hasCause(toThrow);
-  }
-
-  @Test
-  public void scan_ResultGivenFromStorage_ShouldUpdateSnapshotAndReturn()
-      throws ExecutionException, CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(true, TransactionState.COMMITTED);
-    when(snapshot.get(any(Snapshot.Key.class))).thenReturn(Optional.empty());
-    doNothing()
-        .when(snapshot)
-        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    // doCallRealMethod().when(scanner).forEach(any(Consumer.class));
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act
-    List<Result> results = handler.scan(scan);
-
-    // Assert
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
-    TransactionResult expected = new TransactionResult(result);
-    verify(snapshot).put(key, Optional.of(expected));
-    assertThat(results.size()).isEqualTo(1);
-    assertThat(results.get(0)).isEqualTo(expected);
-  }
-
-  @Test
-  public void
-      scan_PreparedResultGivenFromStorage_ShouldNeverUpdateSnapshotThrowUncommittedRecordException()
-          throws ExecutionException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(false, TransactionState.PREPARED);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act
-    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(snapshot, never())
-        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-  }
-
-  @Test
-  public void scan_CalledTwice_SecondTimeShouldReturnTheSameFromSnapshot()
-      throws ExecutionException, CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(true, TransactionState.COMMITTED);
-    doNothing()
-        .when(snapshot)
-        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
-    when(snapshot.get(scan))
-        .thenReturn(Optional.empty())
-        .thenReturn(Optional.of(Collections.singletonList(key)));
-    when(snapshot.containsKey(key)).thenReturn(false).thenReturn(true);
-    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
-
-    // Act
-    List<Result> results1 = handler.scan(scan);
-    List<Result> results2 = handler.scan(scan);
-
-    // Assert
-    TransactionResult expected = new TransactionResult(result);
-    verify(snapshot).put(key, Optional.of(expected));
-    assertThat(results1.size()).isEqualTo(1);
-    assertThat(results1.get(0)).isEqualTo(expected);
-    assertThat(results1).isEqualTo(results2);
-  }
-
-  @Test
-  public void scan_CalledTwiceUnderRealSnapshot_SecondTimeShouldReturnTheSameFromSnapshot()
-      throws ExecutionException, CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(true, TransactionState.COMMITTED);
-    snapshot =
-        new Snapshot(
-            ANY_TX_ID,
-            Isolation.SNAPSHOT,
-            null,
-            parallelExecutor,
-            new HashMap<>(),
-            new HashMap<>(),
-            new HashMap<>(),
-            new HashMap<>());
-    handler = new CrudHandler(storage, snapshot);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act
-    List<Result> results1 = handler.scan(scan);
-    List<Result> results2 = handler.scan(scan);
-
-    // Assert
-    TransactionResult expected = new TransactionResult(result);
-    assertThat(results1.size()).isEqualTo(1);
-    assertThat(results1.get(0)).isEqualTo(expected);
-    assertThat(results1).isEqualTo(results2);
-  }
-
-  @Test
-  public void scan_GetCalledAfterScan_ShouldReturnFromSnapshot()
-      throws ExecutionException, CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(true, TransactionState.COMMITTED);
-    doNothing()
-        .when(snapshot)
-        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
-    when(snapshot.get(scan)).thenReturn(Optional.empty());
-    when(snapshot.containsKey(key)).thenReturn(false).thenReturn(true);
-    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
-
-    // Act
-    List<Result> results = handler.scan(scan);
-    Optional<Result> result = handler.get(prepareGet());
-
-    // Assert
-    verify(storage, never()).get(any(Get.class));
-    assertThat(results.get(0)).isEqualTo(result.get());
-  }
-
-  @Test
-  public void scan_GetCalledAfterScanUnderRealSnapshot_ShouldReturnFromSnapshot()
-      throws ExecutionException, CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    result = prepareResult(true, TransactionState.COMMITTED);
-    snapshot =
-        new Snapshot(
-            ANY_TX_ID,
-            Isolation.SNAPSHOT,
-            null,
-            parallelExecutor,
-            new HashMap<>(),
-            new HashMap<>(),
-            new HashMap<>(),
-            new HashMap<>());
-    handler = new CrudHandler(storage, snapshot);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act
-    List<Result> results = handler.scan(scan);
-    Optional<Result> result = handler.get(prepareGet());
-
-    // Assert
-    assertThat(results.get(0)).isEqualTo(result.get());
-  }
-}
+// package com.scalar.db.transaction.consensuscommit;
+//
+// import static org.assertj.core.api.Assertions.assertThatThrownBy;
+// import static org.assertj.core.api.Java6Assertions.assertThat;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.Mockito.doNothing;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+//
+// import com.google.common.collect.ImmutableMap;
+// import com.scalar.db.api.DistributedStorage;
+// import com.scalar.db.api.Get;
+// import com.scalar.db.api.Result;
+// import com.scalar.db.api.Scan;
+// import com.scalar.db.api.Scanner;
+// import com.scalar.db.api.TransactionState;
+// import com.scalar.db.exception.storage.ExecutionException;
+// import com.scalar.db.exception.transaction.CrudException;
+// import com.scalar.db.exception.transaction.UncommittedRecordException;
+// import com.scalar.db.io.Key;
+// import com.scalar.db.io.Value;
+// import java.util.Collections;
+// import java.util.HashMap;
+// import java.util.List;
+// import java.util.Optional;
+// import org.junit.Before;
+// import org.junit.Test;
+// import org.mockito.ArgumentMatchers;
+// import org.mockito.InjectMocks;
+// import org.mockito.Mock;
+// import org.mockito.MockitoAnnotations;
+//
+// public class CrudHandlerTest {
+//  private static final String ANY_KEYSPACE_NAME = "keyspace";
+//  private static final String ANY_TABLE_NAME = "table";
+//  private static final String ANY_ID_1 = "id1";
+//  private static final String ANY_ID_2 = "id2";
+//  private static final String ANY_NAME_1 = "name1";
+//  private static final String ANY_NAME_2 = "name2";
+//  private static final String ANY_TEXT_1 = "text1";
+//  private static final String ANY_TEXT_2 = "text2";
+//  private static final String ANY_TX_ID = "tx_id";
+//
+//  @Mock private Snapshot snapshot;
+//  @Mock private DistributedStorage storage;
+//  @Mock private ParallelExecutor parallelExecutor;
+//  @Mock private Scanner scanner;
+//  @Mock private Result result;
+//
+//  @InjectMocks private CrudHandler handler;
+//
+//  @Before
+//  public void setUp() throws Exception {
+//    MockitoAnnotations.openMocks(this).close();
+//  }
+//
+//  private Get prepareGet() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+//    return new Get(partitionKey, clusteringKey)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private Scan prepareScan() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    return new Scan(partitionKey).forNamespace(ANY_KEYSPACE_NAME).forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private void configureResult(Result mock, boolean hasClusteringKey, TransactionState state) {
+//    when(mock.getPartitionKey()).thenReturn(Optional.of(new Key(ANY_NAME_1, ANY_TEXT_1)));
+//    if (hasClusteringKey) {
+//      when(mock.getClusteringKey()).thenReturn(Optional.of(new Key(ANY_NAME_2, ANY_TEXT_2)));
+//    } else {
+//      when(mock.getClusteringKey()).thenReturn(Optional.empty());
+//    }
+//
+//    ImmutableMap<String, Value<?>> values =
+//        ImmutableMap.<String, Value<?>>builder()
+//            .put(Attribute.ID, Attribute.toIdValue(ANY_ID_2))
+//            .put(Attribute.STATE, Attribute.toStateValue(state))
+//            .put(Attribute.VERSION, Attribute.toVersionValue(2))
+//            .put(Attribute.BEFORE_ID, Attribute.toBeforeIdValue(ANY_ID_1))
+//            .put(Attribute.BEFORE_STATE, Attribute.toBeforeStateValue(TransactionState.COMMITTED))
+//            .put(Attribute.BEFORE_VERSION, Attribute.toBeforeVersionValue(1))
+//            .build();
+//
+//    when(mock.getValues()).thenReturn(values);
+//  }
+//
+//  private TransactionResult prepareResult(boolean hasClusteringKey, TransactionState state) {
+//    Result result = mock(Result.class);
+//    configureResult(result, hasClusteringKey, state);
+//    return new TransactionResult(result);
+//  }
+//
+//  @Test
+//  public void get_KeyExistsInSnapshot_ShouldReturnFromSnapshot() throws CrudException {
+//    // Arrange
+//    Get get = prepareGet();
+//    Optional<TransactionResult> expected =
+//        Optional.of(prepareResult(true, TransactionState.COMMITTED));
+//    when(snapshot.containsKey(new Snapshot.Key(get))).thenReturn(true);
+//    when(snapshot.get(new Snapshot.Key(get))).thenReturn(expected);
+//
+//    // Act
+//    Optional<Result> actual = handler.get(get);
+//
+//    // Assert
+//    assertThat(actual).isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void
+//
+// get_KeyNotExistsInSnapshotAndRecordInStorageCommitted_ShouldReturnFromStorageAndUpdateSnapshot()
+//          throws CrudException, ExecutionException {
+//    // Arrange
+//    Get get = prepareGet();
+//    Optional<Result> expected = Optional.of(prepareResult(true, TransactionState.COMMITTED));
+//    when(snapshot.containsKey(new Snapshot.Key(get))).thenReturn(false);
+//    doNothing()
+//        .when(snapshot)
+//        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+//    when(storage.get(get)).thenReturn(expected);
+//
+//    // Act
+//    Optional<Result> result = handler.get(get);
+//
+//    // Assert
+//    assertThat(result).isEqualTo(expected);
+//    verify(storage).get(get);
+//    verify(snapshot).put(new Snapshot.Key(get), Optional.of((TransactionResult) expected.get()));
+//  }
+//
+//  @Test
+//  public void
+//
+// get_KeyNotExistsInSnapshotAndRecordInStorageNotCommitted_ShouldThrowUncommittedRecordException()
+//          throws ExecutionException {
+//    // Arrange
+//    Get get = prepareGet();
+//    Optional<Result> expected = Optional.of(prepareResult(true, TransactionState.PREPARED));
+//    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
+//    when(storage.get(get)).thenReturn(expected);
+//
+//    // Act Assert
+//    assertThatThrownBy(() -> handler.get(get)).isInstanceOf(UncommittedRecordException.class);
+//  }
+//
+//  @Test
+//  public void get_KeyNeitherExistsInSnapshotNorInStorage_ShouldReturnEmpty()
+//      throws CrudException, ExecutionException {
+//    // Arrange
+//    Get get = prepareGet();
+//    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
+//    when(storage.get(get)).thenReturn(Optional.empty());
+//
+//    // Act
+//    Optional<Result> result = handler.get(get);
+//
+//    // Assert
+//    assertThat(result.isPresent()).isFalse();
+//  }
+//
+//  @Test
+//  public void get_KeyNotExistsInCrudSetAndExceptionThrownInStorage_ShouldThrowCrudException()
+//      throws ExecutionException {
+//    // Arrange
+//    Get get = prepareGet();
+//    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
+//    ExecutionException toThrow = mock(ExecutionException.class);
+//    when(storage.get(get)).thenThrow(toThrow);
+//
+//    // Act Assert
+//    assertThatThrownBy(() ->
+// handler.get(get)).isInstanceOf(CrudException.class).hasCause(toThrow);
+//  }
+//
+//  @Test
+//  public void scan_ResultGivenFromStorage_ShouldUpdateSnapshotAndReturn()
+//      throws ExecutionException, CrudException {
+//    // Arrange
+//    Scan scan = prepareScan();
+//    result = prepareResult(true, TransactionState.COMMITTED);
+//    when(snapshot.get(any(Snapshot.Key.class))).thenReturn(Optional.empty());
+//    doNothing()
+//        .when(snapshot)
+//        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+//    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+//    // doCallRealMethod().when(scanner).forEach(any(Consumer.class));
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act
+//    List<Result> results = handler.scan(scan);
+//
+//    // Assert
+//    Snapshot.Key key =
+//        new Snapshot.Key(
+//            scan.forNamespace().get(),
+//            scan.forTable().get(),
+//            scan.getPartitionKey(),
+//            result.getClusteringKey().get());
+//    TransactionResult expected = new TransactionResult(result);
+//    verify(snapshot).put(key, Optional.of(expected));
+//    assertThat(results.size()).isEqualTo(1);
+//    assertThat(results.get(0)).isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void
+//
+// scan_PreparedResultGivenFromStorage_ShouldNeverUpdateSnapshotThrowUncommittedRecordException()
+//          throws ExecutionException {
+//    // Arrange
+//    Scan scan = prepareScan();
+//    result = prepareResult(false, TransactionState.PREPARED);
+//    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act
+//    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(UncommittedRecordException.class);
+//
+//    // Assert
+//    verify(snapshot, never())
+//        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+//  }
+//
+//  @Test
+//  public void scan_CalledTwice_SecondTimeShouldReturnTheSameFromSnapshot()
+//      throws ExecutionException, CrudException {
+//    // Arrange
+//    Scan scan = prepareScan();
+//    result = prepareResult(true, TransactionState.COMMITTED);
+//    doNothing()
+//        .when(snapshot)
+//        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+//    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//    Snapshot.Key key =
+//        new Snapshot.Key(
+//            scan.forNamespace().get(),
+//            scan.forTable().get(),
+//            scan.getPartitionKey(),
+//            result.getClusteringKey().get());
+//    when(snapshot.get(scan))
+//        .thenReturn(Optional.empty())
+//        .thenReturn(Optional.of(Collections.singletonList(key)));
+//    when(snapshot.containsKey(key)).thenReturn(false).thenReturn(true);
+//    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
+//
+//    // Act
+//    List<Result> results1 = handler.scan(scan);
+//    List<Result> results2 = handler.scan(scan);
+//
+//    // Assert
+//    TransactionResult expected = new TransactionResult(result);
+//    verify(snapshot).put(key, Optional.of(expected));
+//    assertThat(results1.size()).isEqualTo(1);
+//    assertThat(results1.get(0)).isEqualTo(expected);
+//    assertThat(results1).isEqualTo(results2);
+//  }
+//
+//  @Test
+//  public void scan_CalledTwiceUnderRealSnapshot_SecondTimeShouldReturnTheSameFromSnapshot()
+//      throws ExecutionException, CrudException {
+//    // Arrange
+//    Scan scan = prepareScan();
+//    result = prepareResult(true, TransactionState.COMMITTED);
+//    snapshot =
+//        new Snapshot(
+//            ANY_TX_ID,
+//            Isolation.SNAPSHOT,
+//            null,
+//            parallelExecutor,
+//            new HashMap<>(),
+//            new HashMap<>(),
+//            new HashMap<>(),
+//            new HashMap<>());
+//    handler = new CrudHandler(storage, snapshot);
+//    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act
+//    List<Result> results1 = handler.scan(scan);
+//    List<Result> results2 = handler.scan(scan);
+//
+//    // Assert
+//    TransactionResult expected = new TransactionResult(result);
+//    assertThat(results1.size()).isEqualTo(1);
+//    assertThat(results1.get(0)).isEqualTo(expected);
+//    assertThat(results1).isEqualTo(results2);
+//  }
+//
+//  @Test
+//  public void scan_GetCalledAfterScan_ShouldReturnFromSnapshot()
+//      throws ExecutionException, CrudException {
+//    // Arrange
+//    Scan scan = prepareScan();
+//    result = prepareResult(true, TransactionState.COMMITTED);
+//    doNothing()
+//        .when(snapshot)
+//        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+//    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//    Snapshot.Key key =
+//        new Snapshot.Key(
+//            scan.forNamespace().get(),
+//            scan.forTable().get(),
+//            scan.getPartitionKey(),
+//            result.getClusteringKey().get());
+//    when(snapshot.get(scan)).thenReturn(Optional.empty());
+//    when(snapshot.containsKey(key)).thenReturn(false).thenReturn(true);
+//    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
+//
+//    // Act
+//    List<Result> results = handler.scan(scan);
+//    Optional<Result> result = handler.get(prepareGet());
+//
+//    // Assert
+//    verify(storage, never()).get(any(Get.class));
+//    assertThat(results.get(0)).isEqualTo(result.get());
+//  }
+//
+//  @Test
+//  public void scan_GetCalledAfterScanUnderRealSnapshot_ShouldReturnFromSnapshot()
+//      throws ExecutionException, CrudException {
+//    // Arrange
+//    Scan scan = prepareScan();
+//    result = prepareResult(true, TransactionState.COMMITTED);
+//    snapshot =
+//        new Snapshot(
+//            ANY_TX_ID,
+//            Isolation.SNAPSHOT,
+//            null,
+//            parallelExecutor,
+//            new HashMap<>(),
+//            new HashMap<>(),
+//            new HashMap<>(),
+//            new HashMap<>());
+//    handler = new CrudHandler(storage, snapshot);
+//    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act
+//    List<Result> results = handler.scan(scan);
+//    Optional<Result> result = handler.get(prepareGet());
+//
+//    // Assert
+//    assertThat(results.get(0)).isEqualTo(result.get());
+//  }
+// }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -1,949 +1,965 @@
-package com.scalar.db.transaction.consensuscommit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.google.common.collect.ImmutableMap;
-import com.scalar.db.api.Consistency;
-import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
-import com.scalar.db.api.Result;
-import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scanner;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.exception.transaction.CommitConflictException;
-import com.scalar.db.io.Key;
-import com.scalar.db.io.TextValue;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-public class SnapshotTest {
-  private static final String ANY_KEYSPACE_NAME = "keyspace";
-  private static final String ANY_TABLE_NAME = "table";
-  private static final String ANY_ID = "id";
-  private static final String ANY_NAME_1 = "name1";
-  private static final String ANY_NAME_2 = "name2";
-  private static final String ANY_NAME_3 = "name3";
-  private static final String ANY_NAME_4 = "name4";
-  private static final String ANY_NAME_5 = "name5";
-  private static final String ANY_NAME_6 = "name6";
-  private static final String ANY_TEXT_1 = "text1";
-  private static final String ANY_TEXT_2 = "text2";
-  private static final String ANY_TEXT_3 = "text3";
-  private static final String ANY_TEXT_4 = "text4";
-  private static final String ANY_TEXT_5 = "text5";
-  private static final String ANY_TEXT_6 = "text6";
-  private Snapshot snapshot;
-  private Map<Snapshot.Key, Optional<TransactionResult>> readSet;
-  private Map<Scan, List<Snapshot.Key>> scanSet;
-  private Map<Snapshot.Key, Put> writeSet;
-  private Map<Snapshot.Key, Delete> deleteSet;
-
-  @Mock private ConsensusCommitConfig config;
-  @Mock private PrepareMutationComposer prepareComposer;
-  @Mock private CommitMutationComposer commitComposer;
-  @Mock private RollbackMutationComposer rollbackComposer;
-  @Mock private TransactionResult result;
-
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
-  }
-
-  private Snapshot prepareSnapshot(Isolation isolation) {
-    return prepareSnapshot(isolation, SerializableStrategy.EXTRA_WRITE);
-  }
-
-  private Snapshot prepareSnapshot(Isolation isolation, SerializableStrategy strategy) {
-    readSet = new ConcurrentHashMap<>();
-    scanSet = new ConcurrentHashMap<>();
-    writeSet = new ConcurrentHashMap<>();
-    deleteSet = new ConcurrentHashMap<>();
-
-    return spy(
-        new Snapshot(
-            ANY_ID,
-            isolation,
-            strategy,
-            new ParallelExecutor(config),
-            readSet,
-            scanSet,
-            writeSet,
-            deleteSet));
-  }
-
-  private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Get prepareAnotherGet() {
-    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
-    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
-    return new Get(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Scan prepareScan() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Scan(partitionKey)
-        .withStart(clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_TEXT_3)
-        .withValue(ANY_NAME_4, ANY_TEXT_4);
-  }
-
-  private Put prepareAnotherPut() {
-    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
-    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
-    return new Put(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Put preparePutWithPartitionKeyOnly() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    return new Put(partitionKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_TEXT_3)
-        .withValue(ANY_NAME_4, ANY_TEXT_4);
-  }
-
-  private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Delete prepareAnotherDelete() {
-    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
-    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
-    return new Delete(partitionKey, clusteringKey)
-        .withConsistency(Consistency.LINEARIZABLE)
-        .forNamespace(ANY_KEYSPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private void configureBehavior() {
-    doNothing().when(prepareComposer).add(any(Put.class), any(TransactionResult.class));
-    doNothing().when(prepareComposer).add(any(Delete.class), any(TransactionResult.class));
-    doNothing().when(commitComposer).add(any(Put.class), any(TransactionResult.class));
-    doNothing().when(commitComposer).add(any(Delete.class), any(TransactionResult.class));
-    doNothing().when(rollbackComposer).add(any(Put.class), any(TransactionResult.class));
-    doNothing().when(rollbackComposer).add(any(Delete.class), any(TransactionResult.class));
-  }
-
-  @Test
-  public void put_ResultGiven_ShouldHoldWhatsGivenInReadSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
-
-    // Act
-    snapshot.put(key, Optional.of(result));
-
-    // Assert
-    assertThat(readSet.get(key)).isEqualTo(Optional.of(result));
-  }
-
-  @Test
-  public void put_PutGiven_ShouldHoldWhatsGivenInWriteSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Snapshot.Key key = new Snapshot.Key(put);
-
-    // Act
-    snapshot.put(key, put);
-
-    // Assert
-    assertThat(writeSet.get(key)).isEqualTo(put);
-  }
-
-  @Test
-  public void put_DeleteGiven_ShouldHoldWhatsGivenInDeleteSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Delete delete = prepareDelete();
-    Snapshot.Key key = new Snapshot.Key(delete);
-
-    // Act
-    snapshot.put(key, delete);
-
-    // Assert
-    assertThat(deleteSet.get(key)).isEqualTo(delete);
-  }
-
-  @Test
-  public void put_ScanGiven_ShouldHoldWhatsGivenInScanSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Scan scan = prepareScan();
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            scan.getStartClusteringKey().get());
-    List<Snapshot.Key> expected = Collections.singletonList(key);
-
-    // Act
-    snapshot.put(scan, expected);
-
-    // Assert
-    assertThat(scanSet.get(scan)).isEqualTo(expected);
-  }
-
-  @Test
-  public void get_KeyGivenContainedInWriteSet_ShouldReturnFromWriteSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
-    snapshot.put(key, Optional.of(result));
-    snapshot.put(key, put);
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.get(key)).isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void get_KeyGivenContainedInReadSet_ShouldReturnFromReadSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
-    snapshot.put(key, Optional.of(result));
-
-    // Act
-    Optional<TransactionResult> actual = snapshot.get(key);
-
-    // Assert
-    assertThat(actual).isEqualTo(Optional.of(result));
-  }
-
-  @Test
-  public void get_KeyGivenNotContainedInSnapshot_ShouldReturnEmpty() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
-
-    // Act
-    Optional<TransactionResult> result = snapshot.get(key);
-
-    // Assert
-    assertThat(result.isPresent()).isFalse();
-  }
-
-  @Test
-  public void get_ScanNotContainedInSnapshotGiven_ShouldReturnEmptyList() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Scan scan = prepareScan();
-
-    // Act
-    Optional<List<Snapshot.Key>> keys = snapshot.get(scan);
-
-    // Assert
-    assertThat(keys.isPresent()).isFalse();
-  }
-
-  @Test
-  public void to_PrepareMutationComposerGivenAndSnapshotIsolationSet_ShouldCallComposerProperly()
-      throws CommitConflictException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Delete delete = prepareAnotherDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
-    configureBehavior();
-
-    // Act
-    snapshot.to(prepareComposer);
-
-    // Assert
-    verify(prepareComposer).add(put, result);
-    verify(prepareComposer).add(delete, result);
-  }
-
-  @Test
-  public void
-      to_PrepareMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
-          throws CommitConflictException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Put put = preparePut();
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    configureBehavior();
-
-    // Act
-    snapshot.to(prepareComposer);
-
-    // Assert
-    Put putFromGet = prepareAnotherPut();
-    verify(prepareComposer).add(put, result);
-    verify(prepareComposer).add(putFromGet, result);
-    verify(snapshot).toSerializableWithExtraWrite(prepareComposer);
-  }
-
-  @Test
-  public void to_CommitMutationComposerGiven_ShouldCallComposerProperly()
-      throws CommitConflictException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Delete delete = prepareAnotherDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
-
-    // Act
-    snapshot.to(commitComposer);
-
-    // Assert
-    verify(commitComposer).add(put, result);
-    verify(commitComposer).add(delete, result);
-  }
-
-  @Test
-  public void
-      to_CommitMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
-          throws CommitConflictException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Put put = preparePut();
-    Delete delete = prepareAnotherDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
-    configureBehavior();
-
-    // Act
-    snapshot.to(commitComposer);
-
-    // Assert
-    // no effect on CommitMutationComposer
-    verify(commitComposer).add(put, result);
-    verify(commitComposer).add(delete, result);
-    verify(snapshot).toSerializableWithExtraWrite(commitComposer);
-  }
-
-  @Test
-  public void to_RollbackMutationComposerGiven_ShouldCallComposerProperly()
-      throws CommitConflictException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Delete delete = prepareAnotherDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
-    configureBehavior();
-
-    // Act
-    snapshot.to(rollbackComposer);
-
-    // Assert
-    verify(rollbackComposer).add(put, result);
-    verify(rollbackComposer).add(delete, result);
-  }
-
-  @Test
-  public void
-      to_RollbackMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
-          throws CommitConflictException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Put put = preparePut();
-    Delete delete = prepareAnotherDelete();
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
-    configureBehavior();
-
-    // Act
-    snapshot.to(rollbackComposer);
-
-    // Assert
-    // no effect on RollbackMutationComposer
-    verify(rollbackComposer).add(put, result);
-    verify(rollbackComposer).add(delete, result);
-    verify(snapshot).toSerializableWithExtraWrite(rollbackComposer);
-  }
-
-  @Test
-  public void
-      toSerializableWithExtraWrite_UnmutatedReadSetExists_ShouldConvertReadSetIntoWriteSet() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Get get = prepareAnotherGet();
-    Put put = preparePut();
-    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)));
-    TransactionResult txResult = new TransactionResult(result);
-    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(new Snapshot.Key(put), put);
-
-    // Act Assert
-    assertThatCode(() -> snapshot.toSerializableWithExtraWrite(prepareComposer))
-        .doesNotThrowAnyException();
-
-    // Assert
-    Put expected =
-        new Put(get.getPartitionKey(), get.getClusteringKey().get())
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(get.forNamespace().get())
-            .forTable(get.forTable().get());
-    assertThat(writeSet).contains(entry(new Snapshot.Key(get), expected));
-    assertThat(writeSet.size()).isEqualTo(2);
-    verify(prepareComposer, never()).add(any(), any());
-  }
-
-  @Test
-  public void
-      toSerializableWithExtraWrite_UnmutatedReadSetForNonExistingExists_ShouldThrowCommitConflictException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Get get = prepareAnotherGet();
-    Put put = preparePut();
-    snapshot.put(new Snapshot.Key(get), Optional.empty());
-    snapshot.put(new Snapshot.Key(put), put);
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.toSerializableWithExtraWrite(prepareComposer));
-
-    // Assert
-    assertThat(thrown).doesNotThrowAnyException();
-    Get expected =
-        new Get(get.getPartitionKey(), get.getClusteringKey().get())
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(get.forNamespace().get())
-            .forTable(get.forTable().get());
-    verify(prepareComposer).add(expected, null);
-  }
-
-  @Test
-  public void
-      toSerializableWithExtraWrite_ScanSetAndWriteSetExist_ShouldThrowCommitConflictException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Scan scan = prepareScan();
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            scan.getStartClusteringKey().get());
-    Put put = preparePut();
-    snapshot.put(scan, Collections.singletonList(key));
-    snapshot.put(new Snapshot.Key(put), put);
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.toSerializableWithExtraWrite(prepareComposer));
-
-    // Assert
-    assertThat(thrown).isInstanceOf(CommitConflictException.class);
-  }
-
-  @Test
-  public void toSerializableWithExtraRead_ReadSetNotChanged_ShouldProcessWithoutExceptions()
-      throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    Get get = prepareAnotherGet();
-    Put put = preparePut();
-    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)));
-    TransactionResult txResult = new TransactionResult(result);
-    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(new Snapshot.Key(put), put);
-    DistributedStorage storage = mock(DistributedStorage.class);
-    when(storage.get(get)).thenReturn(Optional.of(txResult));
-
-    // Act Assert
-    assertThatCode(() -> snapshot.toSerializableWithExtraRead(storage)).doesNotThrowAnyException();
-
-    // Assert
-    verify(storage).get(get);
-  }
-
-  @Test
-  public void toSerializableWithExtraRead_ReadSetUpdated_ShouldThrowCommitConflictException()
-      throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    Get get = prepareAnotherGet();
-    Put put = preparePut();
-    when(result.getValues())
-        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)))
-        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID + "x")));
-    TransactionResult txResult = new TransactionResult(result);
-    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(new Snapshot.Key(put), put);
-    DistributedStorage storage = mock(DistributedStorage.class);
-    TransactionResult changedTxResult = new TransactionResult(result);
-    when(storage.get(get)).thenReturn(Optional.of(changedTxResult));
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
-        .isInstanceOf(CommitConflictException.class);
-
-    // Assert
-    verify(storage).get(get);
-  }
-
-  @Test
-  public void toSerializableWithExtraRead_ReadSetExtended_ShouldThrowCommitConflictException()
-      throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    Get get = prepareAnotherGet();
-    Put put = preparePut();
-    snapshot.put(new Snapshot.Key(get), Optional.empty());
-    snapshot.put(new Snapshot.Key(put), put);
-    DistributedStorage storage = mock(DistributedStorage.class);
-    when(result.getValues()).thenReturn(ImmutableMap.of());
-    TransactionResult txResult = new TransactionResult(result);
-    when(storage.get(get)).thenReturn(Optional.of(txResult));
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
-        .isInstanceOf(CommitConflictException.class);
-
-    // Assert
-    verify(storage).get(get);
-  }
-
-  @Test
-  public void toSerializableWithExtraRead_ScanSetNotChanged_ShouldProcessWithoutExceptions()
-      throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    Scan scan = prepareScan();
-    Get get = prepareGet();
-    Put put = preparePut();
-    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)));
-    TransactionResult txResult = new TransactionResult(result);
-    Snapshot.Key key = new Snapshot.Key(get);
-    snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonList(key));
-    snapshot.put(new Snapshot.Key(put), put);
-    DistributedStorage storage = mock(DistributedStorage.class);
-    Scanner scanner = mock(Scanner.class);
-    when(scanner.iterator()).thenReturn(Collections.singletonList((Result) txResult).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act Assert
-    assertThatCode(() -> snapshot.toSerializableWithExtraRead(storage)).doesNotThrowAnyException();
-
-    // Assert
-    verify(storage).scan(scan);
-  }
-
-  @Test
-  public void toSerializableWithExtraRead_ScanSetUpdated_ShouldProcessWithoutExceptions()
-      throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    Scan scan = prepareScan();
-    Get get = prepareGet();
-    Put put = preparePut();
-    when(result.getValues())
-        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)))
-        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID + "x")));
-    TransactionResult txResult = new TransactionResult(result);
-    Snapshot.Key key = new Snapshot.Key(get);
-    snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonList(key));
-    snapshot.put(new Snapshot.Key(put), put);
-    DistributedStorage storage = mock(DistributedStorage.class);
-    TransactionResult changedTxResult = new TransactionResult(result);
-    Scanner scanner = mock(Scanner.class);
-    when(scanner.iterator())
-        .thenReturn(Collections.singletonList((Result) changedTxResult).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
-        .isInstanceOf(CommitConflictException.class);
-
-    // Assert
-    verify(storage).scan(scan);
-  }
-
-  @Test
-  public void toSerializableWithExtraRead_ScanSetExtended_ShouldProcessWithoutExceptions()
-      throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    Scan scan = prepareScan();
-    Put put = preparePut();
-    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID + "x")));
-    snapshot.put(scan, Collections.emptyList());
-    snapshot.put(new Snapshot.Key(put), put);
-    DistributedStorage storage = mock(DistributedStorage.class);
-    TransactionResult txResult = new TransactionResult(result);
-    Scanner scanner = mock(Scanner.class);
-    when(scanner.iterator()).thenReturn(Collections.singletonList((Result) txResult).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
-        .isInstanceOf(CommitConflictException.class);
-
-    // Assert
-    verify(storage).scan(scan);
-  }
-
-  @Test
-  public void
-      toSerializableWithExtraRead_MultipleScansInScanSetExist_ShouldThrowCommitConflictException()
-          throws ExecutionException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-
-    Scan scan1 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-    Scan scan2 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_2))
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1))
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-
-    Snapshot.Key key1 =
-        new Snapshot.Key(
-            scan1.forNamespace().get(),
-            scan1.forTable().get(),
-            scan1.getPartitionKey(),
-            scan1.getStartClusteringKey().get());
-    Snapshot.Key key2 =
-        new Snapshot.Key(
-            scan2.forNamespace().get(),
-            scan2.forTable().get(),
-            scan2.getPartitionKey(),
-            scan2.getStartClusteringKey().get());
-
-    Result result1 = mock(TransactionResult.class);
-    when(result1.getValues())
-        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(Attribute.ID, "id1")));
-    Result result2 = mock(TransactionResult.class);
-    when(result2.getValues())
-        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(Attribute.ID, "id2")));
-
-    snapshot.put(scan1, Collections.singletonList(key1));
-    snapshot.put(scan2, Collections.singletonList(key2));
-    snapshot.put(key1, Optional.of(new TransactionResult(result1)));
-    snapshot.put(key2, Optional.of(new TransactionResult(result2)));
-
-    DistributedStorage storage = mock(DistributedStorage.class);
-
-    Scanner scanner1 = mock(Scanner.class);
-    when(scanner1.iterator()).thenReturn(Collections.singletonList(result1).iterator());
-    when(storage.scan(scan1)).thenReturn(scanner1);
-
-    Scanner scanner2 = mock(Scanner.class);
-    when(scanner2.iterator()).thenReturn(Collections.singletonList(result2).iterator());
-    when(storage.scan(scan2)).thenReturn(scanner2);
-
-    // Act Assert
-    assertThatCode(() -> snapshot.toSerializableWithExtraRead(storage)).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void put_PutGivenAfterDelete_PutSupercedesDelete() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key getKey = new Snapshot.Key(prepareGet());
-    snapshot.put(getKey, Optional.of(result));
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(preparePut());
-    snapshot.put(putKey, put);
-
-    // Act
-    Delete delete = prepareDelete();
-    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
-    snapshot.put(deleteKey, delete);
-
-    // Assert
-    assertThat(readSet.size()).isEqualTo(1);
-    assertThat(readSet.get(getKey)).isEqualTo(Optional.of(result));
-    assertThat(writeSet.size()).isEqualTo(0);
-    assertThat(deleteSet.size()).isEqualTo(1);
-    assertThat(deleteSet.get(deleteKey)).isEqualTo(delete);
-  }
-
-  @Test
-  public void put_DeleteGivenAfterPut_DeleteSupercedesPut() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key getKey = new Snapshot.Key(prepareGet());
-    snapshot.put(getKey, Optional.of(result));
-    Delete delete = prepareDelete();
-    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
-    snapshot.put(deleteKey, delete);
-
-    // Act
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(preparePut());
-    snapshot.put(putKey, put);
-
-    // Assert
-    assertThat(readSet.size()).isEqualTo(1);
-    assertThat(readSet.get(getKey)).isEqualTo(Optional.of(result));
-    assertThat(deleteSet.size()).isEqualTo(0);
-    assertThat(writeSet.size()).isEqualTo(1);
-    assertThat(writeSet.get(putKey)).isEqualTo(put);
-  }
-
-  @Test
-  public void get_ScanGivenAndPutInWriteSetNotOverlappedWithScan_ShouldNotThrowException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // ["text3", "text4"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_3), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_4), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
-
-    // Assert
-    assertThat(thrown).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void
-      get_ScanGivenAndPutWithSamePartitionKeyWithoutClusteringKeyInWriteSet_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePutWithPartitionKeyOnly();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan = prepareScan();
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
-
-    // Assert
-    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      get_ScanWithNoRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // (-infinite, infinite)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
-
-    // Assert
-    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      get_ScanWithRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan1 =
-        prepareScan()
-            // ["text1", "text3"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
-    Scan scan2 =
-        prepareScan()
-            // ["text2", "text3"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
-    Scan scan3 =
-        prepareScan()
-            // ["text1", "text2"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true);
-    Scan scan4 =
-        prepareScan()
-            // ("text2", "text3"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
-    Scan scan5 =
-        prepareScan()
-            // ["text1", "text2")
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
-
-    // Act Assert
-    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
-    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
-    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
-    Throwable thrown4 = catchThrowable(() -> snapshot.get(scan4));
-    Throwable thrown5 = catchThrowable(() -> snapshot.get(scan5));
-
-    // Assert
-    assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown3).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown4).doesNotThrowAnyException();
-    assertThat(thrown5).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void
-      get_ScanWithEndSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan1 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // (-infinite, "text3"]
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-    Scan scan2 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // (-infinite, "text2"]
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-    Scan scan3 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // (-infinite, "text2")
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-
-    // Act Assert
-    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
-    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
-    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
-
-    // Assert
-    assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown3).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void
-      get_ScanWithStartSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan1 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // ["text1", infinite)
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-    Scan scan2 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // ["text2", infinite)
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-    Scan scan3 =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // ("text2", infinite)
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_KEYSPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-
-    // Act Assert
-    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
-    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
-    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
-
-    // Assert
-    assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
-    assertThat(thrown3).doesNotThrowAnyException();
-  }
-}
+// package com.scalar.db.transaction.consensuscommit;
+//
+// import static org.assertj.core.api.Assertions.assertThat;
+// import static org.assertj.core.api.Assertions.assertThatCode;
+// import static org.assertj.core.api.Assertions.assertThatThrownBy;
+// import static org.assertj.core.api.Assertions.catchThrowable;
+// import static org.assertj.core.api.Assertions.entry;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.Mockito.doNothing;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.spy;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+//
+// import com.google.common.collect.ImmutableMap;
+// import com.scalar.db.api.Consistency;
+// import com.scalar.db.api.Delete;
+// import com.scalar.db.api.DistributedStorage;
+// import com.scalar.db.api.Get;
+// import com.scalar.db.api.Put;
+// import com.scalar.db.api.Result;
+// import com.scalar.db.api.Scan;
+// import com.scalar.db.api.Scanner;
+// import com.scalar.db.exception.storage.ExecutionException;
+// import com.scalar.db.exception.transaction.CommitConflictException;
+// import com.scalar.db.io.Key;
+// import com.scalar.db.io.TextValue;
+// import java.util.Collections;
+// import java.util.List;
+// import java.util.Map;
+// import java.util.Optional;
+// import java.util.concurrent.ConcurrentHashMap;
+// import org.junit.Before;
+// import org.junit.Test;
+// import org.mockito.Mock;
+// import org.mockito.MockitoAnnotations;
+//
+// public class SnapshotTest {
+//  private static final String ANY_KEYSPACE_NAME = "keyspace";
+//  private static final String ANY_TABLE_NAME = "table";
+//  private static final String ANY_ID = "id";
+//  private static final String ANY_NAME_1 = "name1";
+//  private static final String ANY_NAME_2 = "name2";
+//  private static final String ANY_NAME_3 = "name3";
+//  private static final String ANY_NAME_4 = "name4";
+//  private static final String ANY_NAME_5 = "name5";
+//  private static final String ANY_NAME_6 = "name6";
+//  private static final String ANY_TEXT_1 = "text1";
+//  private static final String ANY_TEXT_2 = "text2";
+//  private static final String ANY_TEXT_3 = "text3";
+//  private static final String ANY_TEXT_4 = "text4";
+//  private static final String ANY_TEXT_5 = "text5";
+//  private static final String ANY_TEXT_6 = "text6";
+//  private Snapshot snapshot;
+//  private Map<Snapshot.Key, Optional<TransactionResult>> readSet;
+//  private Map<Scan, List<Snapshot.Key>> scanSet;
+//  private Map<Snapshot.Key, Put> writeSet;
+//  private Map<Snapshot.Key, Delete> deleteSet;
+//
+//  @Mock private ConsensusCommitConfig config;
+//  @Mock private PrepareMutationComposer prepareComposer;
+//  @Mock private CommitMutationComposer commitComposer;
+//  @Mock private RollbackMutationComposer rollbackComposer;
+//  @Mock private TransactionResult result;
+//
+//  @Before
+//  public void setUp() throws Exception {
+//    MockitoAnnotations.openMocks(this).close();
+//  }
+//
+//  private Snapshot prepareSnapshot(Isolation isolation) {
+//    return prepareSnapshot(isolation, SerializableStrategy.EXTRA_WRITE);
+//  }
+//
+//  private Snapshot prepareSnapshot(Isolation isolation, SerializableStrategy strategy) {
+//    readSet = new ConcurrentHashMap<>();
+//    scanSet = new ConcurrentHashMap<>();
+//    writeSet = new ConcurrentHashMap<>();
+//    deleteSet = new ConcurrentHashMap<>();
+//
+//    return spy(
+//        new Snapshot(
+//            ANY_ID,
+//            isolation,
+//            strategy,
+//            new ParallelExecutor(config),
+//            readSet,
+//            scanSet,
+//            writeSet,
+//            deleteSet));
+//  }
+//
+//  private Get prepareGet() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+//    return new Get(partitionKey, clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private Get prepareAnotherGet() {
+//    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
+//    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
+//    return new Get(partitionKey, clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private Scan prepareScan() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+//    return new Scan(partitionKey)
+//        .withStart(clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private Put preparePut() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+//    return new Put(partitionKey, clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME)
+//        .withValue(ANY_NAME_3, ANY_TEXT_3)
+//        .withValue(ANY_NAME_4, ANY_TEXT_4);
+//  }
+//
+//  private Put prepareAnotherPut() {
+//    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
+//    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
+//    return new Put(partitionKey, clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private Put preparePutWithPartitionKeyOnly() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    return new Put(partitionKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME)
+//        .withValue(ANY_NAME_3, ANY_TEXT_3)
+//        .withValue(ANY_NAME_4, ANY_TEXT_4);
+//  }
+//
+//  private Delete prepareDelete() {
+//    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
+//    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+//    return new Delete(partitionKey, clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private Delete prepareAnotherDelete() {
+//    Key partitionKey = new Key(ANY_NAME_5, ANY_TEXT_5);
+//    Key clusteringKey = new Key(ANY_NAME_6, ANY_TEXT_6);
+//    return new Delete(partitionKey, clusteringKey)
+//        .withConsistency(Consistency.LINEARIZABLE)
+//        .forNamespace(ANY_KEYSPACE_NAME)
+//        .forTable(ANY_TABLE_NAME);
+//  }
+//
+//  private void configureBehavior() {
+//    doNothing().when(prepareComposer).add(any(Put.class), any(TransactionResult.class));
+//    doNothing().when(prepareComposer).add(any(Delete.class), any(TransactionResult.class));
+//    doNothing().when(commitComposer).add(any(Put.class), any(TransactionResult.class));
+//    doNothing().when(commitComposer).add(any(Delete.class), any(TransactionResult.class));
+//    doNothing().when(rollbackComposer).add(any(Put.class), any(TransactionResult.class));
+//    doNothing().when(rollbackComposer).add(any(Delete.class), any(TransactionResult.class));
+//  }
+//
+//  @Test
+//  public void put_ResultGiven_ShouldHoldWhatsGivenInReadSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Snapshot.Key key = new Snapshot.Key(prepareGet());
+//
+//    // Act
+//    snapshot.put(key, Optional.of(result));
+//
+//    // Assert
+//    assertThat(readSet.get(key)).isEqualTo(Optional.of(result));
+//  }
+//
+//  @Test
+//  public void put_PutGiven_ShouldHoldWhatsGivenInWriteSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Put put = preparePut();
+//    Snapshot.Key key = new Snapshot.Key(put);
+//
+//    // Act
+//    snapshot.put(key, put);
+//
+//    // Assert
+//    assertThat(writeSet.get(key)).isEqualTo(put);
+//  }
+//
+//  @Test
+//  public void put_DeleteGiven_ShouldHoldWhatsGivenInDeleteSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Delete delete = prepareDelete();
+//    Snapshot.Key key = new Snapshot.Key(delete);
+//
+//    // Act
+//    snapshot.put(key, delete);
+//
+//    // Assert
+//    assertThat(deleteSet.get(key)).isEqualTo(delete);
+//  }
+//
+//  @Test
+//  public void put_ScanGiven_ShouldHoldWhatsGivenInScanSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Scan scan = prepareScan();
+//    Snapshot.Key key =
+//        new Snapshot.Key(
+//            scan.forNamespace().get(),
+//            scan.forTable().get(),
+//            scan.getPartitionKey(),
+//            scan.getStartClusteringKey().get());
+//    List<Snapshot.Key> expected = Collections.singletonList(key);
+//
+//    // Act
+//    snapshot.put(scan, expected);
+//
+//    // Assert
+//    assertThat(scanSet.get(scan)).isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void get_KeyGivenContainedInWriteSet_ShouldReturnFromWriteSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Put put = preparePut();
+//    Snapshot.Key key = new Snapshot.Key(prepareGet());
+//    snapshot.put(key, Optional.of(result));
+//    snapshot.put(key, put);
+//
+//    // Act Assert
+//    assertThatThrownBy(() -> snapshot.get(key)).isInstanceOf(IllegalArgumentException.class);
+//  }
+//
+//  @Test
+//  public void get_KeyGivenContainedInReadSet_ShouldReturnFromReadSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Snapshot.Key key = new Snapshot.Key(prepareGet());
+//    snapshot.put(key, Optional.of(result));
+//
+//    // Act
+//    Optional<TransactionResult> actual = snapshot.get(key);
+//
+//    // Assert
+//    assertThat(actual).isEqualTo(Optional.of(result));
+//  }
+//
+//  @Test
+//  public void get_KeyGivenNotContainedInSnapshot_ShouldReturnEmpty() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Snapshot.Key key = new Snapshot.Key(prepareGet());
+//
+//    // Act
+//    Optional<TransactionResult> result = snapshot.get(key);
+//
+//    // Assert
+//    assertThat(result.isPresent()).isFalse();
+//  }
+//
+//  @Test
+//  public void get_ScanNotContainedInSnapshotGiven_ShouldReturnEmptyList() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Scan scan = prepareScan();
+//
+//    // Act
+//    Optional<List<Snapshot.Key>> keys = snapshot.get(scan);
+//
+//    // Assert
+//    assertThat(keys.isPresent()).isFalse();
+//  }
+//
+//  @Test
+//  public void to_PrepareMutationComposerGivenAndSnapshotIsolationSet_ShouldCallComposerProperly()
+//      throws CommitConflictException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Put put = preparePut();
+//    Delete delete = prepareAnotherDelete();
+//    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    snapshot.put(new Snapshot.Key(delete), delete);
+//    configureBehavior();
+//
+//    // Act
+//    snapshot.to(prepareComposer);
+//
+//    // Assert
+//    verify(prepareComposer).add(put, result);
+//    verify(prepareComposer).add(delete, result);
+//  }
+//
+//  @Test
+//  public void
+//
+// to_PrepareMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
+//          throws CommitConflictException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+//    Put put = preparePut();
+//    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    configureBehavior();
+//
+//    // Act
+//    snapshot.to(prepareComposer);
+//
+//    // Assert
+//    Put putFromGet = prepareAnotherPut();
+//    verify(prepareComposer).add(put, result);
+//    verify(prepareComposer).add(putFromGet, result);
+//    verify(snapshot).toSerializableWithExtraWrite(prepareComposer);
+//  }
+//
+//  @Test
+//  public void to_CommitMutationComposerGiven_ShouldCallComposerProperly()
+//      throws CommitConflictException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Put put = preparePut();
+//    Delete delete = prepareAnotherDelete();
+//    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    snapshot.put(new Snapshot.Key(delete), delete);
+//
+//    // Act
+//    snapshot.to(commitComposer);
+//
+//    // Assert
+//    verify(commitComposer).add(put, result);
+//    verify(commitComposer).add(delete, result);
+//  }
+//
+//  @Test
+//  public void
+//
+// to_CommitMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
+//          throws CommitConflictException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+//    Put put = preparePut();
+//    Delete delete = prepareAnotherDelete();
+//    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    snapshot.put(new Snapshot.Key(delete), delete);
+//    configureBehavior();
+//
+//    // Act
+//    snapshot.to(commitComposer);
+//
+//    // Assert
+//    // no effect on CommitMutationComposer
+//    verify(commitComposer).add(put, result);
+//    verify(commitComposer).add(delete, result);
+//    verify(snapshot).toSerializableWithExtraWrite(commitComposer);
+//  }
+//
+//  @Test
+//  public void to_RollbackMutationComposerGiven_ShouldCallComposerProperly()
+//      throws CommitConflictException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Put put = preparePut();
+//    Delete delete = prepareAnotherDelete();
+//    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    snapshot.put(new Snapshot.Key(delete), delete);
+//    configureBehavior();
+//
+//    // Act
+//    snapshot.to(rollbackComposer);
+//
+//    // Assert
+//    verify(rollbackComposer).add(put, result);
+//    verify(rollbackComposer).add(delete, result);
+//  }
+//
+//  @Test
+//  public void
+//
+// to_RollbackMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
+//          throws CommitConflictException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+//    Put put = preparePut();
+//    Delete delete = prepareAnotherDelete();
+//    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    snapshot.put(new Snapshot.Key(delete), delete);
+//    configureBehavior();
+//
+//    // Act
+//    snapshot.to(rollbackComposer);
+//
+//    // Assert
+//    // no effect on RollbackMutationComposer
+//    verify(rollbackComposer).add(put, result);
+//    verify(rollbackComposer).add(delete, result);
+//    verify(snapshot).toSerializableWithExtraWrite(rollbackComposer);
+//  }
+//
+//  @Test
+//  public void
+//      toSerializableWithExtraWrite_UnmutatedReadSetExists_ShouldConvertReadSetIntoWriteSet() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+//    Get get = prepareAnotherGet();
+//    Put put = preparePut();
+//    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)));
+//    TransactionResult txResult = new TransactionResult(result);
+//    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
+//    snapshot.put(new Snapshot.Key(put), put);
+//
+//    // Act Assert
+//    assertThatCode(() -> snapshot.toSerializableWithExtraWrite(prepareComposer))
+//        .doesNotThrowAnyException();
+//
+//    // Assert
+//    Put expected =
+//        new Put(get.getPartitionKey(), get.getClusteringKey().get())
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(get.forNamespace().get())
+//            .forTable(get.forTable().get());
+//    assertThat(writeSet).contains(entry(new Snapshot.Key(get), expected));
+//    assertThat(writeSet.size()).isEqualTo(2);
+//    verify(prepareComposer, never()).add(any(), any());
+//  }
+//
+//  @Test
+//  public void
+//
+// toSerializableWithExtraWrite_UnmutatedReadSetForNonExistingExists_ShouldThrowCommitConflictException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+//    Get get = prepareAnotherGet();
+//    Put put = preparePut();
+//    snapshot.put(new Snapshot.Key(get), Optional.empty());
+//    snapshot.put(new Snapshot.Key(put), put);
+//
+//    // Act Assert
+//    Throwable thrown = catchThrowable(() ->
+// snapshot.toSerializableWithExtraWrite(prepareComposer));
+//
+//    // Assert
+//    assertThat(thrown).doesNotThrowAnyException();
+//    Get expected =
+//        new Get(get.getPartitionKey(), get.getClusteringKey().get())
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(get.forNamespace().get())
+//            .forTable(get.forTable().get());
+//    verify(prepareComposer).add(expected, null);
+//  }
+//
+//  @Test
+//  public void
+//      toSerializableWithExtraWrite_ScanSetAndWriteSetExist_ShouldThrowCommitConflictException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+//    Scan scan = prepareScan();
+//    Snapshot.Key key =
+//        new Snapshot.Key(
+//            scan.forNamespace().get(),
+//            scan.forTable().get(),
+//            scan.getPartitionKey(),
+//            scan.getStartClusteringKey().get());
+//    Put put = preparePut();
+//    snapshot.put(scan, Collections.singletonList(key));
+//    snapshot.put(new Snapshot.Key(put), put);
+//
+//    // Act Assert
+//    Throwable thrown = catchThrowable(() ->
+// snapshot.toSerializableWithExtraWrite(prepareComposer));
+//
+//    // Assert
+//    assertThat(thrown).isInstanceOf(CommitConflictException.class);
+//  }
+//
+//  @Test
+//  public void toSerializableWithExtraRead_ReadSetNotChanged_ShouldProcessWithoutExceptions()
+//      throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//    Get get = prepareAnotherGet();
+//    Put put = preparePut();
+//    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)));
+//    TransactionResult txResult = new TransactionResult(result);
+//    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//    when(storage.get(get)).thenReturn(Optional.of(txResult));
+//
+//    // Act Assert
+//    assertThatCode(() ->
+// snapshot.toSerializableWithExtraRead(storage)).doesNotThrowAnyException();
+//
+//    // Assert
+//    verify(storage).get(get);
+//  }
+//
+//  @Test
+//  public void toSerializableWithExtraRead_ReadSetUpdated_ShouldThrowCommitConflictException()
+//      throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//    Get get = prepareAnotherGet();
+//    Put put = preparePut();
+//    when(result.getValues())
+//        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)))
+//        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID + "x")));
+//    TransactionResult txResult = new TransactionResult(result);
+//    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//    TransactionResult changedTxResult = new TransactionResult(result);
+//    when(storage.get(get)).thenReturn(Optional.of(changedTxResult));
+//
+//    // Act Assert
+//    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
+//        .isInstanceOf(CommitConflictException.class);
+//
+//    // Assert
+//    verify(storage).get(get);
+//  }
+//
+//  @Test
+//  public void toSerializableWithExtraRead_ReadSetExtended_ShouldThrowCommitConflictException()
+//      throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//    Get get = prepareAnotherGet();
+//    Put put = preparePut();
+//    snapshot.put(new Snapshot.Key(get), Optional.empty());
+//    snapshot.put(new Snapshot.Key(put), put);
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//    when(result.getValues()).thenReturn(ImmutableMap.of());
+//    TransactionResult txResult = new TransactionResult(result);
+//    when(storage.get(get)).thenReturn(Optional.of(txResult));
+//
+//    // Act Assert
+//    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
+//        .isInstanceOf(CommitConflictException.class);
+//
+//    // Assert
+//    verify(storage).get(get);
+//  }
+//
+//  @Test
+//  public void toSerializableWithExtraRead_ScanSetNotChanged_ShouldProcessWithoutExceptions()
+//      throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//    Scan scan = prepareScan();
+//    Get get = prepareGet();
+//    Put put = preparePut();
+//    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)));
+//    TransactionResult txResult = new TransactionResult(result);
+//    Snapshot.Key key = new Snapshot.Key(get);
+//    snapshot.put(key, Optional.of(txResult));
+//    snapshot.put(scan, Collections.singletonList(key));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//    Scanner scanner = mock(Scanner.class);
+//    when(scanner.iterator()).thenReturn(Collections.singletonList((Result) txResult).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act Assert
+//    assertThatCode(() ->
+// snapshot.toSerializableWithExtraRead(storage)).doesNotThrowAnyException();
+//
+//    // Assert
+//    verify(storage).scan(scan);
+//  }
+//
+//  @Test
+//  public void toSerializableWithExtraRead_ScanSetUpdated_ShouldProcessWithoutExceptions()
+//      throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//    Scan scan = prepareScan();
+//    Get get = prepareGet();
+//    Put put = preparePut();
+//    when(result.getValues())
+//        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID)))
+//        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID + "x")));
+//    TransactionResult txResult = new TransactionResult(result);
+//    Snapshot.Key key = new Snapshot.Key(get);
+//    snapshot.put(key, Optional.of(txResult));
+//    snapshot.put(scan, Collections.singletonList(key));
+//    snapshot.put(new Snapshot.Key(put), put);
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//    TransactionResult changedTxResult = new TransactionResult(result);
+//    Scanner scanner = mock(Scanner.class);
+//    when(scanner.iterator())
+//        .thenReturn(Collections.singletonList((Result) changedTxResult).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act Assert
+//    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
+//        .isInstanceOf(CommitConflictException.class);
+//
+//    // Assert
+//    verify(storage).scan(scan);
+//  }
+//
+//  @Test
+//  public void toSerializableWithExtraRead_ScanSetExtended_ShouldProcessWithoutExceptions()
+//      throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//    Scan scan = prepareScan();
+//    Put put = preparePut();
+//    when(result.getValues()).thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(ANY_ID +
+// "x")));
+//    snapshot.put(scan, Collections.emptyList());
+//    snapshot.put(new Snapshot.Key(put), put);
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//    TransactionResult txResult = new TransactionResult(result);
+//    Scanner scanner = mock(Scanner.class);
+//    when(scanner.iterator()).thenReturn(Collections.singletonList((Result) txResult).iterator());
+//    when(storage.scan(scan)).thenReturn(scanner);
+//
+//    // Act Assert
+//    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
+//        .isInstanceOf(CommitConflictException.class);
+//
+//    // Assert
+//    verify(storage).scan(scan);
+//  }
+//
+//  @Test
+//  public void
+//      toSerializableWithExtraRead_MultipleScansInScanSetExist_ShouldThrowCommitConflictException()
+//          throws ExecutionException {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+//
+//    Scan scan1 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//    Scan scan2 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_2))
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1))
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//
+//    Snapshot.Key key1 =
+//        new Snapshot.Key(
+//            scan1.forNamespace().get(),
+//            scan1.forTable().get(),
+//            scan1.getPartitionKey(),
+//            scan1.getStartClusteringKey().get());
+//    Snapshot.Key key2 =
+//        new Snapshot.Key(
+//            scan2.forNamespace().get(),
+//            scan2.forTable().get(),
+//            scan2.getPartitionKey(),
+//            scan2.getStartClusteringKey().get());
+//
+//    Result result1 = mock(TransactionResult.class);
+//    when(result1.getValues())
+//        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(Attribute.ID, "id1")));
+//    Result result2 = mock(TransactionResult.class);
+//    when(result2.getValues())
+//        .thenReturn(ImmutableMap.of(Attribute.ID, new TextValue(Attribute.ID, "id2")));
+//
+//    snapshot.put(scan1, Collections.singletonList(key1));
+//    snapshot.put(scan2, Collections.singletonList(key2));
+//    snapshot.put(key1, Optional.of(new TransactionResult(result1)));
+//    snapshot.put(key2, Optional.of(new TransactionResult(result2)));
+//
+//    DistributedStorage storage = mock(DistributedStorage.class);
+//
+//    Scanner scanner1 = mock(Scanner.class);
+//    when(scanner1.iterator()).thenReturn(Collections.singletonList(result1).iterator());
+//    when(storage.scan(scan1)).thenReturn(scanner1);
+//
+//    Scanner scanner2 = mock(Scanner.class);
+//    when(scanner2.iterator()).thenReturn(Collections.singletonList(result2).iterator());
+//    when(storage.scan(scan2)).thenReturn(scanner2);
+//
+//    // Act Assert
+//    assertThatCode(() ->
+// snapshot.toSerializableWithExtraRead(storage)).doesNotThrowAnyException();
+//  }
+//
+//  @Test
+//  public void put_PutGivenAfterDelete_PutSupercedesDelete() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Snapshot.Key getKey = new Snapshot.Key(prepareGet());
+//    snapshot.put(getKey, Optional.of(result));
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(preparePut());
+//    snapshot.put(putKey, put);
+//
+//    // Act
+//    Delete delete = prepareDelete();
+//    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
+//    snapshot.put(deleteKey, delete);
+//
+//    // Assert
+//    assertThat(readSet.size()).isEqualTo(1);
+//    assertThat(readSet.get(getKey)).isEqualTo(Optional.of(result));
+//    assertThat(writeSet.size()).isEqualTo(0);
+//    assertThat(deleteSet.size()).isEqualTo(1);
+//    assertThat(deleteSet.get(deleteKey)).isEqualTo(delete);
+//  }
+//
+//  @Test
+//  public void put_DeleteGivenAfterPut_DeleteSupercedesPut() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Snapshot.Key getKey = new Snapshot.Key(prepareGet());
+//    snapshot.put(getKey, Optional.of(result));
+//    Delete delete = prepareDelete();
+//    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
+//    snapshot.put(deleteKey, delete);
+//
+//    // Act
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(preparePut());
+//    snapshot.put(putKey, put);
+//
+//    // Assert
+//    assertThat(readSet.size()).isEqualTo(1);
+//    assertThat(readSet.get(getKey)).isEqualTo(Optional.of(result));
+//    assertThat(deleteSet.size()).isEqualTo(0);
+//    assertThat(writeSet.size()).isEqualTo(1);
+//    assertThat(writeSet.get(putKey)).isEqualTo(put);
+//  }
+//
+//  @Test
+//  public void get_ScanGivenAndPutInWriteSetNotOverlappedWithScan_ShouldNotThrowException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    // "text2"
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(put);
+//    snapshot.put(putKey, put);
+//    Scan scan =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // ["text3", "text4"]
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_3), true)
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_4), true)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//
+//    // Act Assert
+//    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
+//
+//    // Assert
+//    assertThat(thrown).doesNotThrowAnyException();
+//  }
+//
+//  @Test
+//  public void
+//
+// get_ScanGivenAndPutWithSamePartitionKeyWithoutClusteringKeyInWriteSet_ShouldThrowIllegalArgumentException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    Put put = preparePutWithPartitionKeyOnly();
+//    Snapshot.Key putKey = new Snapshot.Key(put);
+//    snapshot.put(putKey, put);
+//    Scan scan = prepareScan();
+//
+//    // Act Assert
+//    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
+//
+//    // Assert
+//    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+//  }
+//
+//  @Test
+//  public void
+//
+// get_ScanWithNoRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException()
+// {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    // "text2"
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(put);
+//    snapshot.put(putKey, put);
+//    Scan scan =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // (-infinite, infinite)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//
+//    // Act Assert
+//    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
+//
+//    // Assert
+//    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+//  }
+//
+//  @Test
+//  public void
+//
+// get_ScanWithRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    // "text2"
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(put);
+//    snapshot.put(putKey, put);
+//    Scan scan1 =
+//        prepareScan()
+//            // ["text1", "text3"]
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+//    Scan scan2 =
+//        prepareScan()
+//            // ["text2", "text3"]
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+//    Scan scan3 =
+//        prepareScan()
+//            // ["text1", "text2"]
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true);
+//    Scan scan4 =
+//        prepareScan()
+//            // ("text2", "text3"]
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true);
+//    Scan scan5 =
+//        prepareScan()
+//            // ["text1", "text2")
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
+//
+//    // Act Assert
+//    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
+//    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
+//    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
+//    Throwable thrown4 = catchThrowable(() -> snapshot.get(scan4));
+//    Throwable thrown5 = catchThrowable(() -> snapshot.get(scan5));
+//
+//    // Assert
+//    assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown3).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown4).doesNotThrowAnyException();
+//    assertThat(thrown5).doesNotThrowAnyException();
+//  }
+//
+//  @Test
+//  public void
+//
+// get_ScanWithEndSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    // "text2"
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(put);
+//    snapshot.put(putKey, put);
+//    Scan scan1 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // (-infinite, "text3"]
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_3), true)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//    Scan scan2 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // (-infinite, "text2"]
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), true)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//    Scan scan3 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // (-infinite, "text2")
+//            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//
+//    // Act Assert
+//    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
+//    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
+//    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
+//
+//    // Assert
+//    assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown3).doesNotThrowAnyException();
+//  }
+//
+//  @Test
+//  public void
+//
+// get_ScanWithStartSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+//    // Arrange
+//    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+//    // "text2"
+//    Put put = preparePut();
+//    Snapshot.Key putKey = new Snapshot.Key(put);
+//    snapshot.put(putKey, put);
+//    Scan scan1 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // ["text1", infinite)
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//    Scan scan2 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // ["text2", infinite)
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), true)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//    Scan scan3 =
+//        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
+//            // ("text2", infinite)
+//            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2), false)
+//            .withConsistency(Consistency.LINEARIZABLE)
+//            .forNamespace(ANY_KEYSPACE_NAME)
+//            .forTable(ANY_TABLE_NAME);
+//
+//    // Act Assert
+//    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
+//    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
+//    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
+//
+//    // Assert
+//    assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
+//    assertThat(thrown3).doesNotThrowAnyException();
+//  }
+// }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TableSnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TableSnapshotTest.java
@@ -1,0 +1,529 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextValue;
+import com.scalar.db.io.Value;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+public class TableSnapshotTest {
+
+  private static final int CLUSTERING_KEY_NUM = 10;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void put_Once_WithTableMetadataWithClusteringKey_ShouldPutProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.of(new Key("cKey1", 2, "cKey2", 3));
+    Map<String, Value<?>> values =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 4),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+
+    // Act
+    tableSnapshot.put(partitionKey, clusteringKey, values);
+
+    // Assert
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+    assertThat(result).isPresent();
+    assertThat(result.get().getPartitionKey()).isEqualTo(Optional.of(partitionKey));
+    assertThat(result.get().getClusteringKey()).isEqualTo(clusteringKey);
+    assertThat(result.get().getValue("col1").isPresent()).isTrue();
+    assertThat(result.get().getValue("col1").get().getAsInt()).isEqualTo(4);
+    assertThat(result.get().getValue("col2").isPresent()).isTrue();
+    assertThat(result.get().getValue("col2").get().getAsString()).isEqualTo(Optional.of("aaa"));
+    assertThat(result.get().getValue("col3").isPresent()).isTrue();
+    assertThat(result.get().getValue("col3").get().getAsString()).isEqualTo(Optional.of("bbb"));
+  }
+
+  @Test
+  public void put_Twice_WithTableMetadataWithClusteringKey_ShouldPutProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.of(new Key("cKey1", 2, "cKey2", 3));
+    Map<String, Value<?>> values1 =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 4),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+    Map<String, Value<?>> values2 =
+        ImmutableMap.of("col2", new TextValue("col2", "bbb"), "col3", new TextValue("col3", "ccc"));
+
+    // Act
+    tableSnapshot.put(partitionKey, clusteringKey, values1);
+    tableSnapshot.put(partitionKey, clusteringKey, values2);
+
+    // Assert
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+    assertThat(result).isPresent();
+    assertThat(result.get().getPartitionKey()).isEqualTo(Optional.of(partitionKey));
+    assertThat(result.get().getClusteringKey()).isEqualTo(clusteringKey);
+    assertThat(result.get().getValue("col1").isPresent()).isTrue();
+    assertThat(result.get().getValue("col1").get().getAsInt()).isEqualTo(4);
+    assertThat(result.get().getValue("col2").isPresent()).isTrue();
+    assertThat(result.get().getValue("col2").get().getAsString()).isEqualTo(Optional.of("bbb"));
+    assertThat(result.get().getValue("col3").isPresent()).isTrue();
+    assertThat(result.get().getValue("col3").get().getAsString()).isEqualTo(Optional.of("ccc"));
+  }
+
+  @Test
+  public void put_WithTableMetadataWithoutClusteringKey_ShouldPutProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithoutClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.empty();
+    Map<String, Value<?>> values =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 3),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+
+    // Act
+    tableSnapshot.put(partitionKey, clusteringKey, values);
+
+    // Assert
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+    assertThat(result).isPresent();
+    assertThat(result.get().getPartitionKey()).isEqualTo(Optional.of(partitionKey));
+    assertThat(result.get().getClusteringKey()).isNotPresent();
+    assertThat(result.get().getValue("col1").isPresent()).isTrue();
+    assertThat(result.get().getValue("col1").get().getAsInt()).isEqualTo(3);
+    assertThat(result.get().getValue("col2").isPresent()).isTrue();
+    assertThat(result.get().getValue("col2").get().getAsString()).isEqualTo(Optional.of("aaa"));
+    assertThat(result.get().getValue("col3").isPresent()).isTrue();
+    assertThat(result.get().getValue("col3").get().getAsString()).isEqualTo(Optional.of("bbb"));
+  }
+
+  @Test
+  public void delete_WithTableMetadataWithClusteringKey_ShouldDeleteProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.of(new Key("cKey1", 2, "cKey2", 3));
+    Map<String, Value<?>> values =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 4),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+    tableSnapshot.put(partitionKey, clusteringKey, values);
+
+    // Act
+    tableSnapshot.delete(partitionKey, clusteringKey);
+
+    // Assert
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void delete_WithTableMetadataWithoutClusteringKey_ShouldDeleteProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithoutClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.empty();
+    Map<String, Value<?>> values =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 3),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+    tableSnapshot.put(partitionKey, clusteringKey, values);
+
+    // Act
+    tableSnapshot.delete(partitionKey, clusteringKey);
+
+    // Assert
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void get_WithTableMetadataWithClusteringKey_ShouldGetProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.of(new Key("cKey1", 2, "cKey2", 3));
+    Map<String, Value<?>> values =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 4),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+    tableSnapshot.put(partitionKey, clusteringKey, values);
+
+    // Act
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+
+    // Assert
+    assertThat(result).isPresent();
+    assertThat(result.get().getPartitionKey()).isEqualTo(Optional.of(partitionKey));
+    assertThat(result.get().getClusteringKey()).isEqualTo(clusteringKey);
+    assertThat(result.get().getValue("col1").isPresent()).isTrue();
+    assertThat(result.get().getValue("col1").get().getAsInt()).isEqualTo(4);
+    assertThat(result.get().getValue("col2").isPresent()).isTrue();
+    assertThat(result.get().getValue("col2").get().getAsString()).isEqualTo(Optional.of("aaa"));
+    assertThat(result.get().getValue("col3").isPresent()).isTrue();
+    assertThat(result.get().getValue("col3").get().getAsString()).isEqualTo(Optional.of("bbb"));
+  }
+
+  @Test
+  public void get_WithTableMetadataWithoutClusteringKey_ShouldGetProperly() {
+    // Arrange
+    TableSnapshot tableSnapshot = new TableSnapshot(getTableMetadataWithoutClusteringKey());
+
+    Key partitionKey = new Key("pKey", 1);
+    Optional<Key> clusteringKey = Optional.empty();
+    Map<String, Value<?>> values =
+        ImmutableMap.of(
+            "col1",
+            new IntValue("col1", 4),
+            "col2",
+            new TextValue("col2", "aaa"),
+            "col3",
+            new TextValue("col3", "bbb"));
+    tableSnapshot.put(partitionKey, clusteringKey, values);
+
+    // Act
+    Optional<Result> result = tableSnapshot.get(partitionKey, clusteringKey);
+
+    // Assert
+    assertThat(result).isPresent();
+    assertThat(result.get().getPartitionKey()).isEqualTo(Optional.of(partitionKey));
+    assertThat(result.get().getClusteringKey()).isNotPresent();
+    assertThat(result.get().getValue("col1").isPresent()).isTrue();
+    assertThat(result.get().getValue("col1").get().getAsInt()).isEqualTo(4);
+    assertThat(result.get().getValue("col2").isPresent()).isTrue();
+    assertThat(result.get().getValue("col2").get().getAsString()).isEqualTo(Optional.of("aaa"));
+    assertThat(result.get().getValue("col3").isPresent()).isTrue();
+    assertThat(result.get().getValue("col3").get().getAsString()).isEqualTo(Optional.of("bbb"));
+  }
+
+  @Test
+  public void scan_WithTableMetadataWithClusteringKey_ShouldScanProperly() {
+    for (Order clusteringOrder1 : Order.values()) {
+      for (Order clusteringOrder2 : Order.values()) {
+        scan_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+            clusteringOrder1, clusteringOrder2);
+      }
+    }
+  }
+
+  private void scan_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+      Order clusteringOrder1, Order clusteringOrder2) {
+    // Arrange
+    TableSnapshot tableSnapshot =
+        new TableSnapshot(getTableMetadataWithClusteringKey(clusteringOrder1, clusteringOrder2));
+
+    Key partitionKey = new Key("pKey", 1);
+    prepareForScan(tableSnapshot, partitionKey);
+
+    Optional<Key> startClusteringKey = Optional.empty();
+    boolean startInclusive = true;
+    Optional<Key> endClusteringKey = Optional.empty();
+    boolean endInclusive = true;
+    List<Ordering> orderings = Collections.emptyList();
+    int limit = 0;
+
+    // Act
+    List<Result> results =
+        tableSnapshot.scan(
+            partitionKey,
+            startClusteringKey,
+            startInclusive,
+            endClusteringKey,
+            endInclusive,
+            orderings,
+            limit);
+
+    // Assert
+    assertThat(results.size()).isEqualTo(CLUSTERING_KEY_NUM * CLUSTERING_KEY_NUM);
+    for (int i = 0; i < results.size(); i++) {
+      int index1 = i / CLUSTERING_KEY_NUM;
+      int index2 = i % CLUSTERING_KEY_NUM;
+      assertResult(
+          partitionKey,
+          results.get(i),
+          clusteringOrder1 == Order.ASC ? index1 : CLUSTERING_KEY_NUM - 1 - index1,
+          clusteringOrder2 == Order.ASC ? index2 : CLUSTERING_KEY_NUM - 1 - index2);
+    }
+  }
+
+  @Test
+  public void scan_WithOrdering_WithTableMetadataWithClusteringKey_ShouldScanProperly() {
+    for (Order clusteringOrder1 : Order.values()) {
+      for (Order clusteringOrder2 : Order.values()) {
+        scan_WithOrdering_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+            clusteringOrder1, clusteringOrder2, false);
+        scan_WithOrdering_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+            clusteringOrder1, clusteringOrder2, true);
+      }
+    }
+  }
+
+  private void scan_WithOrdering_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+      Order clusteringOrder1, Order clusteringOrder2, boolean reverse) {
+    // Arrange
+    TableSnapshot tableSnapshot =
+        new TableSnapshot(getTableMetadataWithClusteringKey(clusteringOrder1, clusteringOrder2));
+
+    Key partitionKey = new Key("pKey", 1);
+    prepareForScan(tableSnapshot, partitionKey);
+
+    Optional<Key> startClusteringKey = Optional.empty();
+    boolean startInclusive = true;
+    Optional<Key> endClusteringKey = Optional.empty();
+    boolean endInclusive = true;
+
+    Order order1 = reverse ? reverse(clusteringOrder1) : clusteringOrder1;
+    Order order2 = reverse ? reverse(clusteringOrder2) : clusteringOrder2;
+    List<Ordering> orderings =
+        Arrays.asList(new Ordering("cKey1", order1), new Ordering("cKey2", order2));
+    int limit = 0;
+
+    // Act
+    List<Result> results =
+        tableSnapshot.scan(
+            partitionKey,
+            startClusteringKey,
+            startInclusive,
+            endClusteringKey,
+            endInclusive,
+            orderings,
+            limit);
+
+    // Assert
+    assertThat(results.size()).isEqualTo(CLUSTERING_KEY_NUM * CLUSTERING_KEY_NUM);
+    for (int i = 0; i < results.size(); i++) {
+      int index1 = i / CLUSTERING_KEY_NUM;
+      int index2 = i % CLUSTERING_KEY_NUM;
+      assertResult(
+          partitionKey,
+          results.get(i),
+          order1 == Order.ASC ? index1 : CLUSTERING_KEY_NUM - 1 - index1,
+          order2 == Order.ASC ? index2 : CLUSTERING_KEY_NUM - 1 - index2);
+    }
+  }
+
+  @Test
+  public void scan_WithLimit_WithTableMetadataWithClusteringKey_ShouldScanProperly() {
+    for (Order clusteringOrder1 : Order.values()) {
+      for (Order clusteringOrder2 : Order.values()) {
+        scan_WithLimit_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+            clusteringOrder1, clusteringOrder2);
+      }
+    }
+  }
+
+  private void scan_WithLimit_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+      Order clusteringOrder1, Order clusteringOrder2) {
+    // Arrange
+    TableSnapshot tableSnapshot =
+        new TableSnapshot(getTableMetadataWithClusteringKey(clusteringOrder1, clusteringOrder2));
+
+    Key partitionKey = new Key("pKey", 1);
+    prepareForScan(tableSnapshot, partitionKey);
+
+    Optional<Key> startClusteringKey = Optional.empty();
+    boolean startInclusive = true;
+    Optional<Key> endClusteringKey = Optional.empty();
+    boolean endInclusive = true;
+    List<Ordering> orderings = Collections.emptyList();
+    int limit = 30;
+
+    // Act
+    List<Result> results =
+        tableSnapshot.scan(
+            partitionKey,
+            startClusteringKey,
+            startInclusive,
+            endClusteringKey,
+            endInclusive,
+            orderings,
+            limit);
+
+    // Assert
+    assertThat(results.size()).isEqualTo(limit);
+    for (int i = 0; i < limit; i++) {
+      int index1 = i / CLUSTERING_KEY_NUM;
+      int index2 = i % CLUSTERING_KEY_NUM;
+      assertResult(
+          partitionKey,
+          results.get(i),
+          clusteringOrder1 == Order.ASC ? index1 : CLUSTERING_KEY_NUM - 1 - index1,
+          clusteringOrder2 == Order.ASC ? index2 : CLUSTERING_KEY_NUM - 1 - index2);
+    }
+  }
+
+  @Test
+  public void scan_WithStartClusteringKey_WithTableMetadataWithClusteringKey_ShouldScanProperly() {
+    for (Order clusteringOrder1 : Order.values()) {
+      for (Order clusteringOrder2 : Order.values()) {
+        scan_WithStartClusteringKey_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+            clusteringOrder1, clusteringOrder2, true);
+        scan_WithStartClusteringKey_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+            clusteringOrder1, clusteringOrder2, false);
+      }
+    }
+  }
+
+  public void scan_WithStartClusteringKey_WithTableMetadataWithClusteringKey_ShouldScanProperly(
+      Order clusteringOrder1, Order clusteringOrder2, boolean startInclusive) {
+    TableSnapshot tableSnapshot =
+        new TableSnapshot(getTableMetadataWithClusteringKey(clusteringOrder1, clusteringOrder2));
+
+    // Arrange
+    Key partitionKey = new Key("pKey", 1);
+    prepareForScan(tableSnapshot, partitionKey);
+
+    int cKey1Value = 2;
+    int cKey2Value = 4;
+    Optional<Key> startClusteringKey =
+        Optional.of(new Key("cKey1", cKey1Value, "cKey2", cKey2Value));
+
+    Optional<Key> endClusteringKey = Optional.empty();
+    boolean endInclusive = true;
+
+    List<Ordering> orderings = Collections.emptyList();
+    int limit = 0;
+
+    // Act
+    List<Result> results =
+        tableSnapshot.scan(
+            partitionKey,
+            startClusteringKey,
+            startInclusive,
+            endClusteringKey,
+            endInclusive,
+            orderings,
+            limit);
+
+    // Assert
+    assertThat(results.size())
+        .isEqualTo(CLUSTERING_KEY_NUM - cKey2Value - (startInclusive ? 0 : 1));
+    for (int i = 0; i < results.size(); i++) {
+      assertResult(
+          partitionKey,
+          results.get(i),
+          cKey1Value,
+          clusteringOrder2 == Order.ASC
+              ? i + cKey2Value + (startInclusive ? 0 : 1)
+              : CLUSTERING_KEY_NUM - 1 - i);
+    }
+  }
+
+  // TODO Add more tests
+
+  private TableMetadata getTableMetadataWithClusteringKey() {
+    return getTableMetadataWithClusteringKey(Order.ASC, Order.ASC);
+  }
+
+  private TableMetadata getTableMetadataWithClusteringKey(
+      Order clusteringOrder1, Order clusteringOrder2) {
+    return TableMetadata.newBuilder()
+        .addColumn("pKey", DataType.INT)
+        .addColumn("cKey1", DataType.INT)
+        .addColumn("cKey2", DataType.INT)
+        .addColumn("col1", DataType.INT)
+        .addColumn("col2", DataType.TEXT)
+        .addColumn("col3", DataType.TEXT)
+        .addPartitionKey("pKey")
+        .addClusteringKey("cKey1", clusteringOrder1)
+        .addClusteringKey("cKey2", clusteringOrder2)
+        .build();
+  }
+
+  private TableMetadata getTableMetadataWithoutClusteringKey() {
+    return TableMetadata.newBuilder()
+        .addColumn("pKey", DataType.INT)
+        .addColumn("col1", DataType.INT)
+        .addColumn("col2", DataType.TEXT)
+        .addColumn("col3", DataType.TEXT)
+        .addPartitionKey("pKey")
+        .build();
+  }
+
+  private void prepareForScan(TableSnapshot tableSnapshot, Key partitionKey) {
+    for (int index1 = 0; index1 < CLUSTERING_KEY_NUM; index1++) {
+      for (int index2 = 0; index2 < CLUSTERING_KEY_NUM; index2++) {
+        Optional<Key> clusteringKey = Optional.of(new Key("cKey1", index1, "cKey2", index2));
+        Map<String, Value<?>> values =
+            ImmutableMap.of(
+                "col1",
+                new IntValue("col1", index1 + index2),
+                "col2",
+                new TextValue("col2", "val" + index1),
+                "col3",
+                new TextValue("col3", "val" + index2));
+        tableSnapshot.put(partitionKey, clusteringKey, values);
+      }
+    }
+  }
+
+  private Order reverse(Order order) {
+    switch (order) {
+      case ASC:
+        return Order.DESC;
+      case DESC:
+        return Order.ASC;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  private void assertResult(Key partitionKey, Result result, int index1, int index2) {
+    assertThat(result.getPartitionKey()).isEqualTo(Optional.of(partitionKey));
+    assertThat(result.getClusteringKey())
+        .isEqualTo(Optional.of(new Key("cKey1", index1, "cKey2", index2)));
+    assertThat(result.getValue("col1").isPresent()).isTrue();
+    assertThat(result.getValue("col1").get().getAsInt()).isEqualTo(index1 + index2);
+    assertThat(result.getValue("col2").isPresent()).isTrue();
+    assertThat(result.getValue("col2").get().getAsString()).isEqualTo(Optional.of("val" + index1));
+    assertThat(result.getValue("col3").isPresent()).isTrue();
+    assertThat(result.getValue("col3").get().getAsString()).isEqualTo(Optional.of("val" + index2));
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -20,6 +21,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   private static final String ANY_TX_ID = "any_id";
 
   @Mock private DistributedStorage storage;
+  @Mock private DistributedStorageAdmin admin;
   @Mock private ConsensusCommitConfig config;
   @Mock private Coordinator coordinator;
   @Mock private ParallelExecutor parallelExecutor;
@@ -36,10 +38,11 @@ public class TwoPhaseConsensusCommitManagerTest {
     when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);
     when(config.getSerializableStrategy()).thenReturn(SerializableStrategy.EXTRA_READ);
     when(config.isActiveTransactionsManagementEnabled()).thenReturn(true);
+    when(config.getTableMetadataCacheExpirationTimeSecs()).thenReturn(-1L);
 
     manager =
         new TwoPhaseConsensusCommitManager(
-            storage, config, coordinator, parallelExecutor, recovery, commit);
+            storage, admin, config, coordinator, parallelExecutor, recovery, commit);
   }
 
   @Test
@@ -138,7 +141,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     when(config.isActiveTransactionsManagementEnabled()).thenReturn(false);
     manager =
         new TwoPhaseConsensusCommitManager(
-            storage, config, coordinator, parallelExecutor, recovery, commit);
+            storage, admin, config, coordinator, parallelExecutor, recovery, commit);
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_TX_ID))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -116,7 +116,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void put_PutGiven_ShouldCallCrudHandlerPut() {
+  public void put_PutGiven_ShouldCallCrudHandlerPut() throws CrudException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
@@ -130,7 +130,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() {
+  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() throws CrudException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
@@ -144,7 +144,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() {
+  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() throws CrudException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
@@ -158,7 +158,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() {
+  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() throws CrudException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
@@ -172,7 +172,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete() {
+  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete() throws CrudException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);


### PR DESCRIPTION
(This PR is working in progress. Please don't merge it for now)

This PR allows reading already written data in Consensus Commit.

The main changes are in the following classes:
- CrudHandler
- Snapshot
- TableSnapshot (NEW)

This PR is working in progress, and I need to add more tests and do some refactoring. But I think we can have the first discussion based on it. 

Please take a look!