### PR TITLE
Sort order for Scan without orderings should follow clustering order in Cosmos adapter

### DIFF
--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -27,6 +27,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.util.TableMetadataManager;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -45,8 +46,6 @@ public class SelectStatementHandlerTest {
   private static final String ANY_TEXT_2 = "text2";
   private static final String ANY_TEXT_3 = "text3";
   private static final String ANY_TEXT_4 = "text4";
-  private static final Scan.Ordering.Order ASC_ORDER = Scan.Ordering.Order.ASC;
-  private static final Scan.Ordering.Order DESC_ORDER = Scan.Ordering.Order.DESC;
   private static final int ANY_LIMIT = 100;
 
   private SelectStatementHandler handler;
@@ -171,7 +170,12 @@ public class SelectStatementHandlerTest {
     when(responseIterable.iterator()).thenReturn(Collections.singletonList(expected).iterator());
 
     Scan scan = prepareScan();
-    String query = "select * from Record r where r.concatenatedPartitionKey = '" + ANY_TEXT_1 + "'";
+    String query =
+        "select * from Record r where r.concatenatedPartitionKey = '"
+            + ANY_TEXT_1
+            + "' order by r.concatenatedPartitionKey asc, r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] asc";
 
     // Act Assert
     assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
@@ -240,7 +244,9 @@ public class SelectStatementHandlerTest {
             + ANY_NAME_2
             + "\"] <= '"
             + ANY_TEXT_3
-            + "')";
+            + "') order by r.concatenatedPartitionKey asc, r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] asc";
 
     // Act Assert
     assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
@@ -252,6 +258,10 @@ public class SelectStatementHandlerTest {
   @Test
   public void handle_ScanOperationWithMultipleClusteringKeys_ShouldCallQueryItemsWithProperQuery() {
     // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_2, ANY_NAME_3)));
+    when(metadata.getClusteringOrder(ANY_NAME_3)).thenReturn(Order.DESC);
+
     when(container.queryItems(anyString(), any(CosmosQueryRequestOptions.class), eq(Record.class)))
         .thenReturn(responseIterable);
     Record expected = new Record();
@@ -281,7 +291,11 @@ public class SelectStatementHandlerTest {
             + ANY_NAME_3
             + "\"] <= '"
             + ANY_TEXT_4
-            + "')";
+            + "') order by r.concatenatedPartitionKey asc, r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] asc, r.clusteringKey[\""
+            + ANY_NAME_3
+            + "\"] desc";
 
     // Act Assert
     assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
@@ -314,7 +328,9 @@ public class SelectStatementHandlerTest {
             + ANY_NAME_2
             + "\"] < '"
             + ANY_TEXT_3
-            + "')";
+            + "') order by r.concatenatedPartitionKey asc, r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] asc";
 
     // Act Assert
     assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
@@ -334,7 +350,7 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
             .withLimit(ANY_LIMIT);
 
     String query =
@@ -357,7 +373,8 @@ public class SelectStatementHandlerTest {
   }
 
   @Test
-  public void handle_ScanOperationWithMultipleOrdering_ShouldCallQueryItemsWithProperQuery() {
+  public void
+      handle_ScanOperationWithReversedOrderingAndLimit_ShouldCallQueryItemsWithProperQuery() {
     // Arrange
     when(container.queryItems(anyString(), any(CosmosQueryRequestOptions.class), eq(Record.class)))
         .thenReturn(responseIterable);
@@ -367,8 +384,46 @@ public class SelectStatementHandlerTest {
     Scan scan =
         prepareScan()
             .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
-            .withOrdering(new Scan.Ordering(ANY_NAME_2, ASC_ORDER))
-            .withOrdering(new Scan.Ordering(ANY_NAME_3, DESC_ORDER))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.DESC))
+            .withLimit(ANY_LIMIT);
+
+    String query =
+        "select * from Record r where (r.concatenatedPartitionKey = '"
+            + ANY_TEXT_1
+            + "' and r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] >= '"
+            + ANY_TEXT_2
+            + "') order by r.concatenatedPartitionKey desc, r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] desc offset 0 limit "
+            + ANY_LIMIT;
+
+    // Act Assert
+    assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
+
+    // Assert
+    verify(container).queryItems(eq(query), any(CosmosQueryRequestOptions.class), eq(Record.class));
+  }
+
+  @Test
+  public void
+      handle_ScanOperationWithMultipleOrderingsAndLimit_ShouldCallQueryItemsWithProperQuery() {
+    // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_2, ANY_NAME_3)));
+    when(metadata.getClusteringOrder(ANY_NAME_3)).thenReturn(Order.DESC);
+
+    when(container.queryItems(anyString(), any(CosmosQueryRequestOptions.class), eq(Record.class)))
+        .thenReturn(responseIterable);
+    Record expected = new Record();
+    when(responseIterable.iterator()).thenReturn(Collections.singletonList(expected).iterator());
+
+    Scan scan =
+        prepareScan()
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.ASC))
+            .withOrdering(new Scan.Ordering(ANY_NAME_3, Order.DESC))
             .withLimit(ANY_LIMIT);
 
     String query =
@@ -383,6 +438,47 @@ public class SelectStatementHandlerTest {
             + "\"] asc, r.clusteringKey[\""
             + ANY_NAME_3
             + "\"] desc offset 0 limit "
+            + ANY_LIMIT;
+
+    // Act Assert
+    assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
+
+    // Assert
+    verify(container).queryItems(eq(query), any(CosmosQueryRequestOptions.class), eq(Record.class));
+  }
+
+  @Test
+  public void
+      handle_ScanOperationWithMultipleReversedOrderingsAndLimit_ShouldCallQueryItemsWithProperQuery() {
+    // Arrange
+    when(metadata.getClusteringKeyNames())
+        .thenReturn(new LinkedHashSet<>(Arrays.asList(ANY_NAME_2, ANY_NAME_3)));
+    when(metadata.getClusteringOrder(ANY_NAME_3)).thenReturn(Order.DESC);
+
+    when(container.queryItems(anyString(), any(CosmosQueryRequestOptions.class), eq(Record.class)))
+        .thenReturn(responseIterable);
+    Record expected = new Record();
+    when(responseIterable.iterator()).thenReturn(Collections.singletonList(expected).iterator());
+
+    Scan scan =
+        prepareScan()
+            .withStart(new Key(ANY_NAME_2, ANY_TEXT_2))
+            .withOrdering(new Scan.Ordering(ANY_NAME_2, Order.DESC))
+            .withOrdering(new Scan.Ordering(ANY_NAME_3, Order.ASC))
+            .withLimit(ANY_LIMIT);
+
+    String query =
+        "select * from Record r where (r.concatenatedPartitionKey = '"
+            + ANY_TEXT_1
+            + "' and r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] >= '"
+            + ANY_TEXT_2
+            + "') order by r.concatenatedPartitionKey desc, r.clusteringKey[\""
+            + ANY_NAME_2
+            + "\"] desc, r.clusteringKey[\""
+            + ANY_NAME_3
+            + "\"] asc offset 0 limit "
             + ANY_LIMIT;
 
     // Act Assert


### PR DESCRIPTION
This PR makes the sort order for Scan without orderings follow clustering order in the Cosmos adapter. Please take a look!