### PR TITLE
Allow getting already written data in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -90,14 +90,6 @@ public class ConsensusCommit implements DistributedTransaction {
     return tableName;
   }
 
-  /**
-   * Retrieves a result from the storage through a transaction with the specified {@link Get}
-   * command with a primary key and returns the result.
-   *
-   * @param get a {@code Get} command
-   * @return an {@code Optional} with the returned result
-   * @throws CrudException if the operation failed
-   */
   @Override
   public Optional<Result> get(Get get) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
@@ -111,15 +103,6 @@ public class ConsensusCommit implements DistributedTransaction {
     }
   }
 
-  /**
-   * Retrieves results from the storage through a transaction with the specified {@link Scan}
-   * command with a partition key and returns a list of {@link Result}. Results can be filtered by
-   * specifying a range of clustering keys.
-   *
-   * @param scan a {@code Scan} command
-   * @return a list of {@link Result}
-   * @throws CrudException if the operation failed
-   */
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -37,19 +37,19 @@ public class CrudHandler {
     Optional<TransactionResult> result;
     Snapshot.Key key = new Snapshot.Key(get);
 
-    if (snapshot.containsKey(key)) {
+    if (snapshot.containsKeyInReadSet(key)) {
       return snapshot.get(key).map(r -> r);
     }
 
     result = getFromStorage(get);
     if (!result.isPresent()) {
       snapshot.put(key, result);
-      return Optional.empty();
+      return snapshot.get(key).map(r -> r);
     }
 
     if (result.get().isCommitted()) {
       snapshot.put(key, result);
-      return Optional.of(result.get());
+      return snapshot.get(key).map(r -> r);
     }
     throw new UncommittedRecordException(result.get(), "this record needs recovery");
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -110,14 +110,6 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
     return tableName;
   }
 
-  /**
-   * Retrieves a result from the storage through a transaction with the specified {@link Get}
-   * command with a primary key and returns the result.
-   *
-   * @param get a {@code Get} command
-   * @return an {@code Optional} with the returned result
-   * @throws CrudException if the operation failed
-   */
   @Override
   public Optional<Result> get(Get get) throws CrudException {
     checkStatus("The transaction is not active", Status.ACTIVE);
@@ -133,15 +125,6 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
     }
   }
 
-  /**
-   * Retrieves results from the storage through a transaction with the specified {@link Scan}
-   * command with a partition key and returns a list of {@link Result}. Results can be filtered by
-   * specifying a range of clustering keys.
-   *
-   * @param scan a {@code Scan} command
-   * @return a list of {@link Result}
-   * @throws CrudException if the operation failed
-   */
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
     checkStatus("The transaction is not active", Status.ACTIVE);


### PR DESCRIPTION
This PR allows getting already written data in Consensus Commit.

Note that we only support `get-after-put` in this PR, not `scan-after-put`. `scan-after-put` still throw `IllegalArgumentException` even after this change.

Please take a look!