### PR TITLE
Use before image column names from TransactionalTableMetadata in RollbackMutationComposer

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -99,7 +99,13 @@ public abstract class ConsensusCommitIntegrationTestBase {
     truncateTables();
     storage = spy(originalStorage);
     coordinator = spy(new Coordinator(storage, consensusCommitConfig));
-    recovery = spy(new RecoveryHandler(storage, coordinator, parallelExecutor));
+    recovery =
+        spy(
+            new RecoveryHandler(
+                storage,
+                coordinator,
+                new TransactionalTableMetadataManager(admin, -1),
+                parallelExecutor));
     CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery, parallelExecutor));
     manager =
         new ConsensusCommitManager(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -43,7 +43,7 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
     tableMetadataManager =
         new TransactionalTableMetadataManager(
             admin, config.getTableMetadataCacheExpirationTimeSecs());
-    recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
+    recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
     namespace = storage.getNamespace();
     tableName = storage.getTable();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/MutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/MutationComposer.java
@@ -2,11 +2,12 @@ package com.scalar.db.transaction.consensuscommit;
 
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
+import com.scalar.db.exception.storage.ExecutionException;
 import java.util.List;
 
 public interface MutationComposer {
 
-  void add(Operation base, TransactionResult result);
+  void add(Operation base, TransactionResult result) throws ExecutionException;
 
   List<Mutation> get();
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -54,7 +54,7 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
             admin, config.getTableMetadataCacheExpirationTimeSecs());
     coordinator = new Coordinator(storage, config);
     parallelExecutor = new ParallelExecutor(config);
-    recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
+    recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
 
     if (config.isActiveTransactionsManagementEnabled()) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -28,6 +28,7 @@ public class RecoveryHandlerTest {
 
   @Mock private DistributedStorage storage;
   @Mock private Coordinator coordinator;
+  @Mock private TransactionalTableMetadataManager tableMetadataManager;
   @Mock private Selection selection;
   @Mock private ConsensusCommitConfig config;
 
@@ -37,7 +38,11 @@ public class RecoveryHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = spy(new RecoveryHandler(storage, coordinator, new ParallelExecutor(config)));
+    // Arrange
+    handler =
+        spy(
+            new RecoveryHandler(
+                storage, coordinator, tableMetadataManager, new ParallelExecutor(config)));
   }
 
   private void configureResult(Result mock, long preparedAt, TransactionState transactionState) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -187,7 +187,7 @@ public class SnapshotTest {
         .forTable(ANY_TABLE_NAME);
   }
 
-  private void configureBehavior() {
+  private void configureBehavior() throws ExecutionException {
     doNothing().when(prepareComposer).add(any(Put.class), any(TransactionResult.class));
     doNothing().when(prepareComposer).add(any(Delete.class), any(TransactionResult.class));
     doNothing().when(commitComposer).add(any(Put.class), any(TransactionResult.class));
@@ -407,7 +407,7 @@ public class SnapshotTest {
 
   @Test
   public void to_PrepareMutationComposerGivenAndSnapshotIsolationSet_ShouldCallComposerProperly()
-      throws CommitConflictException {
+      throws CommitConflictException, ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
@@ -430,7 +430,7 @@ public class SnapshotTest {
   @Test
   public void
       to_PrepareMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
-          throws CommitConflictException {
+          throws CommitConflictException, ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();
@@ -452,7 +452,7 @@ public class SnapshotTest {
 
   @Test
   public void to_CommitMutationComposerGiven_ShouldCallComposerProperly()
-      throws CommitConflictException {
+      throws CommitConflictException, ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
@@ -474,7 +474,7 @@ public class SnapshotTest {
   @Test
   public void
       to_CommitMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
-          throws CommitConflictException {
+          throws CommitConflictException, ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();
@@ -498,7 +498,7 @@ public class SnapshotTest {
 
   @Test
   public void to_RollbackMutationComposerGiven_ShouldCallComposerProperly()
-      throws CommitConflictException {
+      throws CommitConflictException, ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
@@ -521,7 +521,7 @@ public class SnapshotTest {
   @Test
   public void
       to_RollbackMutationComposerGivenAndSerializableWithExtraWriteIsolationSet_ShouldCallComposerProperly()
-          throws CommitConflictException {
+          throws CommitConflictException, ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();


### PR DESCRIPTION
Currently, in RollbackMutationComposer, we check if the column name prefix is `before_` to identity if the column is a before image column or not. However, that's not enough, and there are some corner cases actually. Instead, we can use before image column names returned by `TransactionalTableMetadata.getBeforeImageColumnNames()` to address this issue. This PR fixes it. Please take a look!