### PR TITLE
Should not change states of operation instances passed as arguments

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/AdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/AdminIntegrationTestBase.java
@@ -84,7 +84,7 @@ public abstract class AdminIntegrationTestBase {
     if (!initialized) {
       initialize();
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespace1 = getNamespace1();
       namespace2 = getNamespace2();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageColumnValueIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageColumnValueIntegrationTestBase.java
@@ -59,7 +59,7 @@ public abstract class StorageColumnValueIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespace = getNamespace();
       createTable();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageIntegrationTestBase.java
@@ -64,7 +64,8 @@ public abstract class StorageIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       initialize();
-      StorageFactory factory = new StorageFactory(getDatabaseConfig());
+      StorageFactory factory =
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), null));
       admin = factory.getAdmin();
       namespace = getNamespace();
       createTable();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -84,7 +84,7 @@ public abstract class StorageMultipleClusteringKeyScanIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespaceBaseName = getNamespaceBaseName();
       clusteringKeyTypes = getClusteringKeyTypes();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageMultiplePartitionKeyIntegrationTestBase.java
@@ -67,7 +67,7 @@ public abstract class StorageMultiplePartitionKeyIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespaceBaseName = getNamespaceBaseName();
       partitionKeyTypes = getPartitionKeyTypes();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageSecondaryIndexIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageSecondaryIndexIntegrationTestBase.java
