### PR TITLE
Increase no_output_timeout for Cosmos DB adapter CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
 
       - run:
           name: Run integration test
-          no_output_timeout: 20m
+          no_output_timeout: 30m
           command: gradle integrationTestCosmos -Dscalardb.cosmos.uri=${COSMOS_URI} -Dscalardb.cosmos.password=${COSMOS_PASSWORD} -Dscalardb.cosmos.database_prefix="${CIRCLE_BUILD_NUM}_"
 
       - run:


### PR DESCRIPTION
It looks like the Cosmos DB adapter CI is taking longer time recently and it's failing with `Too long with no output (exceeded 20m0s): context deadline exceeded` error. To address this issue, we can increase `no_output_timeout` for Cosmos DB adapter CI. This PR does it. Please take a look!