### PR TITLE
Use only id and version to check if a read record is not changed in the validation in EXTRA_READ

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -13,7 +13,6 @@ import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UncommittedRecordException;
-import com.scalar.db.io.Key;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +72,7 @@ public class CrudHandler {
           throw new UncommittedRecordException(result, "the record needs recovery");
         }
 
-        Snapshot.Key key = getSnapshotKey(r, scan);
+        Snapshot.Key key = new Snapshot.Key(scan, r);
 
         if (!snapshot.containsKeyInReadSet(key)) {
           snapshot.put(key, Optional.of(result));
@@ -120,16 +119,6 @@ public class CrudHandler {
     } catch (ExecutionException e) {
       throw new CrudException("scan failed.", e);
     }
-  }
-
-  private Snapshot.Key getSnapshotKey(Result result, Scan scan) throws CrudException {
-    Optional<Key> partitionKey = result.getPartitionKey();
-    Optional<Key> clusteringKey = result.getClusteringKey();
-    return new Snapshot.Key(
-        scan.forNamespace().get(),
-        scan.forTable().get(),
-        partitionKey.orElseThrow(() -> new CrudException("can't get a snapshot key")),
-        clusteringKey.orElse(null));
   }
 
   public Snapshot getSnapshot() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -276,6 +276,9 @@ public class Snapshot {
             Scanner scanner = null;
             try {
               Scan scan = entry.getKey();
+              // only get tx_id and tx_version columns because we use only them to compare
+              scan.clearProjections();
+              scan.withProjection(Attribute.ID).withProjection(Attribute.VERSION);
               scanner = storage.scan(scan);
               for (Result result : scanner) {
                 TransactionResult transactionResult = new TransactionResult(result);
@@ -331,8 +334,11 @@ public class Snapshot {
 
       tasks.add(
           () -> {
+            // only get tx_id and tx_version columns because we use only them to compare
             Get get =
                 new Get(key.getPartitionKey(), key.getClusteringKey().orElse(null))
+                    .withProjection(Attribute.ID)
+                    .withProjection(Attribute.VERSION)
                     .withConsistency(Consistency.LINEARIZABLE)
                     .forNamespace(key.getNamespace())
                     .forTable(key.getTable());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -186,12 +186,7 @@ public class CrudHandlerTest {
     // Arrange
     Scan scan = prepareScan();
     result = prepareResult(true, TransactionState.COMMITTED);
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
+    Snapshot.Key key = new Snapshot.Key(scan, result);
     when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
     doNothing()
         .when(snapshot)
@@ -238,12 +233,7 @@ public class CrudHandlerTest {
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(scan)).thenReturn(scanner);
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
+    Snapshot.Key key = new Snapshot.Key(scan, result);
     when(snapshot.get(scan))
         .thenReturn(Optional.empty())
         .thenReturn(Optional.of(Collections.singletonList(key)));
@@ -295,12 +285,7 @@ public class CrudHandlerTest {
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(scan)).thenReturn(scanner);
-    Snapshot.Key key =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
+    Snapshot.Key key = new Snapshot.Key(scan, result);
     when(snapshot.get(scan)).thenReturn(Optional.empty());
     when(snapshot.containsKeyInReadSet(key)).thenReturn(false).thenReturn(true);
     when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
@@ -391,20 +376,10 @@ public class CrudHandlerTest {
 
     // check if the scanned data is inserted correctly in the read set
     assertThat(readSet.size()).isEqualTo(2);
-    Snapshot.Key key1 =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result.getClusteringKey().get());
+    Snapshot.Key key1 = new Snapshot.Key(scan, result);
     assertThat(readSet.get(key1).isPresent()).isTrue();
     assertThat(readSet.get(key1).get()).isEqualTo(new TransactionResult(result));
-    Snapshot.Key key2 =
-        new Snapshot.Key(
-            scan.forNamespace().get(),
-            scan.forTable().get(),
-            scan.getPartitionKey(),
-            result2.getClusteringKey().get());
+    Snapshot.Key key2 = new Snapshot.Key(scan, result2);
     assertThat(readSet.get(key2).isPresent()).isTrue();
     assertThat(readSet.get(key2).get()).isEqualTo(new TransactionResult(result2));
   }


### PR DESCRIPTION
I don't think we need to compare all the values of a read record and a re-read record in the validation in EXTRA_READ. I think it's enough to compare `id` and `version` values. This PR makes it. Please take a look!