### PR TITLE
Fix Scan logic in CrudHandler in Consensus Commit

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -2344,6 +2344,26 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   @Test
+  public void scan_DeleteGivenBefore_ShouldScan()
+      throws CommitException, UnknownTransactionStatusException, CrudException {
+    // Arrange
+    ConsensusCommit transaction = manager.start();
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.commit();
+
+    // Act
+    ConsensusCommit transaction1 = manager.start();
+    transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
+    Scan scan = prepareScan(0, 0, 1, namespace1, TABLE_1);
+    List<Result> results = transaction1.scan(scan);
+    assertThatCode(transaction1::commit).doesNotThrowAnyException();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(1);
+  }
+
+  @Test
   public void start_CorrectTransactionIdGiven_ShouldNotThrowAnyExceptions() {
     // Arrange
     String transactionId = ANY_ID_1;

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
@@ -2209,6 +2209,31 @@ public class TwoPhaseConsensusCommitIntegrationTest {
   }
 
   @Test
+  public void scan_DeleteGivenBefore_ShouldScan() throws TransactionException {
+    // Arrange
+    TwoPhaseConsensusCommit transaction = manager.start();
+    transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
+    transaction.put(preparePut(0, 1, TABLE_1).withValue(BALANCE, 1));
+    transaction.prepare();
+    transaction.commit();
+
+    // Act
+    TwoPhaseConsensusCommit transaction1 = manager.start();
+    transaction1.delete(prepareDelete(0, 0, TABLE_1));
+    Scan scan = prepareScan(0, 0, 1, TABLE_1);
+    List<Result> results = transaction1.scan(scan);
+    assertThatCode(
+            () -> {
+              transaction1.prepare();
+              transaction1.commit();
+            })
+        .doesNotThrowAnyException();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(1);
+  }
+
+  @Test
   public void start_CorrectTransactionIdGiven_ShouldNotThrowAnyExceptions() {
     // Arrange
     String transactionId = ANY_ID_1;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -75,13 +75,12 @@ public class CrudHandler {
 
         Snapshot.Key key = getSnapshotKey(r, scan);
 
-        if (snapshot.containsKey(key)) {
-          result = snapshot.get(key).orElse(null);
+        if (!snapshot.containsKeyInReadSet(key)) {
+          snapshot.put(key, Optional.of(result));
         }
 
-        snapshot.put(key, Optional.ofNullable(result));
         keys.add(key);
-        results.add(result);
+        snapshot.get(key).ifPresent(results::add);
       }
     } finally {
       if (scanner != null) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -115,10 +115,6 @@ public class Snapshot {
     deleteSet.put(key, delete);
   }
 
-  public boolean containsKey(Key key) {
-    return writeSet.containsKey(key) || deleteSet.containsKey(key) || readSet.containsKey(key);
-  }
-
   public boolean containsKeyInReadSet(Key key) {
     return readSet.containsKey(key);
   }


### PR DESCRIPTION
It looks like the current scan logic in `CrudHandler` is not correct when a record of the scan result is already deleted (the record is in the delete set). This PR fixes the issue. Please take a look!