### PR TITLE
GraphQL should reject storage access to consensus commit transactional tables

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -31,6 +31,7 @@ import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
 import graphql.Scalars;
+import graphql.execution.AbortExecutionException;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLScalarType;
@@ -270,5 +271,14 @@ public class DataFetcherHelper {
 
   String getObjectTypeName() {
     return tableGraphQlModel.getObjectType().getName();
+  }
+
+  void failIfConsensusCommitTransactionalTable() {
+    if (tableGraphQlModel.isConsensusCommitTransactionalTable()) {
+      throw new AbortExecutionException(
+          "the table "
+              + getTableName()
+              + " has transactional meta columns, but being accessed with the storage method");
+    }
   }
 }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkDeleteDataFetcher.java
@@ -53,6 +53,7 @@ public class MutationBulkDeleteDataFetcher implements DataFetcher<DataFetcherRes
       transaction.delete(deletes);
     } else {
       LOGGER.debug("running Delete operations with storage: {}", deletes);
+      helper.failIfConsensusCommitTransactionalTable();
       storage.delete(deletes);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationBulkPutDataFetcher.java
@@ -52,6 +52,7 @@ public class MutationBulkPutDataFetcher implements DataFetcher<DataFetcherResult
       transaction.put(puts);
     } else {
       LOGGER.debug("running Put operations with storage: {}", puts);
+      helper.failIfConsensusCommitTransactionalTable();
       storage.put(puts);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationDeleteDataFetcher.java
@@ -50,6 +50,7 @@ public class MutationDeleteDataFetcher implements DataFetcher<DataFetcherResult<
       transaction.delete(delete);
     } else {
       LOGGER.debug("running Delete operation with storage: {}", delete);
+      helper.failIfConsensusCommitTransactionalTable();
       storage.delete(delete);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationMutateDataFetcher.java
@@ -61,6 +61,7 @@ public class MutationMutateDataFetcher implements DataFetcher<DataFetcherResult<
       transaction.mutate(mutations);
     } else {
       LOGGER.debug("running Mutation operations with storage: {}", mutations);
+      helper.failIfConsensusCommitTransactionalTable();
       storage.mutate(mutations);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationPutDataFetcher.java
@@ -50,6 +50,7 @@ public class MutationPutDataFetcher implements DataFetcher<DataFetcherResult<Boo
       transaction.put(put);
     } else {
       LOGGER.debug("running Put operation with storage: {}", put);
+      helper.failIfConsensusCommitTransactionalTable();
       storage.put(put);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -84,6 +84,7 @@ public class QueryGetDataFetcher
       return transaction.get(get);
     } else {
       LOGGER.debug("running Get operation with storage: {}", get);
+      helper.failIfConsensusCommitTransactionalTable();
       return storage.get(get);
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -136,6 +136,7 @@ public class QueryScanDataFetcher
       return transaction.scan(scan);
     } else {
       LOGGER.debug("running Scan operation with storage: {}", scan);
+      helper.failIfConsensusCommitTransactionalTable();
       return ImmutableList.copyOf(storage.scan(scan));
     }
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/TableGraphQlModel.java
@@ -34,6 +34,8 @@ public class TableGraphQlModel {
   private final String namespaceName;
   private final String tableName;
   private final TableMetadata tableMetadata;
+
+  private final boolean isConsensusCommitTransactionalTable;
   private final LinkedHashSet<String> fieldNames;
   private final Map<String, GraphQLScalarType> fieldNameGraphQLScalarTypeMap;
 
@@ -63,8 +65,12 @@ public class TableGraphQlModel {
     this.tableName = Objects.requireNonNull(tableName);
     this.tableMetadata = Objects.requireNonNull(tableMetadata);
 
+    this.isConsensusCommitTransactionalTable =
+        ConsensusCommitUtils.isTransactionalTableMetadata(tableMetadata);
     this.fieldNames =
-        ConsensusCommitUtils.removeTransactionalMetaColumns(tableMetadata).getColumnNames();
+        isConsensusCommitTransactionalTable
+            ? ConsensusCommitUtils.removeTransactionalMetaColumns(tableMetadata).getColumnNames()
+            : tableMetadata.getColumnNames();
     this.fieldNameGraphQLScalarTypeMap =
         fieldNames.stream()
             .collect(
@@ -339,6 +345,10 @@ public class TableGraphQlModel {
 
   public TableMetadata getTableMetadata() {
     return tableMetadata;
+  }
+
+  public boolean isConsensusCommitTransactionalTable() {
+    return isConsensusCommitTransactionalTable;
   }
 
   public LinkedHashSet<String> getFieldNames() {


### PR DESCRIPTION
1. In the GraphQL schema generation, the consensus commit meta columns are hidden from the GraphQL schema only if a table has all meta columns. (`ConsensusCommitUtils.isTransactionalTableMetadata(tableMetadata)` is `true`).

2. Accessing a table with storage method will fail if it has consensus commit meta columns.

    |                  | No meta columns | CC meta columns |
    |------------------|-----------------|-----------------|
    | Storage          | OK              | **Error**       |
    | Consensus Commit | Error           | OK              |
    | JDBC             | OK              | OK (*)          |

    (*) Since there is no way to know that the transaction is backed by JDBC native transaction at runtime, the GraphQL interface doesn't reject access to CC tables with JDBC. Alternatively, it would be possible to produce warnings at the startup of the GraphQL server, if the transaction mode is JDBC while there are CC tables in the specified namespaces by the `scalar.db.graphql.namespaces` property.

As pointed out in https://github.com/scalar-labs/scalardb/pull/470#discussion_r788728658, the class design of `DataFetcherHelper` is not good. It should be fixed in the upcoming PR.
