### PR TITLE
Unnecessary columns are not read any more in Consensus Commit

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -28,7 +28,6 @@ import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntValue;
@@ -104,7 +103,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery, parallelExecutor));
     manager =
         new ConsensusCommitManager(
-            storage, consensusCommitConfig, coordinator, parallelExecutor, recovery, commit);
+            storage, admin, consensusCommitConfig, coordinator, parallelExecutor, recovery, commit);
   }
 
   protected void initialize() throws Exception {}
@@ -516,8 +515,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     // Assert
     verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2))
-        .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
@@ -587,7 +585,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     // Assert
     verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     // rollback called twice but executed once actually
     TransactionResult result;
     if (s instanceof Get) {
@@ -865,8 +863,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     // Assert
     verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2))
-        .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     if (s instanceof Get) {
       assertThat(transaction.get((Get) s).isPresent()).isFalse();
     } else {
@@ -928,7 +925,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
 
     // Assert
     verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     // rollback called twice but executed once actually
     TransactionResult result;
     if (s instanceof Get) {

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
@@ -21,7 +21,6 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.TransactionException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntValue;
@@ -119,7 +118,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
 
   private static void initManagerAndCoordinator(DatabaseConfig config) {
     ConsensusCommitConfig consensusCommitConfig = new ConsensusCommitConfig(config.getProperties());
-    manager = new TwoPhaseConsensusCommitManager(storage, consensusCommitConfig);
+    manager = new TwoPhaseConsensusCommitManager(storage, admin, consensusCommitConfig);
     coordinator = new Coordinator(storage, consensusCommitConfig);
   }
 

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -24,6 +25,7 @@ public class TransactionModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(DistributedStorage.class).to(config.getStorageClass()).in(Singleton.class);
+    bind(DistributedStorageAdmin.class).to(config.getAdminClass()).in(Singleton.class);
     bind(DistributedTransactionManager.class)
         .to(config.getTransactionManagerClass())
         .in(Singleton.class);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -14,7 +14,6 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Selection;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.ArrayList;
@@ -94,7 +93,6 @@ public class ConsensusCommit implements DistributedTransaction {
   public Optional<Result> get(Get get) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
     List<String> projections = new ArrayList<>(get.getProjections());
-    get.clearProjections(); // project all
     try {
       return crud.get(get).map(r -> new FilteredResult(r, projections));
     } catch (UncommittedRecordException e) {
@@ -107,7 +105,6 @@ public class ConsensusCommit implements DistributedTransaction {
   public List<Result> scan(Scan scan) throws CrudException {
     ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
     List<String> projections = new ArrayList<>(scan.getProjections());
-    scan.clearProjections(); // project all
     try {
       return crud.scan(scan).stream()
           .map(r -> new FilteredResult(r, projections))

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -2,6 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.config.ConfigUtils.getBoolean;
 import static com.scalar.db.config.ConfigUtils.getInt;
+import static com.scalar.db.config.ConfigUtils.getLong;
 import static com.scalar.db.config.ConfigUtils.getString;
 
 import com.scalar.db.config.DatabaseConfig;
@@ -51,6 +52,8 @@ public class ConsensusCommitConfig {
   private boolean parallelRollbackEnabled;
   private boolean asyncCommitEnabled;
   private boolean asyncRollbackEnabled;
+
+  private long tableMetadataCacheExpirationTimeSecs;
 
   // for two-phase consensus commit
   public static final String TWO_PHASE_CONSENSUS_COMMIT_PREFIX = PREFIX + "2pcc.";
@@ -128,6 +131,11 @@ public class ConsensusCommitConfig {
 
     asyncCommitEnabled = getBoolean(getProperties(), ASYNC_COMMIT_ENABLED, false);
     asyncRollbackEnabled = getBoolean(getProperties(), ASYNC_ROLLBACK_ENABLED, asyncCommitEnabled);
+
+    // Use the same property as the table metadata cache expiration time for the transactional table
+    // metadata expiration time
+    tableMetadataCacheExpirationTimeSecs =
+        getLong(getProperties(), DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, -1);
   }
 
   public Isolation getIsolation() {
@@ -172,5 +180,9 @@ public class ConsensusCommitConfig {
 
   public boolean isAsyncRollbackEnabled() {
     return asyncRollbackEnabled;
+  }
+
+  public long getTableMetadataCacheExpirationTimeSecs() {
+    return tableMetadataCacheExpirationTimeSecs;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -7,6 +7,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -21,7 +22,9 @@ import org.slf4j.LoggerFactory;
 public class ConsensusCommitManager implements DistributedTransactionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusCommitManager.class);
   private final DistributedStorage storage;
+  private final DistributedStorageAdmin admin;
   private final ConsensusCommitConfig config;
+  private final TransactionalTableMetadataManager tableMetadataManager;
   private final Coordinator coordinator;
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
@@ -30,33 +33,43 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   private Optional<String> tableName;
 
   @Inject
-  public ConsensusCommitManager(DistributedStorage storage, ConsensusCommitConfig config) {
+  public ConsensusCommitManager(
+      DistributedStorage storage, DistributedStorageAdmin admin, ConsensusCommitConfig config) {
     this.storage = storage;
+    this.admin = admin;
     this.config = config;
     this.coordinator = new Coordinator(storage, config);
     this.parallelExecutor = new ParallelExecutor(config);
-    this.recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
-    this.commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
-    this.namespace = storage.getNamespace();
-    this.tableName = storage.getTable();
+    tableMetadataManager =
+        new TransactionalTableMetadataManager(
+            admin, config.getTableMetadataCacheExpirationTimeSecs());
+    recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
+    commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
+    namespace = storage.getNamespace();
+    tableName = storage.getTable();
   }
 
   @VisibleForTesting
   public ConsensusCommitManager(
       DistributedStorage storage,
+      DistributedStorageAdmin admin,
       ConsensusCommitConfig config,
       Coordinator coordinator,
       ParallelExecutor parallelExecutor,
       RecoveryHandler recovery,
       CommitHandler commit) {
     this.storage = storage;
+    this.admin = admin;
     this.config = config;
+    tableMetadataManager =
+        new TransactionalTableMetadataManager(
+            admin, config.getTableMetadataCacheExpirationTimeSecs());
     this.coordinator = coordinator;
     this.parallelExecutor = parallelExecutor;
     this.recovery = recovery;
     this.commit = commit;
-    this.namespace = storage.getNamespace();
-    this.tableName = storage.getTable();
+    namespace = storage.getNamespace();
+    tableName = storage.getTable();
   }
 
   @Override
@@ -152,7 +165,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
               + "in DatabaseConfig might cause unexpected anomalies.");
     }
     Snapshot snapshot = new Snapshot(txId, isolation, strategy, parallelExecutor);
-    CrudHandler crud = new CrudHandler(storage, snapshot);
+    CrudHandler crud = new CrudHandler(storage, snapshot, tableMetadataManager);
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
     namespace.ifPresent(consensus::withNamespace);
     tableName.ifPresent(consensus::withTable);
@@ -187,6 +200,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   @Override
   public void close() {
     storage.close();
+    admin.close();
     parallelExecutor.close();
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -105,7 +105,7 @@ public class CrudHandler {
 
   private Optional<TransactionResult> getFromStorage(Get get) throws CrudException {
     try {
-      // only get after image columns
+      // get only after image columns
       get.clearProjections();
       LinkedHashSet<String> afterImageColumnNames =
           tableMetadataManager.getTransactionalTableMetadata(get).getAfterImageColumnNames();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -120,7 +120,7 @@ public class CrudHandler {
 
   private Scanner getFromStorage(Scan scan) throws CrudException {
     try {
-      // only get after image columns
+      // get only after image columns
       scan.clearProjections();
       LinkedHashSet<String> afterImageColumnNames =
           tableMetadataManager.getTransactionalTableMetadata(scan).getAfterImageColumnNames();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -4,11 +4,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.scalar.db.api.Consistency;
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +39,29 @@ public class RecoveryHandler {
   // lazy recovery in read phase
   public void recover(Selection selection, TransactionResult result) {
     LOGGER.debug("recovering for {}", result.getId());
+
+    // as the result doesn't have before image columns, need to get the latest result
+    Optional<TransactionResult> latestResult;
+    try {
+      latestResult = getLatestResult(selection, result);
+    } catch (ExecutionException e) {
+      LOGGER.warn("can't get the latest result", e);
+      return;
+    }
+
+    if (!latestResult.isPresent()) {
+      // indicates the record is deleted in another transaction
+      return;
+    }
+
+    if (latestResult.get().isCommitted()) {
+      // indicates the record is committed in another transaction
+      return;
+    }
+
     Optional<Coordinator.State> state;
     try {
-      state = coordinator.getState(result.getId());
+      state = coordinator.getState(latestResult.get().getId());
     } catch (CoordinatorException e) {
       LOGGER.warn("can't get coordinator state", e);
       return;
@@ -45,12 +69,31 @@ public class RecoveryHandler {
 
     if (state.isPresent()) {
       if (state.get().getState().equals(TransactionState.COMMITTED)) {
-        rollforwardRecord(selection, result);
+        rollforwardRecord(selection, latestResult.get());
       } else {
-        rollbackRecord(selection, result);
+        rollbackRecord(selection, latestResult.get());
       }
     } else {
-      abortIfExpired(selection, result);
+      abortIfExpired(selection, latestResult.get());
+    }
+  }
+
+  @VisibleForTesting
+  Optional<TransactionResult> getLatestResult(Selection selection, TransactionResult result)
+      throws ExecutionException {
+    Get get =
+        new Get(selection.getPartitionKey(), getClusteringKey(selection, result).orElse(null))
+            .withConsistency(Consistency.LINEARIZABLE)
+            .forNamespace(selection.forNamespace().get())
+            .forTable(selection.forTable().get());
+    return storage.get(get).map(TransactionResult::new);
+  }
+
+  private Optional<Key> getClusteringKey(Selection selection, TransactionResult result) {
+    if (selection instanceof Scan) {
+      return result.getClusteringKey();
+    } else {
+      return selection.getClusteringKey();
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -50,12 +50,12 @@ public class RecoveryHandler {
     }
 
     if (!latestResult.isPresent()) {
-      // indicates the record is deleted in another transaction
+      // indicates the record has been deleted by another transaction
       return;
     }
 
     if (latestResult.get().isCommitted()) {
-      // indicates the record is committed in another transaction
+      // indicates the record has been committed by another transaction
       return;
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -18,7 +18,6 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
 import com.scalar.db.exception.transaction.ValidationException;
@@ -116,7 +115,6 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
     updateTransactionExpirationTime();
     setTargetToIfNot(get);
     List<String> projections = new ArrayList<>(get.getProjections());
-    get.clearProjections(); // project all
     try {
       return crud.get(get).map(r -> new FilteredResult(r, projections));
     } catch (UncommittedRecordException e) {
@@ -131,7 +129,6 @@ public class TwoPhaseConsensusCommit implements TwoPhaseCommitTransaction {
     updateTransactionExpirationTime();
     setTargetToIfNot(scan);
     List<String> projections = new ArrayList<>(scan.getProjections());
-    scan.clearProjections(); // project all
     try {
       return crud.scan(scan).stream()
           .map(r -> new FilteredResult(r, projections))

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.RollbackException;
@@ -29,7 +30,9 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
 
   private final DistributedStorage storage;
+  private final DistributedStorageAdmin admin;
   private final ConsensusCommitConfig config;
+  private final TransactionalTableMetadataManager tableMetadataManager;
   private final Coordinator coordinator;
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
@@ -41,10 +44,14 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   @Nullable private final ActiveExpiringMap<String, TwoPhaseConsensusCommit> activeTransactions;
 
   @Inject
-  public TwoPhaseConsensusCommitManager(DistributedStorage storage, ConsensusCommitConfig config) {
+  public TwoPhaseConsensusCommitManager(
+      DistributedStorage storage, DistributedStorageAdmin admin, ConsensusCommitConfig config) {
     this.storage = storage;
+    this.admin = admin;
     this.config = config;
-
+    tableMetadataManager =
+        new TransactionalTableMetadataManager(
+            admin, config.getTableMetadataCacheExpirationTimeSecs());
     coordinator = new Coordinator(storage, config);
     parallelExecutor = new ParallelExecutor(config);
     recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
@@ -71,13 +78,18 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   @VisibleForTesting
   TwoPhaseConsensusCommitManager(
       DistributedStorage storage,
+      DistributedStorageAdmin admin,
       ConsensusCommitConfig config,
       Coordinator coordinator,
       ParallelExecutor parallelExecutor,
       RecoveryHandler recovery,
       CommitHandler commit) {
     this.storage = storage;
+    this.admin = admin;
     this.config = config;
+    tableMetadataManager =
+        new TransactionalTableMetadataManager(
+            admin, config.getTableMetadataCacheExpirationTimeSecs());
     this.coordinator = coordinator;
     this.parallelExecutor = parallelExecutor;
     this.recovery = recovery;
@@ -161,7 +173,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   private TwoPhaseConsensusCommit createNewTransaction(
       String txId, boolean isCoordinator, Isolation isolation, SerializableStrategy strategy) {
     Snapshot snapshot = new Snapshot(txId, isolation, strategy, parallelExecutor);
-    CrudHandler crud = new CrudHandler(storage, snapshot);
+    CrudHandler crud = new CrudHandler(storage, snapshot, tableMetadataManager);
 
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, this);
@@ -217,6 +229,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   @Override
   public void close() {
     storage.close();
+    admin.close();
     parallelExecutor.close();
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/UncommittedRecordException.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/UncommittedRecordException.java
@@ -1,7 +1,7 @@
-package com.scalar.db.exception.transaction;
+package com.scalar.db.transaction.consensuscommit;
 
 import com.google.common.collect.ImmutableList;
-import com.scalar.db.transaction.consensuscommit.TransactionResult;
+import com.scalar.db.exception.transaction.CrudConflictException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -30,9 +30,6 @@ import org.slf4j.LoggerFactory;
 /**
  * This indicates a transaction session of JDBC.
  *
- * <p>Note that the isolation level in a transaction is always SERIALIZABLE in this implementation.
- * Even if the isolation level is specified in the configuration, it will be ignored.
- *
  * @author Toshihiro Suzuki
  */
 @NotThreadSafe

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.scalar.db.config.DatabaseConfig;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isParallelRollbackEnabled()).isEqualTo(false);
     assertThat(config.isAsyncCommitEnabled()).isEqualTo(false);
     assertThat(config.isAsyncRollbackEnabled()).isEqualTo(false);
+    assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
   @Test
@@ -204,5 +206,30 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.isAsyncCommitEnabled()).isEqualTo(true);
     assertThat(config.isAsyncRollbackEnabled()).isEqualTo(true); // use the async commit value
+  }
+
+  @Test
+  public void constructor_TableMetadataCacheExpirationTimeGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, "3600");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(props);
+
+    // Assert
+    assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(3600);
+  }
+
+  @Test
+  public void
+      constructor_InvalidTableMetadataCacheExpirationTimeGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, "aaa");
+
+    // Act Assert
+    assertThatThrownBy(() -> new ConsensusCommitConfig(props))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
@@ -22,6 +23,10 @@ public class ConsensusCommitManagerTest {
   @Mock
   @SuppressWarnings("unused")
   private DistributedStorage storage;
+
+  @Mock
+  @SuppressWarnings("unused")
+  private DistributedStorageAdmin admin;
 
   @Mock private ConsensusCommitConfig config;
   @Mock private Coordinator coordinator;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -17,7 +17,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.Arrays;
 import java.util.Collections;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -2,6 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -13,6 +14,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TransactionState;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Value;
 import java.util.Optional;
 import org.junit.Before;
@@ -38,29 +40,70 @@ public class RecoveryHandlerTest {
     handler = spy(new RecoveryHandler(storage, coordinator, new ParallelExecutor(config)));
   }
 
-  private void configureResult(Result mock, long preparedAt) {
+  private void configureResult(Result mock, long preparedAt, TransactionState transactionState) {
     ImmutableMap<String, Value<?>> values =
         ImmutableMap.<String, Value<?>>builder()
             .put(Attribute.ID, Attribute.toIdValue(ANY_ID_1))
             .put(Attribute.PREPARED_AT, Attribute.toPreparedAtValue(preparedAt))
-            .put(Attribute.STATE, Attribute.toStateValue(TransactionState.PREPARED))
+            .put(Attribute.STATE, Attribute.toStateValue(transactionState))
             .put(Attribute.VERSION, Attribute.toVersionValue(1))
             .build();
 
     when(mock.getValues()).thenReturn(values);
   }
 
-  private TransactionResult prepareResult(long preparedAt) {
+  private TransactionResult preparePreparedResult(long preparedAt) {
     Result result = mock(Result.class);
-    configureResult(result, preparedAt);
+    configureResult(result, preparedAt, TransactionState.PREPARED);
+    return new TransactionResult(result);
+  }
+
+  private TransactionResult prepareCommittedResult(long preparedAt) {
+    Result result = mock(Result.class);
+    configureResult(result, preparedAt, TransactionState.COMMITTED);
     return new TransactionResult(result);
   }
 
   @Test
-  public void recover_SelectionAndResultGivenWhenCoordinatorStateCommitted_ShouldRollforward()
-      throws CoordinatorException {
+  public void recover_SelectionAndResultGivenWhenStorageReturnsEmptyResult_ShouldDoNothing()
+      throws CoordinatorException, ExecutionException {
     // Arrange
-    TransactionResult result = prepareResult(ANY_TIME_1);
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    doReturn(Optional.empty()).when(handler).getLatestResult(selection, result);
+
+    // Act
+    handler.recover(selection, result);
+
+    // Assert
+    verify(coordinator, never()).putState(any());
+    verify(handler, never()).rollforwardRecord(any(), any());
+    verify(handler, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void recover_SelectionAndResultGivenWhenStorageReturnsCommittedRecord_ShouldDoNothing()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    doReturn(Optional.of(prepareCommittedResult(ANY_TIME_1)))
+        .when(handler)
+        .getLatestResult(selection, result);
+
+    // Act
+    handler.recover(selection, result);
+
+    // Assert
+    verify(coordinator, never()).putState(any());
+    verify(handler, never()).rollforwardRecord(any(), any());
+    verify(handler, never()).rollbackRecord(any(), any());
+  }
+
+  @Test
+  public void recover_SelectionAndResultGivenWhenCoordinatorStateCommitted_ShouldRollforward()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    doReturn(Optional.of(result)).when(handler).getLatestResult(selection, result);
     when(coordinator.getState(ANY_ID_1))
         .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.COMMITTED)));
     doNothing().when(handler).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
@@ -74,9 +117,10 @@ public class RecoveryHandlerTest {
 
   @Test
   public void recover_SelectionAndResultGivenWhenCoordinatorStateAborted_ShouldRollback()
-      throws CoordinatorException {
+      throws CoordinatorException, ExecutionException {
     // Arrange
-    TransactionResult result = prepareResult(ANY_TIME_1);
+    TransactionResult result = preparePreparedResult(ANY_TIME_1);
+    doReturn(Optional.of(result)).when(handler).getLatestResult(selection, result);
     when(coordinator.getState(ANY_ID_1))
         .thenReturn(Optional.of(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED)));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
@@ -91,9 +135,10 @@ public class RecoveryHandlerTest {
   @Test
   public void
       recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndNotExpired_ShouldDoNothing()
-          throws CoordinatorException {
+          throws CoordinatorException, ExecutionException {
     // Arrange
-    TransactionResult result = prepareResult(System.currentTimeMillis());
+    TransactionResult result = preparePreparedResult(System.currentTimeMillis());
+    doReturn(Optional.of(result)).when(handler).getLatestResult(selection, result);
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));
 
@@ -108,10 +153,12 @@ public class RecoveryHandlerTest {
 
   @Test
   public void recover_SelectionAndResultGivenWhenCoordinatorStateNotExistsAndExpired_ShouldAbort()
-      throws CoordinatorException {
+      throws CoordinatorException, ExecutionException {
     // Arrange
     TransactionResult result =
-        prepareResult(System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+        preparePreparedResult(
+            System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS * 2);
+    doReturn(Optional.of(result)).when(handler).getLatestResult(selection, result);
     when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecord(any(Selection.class), any(TransactionResult.class));

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -20,6 +21,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   private static final String ANY_TX_ID = "any_id";
 
   @Mock private DistributedStorage storage;
+  @Mock private DistributedStorageAdmin admin;
   @Mock private ConsensusCommitConfig config;
   @Mock private Coordinator coordinator;
   @Mock private ParallelExecutor parallelExecutor;
@@ -39,7 +41,7 @@ public class TwoPhaseConsensusCommitManagerTest {
 
     manager =
         new TwoPhaseConsensusCommitManager(
-            storage, config, coordinator, parallelExecutor, recovery, commit);
+            storage, admin, config, coordinator, parallelExecutor, recovery, commit);
   }
 
   @Test
@@ -138,7 +140,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     when(config.isActiveTransactionsManagementEnabled()).thenReturn(false);
     manager =
         new TwoPhaseConsensusCommitManager(
-            storage, config, coordinator, parallelExecutor, recovery, commit);
+            storage, admin, config, coordinator, parallelExecutor, recovery, commit);
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_TX_ID))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -18,7 +18,6 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
-import com.scalar.db.exception.transaction.UncommittedRecordException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommit.Status;


### PR DESCRIPTION
After this change, when reading a record in Consensus Commit, we filter out the before image columns to reduce the query cost (disk I/O and network I/O). Please take a look!