### PR TITLE
Handle SQL Server conflict error

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -169,6 +169,13 @@ public final class JdbcUtils {
           return true;
         }
         break;
+      case SQL_SERVER:
+        if (e.getErrorCode() == 1205) {
+          // Transaction was deadlocked on lock resources with another process and has been chosen
+          // as the deadlock victim
+          return true;
+        }
+        break;
       default:
         break;
     }


### PR DESCRIPTION
This PR handles SQL Server conflict error. After this change, when SQL Server throws a conflict error exception, the JDBC adapter throws `XXXConflictException`. Please take a look!