### PR TITLE
Fix bug where projections don't work properly with transactions

### DIFF
--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcher.java
@@ -12,6 +12,8 @@ import com.scalar.db.exception.transaction.CrudException;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -40,10 +42,11 @@ public class QueryGetDataFetcher
         DataFetcherResult.newResult();
     ImmutableMap.Builder<String, Object> data = ImmutableMap.builder();
     try {
+      List<String> projections = new ArrayList<>(get.getProjections());
       performGet(environment, get)
           .ifPresent(
               dbResult -> {
-                for (String fieldName : get.getProjections()) {
+                for (String fieldName : projections) {
                   dbResult.getValue(fieldName).ifPresent(value -> data.put(fieldName, value.get()));
                 }
               });

--- a/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
+++ b/graphql/src/main/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcher.java
@@ -18,6 +18,7 @@ import com.scalar.db.io.Key;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -46,9 +47,10 @@ public class QueryScanDataFetcher
         DataFetcherResult.newResult();
     ImmutableList.Builder<Map<String, Object>> list = ImmutableList.builder();
     try {
+      List<String> projections = new ArrayList<>(scan.getProjections());
       for (Result dbResult : performScan(environment, scan)) {
         ImmutableMap.Builder<String, Object> map = ImmutableMap.builder();
-        for (String fieldName : scan.getProjections()) {
+        for (String fieldName : projections) {
           dbResult.getValue(fieldName).ifPresent(value -> map.put(fieldName, value.get()));
         }
         list.add(map.build());

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryGetDataFetcherTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -130,7 +130,15 @@ public class QueryGetDataFetcherTest extends DataFetcherTestBase {
     when(mockResult.getValue(COL1)).thenReturn(Optional.of(new IntValue(1)));
     when(mockResult.getValue(COL2)).thenReturn(Optional.of(new TextValue("A")));
     when(mockResult.getValue(COL3)).thenReturn(Optional.of(new DoubleValue(2.0)));
-    doReturn(Optional.of(mockResult)).when(dataFetcher).performGet(eq(environment), any(Get.class));
+    doAnswer(
+            invocation -> {
+              // clearProjections() is called when run with ConsensusCommit or
+              // TwoPhaseConsensusCommit
+              ((Get) invocation.getArgument(1)).clearProjections();
+              return Optional.of(mockResult);
+            })
+        .when(dataFetcher)
+        .performGet(eq(environment), any(Get.class));
 
     // Act
     DataFetcherResult<Map<String, Map<String, Object>>> result = dataFetcher.get(environment);

--- a/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
+++ b/graphql/src/test/java/com/scalar/db/graphql/datafetcher/QueryScanDataFetcherTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -152,7 +152,13 @@ public class QueryScanDataFetcherTest extends DataFetcherTestBase {
     when(mockResult2.getValue(COL1)).thenReturn(Optional.of(new IntValue(2)));
     when(mockResult2.getValue(COL2)).thenReturn(Optional.of(new TextValue("B")));
     when(mockResult2.getValue(COL3)).thenReturn(Optional.of(new BigIntValue(3L)));
-    doReturn(Arrays.asList(mockResult1, mockResult2))
+    doAnswer(
+            invocation -> {
+              // clearProjections() is called when run with ConsensusCommit or
+              // TwoPhaseConsensusCommit
+              ((Scan) invocation.getArgument(1)).clearProjections();
+              return Arrays.asList(mockResult1, mockResult2);
+            })
         .when(dataFetcher)
         .performScan(eq(environment), any(Scan.class));
 


### PR DESCRIPTION
This PR fixes a bug where a get or scan query returns nothing if it is run with `ConsensusCommit` or `TwoPhaseConsensusCommit`.

This was because `projections` of a get or scan operation are cleared by `clearProjections()` when it is passed to `get()` or `scan()` of the above classes.