### PR TITLE
Fix OperationChecker for mutation operations

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
@@ -233,7 +233,8 @@ public class OperationChecker {
 
     Mutation first = mutations.get(0);
     for (Mutation mutation : mutations) {
-      if (!mutation.forTable().equals(first.forTable())
+      if (!mutation.forNamespace().equals(first.forNamespace())
+          || !mutation.forTable().equals(first.forTable())
           || !mutation.getPartitionKey().equals(first.getPartitionKey())) {
         throw new IllegalArgumentException("Mutations that span multi-partition are not supported");
       }

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -1028,7 +1028,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingMutateOperationWithMutationsWithDifferentPartitionKeysWithNotAllowPartitions_shouldThrowIllegalArgumentException() {
+      whenCheckingMutateOperationWithMutationsWithDifferentPartitionKeys_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey1 = new Key(PKEY1, 1, PKEY2, "val1");
     Key partitionKey2 = new Key(PKEY1, 2, PKEY2, "val2");
@@ -1037,6 +1037,22 @@ public class OperationCheckerTest {
     ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
     Delete delete = new Delete(partitionKey2, clusteringKey);
     ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingMutateOperationWithMutationsWithSameTableAndPartitionKeyButDifferentNamespace_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
+    Put put = new Put(partitionKey, clusteringKey).withValue(COL1, 1);
+    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Delete delete = new Delete(partitionKey, clusteringKey);
+    ScalarDbUtils.setTargetToIfNot(delete, Optional.of("s2"), TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))


### PR DESCRIPTION
Currently, the check for mutation operations in `OperationChecker` doesn't take `Namespace` into account. So when we specify multiple mutations with the same table and partition key but a different namespace, `OperationChecker` doesn't throw `IllegalArgumentException`. This PR fixes this bug. Please take a look!