### PR TITLE
Add projections to Get and Scan operations in GraphQL

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.api.Selection;
 import com.scalar.db.graphql.schema.CommonSchema;
 import com.scalar.db.graphql.schema.Constants;
 import com.scalar.db.graphql.schema.DeleteConditionType;
@@ -33,6 +34,7 @@ import graphql.Scalars;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLScalarType;
+import graphql.schema.SelectedField;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -254,6 +256,18 @@ public class DataFetcherHelper {
       }
     }
     return delete;
+  }
+
+  void addProjections(Selection selection, DataFetchingEnvironment environment) {
+    // Add specified field names of the get or scan GraphQL input to the Selection object as
+    // projections. The fields are filtered by "*/*" since they are represented in the following
+    // format:
+    // <object_type_name>_(Get|Scan)PayLoad.<object_type_name>/<object_type_name>.<field_name>
+    List<String> selectedFieldNames =
+        environment.getSelectionSet().getFields("*/*").stream()
+            .map(SelectedField::getName)
+            .collect(Collectors.toList());
+    selection.withProjections(selectedFieldNames);
   }
 
   String getNamespaceName() {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -278,10 +278,6 @@ public class DataFetcherHelper {
     return tableGraphQlModel.getTableName();
   }
 
-  LinkedHashSet<String> getFieldNames() {
-    return tableGraphQlModel.getFieldNames();
-  }
-
   String getObjectTypeName() {
     return tableGraphQlModel.getObjectType().getName();
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -13,7 +13,6 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
-import com.scalar.db.api.Selection;
 import com.scalar.db.graphql.schema.CommonSchema;
 import com.scalar.db.graphql.schema.Constants;
 import com.scalar.db.graphql.schema.DeleteConditionType;
@@ -35,6 +34,7 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.SelectedField;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -258,16 +258,14 @@ public class DataFetcherHelper {
     return delete;
   }
 
-  void addProjections(Selection selection, DataFetchingEnvironment environment) {
+  static Collection<String> getProjections(DataFetchingEnvironment environment) {
     // Add specified field names of the get or scan GraphQL input to the Selection object as
     // projections. The fields are filtered by "*/*" since they are represented in the following
     // format:
     // <object_type_name>_(Get|Scan)PayLoad.<object_type_name>/<object_type_name>.<field_name>
-    List<String> selectedFieldNames =
-        environment.getSelectionSet().getFields("*/*").stream()
-            .map(SelectedField::getName)
-            .collect(Collectors.toList());
-    selection.withProjections(selectedFieldNames);
+    return environment.getSelectionSet().getFields("*/*").stream()
+        .map(SelectedField::getName)
+        .collect(Collectors.toList());
   }
 
   String getNamespaceName() {

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -65,12 +65,12 @@ public class QueryGetDataFetcher
                 helper.createPartitionKeyFromKeyArgument(key),
                 helper.createClusteringKeyFromKeyArgument(key))
             .forNamespace(helper.getNamespaceName())
-            .forTable(helper.getTableName());
+            .forTable(helper.getTableName())
+            .withProjections(DataFetcherHelper.getProjections(environment));
     String consistency = (String) getInput.get("consistency");
     if (consistency != null) {
       get.withConsistency(Consistency.valueOf(consistency));
     }
-    helper.addProjections(get, environment);
 
     return get;
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -43,7 +43,7 @@ public class QueryGetDataFetcher
       performGet(environment, get)
           .ifPresent(
               dbResult -> {
-                for (String fieldName : helper.getFieldNames()) {
+                for (String fieldName : get.getProjections()) {
                   dbResult.getValue(fieldName).ifPresent(value -> data.put(fieldName, value.get()));
                 }
               });

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -33,7 +33,8 @@ public class QueryGetDataFetcher
       DataFetchingEnvironment environment) {
     Map<String, Object> getInput = environment.getArgument("get");
     LOGGER.debug("got get argument: {}", getInput);
-    Get get = createGet(getInput);
+    Get get = createGet(getInput, environment);
+    LOGGER.debug("running get: {}", get);
 
     DataFetcherResult.Builder<Map<String, Map<String, Object>>> result =
         DataFetcherResult.newResult();
@@ -57,7 +58,7 @@ public class QueryGetDataFetcher
 
   @VisibleForTesting
   @SuppressWarnings("unchecked")
-  Get createGet(Map<String, Object> getInput) {
+  Get createGet(Map<String, Object> getInput, DataFetchingEnvironment environment) {
     Map<String, Object> key = (Map<String, Object>) getInput.get("key");
     Get get =
         new Get(
@@ -69,6 +70,7 @@ public class QueryGetDataFetcher
     if (consistency != null) {
       get.withConsistency(Consistency.valueOf(consistency));
     }
+    helper.addProjections(get, environment);
 
     return get;
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -70,7 +70,8 @@ public class QueryScanDataFetcher
                 helper.createPartitionKeyFromKeyArgument(
                     (Map<String, Object>) scanInput.get("partitionKey")))
             .forNamespace(helper.getNamespaceName())
-            .forTable(helper.getTableName());
+            .forTable(helper.getTableName())
+            .withProjections(DataFetcherHelper.getProjections(environment));
 
     List<Map<String, Object>> startInput = (List<Map<String, Object>>) scanInput.get("start");
     Boolean startInclusiveInput = (Boolean) scanInput.get("startInclusive");
@@ -122,8 +123,6 @@ public class QueryScanDataFetcher
     if (consistencyInput != null) {
       scan.withConsistency(Consistency.valueOf(consistencyInput));
     }
-
-    helper.addProjections(scan, environment);
 
     return scan;
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -18,9 +18,11 @@ import com.scalar.db.io.Key;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.SelectedField;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +44,15 @@ public class QueryScanDataFetcher
     LOGGER.debug("got scan argument: {}", scanInput);
     Scan scan = createScan(scanInput);
 
-    // TODO: scan.withProjections()
+    // Add the specified field names, filtered by "*/*", to the scan object as the projections
+    // since the fields of the scan input are represented in the following format:
+    // <object_type_name>_ScanPayLoad.<object_type_name>/<object_type_name>.<field_name>
+    List<String> selectedFieldNames =
+        environment.getSelectionSet().getFields("*/*").stream()
+            .map(SelectedField::getName)
+            .collect(Collectors.toList());
+    LOGGER.debug("scan projections: {}", selectedFieldNames);
+    scan.withProjections(selectedFieldNames);
 
     DataFetcherResult.Builder<Map<String, List<Map<String, Object>>>> result =
         DataFetcherResult.newResult();

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -18,7 +18,6 @@ import com.scalar.db.io.Key;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -45,12 +44,11 @@ public class QueryScanDataFetcher
 
     DataFetcherResult.Builder<Map<String, List<Map<String, Object>>>> result =
         DataFetcherResult.newResult();
-    LinkedHashSet<String> fieldNames = helper.getFieldNames();
     ImmutableList.Builder<Map<String, Object>> list = ImmutableList.builder();
     try {
       for (Result dbResult : performScan(environment, scan)) {
         ImmutableMap.Builder<String, Object> map = ImmutableMap.builder();
-        for (String fieldName : fieldNames) {
+        for (String fieldName : scan.getProjections()) {
           dbResult.getValue(fieldName).ifPresent(value -> map.put(fieldName, value.get()));
         }
         list.add(map.build());

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -3,7 +3,6 @@ package com.scalar.db.graphql.datafetcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -28,15 +27,11 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import graphql.execution.DataFetcherResult;
-import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.SelectedField;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 
 public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   private static final String COL1 = "c1";
@@ -47,7 +42,6 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   private QueryGetDataFetcher dataFetcher;
   private Map<String, Object> getInput;
   private Get expectedGet;
-  @Mock private DataFetchingFieldSelectionSet selectionSet;
 
   @Override
   public void doSetUp() {
@@ -71,10 +65,6 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     getInput = new HashMap<>();
     getInput.put("key", ImmutableMap.of(COL1, 1, COL2, "A"));
     when(environment.getArgument("get")).thenReturn(getInput);
-
-    // Set empty selection set as default
-    when(selectionSet.getFields(anyString())).thenReturn(Collections.emptyList());
-    when(environment.getSelectionSet()).thenReturn(selectionSet);
 
     expectedGet =
         new Get(new Key(COL1, 1), new Key(COL2, "A"))
@@ -127,6 +117,8 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenGetSucceeds_ShouldReturnResultAsMap() throws Exception {
     // Arrange
     prepareGetInputAndExpectedGet();
+    addSelectionSetToEnvironment(environment, COL1, COL2, COL3);
+
     Result mockResult = mock(Result.class);
     when(mockResult.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
@@ -194,13 +186,7 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     //     c2, c3
     //   }
     // }
-    SelectedField selectedField1 = mock(SelectedField.class);
-    when(selectedField1.getName()).thenReturn(COL2);
-    SelectedField selectedField2 = mock(SelectedField.class);
-    when(selectedField2.getName()).thenReturn(COL3);
-    when(selectionSet.getFields(anyString()))
-        .thenReturn(ImmutableList.of(selectedField1, selectedField2));
-    when(environment.getSelectionSet()).thenReturn(selectionSet);
+    addSelectionSetToEnvironment(environment, COL2, COL3);
     expectedGet.withProjections(ImmutableList.of(COL2, COL3));
 
     // Act

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
@@ -3,7 +3,6 @@ package com.scalar.db.graphql.datafetcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -29,8 +28,6 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import graphql.execution.DataFetcherResult;
-import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.SelectedField;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +36,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 
 public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   private static final String COL1 = "c1";
@@ -53,7 +49,6 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   private QueryScanDataFetcher dataFetcher;
   private Map<String, Object> scanInput;
   private Scan expectedScan;
-  @Mock private DataFetchingFieldSelectionSet selectionSet;
 
   @Override
   protected void doSetUp() throws Exception {
@@ -88,10 +83,6 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     scanInput = new HashMap<>();
     scanInput.put("partitionKey", ImmutableMap.of(COL1, 1, COL2, "A"));
     when(environment.getArgument("scan")).thenReturn(scanInput);
-
-    // Set empty selection set as default
-    when(selectionSet.getFields(anyString())).thenReturn(Collections.emptyList());
-    when(environment.getSelectionSet()).thenReturn(selectionSet);
 
     expectedScan =
         new Scan(new Key(new IntValue(COL1, 1), new TextValue(COL2, "A")))
@@ -144,6 +135,8 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
   public void get_WhenScanSucceeds_ShouldReturnListData() throws Exception {
     // Arrange
     prepareScanInputAndExpectedScan();
+    addSelectionSetToEnvironment(environment, COL1, COL2, COL3);
+
     Result mockResult1 = mock(Result.class);
     when(mockResult1.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult1.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
@@ -290,13 +283,7 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     //     c2, c3
     //   }
     // }
-    SelectedField selectedField1 = mock(SelectedField.class);
-    when(selectedField1.getName()).thenReturn(COL2);
-    SelectedField selectedField2 = mock(SelectedField.class);
-    when(selectedField2.getName()).thenReturn(COL3);
-    when(selectionSet.getFields(anyString()))
-        .thenReturn(ImmutableList.of(selectedField1, selectedField2));
-    when(environment.getSelectionSet()).thenReturn(selectionSet);
+    addSelectionSetToEnvironment(environment, COL2, COL3);
     expectedScan.withProjections(ImmutableList.of(COL2, COL3));
 
     // Act


### PR DESCRIPTION
For get and scan operations, use the `withProjections()` according to the specified selections of the GraphQL inputs.

For example, the GraphQL query

```graphql
query {
  table1_scan(scan: { partitionKey: { c1: 1 }}) {
    table1 {
      c1
      c2
  }
}
```

will be converted to a `Scan` command like the following:

```java
new Scan(new Key(new IntValue("c1", 1)))
  .withProjections(Arrays.asList("c1", "c2"))
```
