### PR TITLE
GraphQL constants

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlConstants.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlConstants.java
@@ -3,11 +3,7 @@ package com.scalar.db.graphql;
 import com.google.common.collect.ImmutableSet;
 
 public final class GraphQlConstants {
-  public static final String TRANSACTION_DIRECTIVE_NAME = "transaction";
-  public static final String TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME = "txId";
-  public static final String TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME = "commit";
   public static final String CONTEXT_TRANSACTION_KEY = "transaction";
-  public static final String ERRORS_EXTENSIONS_EXCEPTION_KEY = "exception";
   public static final ImmutableSet<String> SCALAR_VALUE_FIELD_NAMES =
       ImmutableSet.of(
           "intValue", "bigIntValue", "floatValue", "doubleValue", "textValue", "booleanValue");

--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlConstants.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlConstants.java
@@ -1,8 +1,8 @@
-package com.scalar.db.graphql.schema;
+package com.scalar.db.graphql;
 
 import com.google.common.collect.ImmutableSet;
 
-public final class Constants {
+public final class GraphQlConstants {
   public static final String TRANSACTION_DIRECTIVE_NAME = "transaction";
   public static final String TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME = "txId";
   public static final String TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME = "commit";
@@ -12,5 +12,5 @@ public final class Constants {
       ImmutableSet.of(
           "intValue", "bigIntValue", "floatValue", "doubleValue", "textValue", "booleanValue");
 
-  private Constants() {}
+  private GraphQlConstants() {}
 }

--- a/graphql/src/main/java/com/scalar/db/graphql/GraphQlConstants.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/GraphQlConstants.java
@@ -8,7 +8,7 @@ public final class GraphQlConstants {
   public static final String TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME = "commit";
   public static final String CONTEXT_TRANSACTION_KEY = "transaction";
   public static final String ERRORS_EXTENSIONS_EXCEPTION_KEY = "exception";
-  public static final ImmutableSet<String> SCALAR_VALUE_KEYS =
+  public static final ImmutableSet<String> SCALAR_VALUE_FIELD_NAMES =
       ImmutableSet.of(
           "intValue", "bigIntValue", "floatValue", "doubleValue", "textValue", "booleanValue");
 

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DataFetcherHelper {
-
   private final TableGraphQlModel tableGraphQlModel;
 
   public DataFetcherHelper(TableGraphQlModel tableGraphQlModel) {
@@ -91,7 +90,7 @@ public class DataFetcherHelper {
     String exName = exception.getClass().getSimpleName();
     return GraphqlErrorBuilder.newError(environment)
         .message("Scalar DB %s happened while fetching data: %s", exName, exception.getMessage())
-        .extensions(ImmutableMap.of(GraphQlConstants.ERRORS_EXTENSIONS_EXCEPTION_KEY, exName))
+        .extensions(ImmutableMap.of("exception", exName))
         .errorType(ErrorType.DataFetchingException)
         .build();
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -14,7 +14,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import com.scalar.db.graphql.schema.ScalarDbTypes;
 import com.scalar.db.graphql.schema.ScalarDbTypes.DeleteConditionType;
 import com.scalar.db.graphql.schema.ScalarDbTypes.PutConditionType;
@@ -51,7 +51,7 @@ public class DataFetcherHelper {
   }
 
   static DistributedTransaction getCurrentTransaction(DataFetchingEnvironment environment) {
-    return environment.getGraphQlContext().get(Constants.CONTEXT_TRANSACTION_KEY);
+    return environment.getGraphQlContext().get(GraphQlConstants.CONTEXT_TRANSACTION_KEY);
   }
 
   static Value<?> createValueFromMap(String name, Map<String, Object> map) {
@@ -76,10 +76,10 @@ public class DataFetcherHelper {
   }
 
   private static Object getOneScalarValue(Map<String, Object> map) {
-    Set<String> valueKeys = Sets.intersection(map.keySet(), Constants.SCALAR_VALUE_KEYS);
+    Set<String> valueKeys = Sets.intersection(map.keySet(), GraphQlConstants.SCALAR_VALUE_KEYS);
     if (valueKeys.size() != 1) {
       throw new IllegalArgumentException(
-          "One and only one of " + Constants.SCALAR_VALUE_KEYS + " must be specified.");
+          "One and only one of " + GraphQlConstants.SCALAR_VALUE_KEYS + " must be specified.");
     }
     return map.get(valueKeys.stream().findFirst().get());
   }
@@ -88,7 +88,7 @@ public class DataFetcherHelper {
     String exName = exception.getClass().getSimpleName();
     return GraphqlErrorBuilder.newError(environment)
         .message("Scalar DB %s happened while fetching data: %s", exName, exception.getMessage())
-        .extensions(ImmutableMap.of(Constants.ERRORS_EXTENSIONS_EXCEPTION_KEY, exName))
+        .extensions(ImmutableMap.of(GraphQlConstants.ERRORS_EXTENSIONS_EXCEPTION_KEY, exName))
         .errorType(ErrorType.DataFetchingException)
         .build();
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/DataFetcherHelper.java
@@ -76,10 +76,13 @@ public class DataFetcherHelper {
   }
 
   private static Object getOneScalarValue(Map<String, Object> map) {
-    Set<String> valueKeys = Sets.intersection(map.keySet(), GraphQlConstants.SCALAR_VALUE_KEYS);
+    Set<String> valueKeys =
+        Sets.intersection(map.keySet(), GraphQlConstants.SCALAR_VALUE_FIELD_NAMES);
     if (valueKeys.size() != 1) {
       throw new IllegalArgumentException(
-          "One and only one of " + GraphQlConstants.SCALAR_VALUE_KEYS + " must be specified.");
+          "One and only one of "
+              + GraphQlConstants.SCALAR_VALUE_FIELD_NAMES
+              + " must be specified.");
     }
     return map.get(valueKeys.stream().findFirst().get());
   }

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationAbortDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/MutationAbortDataFetcher.java
@@ -2,7 +2,7 @@ package com.scalar.db.graphql.datafetcher;
 
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.exception.transaction.AbortException;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import graphql.GraphQLContext;
 import graphql.execution.AbortExecutionException;
 import graphql.execution.DataFetcherResult;
@@ -17,7 +17,8 @@ public class MutationAbortDataFetcher implements DataFetcher<DataFetcherResult<B
   @Override
   public DataFetcherResult<Boolean> get(DataFetchingEnvironment environment) throws Exception {
     GraphQLContext graphQLContext = environment.getGraphQlContext();
-    DistributedTransaction transaction = graphQLContext.get(Constants.CONTEXT_TRANSACTION_KEY);
+    DistributedTransaction transaction =
+        graphQLContext.get(GraphQlConstants.CONTEXT_TRANSACTION_KEY);
     if (transaction == null) {
       LOGGER.warn("got abort mutation, but transaction was not found");
       return DataFetcherResult.<Boolean>newResult()

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentation.java
@@ -67,19 +67,15 @@ public class TransactionInstrumentation extends SimpleInstrumentation {
     GraphQLContext graphQLContext = executionContext.getGraphQLContext();
 
     List<Directive> transactionDirectives =
-        executionContext
-            .getOperationDefinition()
-            .getDirectives(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME);
+        executionContext.getOperationDefinition().getDirectives("transaction");
 
     if (transactionDirectives.isEmpty()) {
       return SimpleInstrumentationContext.noOp();
     }
 
     Directive directive = transactionDirectives.get(0); // @transaction is not repeatable
-    Argument txIdArg =
-        directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME);
-    Argument commitArg =
-        directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME);
+    Argument txIdArg = directive.getArgument("txId");
+    Argument commitArg = directive.getArgument("commit");
 
     DistributedTransaction transaction;
     if (txIdArg == null) {

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentation.java
@@ -9,7 +9,7 @@ import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import com.scalar.db.util.ActiveExpiringMap;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
@@ -69,16 +69,17 @@ public class TransactionInstrumentation extends SimpleInstrumentation {
     List<Directive> transactionDirectives =
         executionContext
             .getOperationDefinition()
-            .getDirectives(Constants.TRANSACTION_DIRECTIVE_NAME);
+            .getDirectives(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME);
 
     if (transactionDirectives.isEmpty()) {
       return SimpleInstrumentationContext.noOp();
     }
 
     Directive directive = transactionDirectives.get(0); // @transaction is not repeatable
-    Argument txIdArg = directive.getArgument(Constants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME);
+    Argument txIdArg =
+        directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME);
     Argument commitArg =
-        directive.getArgument(Constants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME);
+        directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME);
 
     DistributedTransaction transaction;
     if (txIdArg == null) {
@@ -107,7 +108,7 @@ public class TransactionInstrumentation extends SimpleInstrumentation {
                     return new AbortExecutionException(message);
                   });
     }
-    graphQLContext.put(Constants.CONTEXT_TRANSACTION_KEY, transaction);
+    graphQLContext.put(GraphQlConstants.CONTEXT_TRANSACTION_KEY, transaction);
 
     boolean isCommitTrue =
         commitArg != null
@@ -169,7 +170,8 @@ public class TransactionInstrumentation extends SimpleInstrumentation {
 
     // If a transaction is ongoing, transaction ID should be included in the "extensions" key of the
     // result.
-    DistributedTransaction transaction = graphQLContext.get(Constants.CONTEXT_TRANSACTION_KEY);
+    DistributedTransaction transaction =
+        graphQLContext.get(GraphQlConstants.CONTEXT_TRANSACTION_KEY);
     if (transaction == null) {
       return CompletableFuture.completedFuture(executionResult);
     }

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/AbortFieldValidation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/AbortFieldValidation.java
@@ -1,7 +1,6 @@
 package com.scalar.db.graphql.instrumentation.validation;
 
 import com.google.common.collect.ImmutableList;
-import com.scalar.db.graphql.GraphQlConstants;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
@@ -35,8 +34,7 @@ public class AbortFieldValidation implements FieldValidation {
     }
 
     ImmutableList.Builder<GraphQLError> errors = ImmutableList.builder();
-    List<Directive> transactionDirectives =
-        operationDefinition.getDirectives(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME);
+    List<Directive> transactionDirectives = operationDefinition.getDirectives("transaction");
     SourceLocation location = abortField.get().getSourceLocation();
     if (transactionDirectives.isEmpty()) {
       errors.add(
@@ -44,10 +42,8 @@ public class AbortFieldValidation implements FieldValidation {
               "transaction directive with txId is required to abort transaction", location));
     } else {
       Directive directive = transactionDirectives.get(0); // @transaction is not repeatable
-      Argument txIdArg =
-          directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME);
-      Argument commitArg =
-          directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME);
+      Argument txIdArg = directive.getArgument("txId");
+      Argument commitArg = directive.getArgument("commit");
       if (txIdArg == null
           || txIdArg.getValue() == null
           || txIdArg.getValue() instanceof NullValue) {

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/AbortFieldValidation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/AbortFieldValidation.java
@@ -1,7 +1,7 @@
 package com.scalar.db.graphql.instrumentation.validation;
 
 import com.google.common.collect.ImmutableList;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
@@ -36,7 +36,7 @@ public class AbortFieldValidation implements FieldValidation {
 
     ImmutableList.Builder<GraphQLError> errors = ImmutableList.builder();
     List<Directive> transactionDirectives =
-        operationDefinition.getDirectives(Constants.TRANSACTION_DIRECTIVE_NAME);
+        operationDefinition.getDirectives(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME);
     SourceLocation location = abortField.get().getSourceLocation();
     if (transactionDirectives.isEmpty()) {
       errors.add(
@@ -44,9 +44,10 @@ public class AbortFieldValidation implements FieldValidation {
               "transaction directive with txId is required to abort transaction", location));
     } else {
       Directive directive = transactionDirectives.get(0); // @transaction is not repeatable
-      Argument txIdArg = directive.getArgument(Constants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME);
+      Argument txIdArg =
+          directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME);
       Argument commitArg =
-          directive.getArgument(Constants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME);
+          directive.getArgument(GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME);
       if (txIdArg == null
           || txIdArg.getValue() == null
           || txIdArg.getValue() instanceof NullValue) {

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ConditionalExpressionValidation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ConditionalExpressionValidation.java
@@ -98,10 +98,12 @@ public class ConditionalExpressionValidation implements FieldValidation {
               "expressions must be present for " + type + " condition type", fieldAndArguments));
     } else if (expressions.stream()
         .anyMatch(
-            ex -> Sets.intersection(ex.keySet(), GraphQlConstants.SCALAR_VALUE_KEYS).size() != 1)) {
+            ex ->
+                Sets.intersection(ex.keySet(), GraphQlConstants.SCALAR_VALUE_FIELD_NAMES).size()
+                    != 1)) {
       return Optional.of(
           createError(
-              "expression must have only one of " + GraphQlConstants.SCALAR_VALUE_KEYS,
+              "expression must have only one of " + GraphQlConstants.SCALAR_VALUE_FIELD_NAMES,
               fieldAndArguments));
     }
     return Optional.empty();

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ConditionalExpressionValidation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ConditionalExpressionValidation.java
@@ -1,7 +1,7 @@
 package com.scalar.db.graphql.instrumentation.validation;
 
 import com.google.common.collect.Sets;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import com.scalar.db.graphql.schema.ScalarDbTypes.DeleteConditionType;
 import com.scalar.db.graphql.schema.ScalarDbTypes.PutConditionType;
 import graphql.ErrorType;
@@ -97,10 +97,11 @@ public class ConditionalExpressionValidation implements FieldValidation {
           createError(
               "expressions must be present for " + type + " condition type", fieldAndArguments));
     } else if (expressions.stream()
-        .anyMatch(ex -> Sets.intersection(ex.keySet(), Constants.SCALAR_VALUE_KEYS).size() != 1)) {
+        .anyMatch(
+            ex -> Sets.intersection(ex.keySet(), GraphQlConstants.SCALAR_VALUE_KEYS).size() != 1)) {
       return Optional.of(
           createError(
-              "expression must have only one of " + Constants.SCALAR_VALUE_KEYS,
+              "expression must have only one of " + GraphQlConstants.SCALAR_VALUE_KEYS,
               fieldAndArguments));
     }
     return Optional.empty();

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ScanStartAndEndValidation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ScanStartAndEndValidation.java
@@ -45,7 +45,7 @@ public class ScanStartAndEndValidation implements FieldValidation {
   private Optional<GraphQLError> validateClusteringKey(
       String argName, Map<String, Object> clusteringKey, FieldAndArguments fieldAndArguments) {
     Set<String> valueKeys =
-        Sets.intersection(clusteringKey.keySet(), GraphQlConstants.SCALAR_VALUE_KEYS);
+        Sets.intersection(clusteringKey.keySet(), GraphQlConstants.SCALAR_VALUE_FIELD_NAMES);
     if (valueKeys.size() == 1) {
       return Optional.empty();
     } else {
@@ -53,7 +53,7 @@ public class ScanStartAndEndValidation implements FieldValidation {
           GraphqlErrorBuilder.newError()
               .message(
                   "the %s clustering key must have only one of %s",
-                  argName, GraphQlConstants.SCALAR_VALUE_KEYS)
+                  argName, GraphQlConstants.SCALAR_VALUE_FIELD_NAMES)
               .errorType(ErrorType.ValidationError)
               .path(fieldAndArguments.getPath())
               .location(fieldAndArguments.getField().getSourceLocation())

--- a/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ScanStartAndEndValidation.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/instrumentation/validation/ScanStartAndEndValidation.java
@@ -1,7 +1,7 @@
 package com.scalar.db.graphql.instrumentation.validation;
 
 import com.google.common.collect.Sets;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
@@ -44,7 +44,8 @@ public class ScanStartAndEndValidation implements FieldValidation {
 
   private Optional<GraphQLError> validateClusteringKey(
       String argName, Map<String, Object> clusteringKey, FieldAndArguments fieldAndArguments) {
-    Set<String> valueKeys = Sets.intersection(clusteringKey.keySet(), Constants.SCALAR_VALUE_KEYS);
+    Set<String> valueKeys =
+        Sets.intersection(clusteringKey.keySet(), GraphQlConstants.SCALAR_VALUE_KEYS);
     if (valueKeys.size() == 1) {
       return Optional.empty();
     } else {
@@ -52,7 +53,7 @@ public class ScanStartAndEndValidation implements FieldValidation {
           GraphqlErrorBuilder.newError()
               .message(
                   "the %s clustering key must have only one of %s",
-                  argName, Constants.SCALAR_VALUE_KEYS)
+                  argName, GraphQlConstants.SCALAR_VALUE_KEYS)
               .errorType(ErrorType.ValidationError)
               .path(fieldAndArguments.getPath())
               .location(fieldAndArguments.getField().getSourceLocation())

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/ScalarDbTypes.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/ScalarDbTypes.java
@@ -14,7 +14,6 @@ import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Scan.Ordering.Order;
-import com.scalar.db.graphql.GraphQlConstants;
 import com.scalar.db.io.DataType;
 import graphql.Scalars;
 import graphql.introspection.Introspection.DirectiveLocation;
@@ -29,15 +28,9 @@ import java.util.List;
 public final class ScalarDbTypes {
   public static final GraphQLDirective TRANSACTION_DIRECTIVE =
       newDirective()
-          .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
-          .argument(
-              newArgument()
-                  .name(GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME)
-                  .type(Scalars.GraphQLString))
-          .argument(
-              newArgument()
-                  .name(GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME)
-                  .type(Scalars.GraphQLBoolean))
+          .name("transaction")
+          .argument(newArgument().name("txId").type(Scalars.GraphQLString))
+          .argument(newArgument().name("commit").type(Scalars.GraphQLBoolean))
           .validLocations(DirectiveLocation.MUTATION, DirectiveLocation.QUERY)
           .build();
 

--- a/graphql/src/main/java/com/scalar/db/graphql/schema/ScalarDbTypes.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/schema/ScalarDbTypes.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.graphql.GraphQlConstants;
 import com.scalar.db.io.DataType;
 import graphql.Scalars;
 import graphql.introspection.Introspection.DirectiveLocation;
@@ -28,14 +29,14 @@ import java.util.List;
 public final class ScalarDbTypes {
   public static final GraphQLDirective TRANSACTION_DIRECTIVE =
       newDirective()
-          .name(Constants.TRANSACTION_DIRECTIVE_NAME)
+          .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
           .argument(
               newArgument()
-                  .name(Constants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME)
+                  .name(GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME)
                   .type(Scalars.GraphQLString))
           .argument(
               newArgument()
-                  .name(Constants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME)
+                  .name(GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME)
                   .type(Scalars.GraphQLBoolean))
           .validLocations(DirectiveLocation.MUTATION, DirectiveLocation.QUERY)
           .build();

--- a/graphql/src/test/java/com/scalar/db/graphql/GraphQlFactoryTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/GraphQlFactoryTest.java
@@ -143,7 +143,7 @@ public class GraphQlFactoryTest {
     assertThat(schema.containsType(TABLE_NAME_1)).isTrue();
     assertThat(schema.containsType("Query")).isTrue();
     assertThat(schema.containsType("Mutation")).isTrue();
-    assertThat(schema.getDirective(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)).isNotNull();
+    assertThat(schema.getDirective("transaction")).isNotNull();
     for (GraphQLType type : ScalarDbTypes.SCALAR_DB_GRAPHQL_TYPES) {
       assertThat(schema.containsType(((GraphQLNamedType) type).getName())).isTrue();
     }
@@ -238,7 +238,7 @@ public class GraphQlFactoryTest {
 
     // Assert
     GraphQLSchema schema = graphql.getGraphQLSchema();
-    assertThat(schema.getDirective(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)).isNull();
+    assertThat(schema.getDirective("transaction")).isNull();
     Instrumentation instrumentation = graphql.getInstrumentation();
 
     Field field = instrumentation.getClass().getDeclaredField("instrumentations");

--- a/graphql/src/test/java/com/scalar/db/graphql/GraphQlFactoryTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/GraphQlFactoryTest.java
@@ -11,7 +11,6 @@ import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.graphql.instrumentation.TransactionInstrumentation;
-import com.scalar.db.graphql.schema.Constants;
 import com.scalar.db.graphql.schema.ScalarDbTypes;
 import com.scalar.db.io.DataType;
 import com.scalar.db.service.StorageFactory;
@@ -144,7 +143,7 @@ public class GraphQlFactoryTest {
     assertThat(schema.containsType(TABLE_NAME_1)).isTrue();
     assertThat(schema.containsType("Query")).isTrue();
     assertThat(schema.containsType("Mutation")).isTrue();
-    assertThat(schema.getDirective(Constants.TRANSACTION_DIRECTIVE_NAME)).isNotNull();
+    assertThat(schema.getDirective(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)).isNotNull();
     for (GraphQLType type : ScalarDbTypes.SCALAR_DB_GRAPHQL_TYPES) {
       assertThat(schema.containsType(((GraphQLNamedType) type).getName())).isTrue();
     }
@@ -239,7 +238,7 @@ public class GraphQlFactoryTest {
 
     // Assert
     GraphQLSchema schema = graphql.getGraphQLSchema();
-    assertThat(schema.getDirective(Constants.TRANSACTION_DIRECTIVE_NAME)).isNull();
+    assertThat(schema.getDirective(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)).isNull();
     Instrumentation instrumentation = graphql.getInstrumentation();
 
     Field field = instrumentation.getClass().getDeclaredField("instrumentations");

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
@@ -90,7 +90,7 @@ public abstract class DataFetcherTestBase {
             .filter(
                 e ->
                     exName.equals(
-                        e.getExtensions().get(GraphQlConstants.ERRORS_EXTENSIONS_EXCEPTION_KEY)))
+                        e.getExtensions().get("exception")))
             .findFirst()
             .orElse(null);
     assertThat(error).isNotNull();

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransaction;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Scalars;
@@ -79,7 +79,7 @@ public abstract class DataFetcherTestBase {
   }
 
   protected void setTransactionStarted() {
-    when(graphQlContext.get(Constants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
+    when(graphQlContext.get(GraphQlConstants.CONTEXT_TRANSACTION_KEY)).thenReturn(transaction);
   }
 
   protected void assertThatDataFetcherResultHasErrorForException(
@@ -89,7 +89,8 @@ public abstract class DataFetcherTestBase {
         result.getErrors().stream()
             .filter(
                 e ->
-                    exName.equals(e.getExtensions().get(Constants.ERRORS_EXTENSIONS_EXCEPTION_KEY)))
+                    exName.equals(
+                        e.getExtensions().get(GraphQlConstants.ERRORS_EXTENSIONS_EXCEPTION_KEY)))
             .findFirst()
             .orElse(null);
     assertThat(error).isNotNull();

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/DataFetcherTestBase.java
@@ -87,10 +87,7 @@ public abstract class DataFetcherTestBase {
     String exName = exception.getClass().getSimpleName();
     GraphQLError error =
         result.getErrors().stream()
-            .filter(
-                e ->
-                    exName.equals(
-                        e.getExtensions().get("exception")))
+            .filter(e -> exName.equals(e.getExtensions().get("exception")))
             .findFirst()
             .orElse(null);
     assertThat(error).isNotNull();

--- a/graphql/src/test/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentationTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentationTest.java
@@ -85,7 +85,7 @@ public class TransactionInstrumentationTest {
   }
 
   private void prepareDirective(Directive transactionDirective) {
-    when(operationDefinition.getDirectives(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME))
+    when(operationDefinition.getDirectives("transaction"))
         .thenReturn(Collections.singletonList(transactionDirective));
   }
 
@@ -99,7 +99,7 @@ public class TransactionInstrumentationTest {
       throws Exception {
     // Arrange
     prepareForBeginExecuteOperationTests();
-    prepareDirective(new Directive(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME));
+    prepareDirective(new Directive("transaction"));
 
     // Act
     InstrumentationContext<ExecutionResult> context =
@@ -119,11 +119,8 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
-            .argument(
-                new Argument(
-                    GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME,
-                    new BooleanValue(true)))
+            .name("transaction")
+            .argument(new Argument("commit", new BooleanValue(true)))
             .build());
 
     // Act
@@ -141,7 +138,7 @@ public class TransactionInstrumentationTest {
       throws Exception {
     // Arrange
     prepareForBeginExecuteOperationTests();
-    prepareDirective(new Directive(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME));
+    prepareDirective(new Directive("transaction"));
     when(transactionManager.start()).thenThrow(TransactionException.class);
 
     // Act Assert
@@ -159,11 +156,8 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
-            .argument(
-                new Argument(
-                    GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
-                    new StringValue(ANY_TX_ID)))
+            .name("transaction")
+            .argument(new Argument("txId", new StringValue(ANY_TX_ID)))
             .build());
     instrumentation.activeTransactions.put(ANY_TX_ID, transaction);
 
@@ -185,15 +179,9 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
-            .argument(
-                new Argument(
-                    GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
-                    new StringValue(ANY_TX_ID)))
-            .argument(
-                new Argument(
-                    GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME,
-                    new BooleanValue(true)))
+            .name("transaction")
+            .argument(new Argument("txId", new StringValue(ANY_TX_ID)))
+            .argument(new Argument("commit", new BooleanValue(true)))
             .build());
     instrumentation.activeTransactions.put(ANY_TX_ID, transaction);
 
@@ -214,11 +202,8 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
-            .argument(
-                new Argument(
-                    GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
-                    new StringValue(ANY_TX_ID)))
+            .name("transaction")
+            .argument(new Argument("txId", new StringValue(ANY_TX_ID)))
             .build());
 
     // Act Assert

--- a/graphql/src/test/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentationTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/instrumentation/TransactionInstrumentationTest.java
@@ -20,7 +20,7 @@ import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.graphql.schema.Constants;
+import com.scalar.db.graphql.GraphQlConstants;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.GraphQLContext;
@@ -85,7 +85,7 @@ public class TransactionInstrumentationTest {
   }
 
   private void prepareDirective(Directive transactionDirective) {
-    when(operationDefinition.getDirectives(Constants.TRANSACTION_DIRECTIVE_NAME))
+    when(operationDefinition.getDirectives(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME))
         .thenReturn(Collections.singletonList(transactionDirective));
   }
 
@@ -99,7 +99,7 @@ public class TransactionInstrumentationTest {
       throws Exception {
     // Arrange
     prepareForBeginExecuteOperationTests();
-    prepareDirective(new Directive(Constants.TRANSACTION_DIRECTIVE_NAME));
+    prepareDirective(new Directive(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME));
 
     // Act
     InstrumentationContext<ExecutionResult> context =
@@ -107,7 +107,7 @@ public class TransactionInstrumentationTest {
 
     // Assert
     verify(transactionManager, times(1)).start();
-    verify(graphQlContext).put(Constants.CONTEXT_TRANSACTION_KEY, transaction);
+    verify(graphQlContext).put(GraphQlConstants.CONTEXT_TRANSACTION_KEY, transaction);
     assertThat(context).isInstanceOf(SimpleInstrumentationContext.class);
   }
 
@@ -119,10 +119,11 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(Constants.TRANSACTION_DIRECTIVE_NAME)
+            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
             .argument(
                 new Argument(
-                    Constants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME, new BooleanValue(true)))
+                    GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME,
+                    new BooleanValue(true)))
             .build());
 
     // Act
@@ -131,7 +132,7 @@ public class TransactionInstrumentationTest {
 
     // Assert
     verify(transactionManager, times(1)).start();
-    verify(graphQlContext).put(Constants.CONTEXT_TRANSACTION_KEY, transaction);
+    verify(graphQlContext).put(GraphQlConstants.CONTEXT_TRANSACTION_KEY, transaction);
     assertThat(context).isInstanceOf(SimpleInstrumentationContext.class);
   }
 
@@ -140,7 +141,7 @@ public class TransactionInstrumentationTest {
       throws Exception {
     // Arrange
     prepareForBeginExecuteOperationTests();
-    prepareDirective(new Directive(Constants.TRANSACTION_DIRECTIVE_NAME));
+    prepareDirective(new Directive(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME));
     when(transactionManager.start()).thenThrow(TransactionException.class);
 
     // Act Assert
@@ -158,10 +159,10 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(Constants.TRANSACTION_DIRECTIVE_NAME)
+            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
             .argument(
                 new Argument(
-                    Constants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
+                    GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
                     new StringValue(ANY_TX_ID)))
             .build());
     instrumentation.activeTransactions.put(ANY_TX_ID, transaction);
@@ -172,7 +173,7 @@ public class TransactionInstrumentationTest {
 
     // Assert
     verify(transactionManager, never()).start();
-    verify(graphQlContext).put(Constants.CONTEXT_TRANSACTION_KEY, transaction);
+    verify(graphQlContext).put(GraphQlConstants.CONTEXT_TRANSACTION_KEY, transaction);
     assertThat(context).isInstanceOf(SimpleInstrumentationContext.class);
   }
 
@@ -184,14 +185,15 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(Constants.TRANSACTION_DIRECTIVE_NAME)
+            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
             .argument(
                 new Argument(
-                    Constants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
+                    GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
                     new StringValue(ANY_TX_ID)))
             .argument(
                 new Argument(
-                    Constants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME, new BooleanValue(true)))
+                    GraphQlConstants.TRANSACTION_DIRECTIVE_COMMIT_ARGUMENT_NAME,
+                    new BooleanValue(true)))
             .build());
     instrumentation.activeTransactions.put(ANY_TX_ID, transaction);
 
@@ -201,7 +203,7 @@ public class TransactionInstrumentationTest {
 
     // Assert
     verify(transactionManager, never()).start();
-    verify(graphQlContext).put(Constants.CONTEXT_TRANSACTION_KEY, transaction);
+    verify(graphQlContext).put(GraphQlConstants.CONTEXT_TRANSACTION_KEY, transaction);
     assertThat(context).isInstanceOf(SimpleInstrumentationContext.class);
   }
 
@@ -212,10 +214,10 @@ public class TransactionInstrumentationTest {
     prepareForBeginExecuteOperationTests();
     prepareDirective(
         Directive.newDirective()
-            .name(Constants.TRANSACTION_DIRECTIVE_NAME)
+            .name(GraphQlConstants.TRANSACTION_DIRECTIVE_NAME)
             .argument(
                 new Argument(
-                    Constants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
+                    GraphQlConstants.TRANSACTION_DIRECTIVE_TX_ID_ARGUMENT_NAME,
                     new StringValue(ANY_TX_ID)))
             .build());
 
@@ -252,7 +254,7 @@ public class TransactionInstrumentationTest {
       throws Exception {
     // Arrange
     prepareForInstrumentExecutionResultTests();
-    graphQlContext.put(Constants.CONTEXT_TRANSACTION_KEY, transaction);
+    graphQlContext.put(GraphQlConstants.CONTEXT_TRANSACTION_KEY, transaction);
     Object originalData = ImmutableMap.of("data", 1);
     List<GraphQLError> originalErrors = ImmutableList.of(new AbortExecutionException());
     Map<Object, Object> originalExt = ImmutableMap.of("ext1", 1, "ext2", 2);
@@ -336,7 +338,8 @@ public class TransactionInstrumentationTest {
     ArgumentCaptor<InstrumentationExecutionParameters> captor =
         ArgumentCaptor.forClass(InstrumentationExecutionParameters.class);
     verify(instrumentation).instrumentExecutionResult(any(ExecutionResult.class), captor.capture());
-    assertThat(captor.getValue().getGraphQLContext().hasKey(Constants.CONTEXT_TRANSACTION_KEY))
+    assertThat(
+            captor.getValue().getGraphQLContext().hasKey(GraphQlConstants.CONTEXT_TRANSACTION_KEY))
         .isTrue();
   }
 


### PR DESCRIPTION
Refactoring of the "`Constants`" class.

1. Moved the class from the package `com.scalar.graphql.schema` to `com.scalar.graphql` (and renamed it to `GraphQlConstants `) since it is not limited to schema-related things.
2. Inlined constants of the schema element names (`"transaction"`, `"txId"`, and `"commit"`), since other keywords of the same kind, such as `"get"`, `"name"`, and `"PutCondition"`, are simply hard-coded.