@@ -54,7 +54,7 @@ public abstract class StorageSecondaryIndexIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespace = getNamespace();
       secondaryIndexTypes = getSecondaryIndexTypes();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -65,7 +65,7 @@ public abstract class StorageSingleClusteringKeyScanIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespace = getNamespace();
       clusteringKeyTypes = getClusteringKeyTypes();

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageSinglePartitionKeyIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageSinglePartitionKeyIntegrationTestBase.java
@@ -53,7 +53,7 @@ public abstract class StorageSinglePartitionKeyIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       StorageFactory factory =
-          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+          new StorageFactory(TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME));
       admin = factory.getAdmin();
       namespace = getNamespace();
       partitionKeyTypes = getPartitionKeyTypes();

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -83,7 +83,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   public void setUp() throws Exception {
     if (!initialized) {
       initialize();
-      DatabaseConfig config = TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME);
+      DatabaseConfig config = TestUtils.configureForTest(getDatabaseConfig(), TEST_NAME);
       StorageFactory factory = new StorageFactory(config);
       admin = factory.getAdmin();
       consensusCommitConfig = new ConsensusCommitConfig(config.getProperties());

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -48,7 +48,7 @@ public class JdbcTransactionIntegrationTest {
 
   @BeforeClass
   public static void setUpBeforeClass() throws ExecutionException {
-    DatabaseConfig databaseConfig = TestUtils.addSuffix(JdbcEnv.getJdbcConfig(), TEST_NAME);
+    DatabaseConfig databaseConfig = TestUtils.configureForTest(JdbcEnv.getJdbcConfig(), TEST_NAME);
     JdbcConfig config = new JdbcConfig(databaseConfig.getProperties());
     StorageFactory factory = new StorageFactory(config);
     admin = factory.getAdmin();

--- a/core/src/main/java/com/scalar/db/api/Delete.java
+++ b/core/src/main/java/com/scalar/db/api/Delete.java
@@ -32,6 +32,10 @@ public class Delete extends Mutation {
     super(partitionKey, clusteringKey);
   }
 
+  public Delete(Delete delete) {
+    super(delete);
+  }
+
   @Override
   public Delete forNamespace(String namespace) {
     return (Delete) super.forNamespace(namespace);

--- a/core/src/main/java/com/scalar/db/api/Get.java
+++ b/core/src/main/java/com/scalar/db/api/Get.java
@@ -33,6 +33,10 @@ public class Get extends Selection {
     super(partitionKey, clusteringKey);
   }
 
+  public Get(Get get) {
+    super(get);
+  }
+
   @Override
   public Get forNamespace(String namespace) {
     return (Get) super.forNamespace(namespace);

--- a/core/src/main/java/com/scalar/db/api/Mutation.java
+++ b/core/src/main/java/com/scalar/db/api/Mutation.java
@@ -21,6 +21,11 @@ public abstract class Mutation extends Operation {
     condition = Optional.empty();
   }
 
+  public Mutation(Mutation mutation) {
+    super(mutation);
+    condition = mutation.condition;
+  }
+
   /**
    * Returns the {@link MutationCondition}
    *

--- a/core/src/main/java/com/scalar/db/api/Operation.java
+++ b/core/src/main/java/com/scalar/db/api/Operation.java
@@ -35,6 +35,14 @@ public abstract class Operation {
     consistency = Consistency.SEQUENTIAL;
   }
 
+  public Operation(Operation operation) {
+    this.partitionKey = operation.partitionKey;
+    this.clusteringKey = operation.clusteringKey;
+    namespace = operation.namespace;
+    tableName = operation.tableName;
+    consistency = operation.consistency;
+  }
+
   /**
    * Returns the namespace for this operation
    *

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -48,6 +48,11 @@ public class Put extends Mutation {
     values = new LinkedHashMap<>();
   }
 
+  public Put(Put put) {
+    super(put);
+    values = new LinkedHashMap<>(put.values);
+  }
+
   /**
    * Adds the specified {@link Value} to the list of put values.
    *

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -42,6 +42,16 @@ public class Scan extends Selection {
     limit = 0;
   }
 
+  public Scan(Scan scan) {
+    super(scan);
+    startClusteringKey = scan.startClusteringKey;
+    startInclusive = scan.startInclusive;
+    endClusteringKey = scan.endClusteringKey;
+    endInclusive = scan.endInclusive;
+    orderings = new ArrayList<>(scan.orderings);
+    limit = scan.limit;
+  }
+
   /**
    * Sets the specified clustering key as a starting point for scan. The boundary is inclusive.
    *

--- a/core/src/main/java/com/scalar/db/api/Selection.java
+++ b/core/src/main/java/com/scalar/db/api/Selection.java
@@ -25,6 +25,11 @@ public abstract class Selection extends Operation {
     projections = new ArrayList<>();
   }
 
+  public Selection(Selection selection) {
+    super(selection);
+    projections = new ArrayList<>(selection.projections);
+  }
+
   /**
    * Appends the specified name of {@link Value} to the list of projections.
    *

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -1,6 +1,7 @@
 package com.scalar.db.config;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.scalar.db.config.ConfigUtils.getBoolean;
 import static com.scalar.db.config.ConfigUtils.getInt;
 import static com.scalar.db.config.ConfigUtils.getLong;
 import static com.scalar.db.config.ConfigUtils.getString;
@@ -52,6 +53,7 @@ public class DatabaseConfig {
   private Class<? extends DistributedTransactionManager> transactionManagerClass;
   private Class<? extends TwoPhaseCommitTransactionManager> twoPhaseCommitTransactionManagerClass;
   private long tableMetadataCacheExpirationTimeSecs;
+  private boolean needOperationCopy;
 
   public static final String PREFIX = "scalar.db.";
   public static final String CONTACT_POINTS = PREFIX + "contact_points";
@@ -62,6 +64,7 @@ public class DatabaseConfig {
   public static final String TRANSACTION_MANAGER = PREFIX + "transaction_manager";
   public static final String TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS =
       PREFIX + "table_metadata.cache_expiration_time_secs";
+  public static final String NEED_OPERATION_COPY = PREFIX + "need_operation_copy";
 
   public DatabaseConfig(File propertiesFile) throws IOException {
     try (FileInputStream stream = new FileInputStream(propertiesFile)) {
@@ -165,6 +168,8 @@ public class DatabaseConfig {
 
     tableMetadataCacheExpirationTimeSecs =
         getLong(getProperties(), TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, -1);
+
+    needOperationCopy = getBoolean(getProperties(), NEED_OPERATION_COPY, true);
   }
 
   public List<String> getContactPoints() {
@@ -202,5 +207,9 @@ public class DatabaseConfig {
 
   public long getTableMetadataCacheExpirationTimeSecs() {
     return tableMetadataCacheExpirationTimeSecs;
+  }
+
+  public boolean needOperationCopy() {
+    return needOperationCopy;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/common/AbstractDistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/common/AbstractDistributedStorage.java
@@ -1,0 +1,71 @@
+package com.scalar.db.storage.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class AbstractDistributedStorage implements DistributedStorage {
+
+  private final boolean needOperationCopy;
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractDistributedStorage(DatabaseConfig config) {
+    needOperationCopy = config.needOperationCopy();
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+
+  protected <T extends Mutation> List<T> setTargetToIfNot(List<T> mutations) {
+    return ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName, needOperationCopy);
+  }
+
+  protected Get setTargetToIfNot(Get get) {
+    return ScalarDbUtils.setTargetToIfNot(get, namespace, tableName, needOperationCopy);
+  }
+
+  protected Scan setTargetToIfNot(Scan scan) {
+    return ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName, needOperationCopy);
+  }
+
+  protected Put setTargetToIfNot(Put put) {
+    return ScalarDbUtils.setTargetToIfNot(put, namespace, tableName, needOperationCopy);
+  }
+
+  protected Delete setTargetToIfNot(Delete delete) {
+    return ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName, needOperationCopy);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -16,8 +16,8 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.storage.common.AbstractDistributedStorage;
 import com.scalar.db.storage.common.checker.OperationChecker;
-import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Yuji Ito
  */
 @ThreadSafe
-public class Cosmos implements DistributedStorage {
+public class Cosmos extends AbstractDistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(Cosmos.class);
 
   private final CosmosClient client;
@@ -42,11 +42,11 @@ public class Cosmos implements DistributedStorage {
   private final DeleteStatementHandler deleteStatementHandler;
   private final BatchHandler batchHandler;
   private final OperationChecker operationChecker;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public Cosmos(CosmosConfig config) {
+    super(config);
+
     client =
         new CosmosClientBuilder()
             .endpoint(config.getContactPoints().get(0))
@@ -54,9 +54,6 @@ public class Cosmos implements DistributedStorage {
             .directMode()
             .consistencyLevel(ConsistencyLevel.STRONG)
             .buildClient();
-
-    namespace = Optional.empty();
-    tableName = Optional.empty();
 
     metadataManager =
         new TableMetadataManager(
@@ -72,35 +69,9 @@ public class Cosmos implements DistributedStorage {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = setTargetToIfNot(get);
     operationChecker.check(get);
 
     List<Record> records = selectStatementHandler.handle(get);
@@ -118,7 +89,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = setTargetToIfNot(scan);
     operationChecker.check(scan);
 
     List<Record> records = selectStatementHandler.handle(scan);
@@ -129,7 +100,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = setTargetToIfNot(put);
     operationChecker.check(put);
 
     putStatementHandler.handle(put);
@@ -142,7 +113,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = setTargetToIfNot(delete);
     operationChecker.check(delete);
 
     deleteStatementHandler.handle(delete);
@@ -166,7 +137,7 @@ public class Cosmos implements DistributedStorage {
       return;
     }
 
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+    mutations = setTargetToIfNot(mutations);
     operationChecker.check(mutations);
     for (Mutation mutation : mutations) {
       operationChecker.check(mutation);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -51,10 +51,8 @@ public class JdbcService {
     this.queryBuilder = Objects.requireNonNull(queryBuilder);
   }
 
-  public Optional<Result> get(
-      Get get, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public Optional<Result> get(Get get, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
     operationChecker.check(get);
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(get);
     ScalarDbUtils.addProjectionsForKeys(get, tableMetadata);
@@ -84,10 +82,8 @@ public class JdbcService {
   }
 
   @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
-  public Scanner getScanner(
-      Scan scan, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public Scanner getScanner(Scan scan, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
     operationChecker.check(scan);
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
     ScalarDbUtils.addProjectionsForKeys(scan, tableMetadata);
@@ -103,10 +99,8 @@ public class JdbcService {
         resultSet);
   }
 
-  public List<Result> scan(
-      Scan scan, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public List<Result> scan(Scan scan, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
     operationChecker.check(scan);
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
     ScalarDbUtils.addProjectionsForKeys(scan, tableMetadata);
@@ -141,10 +135,7 @@ public class JdbcService {
         .build();
   }
 
-  public boolean put(
-      Put put, Connection connection, Optional<String> namespace, Optional<String> tableName)
-      throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+  public boolean put(Put put, Connection connection) throws SQLException, ExecutionException {
     operationChecker.check(put);
 
     if (!put.getCondition().isPresent()) {
@@ -163,10 +154,8 @@ public class JdbcService {
     }
   }
 
-  public boolean delete(
-      Delete delete, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public boolean delete(Delete delete, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
     operationChecker.check(delete);
 
     if (!delete.getCondition().isPresent()) {
@@ -185,23 +174,18 @@ public class JdbcService {
     }
   }
 
-  public boolean mutate(
-      List<? extends Mutation> mutations,
-      Connection connection,
-      Optional<String> namespace,
-      Optional<String> tableName)
+  public boolean mutate(List<? extends Mutation> mutations, Connection connection)
       throws SQLException, ExecutionException {
     checkArgument(mutations.size() != 0);
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
     operationChecker.check(mutations);
 
     for (Mutation mutation : mutations) {
       if (mutation instanceof Put) {
-        if (!put((Put) mutation, connection, namespace, tableName)) {
+        if (!put((Put) mutation, connection)) {
           return false;
         }
       } else {
-        if (!delete((Delete) mutation, connection, namespace, tableName)) {
+        if (!delete((Delete) mutation, connection)) {
           return false;
         }
       }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransaction.java
@@ -1,0 +1,68 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class AbstractDistributedTransaction implements DistributedTransaction {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractDistributedTransaction() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+
+  protected <T extends Mutation> List<T> setTargetToIfNot(List<T> mutations) {
+    return ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName, true);
+  }
+
+  protected Get setTargetToIfNot(Get get) {
+    return ScalarDbUtils.setTargetToIfNot(get, namespace, tableName, true);
+  }
+
+  protected Scan setTargetToIfNot(Scan scan) {
+    return ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName, true);
+  }
+
+  protected Put setTargetToIfNot(Put put) {
+    return ScalarDbUtils.setTargetToIfNot(put, namespace, tableName, true);
+  }
+
+  protected Delete setTargetToIfNot(Delete delete) {
+    return ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName, true);
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -1,0 +1,42 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.DistributedTransactionManager;
+import java.util.Optional;
+
+public abstract class AbstractDistributedTransactionManager
+    implements DistributedTransactionManager {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractDistributedTransactionManager() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransaction.java
@@ -1,0 +1,68 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractTwoPhaseCommitTransaction() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+
+  protected <T extends Mutation> List<T> setTargetToIfNot(List<T> mutations) {
+    return ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName, true);
+  }
+
+  protected Get setTargetToIfNot(Get get) {
+    return ScalarDbUtils.setTargetToIfNot(get, namespace, tableName, true);
+  }
+
+  protected Scan setTargetToIfNot(Scan scan) {
+    return ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName, true);
+  }
+
+  protected Put setTargetToIfNot(Put put) {
+    return ScalarDbUtils.setTargetToIfNot(put, namespace, tableName, true);
+  }
+
+  protected Delete setTargetToIfNot(Delete delete) {
+    return ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName, true);
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -1,0 +1,42 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import java.util.Optional;
+
+public abstract class AbstractTwoPhaseCommitTransactionManager
+    implements TwoPhaseCommitTransactionManager {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractTwoPhaseCommitTransactionManager() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
@@ -15,7 +14,7 @@ import com.scalar.db.api.Selection;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.db.transaction.common.AbstractDistributedTransaction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -38,13 +37,11 @@ import org.slf4j.LoggerFactory;
  * and read-only anomalies, which are known to be usual SI anomalies.
  */
 @NotThreadSafe
-public class ConsensusCommit implements DistributedTransaction {
+public class ConsensusCommit extends AbstractDistributedTransaction {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusCommit.class);
   private final CrudHandler crud;
   private final CommitHandler commit;
   private final RecoveryHandler recovery;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
   private Runnable beforeRecoveryHook;
   private Runnable beforeCommitHook;
 
@@ -52,8 +49,6 @@ public class ConsensusCommit implements DistributedTransaction {
     this.crud = checkNotNull(crud);
     this.commit = checkNotNull(commit);
     this.recovery = checkNotNull(recovery);
-    namespace = Optional.empty();
-    tableName = Optional.empty();
     this.beforeRecoveryHook = () -> {};
     this.beforeCommitHook = () -> {};
   }
@@ -64,34 +59,8 @@ public class ConsensusCommit implements DistributedTransaction {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public Optional<Result> get(Get get) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = setTargetToIfNot(get);
     List<String> projections = new ArrayList<>(get.getProjections());
     try {
       return crud.get(get).map(r -> new FilteredResult(r, projections));
@@ -103,7 +72,7 @@ public class ConsensusCommit implements DistributedTransaction {
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = setTargetToIfNot(scan);
     List<String> projections = new ArrayList<>(scan.getProjections());
     try {
       return crud.scan(scan).stream()
@@ -117,7 +86,7 @@ public class ConsensusCommit implements DistributedTransaction {
 
   @Override
   public void put(Put put) {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = setTargetToIfNot(put);
     crud.put(put);
   }
 
@@ -129,7 +98,7 @@ public class ConsensusCommit implements DistributedTransaction {
 
   @Override
   public void delete(Delete delete) {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = setTargetToIfNot(delete);
     crud.delete(delete);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -8,9 +8,9 @@ import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
-import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class ConsensusCommitManager implements DistributedTransactionManager {
+public class ConsensusCommitManager extends AbstractDistributedTransactionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusCommitManager.class);
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;
@@ -29,8 +29,6 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public ConsensusCommitManager(
@@ -45,8 +43,6 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
             admin, config.getTableMetadataCacheExpirationTimeSecs());
     recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
     commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
-    namespace = storage.getNamespace();
-    tableName = storage.getTable();
   }
 
   @VisibleForTesting
@@ -68,34 +64,6 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
     this.parallelExecutor = parallelExecutor;
     this.recovery = recovery;
     this.commit = commit;
-    namespace = storage.getNamespace();
-    tableName = storage.getTable();
-  }
-
-  @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
   }
 
   @Override
@@ -167,8 +135,8 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
     Snapshot snapshot = new Snapshot(txId, isolation, strategy, parallelExecutor);
     CrudHandler crud = new CrudHandler(storage, snapshot, tableMetadataManager);
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
-    namespace.ifPresent(consensus::withNamespace);
-    tableName.ifPresent(consensus::withTable);
+    getNamespace().ifPresent(consensus::withNamespace);
+    getTable().ifPresent(consensus::withTable);
     return consensus;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -7,10 +7,10 @@ import com.google.common.base.Strings;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.util.ActiveExpiringMap;
 import java.util.Optional;
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransactionManager {
+public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransactionManager {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(TwoPhaseConsensusCommitManager.class);
 
@@ -37,9 +37,6 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
-
-  private Optional<String> namespace = Optional.empty();
-  private Optional<String> tableName = Optional.empty();
 
   @Nullable private final ActiveExpiringMap<String, TwoPhaseConsensusCommit> activeTransactions;
 
@@ -102,32 +99,6 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public TwoPhaseConsensusCommit start() {
     String txId = UUID.randomUUID().toString();
     return start(txId, config.getIsolation(), config.getSerializableStrategy());
@@ -178,8 +149,8 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, this);
 
-    namespace.ifPresent(transaction::withNamespace);
-    tableName.ifPresent(transaction::withTable);
+    getNamespace().ifPresent(transaction::withNamespace);
+    getTable().ifPresent(transaction::withTable);
     return transaction;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -3,7 +3,6 @@ package com.scalar.db.transaction.jdbc;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
@@ -19,6 +18,7 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
+import com.scalar.db.transaction.common.AbstractDistributedTransaction;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -33,29 +33,20 @@ import org.slf4j.LoggerFactory;
  * @author Toshihiro Suzuki
  */
 @NotThreadSafe
-public class JdbcTransaction implements DistributedTransaction {
+public class JdbcTransaction extends AbstractDistributedTransaction {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcTransaction.class);
 
   private final String txId;
   private final JdbcService jdbcService;
   private final Connection connection;
   private final RdbEngine rdbEngine;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   JdbcTransaction(
-      String txId,
-      JdbcService jdbcService,
-      Connection connection,
-      RdbEngine rdbEngine,
-      Optional<String> namespace,
-      Optional<String> tableName) {
+      String txId, JdbcService jdbcService, Connection connection, RdbEngine rdbEngine) {
     this.txId = txId;
     this.jdbcService = jdbcService;
     this.connection = connection;
     this.rdbEngine = rdbEngine;
-    this.namespace = namespace;
-    this.tableName = tableName;
   }
 
   @Override
@@ -64,35 +55,10 @@ public class JdbcTransaction implements DistributedTransaction {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public Optional<Result> get(Get get) throws CrudException {
+    get = setTargetToIfNot(get);
     try {
-      return jdbcService.get(get, connection, namespace, tableName);
+      return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "get operation failed");
     } catch (ExecutionException e) {
@@ -102,8 +68,9 @@ public class JdbcTransaction implements DistributedTransaction {
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
+    scan = setTargetToIfNot(scan);
     try {
-      return jdbcService.scan(scan, connection, namespace, tableName);
+      return jdbcService.scan(scan, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "scan operation failed");
     } catch (ExecutionException e) {
@@ -113,6 +80,8 @@ public class JdbcTransaction implements DistributedTransaction {
 
   @Override
   public void put(Put put) throws CrudException {
+    put = setTargetToIfNot(put);
+
     // Ignore the condition in the put
     if (put.getCondition().isPresent()) {
       LOGGER.warn("ignoring the condition of the mutation: " + put);
@@ -120,7 +89,7 @@ public class JdbcTransaction implements DistributedTransaction {
     }
 
     try {
-      jdbcService.put(put, connection, namespace, tableName);
+      jdbcService.put(put, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "put operation failed");
     } catch (ExecutionException e) {
@@ -138,6 +107,8 @@ public class JdbcTransaction implements DistributedTransaction {
 
   @Override
   public void delete(Delete delete) throws CrudException {
+    delete = setTargetToIfNot(delete);
+
     // Ignore the condition in the delete
     if (delete.getCondition().isPresent()) {
       LOGGER.warn("ignoring the condition of the mutation: " + delete);
@@ -145,7 +116,7 @@ public class JdbcTransaction implements DistributedTransaction {
     }
 
     try {
-      jdbcService.delete(delete, connection, namespace, tableName);
+      jdbcService.delete(delete, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "delete operation failed");
     } catch (ExecutionException e) {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -1,7 +1,12 @@
 package com.scalar.db.util;
 
 import com.google.common.collect.Streams;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.Value;
@@ -9,17 +14,77 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public final class ScalarDbUtils {
 
-  public static void setTargetToIfNot(
-      List<? extends Operation> operations,
-      Optional<String> namespace,
-      Optional<String> tableName) {
-    operations.forEach(o -> setTargetToIfNot(o, namespace, tableName));
+  private ScalarDbUtils() {}
+
+  @SuppressWarnings("unchecked")
+  public static <T extends Mutation> List<T> setTargetToIfNot(
+      List<T> mutations, Optional<String> namespace, Optional<String> tableName, boolean needCopy) {
+    if (needCopy) {
+      return mutations.stream()
+          .map(
+              m -> {
+                if (m instanceof Put) {
+                  return (T) setTargetToIfNot((Put) m, namespace, tableName, true);
+                } else { // Delete
+                  return (T) setTargetToIfNot((Delete) m, namespace, tableName, true);
+                }
+              })
+          .collect(Collectors.toList());
+    }
+
+    mutations.forEach(
+        m -> {
+          if (m instanceof Put) {
+            setTargetToIfNot((Put) m, namespace, tableName, false);
+          } else { // Delete
+            setTargetToIfNot((Delete) m, namespace, tableName, false);
+          }
+        });
+    return mutations;
   }
 
-  public static void setTargetToIfNot(
+  public static Get setTargetToIfNot(
+      Get get, Optional<String> namespace, Optional<String> tableName, boolean needCopy) {
+    Get ret = needCopy ? new Get(get) : get;
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  public static Scan setTargetToIfNot(
+      Scan scan, Optional<String> namespace, Optional<String> tableName, boolean needCopy) {
+    Scan ret = needCopy ? new Scan(scan) : scan;
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  public static Mutation setTargetToIfNot(
+      Mutation mutation, Optional<String> namespace, Optional<String> tableName, boolean needCopy) {
+    if (mutation instanceof Put) {
+      return setTargetToIfNot((Put) mutation, namespace, tableName, needCopy);
+    } else { // Delete
+      return setTargetToIfNot((Delete) mutation, namespace, tableName, needCopy);
+    }
+  }
+
+  public static Put setTargetToIfNot(
+      Put put, Optional<String> namespace, Optional<String> tableName, boolean needCopy) {
+    Put ret = needCopy ? new Put(put) : put;
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  public static Delete setTargetToIfNot(
+      Delete delete, Optional<String> namespace, Optional<String> tableName, boolean needCopy) {
+    Delete ret = needCopy ? new Delete(delete) : delete;
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  private static void setTargetToIfNot(
       Operation operation, Optional<String> namespace, Optional<String> tableName) {
     if (!operation.forNamespace().isPresent()) {
       operation.forNamespace(namespace.orElse(null));

--- a/core/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -77,7 +77,24 @@ public class DeleteTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Delete(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Delete((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_DeleteGiven_ShouldCopyProperly() {
+    // Arrange
+    Delete del =
+        prepareDelete()
+            .withCondition(new DeleteIfExists())
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Delete actual = new Delete(del);
+
+    // Assert
+    assertThat(actual).isEqualTo(del);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/GetTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetTest.java
@@ -136,7 +136,24 @@ public class GetTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Get(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Get((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_GetGiven_ShouldCopyProperly() {
+    // Arrange
+    Get get =
+        prepareGet()
+            .withProjection("c1")
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Get actual = new Get(get);
+
+    // Assert
+    assertThat(actual).isEqualTo(get);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/PutTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutTest.java
@@ -162,7 +162,25 @@ public class PutTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Put(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Put((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_PutGiven_ShouldCopyProperly() {
+    // Arrange
+    Put put =
+        preparePut()
+            .withValue("c1", 1)
+            .withCondition(new PutIfExists())
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Put actual = new Put(put);
+
+    // Assert
+    assertThat(actual).isEqualTo(put);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/ScanTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanTest.java
@@ -76,7 +76,24 @@ public class ScanTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Scan(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Scan((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_ScanGiven_ShouldCopyProperly() {
+    // Arrange
+    Scan scan =
+        prepareScan()
+            .withLimit(100)
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Scan actual = new Scan(scan);
+
+    // Assert
+    assertThat(actual).isEqualTo(scan);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -50,6 +50,7 @@ public class DatabaseConfigTest {
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.needOperationCopy()).isEqualTo(true);
   }
 
   @Test
@@ -73,6 +74,7 @@ public class DatabaseConfigTest {
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.needOperationCopy()).isEqualTo(true);
   }
 
   @Test
@@ -96,6 +98,7 @@ public class DatabaseConfigTest {
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.needOperationCopy()).isEqualTo(true);
   }
 
   @Test
@@ -121,6 +124,7 @@ public class DatabaseConfigTest {
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.needOperationCopy()).isEqualTo(true);
   }
 
   @Test
@@ -138,8 +142,6 @@ public class DatabaseConfigTest {
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
     props.setProperty(DatabaseConfig.CONTACT_PORT, Integer.toString(-1));
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
 
     // Act Assert
     assertThatThrownBy(() -> new DatabaseConfig(props))
@@ -151,8 +153,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "cassandra");
 
     // Act
@@ -160,11 +160,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
     assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
   }
@@ -174,8 +169,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "cosmos");
 
     // Act
@@ -183,11 +176,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
     assertThat(config.getAdminClass()).isEqualTo(CosmosAdmin.class);
   }
@@ -197,8 +185,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "dynamo");
 
     // Act
@@ -206,11 +192,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
     assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
   }
@@ -220,8 +201,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "jdbc");
 
     // Act
@@ -229,11 +208,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
     assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
   }
@@ -249,9 +223,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isNull();
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isFalse();
-    assertThat(config.getPassword().isPresent()).isFalse();
     assertThat(config.getStorageClass()).isEqualTo(MultiStorage.class);
     assertThat(config.getAdminClass()).isEqualTo(MultiStorageAdmin.class);
   }
@@ -261,8 +232,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "grpc");
 
     // Act
@@ -270,11 +239,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(GrpcStorage.class);
     assertThat(config.getAdminClass()).isEqualTo(GrpcAdmin.class);
   }
@@ -284,8 +248,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "WrongStorage");
 
     // Act Assert
@@ -299,8 +261,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "consensus-commit");
 
     // Act
@@ -308,13 +268,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
-    assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
   }
 
@@ -324,8 +277,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "jdbc");
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
 
@@ -334,11 +285,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
     assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(JdbcTransactionManager.class);
@@ -350,8 +296,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "cassandra");
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
 
@@ -366,8 +310,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "grpc");
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "grpc");
 
@@ -376,11 +318,6 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(GrpcStorage.class);
     assertThat(config.getAdminClass()).isEqualTo(GrpcAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(GrpcTransactionManager.class);
@@ -392,8 +329,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.STORAGE, "cassandra");
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "grpc");
 
@@ -407,8 +342,6 @@ public class DatabaseConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
-    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
     props.setProperty(DatabaseConfig.TABLE_METADATA_CACHE_EXPIRATION_TIME_SECS, "3600");
 
     // Act
@@ -416,11 +349,21 @@ public class DatabaseConfigTest {
 
     // Assert
     assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
-    assertThat(config.getContactPort()).isEqualTo(0);
-    assertThat(config.getUsername().isPresent()).isTrue();
-    assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
-    assertThat(config.getPassword().isPresent()).isTrue();
-    assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(3600);
+  }
+
+  @Test
+  public void constructor_PropertiesWithNeedOperationCopyGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(DatabaseConfig.NEED_OPERATION_COPY, "false");
+
+    // Act
+    DatabaseConfig config = new DatabaseConfig(props);
+
+    // Assert
+    assertThat(config.getContactPoints()).isEqualTo(Collections.singletonList(ANY_HOST));
+    assertThat(config.needOperationCopy()).isEqualTo(false);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -25,12 +25,10 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -38,8 +36,8 @@ import org.mockito.MockitoAnnotations;
 
 public class OperationCheckerTest {
 
-  private static final Optional<String> NAMESPACE = Optional.of("s1");
-  private static final Optional<String> TABLE_NAME = Optional.of("t1");
+  private static final String NAMESPACE = "s1";
+  private static final String TABLE_NAME = "t1";
   private static final String PKEY1 = "p1";
   private static final String PKEY2 = "p2";
   private static final String CKEY1 = "c1";
@@ -83,8 +81,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Returning null means table not found
     when(metadataManager.getTableMetadata(any())).thenReturn(null);
@@ -100,8 +101,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
@@ -113,8 +117,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -128,8 +135,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -143,8 +153,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, "1", PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -158,8 +171,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, "c3", "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -173,8 +189,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, "2", CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -188,8 +207,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -211,8 +233,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -233,8 +256,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -255,8 +279,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -277,8 +302,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -299,8 +325,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -320,8 +347,9 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -340,8 +368,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withEnd(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -363,8 +392,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -387,8 +417,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -411,8 +442,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -435,8 +467,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -459,8 +492,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -482,8 +516,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -505,8 +540,9 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -522,8 +558,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfNotExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -538,8 +578,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = null;
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -555,8 +599,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -573,8 +621,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -591,8 +643,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfNotExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -608,8 +664,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue("v4", true));
     MutationCondition condition = new PutIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -625,8 +685,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new TextValue(COL1, "1"), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfNotExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -645,8 +709,12 @@ public class OperationCheckerTest {
     MutationCondition condition =
         new PutIf(
             new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -663,8 +731,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new DeleteIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -680,8 +752,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new DeleteIf();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -697,8 +773,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -714,8 +793,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -731,8 +813,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -748,8 +833,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -776,8 +864,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, (byte[]) null);
     Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -804,8 +895,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, new byte[0]);
     Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -832,8 +926,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = new Key(CKEY1, (byte[]) null);
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -860,8 +957,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = new Key(CKEY1, new byte[0]);
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -876,8 +976,11 @@ public class OperationCheckerTest {
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new IntValue(1), ConditionalExpression.Operator.EQ));
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(delete)).doesNotThrowAnyException();
@@ -889,8 +992,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = null;
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(delete)).doesNotThrowAnyException();
@@ -903,8 +1009,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new DeleteIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -918,8 +1027,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, "c3", "val1");
     MutationCondition condition = new DeleteIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -933,8 +1045,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     MutationCondition condition = new DeleteIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -947,8 +1062,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIf();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -962,8 +1080,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -977,8 +1098,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfNotExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -994,8 +1118,11 @@ public class OperationCheckerTest {
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1007,10 +1134,13 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Put put = new Put(partitionKey, clusteringKey).withValue(COL1, 1);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-    Delete delete = new Delete(partitionKey, clusteringKey);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(COL1, 1)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1033,10 +1163,13 @@ public class OperationCheckerTest {
     Key partitionKey1 = new Key(PKEY1, 1, PKEY2, "val1");
     Key partitionKey2 = new Key(PKEY1, 2, PKEY2, "val2");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
-    Put put = new Put(partitionKey1, clusteringKey).withValue(COL1, 1);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-    Delete delete = new Delete(partitionKey2, clusteringKey);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey1, clusteringKey)
+            .withValue(COL1, 1)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey2, clusteringKey).forNamespace(NAMESPACE).forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1049,10 +1182,12 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
-    Put put = new Put(partitionKey, clusteringKey).withValue(COL1, 1);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-    Delete delete = new Delete(partitionKey, clusteringKey);
-    ScalarDbUtils.setTargetToIfNot(delete, Optional.of("s2"), TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(COL1, 1)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
+    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace("s2").forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1065,8 +1200,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL1, 1);
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
@@ -1079,8 +1217,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL2, 0.1d);
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1094,8 +1235,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL1, "1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1109,8 +1253,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL1, 1);
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1131,8 +1278,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -1152,8 +1300,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1174,8 +1323,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1196,8 +1346,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1219,8 +1370,9 @@ public class OperationCheckerTest {
             .withStart(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -37,7 +37,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -46,8 +45,8 @@ import org.mockito.MockitoAnnotations;
 @SuppressFBWarnings({"RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", "OBL_UNSATISFIED_OBLIGATION"})
 public class JdbcServiceTest {
 
-  private static final Optional<String> NAMESPACE = Optional.of("s1");
-  private static final Optional<String> TABLE = Optional.of("t1");
+  private static final String NAMESPACE = "ns";
+  private static final String TABLE = "tbl";
 
   @Mock private QueryBuilder queryBuilder;
   @Mock private OperationChecker operationChecker;
@@ -99,8 +98,8 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Get get = new Get(new Key("p1", "val"));
-    jdbcService.get(get, connection, NAMESPACE, TABLE);
+    Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    jdbcService.get(get, connection);
 
     // Assert
     verify(operationChecker).check(any(Get.class));
@@ -125,8 +124,8 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val"));
-    jdbcService.getScanner(scan, connection, NAMESPACE, TABLE);
+    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    jdbcService.getScanner(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(Scan.class));
@@ -151,8 +150,8 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val"));
-    jdbcService.scan(scan, connection, NAMESPACE, TABLE);
+    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    jdbcService.scan(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(Scan.class));
@@ -168,8 +167,12 @@ public class JdbcServiceTest {
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
 
     // Act
-    Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+    Put put =
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -195,8 +198,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new PutIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -222,8 +227,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new PutIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -244,8 +251,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -266,8 +277,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -287,8 +302,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfNotExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfNotExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -310,8 +329,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfNotExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfNotExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -328,8 +351,8 @@ public class JdbcServiceTest {
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1"));
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -353,8 +376,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new DeleteIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -378,8 +403,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new DeleteIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -399,8 +426,12 @@ public class JdbcServiceTest {
     when(preparedStatement.executeUpdate()).thenReturn(1);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1")).withCondition(new DeleteIfExists());
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+    Delete delete =
+        new Delete(new Key("p1", "val1"))
+            .withCondition(new DeleteIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -420,8 +451,12 @@ public class JdbcServiceTest {
     when(preparedStatement.executeUpdate()).thenReturn(0);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1")).withCondition(new DeleteIfExists());
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+    Delete delete =
+        new Delete(new Key("p1", "val1"))
+            .withCondition(new DeleteIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -443,9 +478,13 @@ public class JdbcServiceTest {
     when(deleteQueryBuilder.build()).thenReturn(deleteQuery);
 
     // Act
-    Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-    Delete delete = new Delete(new Key("p1", "val1"));
-    boolean ret = jdbcService.mutate(Arrays.asList(put, delete), connection, NAMESPACE, TABLE);
+    Put put =
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    boolean ret = jdbcService.mutate(Arrays.asList(put, delete), connection);
 
     // Assert
     assertThat(ret).isTrue();

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
@@ -53,6 +53,8 @@ public class MultiStorageConfigTest {
     assertThat(c.getUsername().get()).isEqualTo("cassandra");
     assertThat(c.getPassword().isPresent()).isTrue();
     assertThat(c.getPassword().get()).isEqualTo("cassandra");
+    assertThat(c.needOperationCopy()).isEqualTo(false);
+
     assertThat(config.getDatabaseConfigMap().containsKey("mysql")).isTrue();
     c = config.getDatabaseConfigMap().get("mysql");
     assertThat(c.getStorageClass()).isEqualTo(JdbcDatabase.class);
@@ -62,6 +64,7 @@ public class MultiStorageConfigTest {
     assertThat(c.getUsername().get()).isEqualTo("root");
     assertThat(c.getPassword().isPresent()).isTrue();
     assertThat(c.getPassword().get()).isEqualTo("mysql");
+    assertThat(c.needOperationCopy()).isEqualTo(false);
 
     assertThat(config.getTableStorageMap().size()).isEqualTo(3);
     assertThat(config.getTableStorageMap().get("user.order")).isEqualTo("cassandra");

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -32,6 +32,7 @@ public class MultiStorageTest {
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";
 
+  @Mock private MultiStorageConfig config;
   @Mock private DistributedStorage storage1;
   @Mock private DistributedStorage storage2;
   @Mock private DistributedStorage storage3;
@@ -49,7 +50,7 @@ public class MultiStorageTest {
     Map<String, DistributedStorage> namespaceStorageMap = new HashMap<>();
     namespaceStorageMap.put(NAMESPACE2, storage2);
     DistributedStorage defaultStorage = storage3;
-    multiStorage = new MultiStorage(tableStorageMap, namespaceStorageMap, defaultStorage);
+    multiStorage = new MultiStorage(config, tableStorageMap, namespaceStorageMap, defaultStorage);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
@@ -1,0 +1,197 @@
+package com.scalar.db.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+
+@SuppressWarnings("ReferenceEquality")
+public class ScalarDbUtilsTest {
+
+  private static final Optional<String> NAMESPACE = Optional.of("ns");
+  private static final Optional<String> TABLE = Optional.of("tbl");
+
+  @Test
+  public void setTargetToIfNot_GetGivenWithoutCopy_ShouldReturnSameInstance() {
+    // Arrange
+    Get get = new Get(new Key("c1", "v1"));
+
+    // Act
+    Get actual = ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE, false);
+
+    // Assert
+    assertThat(actual == get).isTrue();
+    assertThat(get.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(get.forTable()).isEqualTo(TABLE);
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_GetGivenWithCopy_ShouldReturnDifferentInstance() {
+    // Arrange
+    Get get = new Get(new Key("c1", "v1"));
+
+    // Act
+    Get actual = ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE, true);
+
+    // Assert
+    assertThat(actual == get).isFalse();
+    assertThat(get.forNamespace()).isNotPresent();
+    assertThat(get.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_ScanGivenWithoutCopy_ShouldReturnSameInstance() {
+    // Arrange
+    Scan scan = new Scan(new Key("c1", "v1"));
+
+    // Act
+    Scan actual = ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE, false);
+
+    // Assert
+    assertThat(actual == scan).isTrue();
+    assertThat(scan.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(scan.forTable()).isEqualTo(TABLE);
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_ScanGivenWithCopy_ShouldReturnDifferentInstance() {
+    // Arrange
+    Scan scan = new Scan(new Key("c1", "v1"));
+
+    // Act
+    Scan actual = ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE, true);
+
+    // Assert
+    assertThat(actual == scan).isFalse();
+    assertThat(scan.forNamespace()).isNotPresent();
+    assertThat(scan.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_PutGivenWithoutCopy_ShouldReturnSameInstance() {
+    // Arrange
+    Put put = new Put(new Key("c1", "v1"));
+
+    // Act
+    Put actual = ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE, false);
+
+    // Assert
+    assertThat(actual == put).isTrue();
+    assertThat(put.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(put.forTable()).isEqualTo(TABLE);
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_PutGivenWithCopy_ShouldReturnDifferentInstance() {
+    // Arrange
+    Put put = new Put(new Key("c1", "v1"));
+
+    // Act
+    Put actual = ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE, true);
+
+    // Assert
+    assertThat(actual == put).isFalse();
+    assertThat(put.forNamespace()).isNotPresent();
+    assertThat(put.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_DeleteGivenWithoutCopy_ShouldReturnSameInstance() {
+    // Arrange
+    Delete delete = new Delete(new Key("c1", "v1"));
+
+    // Act
+    Delete actual = ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE, false);
+
+    // Assert
+    assertThat(actual == delete).isTrue();
+    assertThat(delete.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(delete.forTable()).isEqualTo(TABLE);
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_DeleteGivenWithCopy_ShouldReturnDifferentInstance() {
+    // Arrange
+    Delete delete = new Delete(new Key("c1", "v1"));
+
+    // Act
+    Delete actual = ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE, true);
+
+    // Assert
+    assertThat(actual == delete).isFalse();
+    assertThat(delete.forNamespace()).isNotPresent();
+    assertThat(delete.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_MutationsGivenWithoutCopy_ShouldReturnSameInstance() {
+    // Arrange
+    Put put = new Put(new Key("c1", "v1"));
+    Delete delete = new Delete(new Key("c1", "v1"));
+    List<Mutation> mutations = Arrays.asList(put, delete);
+
+    // Act
+    List<Mutation> actual = ScalarDbUtils.setTargetToIfNot(mutations, NAMESPACE, TABLE, false);
+
+    // Assert
+    assertThat(actual == mutations).isTrue();
+    assertThat(actual.get(0) == put).isTrue();
+    assertThat(actual.get(1) == delete).isTrue();
+    assertThat(put.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(put.forTable()).isEqualTo(TABLE);
+    assertThat(delete.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(delete.forTable()).isEqualTo(TABLE);
+    assertThat(actual.get(0).forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.get(0).forTable()).isEqualTo(TABLE);
+    assertThat(actual.get(1).forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.get(1).forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void setTargetToIfNot_MutationsGivenWithCopy_ShouldReturnDifferentInstance() {
+    // Arrange
+    Put put = new Put(new Key("c1", "v1"));
+    Delete delete = new Delete(new Key("c1", "v1"));
+    List<Mutation> mutations = Arrays.asList(put, delete);
+
+    // Act
+    List<Mutation> actual = ScalarDbUtils.setTargetToIfNot(mutations, NAMESPACE, TABLE, true);
+
+    // Assert
+    assertThat(actual == mutations).isFalse();
+    assertThat(actual.get(0) == put).isFalse();
+    assertThat(actual.get(1) == delete).isFalse();
+    assertThat(put.forNamespace()).isNotPresent();
+    assertThat(put.forTable()).isNotPresent();
+    assertThat(delete.forNamespace()).isNotPresent();
+    assertThat(delete.forTable()).isNotPresent();
+    assertThat(actual.get(0).forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.get(0).forTable()).isEqualTo(TABLE);
+    assertThat(actual.get(1).forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.get(1).forTable()).isEqualTo(TABLE);
+  }
+}


### PR DESCRIPTION
Currently, we change the states of operation instances (`Get`/`Scan`/`Put`/`Delete`) passed as arguments, which could be confusing and might be causing a bug. To address issue, we can copy operation instances at the begging of the methods (`get()`, `scan()`, `put()`, `delete()`, and `mutate()`) of `DistributedStorage` and `DistributedTransaction` and use them.

One problem here is that Multi Storage and Consensus Commit use `DistributedStorage` instances internally, so we copy operation instances twice in that case. To avoid that situation, this PR introduces a new configuration `scalar.db. need_operation_copy` where the operation copy is disabled in `DistributedStorage` when it's set to `false`. And we can set it to `false` for the internally used storage instances when we use Multi Storage and Consensus Commit.

Actually, it's a bigger PR than I thought... So I will add inline comments to make it more readable. Please take a look!

