### PR TITLE
Move ResultImpl to the util package

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cassandra/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ResultInterpreter.java
@@ -12,7 +12,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.storage.common.ResultImpl;
+import com.scalar.db.util.ResultImpl;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ResultInterpreter.java
@@ -11,7 +11,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.storage.common.ResultImpl;
+import com.scalar.db.util.ResultImpl;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;

--- a/core/src/main/java/com/scalar/db/storage/dynamo/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/ResultInterpreter.java
@@ -11,7 +11,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.storage.common.ResultImpl;
+import com.scalar.db.util.ResultImpl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/ResultInterpreter.java
@@ -11,7 +11,7 @@ import com.scalar.db.io.FloatValue;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.storage.common.ResultImpl;
+import com.scalar.db.util.ResultImpl;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;

--- a/core/src/main/java/com/scalar/db/util/ProtoUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ProtoUtils.java
@@ -29,7 +29,6 @@ import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
 import com.scalar.db.rpc.MutateCondition;
 import com.scalar.db.rpc.Order;
-import com.scalar.db.storage.common.ResultImpl;
 import java.util.Map;
 import java.util.stream.Collectors;
 

--- a/core/src/main/java/com/scalar/db/util/ResultImpl.java
+++ b/core/src/main/java/com/scalar/db/util/ResultImpl.java
@@ -1,4 +1,4 @@
-package com.scalar.db.storage.common;
+package com.scalar.db.util;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;

--- a/core/src/test/java/com/scalar/db/storage/common/ResultImplTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/ResultImplTest.java
@@ -15,6 +15,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import com.scalar.db.util.ResultImpl;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
@@ -10,7 +10,7 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.storage.common.ResultImpl;
+import com.scalar.db.util.ResultImpl;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;


### PR DESCRIPTION
Now that the `ResultImpl` class is not used only for the classes in the `storage` package, we should move it to the `util` package. This PR does that. Please take a look!