### PR TITLE
GraphQL package reorganization

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlFactory.java
@@ -16,7 +16,7 @@ import com.scalar.db.graphql.datafetcher.MutationMutateDataFetcher;
 import com.scalar.db.graphql.datafetcher.MutationPutDataFetcher;
 import com.scalar.db.graphql.datafetcher.QueryGetDataFetcher;
 import com.scalar.db.graphql.datafetcher.QueryScanDataFetcher;
-import com.scalar.db.graphql.datafetcher.TransactionInstrumentation;
+import com.scalar.db.graphql.instrumentation.TransactionInstrumentation;
 import com.scalar.db.graphql.instrumentation.validation.AbortFieldValidation;
 import com.scalar.db.graphql.instrumentation.validation.ConditionalExpressionValidation;
 import com.scalar.db.graphql.instrumentation.validation.ScanStartAndEndValidation;

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/ScalarDbTransactionError.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/ScalarDbTransactionError.java
@@ -1,4 +1,4 @@
-package com.scalar.db.graphql.datafetcher;
+package com.scalar.db.graphql.instrumentation;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentation.java
@@ -1,4 +1,4 @@
-package com.scalar.db.graphql.datafetcher;
+package com.scalar.db.graphql.instrumentation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/graphql/src/test/java/com/scalar/db/graphql/GraphQlFactoryTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/GraphQlFactoryTest.java
@@ -10,7 +10,7 @@ import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.graphql.datafetcher.TransactionInstrumentation;
+import com.scalar.db.graphql.instrumentation.TransactionInstrumentation;
 import com.scalar.db.graphql.schema.Constants;
 import com.scalar.db.graphql.schema.ScalarDbTypes;
 import com.scalar.db.io.DataType;

--- a/graphql/src/test/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentationTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.scalar.db.graphql.datafetcher;
+package com.scalar.db.graphql.instrumentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
As mentioned in https://github.com/scalar-labs/scalardb/pull/471#issue-1110295385, this PR moves the `TransactionInstrumentation` (and `ScalarDbTransactionError`) class from the package `com.scalar.db.graphql.datafetcher` to `com.scalar.db.graphql.instrumentation`.

