### PR TITLE
Should not publish a fat jar for Schema Loader to the maven repository

### DIFF
--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -269,5 +269,7 @@ check.dependsOn += spotbugsIntegrationTest
 if (!project.gradle.startParameter.taskNames.isEmpty() &&
         (project.gradle.startParameter.taskNames[0].endsWith('publish') ||
                 project.gradle.startParameter.taskNames[0].endsWith('publishToMavenLocal'))) {
+    // not to publish the fat jar
+    project.gradle.startParameter.excludedTaskNames= ["shadowJar"]
     apply from: 'archive.gradle'
 }


### PR DESCRIPTION
Currently, the `shadowJar` task for Schema Loader overwrites the original jar because we set `archiveClassifier` to empty in the `shadowJar` task as follows:
https://github.com/scalar-labs/scalardb/blob/cb65eaacd27795e98aa51c5208ac602b4e130a83/schema-loader/build.gradle#L141

As a result, we publish the fat jar to the maven repository, which can cause a dependency conflict issue. To address this issue, it seems like we can exclude the `shadowJar` task when we run the `publish` task (and the `publishToMavenLocal` task). This PR fixes it. Please take a look!