### PR TITLE
Should not change states of operation instances passed as arguments

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Delete.java
+++ b/core/src/main/java/com/scalar/db/api/Delete.java
@@ -32,6 +32,10 @@ public class Delete extends Mutation {
     super(partitionKey, clusteringKey);
   }
 
+  public Delete(Delete delete) {
+    super(delete);
+  }
+
   @Override
   public Delete forNamespace(String namespace) {
     return (Delete) super.forNamespace(namespace);

--- a/core/src/main/java/com/scalar/db/api/Get.java
+++ b/core/src/main/java/com/scalar/db/api/Get.java
@@ -33,6 +33,10 @@ public class Get extends Selection {
     super(partitionKey, clusteringKey);
   }
 
+  public Get(Get get) {
+    super(get);
+  }
+
   @Override
   public Get forNamespace(String namespace) {
     return (Get) super.forNamespace(namespace);

--- a/core/src/main/java/com/scalar/db/api/Mutation.java
+++ b/core/src/main/java/com/scalar/db/api/Mutation.java
@@ -21,6 +21,11 @@ public abstract class Mutation extends Operation {
     condition = Optional.empty();
   }
 
+  public Mutation(Mutation mutation) {
+    super(mutation);
+    condition = mutation.condition;
+  }
+
   /**
    * Returns the {@link MutationCondition}
    *

--- a/core/src/main/java/com/scalar/db/api/Operation.java
+++ b/core/src/main/java/com/scalar/db/api/Operation.java
@@ -35,6 +35,14 @@ public abstract class Operation {
     consistency = Consistency.SEQUENTIAL;
   }
 
+  public Operation(Operation operation) {
+    this.partitionKey = operation.partitionKey;
+    this.clusteringKey = operation.clusteringKey;
+    namespace = operation.namespace;
+    tableName = operation.tableName;
+    consistency = operation.consistency;
+  }
+
   /**
    * Returns the namespace for this operation
    *

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -48,6 +48,11 @@ public class Put extends Mutation {
     values = new LinkedHashMap<>();
   }
 
+  public Put(Put put) {
+    super(put);
+    values = new LinkedHashMap<>(put.values);
+  }
+
   /**
    * Adds the specified {@link Value} to the list of put values.
    *

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -42,6 +42,16 @@ public class Scan extends Selection {
     limit = 0;
   }
 
+  public Scan(Scan scan) {
+    super(scan);
+    startClusteringKey = scan.startClusteringKey;
+    startInclusive = scan.startInclusive;
+    endClusteringKey = scan.endClusteringKey;
+    endInclusive = scan.endInclusive;
+    orderings = new ArrayList<>(scan.orderings);
+    limit = scan.limit;
+  }
+
   /**
    * Sets the specified clustering key as a starting point for scan. The boundary is inclusive.
    *

--- a/core/src/main/java/com/scalar/db/api/Selection.java
+++ b/core/src/main/java/com/scalar/db/api/Selection.java
@@ -25,6 +25,11 @@ public abstract class Selection extends Operation {
     projections = new ArrayList<>();
   }
 
+  public Selection(Selection selection) {
+    super(selection);
+    projections = new ArrayList<>(selection.projections);
+  }
+
   /**
    * Appends the specified name of {@link Value} to the list of projections.
    *

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -17,6 +17,7 @@ import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.storage.common.AbstractDistributedStorage;
 import com.scalar.db.storage.common.checker.OperationChecker;
 import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
@@ -33,15 +34,13 @@ import org.slf4j.LoggerFactory;
  * @author Hiroyuki Yamada
  */
 @ThreadSafe
-public class Cassandra implements DistributedStorage {
+public class Cassandra extends AbstractDistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(Cassandra.class);
   private final StatementHandlerManager handlers;
   private final BatchHandler batch;
   private final ClusterManager clusterManager;
   private final TableMetadataManager metadataManager;
   private final OperationChecker operationChecker;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public Cassandra(DatabaseConfig config) {
@@ -64,42 +63,13 @@ public class Cassandra implements DistributedStorage {
             new CassandraAdmin(clusterManager, config),
             config.getTableMetadataCacheExpirationTimeSecs());
     operationChecker = new OperationChecker(metadataManager);
-
-    namespace = Optional.empty();
-    tableName = Optional.empty();
-  }
-
-  @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
   }
 
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
     LOGGER.debug("executing get operation with " + get);
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = copyAndSetTargetToIfNot(get);
     operationChecker.check(get);
     TableMetadata metadata = metadataManager.getTableMetadata(get);
     ScalarDbUtils.addProjectionsForKeys(get, metadata);
@@ -120,7 +90,7 @@ public class Cassandra implements DistributedStorage {
   @Nonnull
   public Scanner scan(Scan scan) throws ExecutionException {
     LOGGER.debug("executing scan operation with " + scan);
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = copyAndSetTargetToIfNot(scan);
     operationChecker.check(scan);
     TableMetadata metadata = metadataManager.getTableMetadata(scan);
     ScalarDbUtils.addProjectionsForKeys(scan, metadata);
@@ -133,7 +103,7 @@ public class Cassandra implements DistributedStorage {
   @Override
   public void put(Put put) throws ExecutionException {
     LOGGER.debug("executing put operation with " + put);
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = copyAndSetTargetToIfNot(put);
     operationChecker.check(put);
     handlers.get(put).handle(put);
   }
@@ -147,7 +117,7 @@ public class Cassandra implements DistributedStorage {
   @Override
   public void delete(Delete delete) throws ExecutionException {
     LOGGER.debug("executing delete operation with " + delete);
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = copyAndSetTargetToIfNot(delete);
     operationChecker.check(delete);
     handlers.delete().handle(delete);
   }
@@ -172,7 +142,7 @@ public class Cassandra implements DistributedStorage {
       return;
     }
 
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+    mutations = copyAndSetTargetToIfNot(mutations);
     operationChecker.check(mutations);
     for (Mutation mutation : mutations) {
       operationChecker.check(mutation);

--- a/core/src/main/java/com/scalar/db/storage/common/AbstractDistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/common/AbstractDistributedStorage.java
@@ -1,0 +1,68 @@
+package com.scalar.db.storage.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class AbstractDistributedStorage implements DistributedStorage {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractDistributedStorage() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+
+  protected <T extends Mutation> List<T> copyAndSetTargetToIfNot(List<T> mutations) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(mutations, namespace, tableName);
+  }
+
+  protected Get copyAndSetTargetToIfNot(Get get) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(get, namespace, tableName);
+  }
+
+  protected Scan copyAndSetTargetToIfNot(Scan scan) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(scan, namespace, tableName);
+  }
+
+  protected Put copyAndSetTargetToIfNot(Put put) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(put, namespace, tableName);
+  }
+
+  protected Delete copyAndSetTargetToIfNot(Delete delete) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(delete, namespace, tableName);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -16,8 +16,8 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.storage.common.AbstractDistributedStorage;
 import com.scalar.db.storage.common.checker.OperationChecker;
-import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Yuji Ito
  */
 @ThreadSafe
-public class Cosmos implements DistributedStorage {
+public class Cosmos extends AbstractDistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(Cosmos.class);
 
   private final CosmosClient client;
@@ -42,8 +42,6 @@ public class Cosmos implements DistributedStorage {
   private final DeleteStatementHandler deleteStatementHandler;
   private final BatchHandler batchHandler;
   private final OperationChecker operationChecker;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public Cosmos(CosmosConfig config) {
@@ -54,9 +52,6 @@ public class Cosmos implements DistributedStorage {
             .directMode()
             .consistencyLevel(ConsistencyLevel.STRONG)
             .buildClient();
-
-    namespace = Optional.empty();
-    tableName = Optional.empty();
 
     metadataManager =
         new TableMetadataManager(
@@ -72,35 +67,9 @@ public class Cosmos implements DistributedStorage {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = copyAndSetTargetToIfNot(get);
     operationChecker.check(get);
 
     List<Record> records = selectStatementHandler.handle(get);
@@ -118,7 +87,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = copyAndSetTargetToIfNot(scan);
     operationChecker.check(scan);
 
     List<Record> records = selectStatementHandler.handle(scan);
@@ -129,7 +98,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = copyAndSetTargetToIfNot(put);
     operationChecker.check(put);
 
     putStatementHandler.handle(put);
@@ -142,7 +111,7 @@ public class Cosmos implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = copyAndSetTargetToIfNot(delete);
     operationChecker.check(delete);
 
     deleteStatementHandler.handle(delete);
@@ -166,7 +135,7 @@ public class Cosmos implements DistributedStorage {
       return;
     }
 
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+    mutations = copyAndSetTargetToIfNot(mutations);
     operationChecker.check(mutations);
     for (Mutation mutation : mutations) {
       operationChecker.check(mutation);

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.storage.common.AbstractDistributedStorage;
 import com.scalar.db.storage.common.checker.OperationChecker;
 import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
@@ -37,7 +38,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * @author Yuji Ito
  */
 @ThreadSafe
-public class Dynamo implements DistributedStorage {
+public class Dynamo extends AbstractDistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(Dynamo.class);
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
@@ -46,8 +47,6 @@ public class Dynamo implements DistributedStorage {
   private final DeleteStatementHandler deleteStatementHandler;
   private final BatchHandler batchHandler;
   private final OperationChecker operationChecker;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public Dynamo(DynamoConfig config) {
@@ -61,9 +60,6 @@ public class Dynamo implements DistributedStorage {
                         config.getUsername().orElse(null), config.getPassword().orElse(null))))
             .region(Region.of(config.getContactPoints().get(0)))
             .build();
-
-    namespace = Optional.empty();
-    tableName = Optional.empty();
 
     metadataManager =
         new TableMetadataManager(
@@ -79,35 +75,9 @@ public class Dynamo implements DistributedStorage {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = copyAndSetTargetToIfNot(get);
     operationChecker.check(get);
     TableMetadata metadata = metadataManager.getTableMetadata(get);
     ScalarDbUtils.addProjectionsForKeys(get, metadata);
@@ -126,7 +96,7 @@ public class Dynamo implements DistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = copyAndSetTargetToIfNot(scan);
     operationChecker.check(scan);
     TableMetadata metadata = metadataManager.getTableMetadata(scan);
     ScalarDbUtils.addProjectionsForKeys(scan, metadata);
@@ -138,7 +108,7 @@ public class Dynamo implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = copyAndSetTargetToIfNot(put);
     operationChecker.check(put);
 
     putStatementHandler.handle(put);
@@ -151,7 +121,7 @@ public class Dynamo implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = copyAndSetTargetToIfNot(delete);
     operationChecker.check(delete);
 
     deleteStatementHandler.handle(delete);
@@ -175,7 +145,7 @@ public class Dynamo implements DistributedStorage {
       return;
     }
 
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+    mutations = copyAndSetTargetToIfNot(mutations);
     operationChecker.check(mutations);
     for (Mutation mutation : mutations) {
       operationChecker.check(mutation);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.Scanner;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
+import com.scalar.db.storage.common.AbstractDistributedStorage;
 import com.scalar.db.storage.common.checker.OperationChecker;
 import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import com.scalar.db.util.TableMetadataManager;
@@ -34,15 +35,13 @@ import org.slf4j.LoggerFactory;
  * @author Toshihiro Suzuki
  */
 @ThreadSafe
-public class JdbcDatabase implements DistributedStorage {
+public class JdbcDatabase extends AbstractDistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcDatabase.class);
 
   private final BasicDataSource dataSource;
   private final BasicDataSource tableMetadataDataSource;
   private final RdbEngine rdbEngine;
   private final JdbcService jdbcService;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public JdbcDatabase(JdbcConfig config) {
@@ -58,8 +57,6 @@ public class JdbcDatabase implements DistributedStorage {
     OperationChecker operationChecker = new OperationChecker(tableMetadataManager);
     QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);
     jdbcService = new JdbcService(tableMetadataManager, operationChecker, queryBuilder);
-    namespace = Optional.empty();
-    tableName = Optional.empty();
   }
 
   @VisibleForTesting
@@ -75,37 +72,12 @@ public class JdbcDatabase implements DistributedStorage {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public Optional<Result> get(Get get) throws ExecutionException {
+    get = copyAndSetTargetToIfNot(get);
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      return jdbcService.get(get, connection, namespace, tableName);
+      return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw new ExecutionException("get operation failed", e);
     } finally {
@@ -115,10 +87,11 @@ public class JdbcDatabase implements DistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
+    scan = copyAndSetTargetToIfNot(scan);
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      return jdbcService.getScanner(scan, connection, namespace, tableName);
+      return jdbcService.getScanner(scan, connection);
     } catch (SQLException e) {
       close(connection);
       throw new ExecutionException("scan operation failed", e);
@@ -127,10 +100,11 @@ public class JdbcDatabase implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
+    put = copyAndSetTargetToIfNot(put);
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      if (!jdbcService.put(put, connection, namespace, tableName)) {
+      if (!jdbcService.put(put, connection)) {
         throw new NoMutationException("no mutation was applied");
       }
     } catch (SQLException e) {
@@ -147,10 +121,11 @@ public class JdbcDatabase implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
+    delete = copyAndSetTargetToIfNot(delete);
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      if (!jdbcService.delete(delete, connection, namespace, tableName)) {
+      if (!jdbcService.delete(delete, connection)) {
         throw new NoMutationException("no mutation was applied");
       }
     } catch (SQLException e) {
@@ -177,6 +152,7 @@ public class JdbcDatabase implements DistributedStorage {
       return;
     }
 
+    mutations = copyAndSetTargetToIfNot(mutations);
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
@@ -187,7 +163,7 @@ public class JdbcDatabase implements DistributedStorage {
     }
 
     try {
-      if (!jdbcService.mutate(mutations, connection, namespace, tableName)) {
+      if (!jdbcService.mutate(mutations, connection)) {
         try {
           connection.rollback();
         } catch (SQLException e) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -51,10 +51,8 @@ public class JdbcService {
     this.queryBuilder = Objects.requireNonNull(queryBuilder);
   }
 
-  public Optional<Result> get(
-      Get get, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public Optional<Result> get(Get get, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
     operationChecker.check(get);
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(get);
     ScalarDbUtils.addProjectionsForKeys(get, tableMetadata);
@@ -84,10 +82,8 @@ public class JdbcService {
   }
 
   @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
-  public Scanner getScanner(
-      Scan scan, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public Scanner getScanner(Scan scan, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
     operationChecker.check(scan);
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
     ScalarDbUtils.addProjectionsForKeys(scan, tableMetadata);
@@ -103,10 +99,8 @@ public class JdbcService {
         resultSet);
   }
 
-  public List<Result> scan(
-      Scan scan, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public List<Result> scan(Scan scan, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
     operationChecker.check(scan);
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
     ScalarDbUtils.addProjectionsForKeys(scan, tableMetadata);
@@ -141,10 +135,7 @@ public class JdbcService {
         .build();
   }
 
-  public boolean put(
-      Put put, Connection connection, Optional<String> namespace, Optional<String> tableName)
-      throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+  public boolean put(Put put, Connection connection) throws SQLException, ExecutionException {
     operationChecker.check(put);
 
     if (!put.getCondition().isPresent()) {
@@ -163,10 +154,8 @@ public class JdbcService {
     }
   }
 
-  public boolean delete(
-      Delete delete, Connection connection, Optional<String> namespace, Optional<String> tableName)
+  public boolean delete(Delete delete, Connection connection)
       throws SQLException, ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
     operationChecker.check(delete);
 
     if (!delete.getCondition().isPresent()) {
@@ -185,23 +174,18 @@ public class JdbcService {
     }
   }
 
-  public boolean mutate(
-      List<? extends Mutation> mutations,
-      Connection connection,
-      Optional<String> namespace,
-      Optional<String> tableName)
+  public boolean mutate(List<? extends Mutation> mutations, Connection connection)
       throws SQLException, ExecutionException {
     checkArgument(mutations.size() != 0);
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
     operationChecker.check(mutations);
 
     for (Mutation mutation : mutations) {
       if (mutation instanceof Put) {
-        if (!put((Put) mutation, connection, namespace, tableName)) {
+        if (!put((Put) mutation, connection)) {
           return false;
         }
       } else {
-        if (!delete((Delete) mutation, connection, namespace, tableName)) {
+        if (!delete((Delete) mutation, connection)) {
           return false;
         }
       }

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
@@ -5,7 +5,6 @@ import static com.scalar.db.util.retry.Retry.executeWithRetries;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
@@ -19,8 +18,8 @@ import com.scalar.db.rpc.DistributedStorageGrpc;
 import com.scalar.db.rpc.GetRequest;
 import com.scalar.db.rpc.GetResponse;
 import com.scalar.db.rpc.MutateRequest;
+import com.scalar.db.storage.common.AbstractDistributedStorage;
 import com.scalar.db.util.ProtoUtils;
-import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
 import com.scalar.db.util.ThrowableSupplier;
 import com.scalar.db.util.retry.Retry;
@@ -37,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class GrpcStorage implements DistributedStorage {
+public class GrpcStorage extends AbstractDistributedStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcStorage.class);
   private static final int DEFAULT_SCALAR_DB_SERVER_PORT = 60051;
 
@@ -58,9 +57,6 @@ public class GrpcStorage implements DistributedStorage {
   private final DistributedStorageGrpc.DistributedStorageBlockingStub blockingStub;
   private final TableMetadataManager metadataManager;
 
-  private Optional<String> namespace;
-  private Optional<String> tableName;
-
   @Inject
   public GrpcStorage(GrpcConfig config) {
     this.config = config;
@@ -77,8 +73,6 @@ public class GrpcStorage implements DistributedStorage {
     metadataManager =
         new TableMetadataManager(
             new GrpcAdmin(channel, config), config.getTableMetadataCacheExpirationTimeSecs());
-    namespace = Optional.empty();
-    tableName = Optional.empty();
   }
 
   @VisibleForTesting
@@ -92,39 +86,11 @@ public class GrpcStorage implements DistributedStorage {
     this.stub = stub;
     this.blockingStub = blockingStub;
     this.metadataManager = metadataManager;
-    namespace = Optional.empty();
-    tableName = Optional.empty();
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
-  public Optional<Result> get(Get get) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+  public Optional<Result> get(Get originalGet) throws ExecutionException {
+    Get get = copyAndSetTargetToIfNot(originalGet);
     return execute(
         () -> {
           GetResponse response =
@@ -140,8 +106,8 @@ public class GrpcStorage implements DistributedStorage {
   }
 
   @Override
-  public Scanner scan(Scan scan) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+  public Scanner scan(Scan originalScan) throws ExecutionException {
+    Scan scan = copyAndSetTargetToIfNot(originalScan);
     return executeWithRetries(
         () -> {
           TableMetadata tableMetadata = metadataManager.getTableMetadata(scan);
@@ -152,6 +118,7 @@ public class GrpcStorage implements DistributedStorage {
 
   @Override
   public void put(Put put) throws ExecutionException {
+    put = copyAndSetTargetToIfNot(put);
     mutate(put);
   }
 
@@ -162,6 +129,7 @@ public class GrpcStorage implements DistributedStorage {
 
   @Override
   public void delete(Delete delete) throws ExecutionException {
+    delete = copyAndSetTargetToIfNot(delete);
     mutate(delete);
   }
 
@@ -171,7 +139,6 @@ public class GrpcStorage implements DistributedStorage {
   }
 
   private void mutate(Mutation mutation) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(mutation, namespace, tableName);
     execute(
         () -> {
           blockingStub
@@ -183,8 +150,8 @@ public class GrpcStorage implements DistributedStorage {
   }
 
   @Override
-  public void mutate(List<? extends Mutation> mutations) throws ExecutionException {
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+  public void mutate(List<? extends Mutation> originalMutations) throws ExecutionException {
+    List<? extends Mutation> mutations = copyAndSetTargetToIfNot(originalMutations);
     execute(
         () -> {
           MutateRequest.Builder builder = MutateRequest.newBuilder();

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransaction.java
@@ -1,0 +1,68 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class AbstractDistributedTransaction implements DistributedTransaction {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractDistributedTransaction() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+
+  protected <T extends Mutation> List<T> copyAndSetTargetToIfNot(List<T> mutations) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(mutations, namespace, tableName);
+  }
+
+  protected Get copyAndSetTargetToIfNot(Get get) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(get, namespace, tableName);
+  }
+
+  protected Scan copyAndSetTargetToIfNot(Scan scan) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(scan, namespace, tableName);
+  }
+
+  protected Put copyAndSetTargetToIfNot(Put put) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(put, namespace, tableName);
+  }
+
+  protected Delete copyAndSetTargetToIfNot(Delete delete) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(delete, namespace, tableName);
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -1,0 +1,42 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.DistributedTransactionManager;
+import java.util.Optional;
+
+public abstract class AbstractDistributedTransactionManager
+    implements DistributedTransactionManager {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractDistributedTransactionManager() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransaction.java
@@ -1,0 +1,68 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractTwoPhaseCommitTransaction() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+
+  protected <T extends Mutation> List<T> copyAndSetTargetToIfNot(List<T> mutations) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(mutations, namespace, tableName);
+  }
+
+  protected Get copyAndSetTargetToIfNot(Get get) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(get, namespace, tableName);
+  }
+
+  protected Scan copyAndSetTargetToIfNot(Scan scan) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(scan, namespace, tableName);
+  }
+
+  protected Put copyAndSetTargetToIfNot(Put put) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(put, namespace, tableName);
+  }
+
+  protected Delete copyAndSetTargetToIfNot(Delete delete) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(delete, namespace, tableName);
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -1,0 +1,42 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import java.util.Optional;
+
+public abstract class AbstractTwoPhaseCommitTransactionManager
+    implements TwoPhaseCommitTransactionManager {
+
+  private Optional<String> namespace;
+  private Optional<String> tableName;
+
+  public AbstractTwoPhaseCommitTransactionManager() {
+    namespace = Optional.empty();
+    tableName = Optional.empty();
+  }
+
+  @Override
+  public void with(String namespace, String tableName) {
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public void withNamespace(String namespace) {
+    this.namespace = Optional.ofNullable(namespace);
+  }
+
+  @Override
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  @Override
+  public void withTable(String tableName) {
+    this.tableName = Optional.ofNullable(tableName);
+  }
+
+  @Override
+  public Optional<String> getTable() {
+    return tableName;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -8,9 +8,9 @@ import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
-import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class ConsensusCommitManager implements DistributedTransactionManager {
+public class ConsensusCommitManager extends AbstractDistributedTransactionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusCommitManager.class);
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;
@@ -29,8 +29,6 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   @Inject
   public ConsensusCommitManager(
@@ -45,8 +43,6 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
             admin, config.getTableMetadataCacheExpirationTimeSecs());
     recovery = new RecoveryHandler(storage, coordinator, parallelExecutor);
     commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
-    namespace = storage.getNamespace();
-    tableName = storage.getTable();
   }
 
   @VisibleForTesting
@@ -68,34 +64,6 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
     this.parallelExecutor = parallelExecutor;
     this.recovery = recovery;
     this.commit = commit;
-    namespace = storage.getNamespace();
-    tableName = storage.getTable();
-  }
-
-  @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
   }
 
   @Override
@@ -167,8 +135,8 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
     Snapshot snapshot = new Snapshot(txId, isolation, strategy, parallelExecutor);
     CrudHandler crud = new CrudHandler(storage, snapshot, tableMetadataManager);
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
-    namespace.ifPresent(consensus::withNamespace);
-    tableName.ifPresent(consensus::withTable);
+    getNamespace().ifPresent(consensus::withNamespace);
+    getTable().ifPresent(consensus::withTable);
     return consensus;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -7,10 +7,10 @@ import com.google.common.base.Strings;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.util.ActiveExpiringMap;
 import java.util.Optional;
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransactionManager {
+public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransactionManager {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(TwoPhaseConsensusCommitManager.class);
 
@@ -37,9 +37,6 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
-
-  private Optional<String> namespace = Optional.empty();
-  private Optional<String> tableName = Optional.empty();
 
   @Nullable private final ActiveExpiringMap<String, TwoPhaseConsensusCommit> activeTransactions;
 
@@ -102,32 +99,6 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public TwoPhaseConsensusCommit start() {
     String txId = UUID.randomUUID().toString();
     return start(txId, config.getIsolation(), config.getSerializableStrategy());
@@ -178,8 +149,8 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, this);
 
-    namespace.ifPresent(transaction::withNamespace);
-    tableName.ifPresent(transaction::withTable);
+    getNamespace().ifPresent(transaction::withNamespace);
+    getTable().ifPresent(transaction::withTable);
     return transaction;
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -3,7 +3,6 @@ package com.scalar.db.transaction.jdbc;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
@@ -19,6 +18,7 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
+import com.scalar.db.transaction.common.AbstractDistributedTransaction;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -33,29 +33,20 @@ import org.slf4j.LoggerFactory;
  * @author Toshihiro Suzuki
  */
 @NotThreadSafe
-public class JdbcTransaction implements DistributedTransaction {
+public class JdbcTransaction extends AbstractDistributedTransaction {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcTransaction.class);
 
   private final String txId;
   private final JdbcService jdbcService;
   private final Connection connection;
   private final RdbEngine rdbEngine;
-  private Optional<String> namespace;
-  private Optional<String> tableName;
 
   JdbcTransaction(
-      String txId,
-      JdbcService jdbcService,
-      Connection connection,
-      RdbEngine rdbEngine,
-      Optional<String> namespace,
-      Optional<String> tableName) {
+      String txId, JdbcService jdbcService, Connection connection, RdbEngine rdbEngine) {
     this.txId = txId;
     this.jdbcService = jdbcService;
     this.connection = connection;
     this.rdbEngine = rdbEngine;
-    this.namespace = namespace;
-    this.tableName = tableName;
   }
 
   @Override
@@ -64,35 +55,10 @@ public class JdbcTransaction implements DistributedTransaction {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public Optional<Result> get(Get get) throws CrudException {
+    get = copyAndSetTargetToIfNot(get);
     try {
-      return jdbcService.get(get, connection, namespace, tableName);
+      return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "get operation failed");
     } catch (ExecutionException e) {
@@ -102,8 +68,9 @@ public class JdbcTransaction implements DistributedTransaction {
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
+    scan = copyAndSetTargetToIfNot(scan);
     try {
-      return jdbcService.scan(scan, connection, namespace, tableName);
+      return jdbcService.scan(scan, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "scan operation failed");
     } catch (ExecutionException e) {
@@ -113,6 +80,8 @@ public class JdbcTransaction implements DistributedTransaction {
 
   @Override
   public void put(Put put) throws CrudException {
+    put = copyAndSetTargetToIfNot(put);
+
     // Ignore the condition in the put
     if (put.getCondition().isPresent()) {
       LOGGER.warn("ignoring the condition of the mutation: " + put);
@@ -120,7 +89,7 @@ public class JdbcTransaction implements DistributedTransaction {
     }
 
     try {
-      jdbcService.put(put, connection, namespace, tableName);
+      jdbcService.put(put, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "put operation failed");
     } catch (ExecutionException e) {
@@ -138,6 +107,8 @@ public class JdbcTransaction implements DistributedTransaction {
 
   @Override
   public void delete(Delete delete) throws CrudException {
+    delete = copyAndSetTargetToIfNot(delete);
+
     // Ignore the condition in the delete
     if (delete.getCondition().isPresent()) {
       LOGGER.warn("ignoring the condition of the mutation: " + delete);
@@ -145,7 +116,7 @@ public class JdbcTransaction implements DistributedTransaction {
     }
 
     try {
-      jdbcService.delete(delete, connection, namespace, tableName);
+      jdbcService.delete(delete, connection);
     } catch (SQLException e) {
       throw createCrudException(e, "delete operation failed");
     } catch (ExecutionException e) {

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransaction.java
@@ -1,7 +1,6 @@
 package com.scalar.db.transaction.rpc;
 
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
@@ -11,29 +10,20 @@ import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.db.transaction.common.AbstractDistributedTransaction;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.NotThreadSafe;
 
 @NotThreadSafe
-public class GrpcTransaction implements DistributedTransaction {
+public class GrpcTransaction extends AbstractDistributedTransaction {
 
   private final String txId;
   private final GrpcTransactionOnBidirectionalStream stream;
 
-  private Optional<String> namespace;
-  private Optional<String> tableName;
-
-  public GrpcTransaction(
-      String txId,
-      GrpcTransactionOnBidirectionalStream stream,
-      Optional<String> namespace,
-      Optional<String> tableName) {
+  public GrpcTransaction(String txId, GrpcTransactionOnBidirectionalStream stream) {
     this.txId = txId;
     this.stream = stream;
-    this.namespace = namespace;
-    this.tableName = tableName;
   }
 
   @Override
@@ -42,46 +32,20 @@ public class GrpcTransaction implements DistributedTransaction {
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public Optional<Result> get(Get get) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = copyAndSetTargetToIfNot(get);
     return stream.get(get);
   }
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = copyAndSetTargetToIfNot(scan);
     return stream.scan(scan);
   }
 
   @Override
   public void put(Put put) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = copyAndSetTargetToIfNot(put);
     stream.mutate(put);
   }
 
@@ -92,7 +56,7 @@ public class GrpcTransaction implements DistributedTransaction {
 
   @Override
   public void delete(Delete delete) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = copyAndSetTargetToIfNot(delete);
     stream.mutate(delete);
   }
 
@@ -103,7 +67,7 @@ public class GrpcTransaction implements DistributedTransaction {
 
   @Override
   public void mutate(List<? extends Mutation> mutations) throws CrudException {
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+    mutations = copyAndSetTargetToIfNot(mutations);
     stream.mutate(mutations);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransaction.java
@@ -6,42 +6,34 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransaction;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.NotThreadSafe;
 
 @NotThreadSafe
-public class GrpcTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction {
+public class GrpcTwoPhaseCommitTransaction extends AbstractTwoPhaseCommitTransaction {
 
   private final String txId;
   private final GrpcTwoPhaseCommitTransactionOnBidirectionalStream stream;
   private final boolean isCoordinator;
   private final GrpcTwoPhaseCommitTransactionManager manager;
 
-  private Optional<String> namespace;
-  private Optional<String> tableName;
-
   public GrpcTwoPhaseCommitTransaction(
       String txId,
       GrpcTwoPhaseCommitTransactionOnBidirectionalStream stream,
       boolean isCoordinator,
-      GrpcTwoPhaseCommitTransactionManager manager,
-      Optional<String> namespace,
-      Optional<String> tableName) {
+      GrpcTwoPhaseCommitTransactionManager manager) {
     this.txId = txId;
     this.stream = stream;
     this.isCoordinator = isCoordinator;
     this.manager = manager;
-    this.namespace = namespace;
-    this.tableName = tableName;
   }
 
   @Override
@@ -50,49 +42,23 @@ public class GrpcTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction 
   }
 
   @Override
-  public void with(String namespace, String tableName) {
-    this.namespace = Optional.ofNullable(namespace);
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public void withNamespace(String namespace) {
-    this.namespace = Optional.ofNullable(namespace);
-  }
-
-  @Override
-  public Optional<String> getNamespace() {
-    return namespace;
-  }
-
-  @Override
-  public void withTable(String tableName) {
-    this.tableName = Optional.ofNullable(tableName);
-  }
-
-  @Override
-  public Optional<String> getTable() {
-    return tableName;
-  }
-
-  @Override
   public Optional<Result> get(Get get) throws CrudException {
     updateTransactionExpirationTime();
-    ScalarDbUtils.setTargetToIfNot(get, namespace, tableName);
+    get = copyAndSetTargetToIfNot(get);
     return stream.get(get);
   }
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
     updateTransactionExpirationTime();
-    ScalarDbUtils.setTargetToIfNot(scan, namespace, tableName);
+    scan = copyAndSetTargetToIfNot(scan);
     return stream.scan(scan);
   }
 
   @Override
   public void put(Put put) throws CrudException {
     updateTransactionExpirationTime();
-    ScalarDbUtils.setTargetToIfNot(put, namespace, tableName);
+    put = copyAndSetTargetToIfNot(put);
     stream.mutate(put);
   }
 
@@ -104,7 +70,7 @@ public class GrpcTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction 
   @Override
   public void delete(Delete delete) throws CrudException {
     updateTransactionExpirationTime();
-    ScalarDbUtils.setTargetToIfNot(delete, namespace, tableName);
+    delete = copyAndSetTargetToIfNot(delete);
     stream.mutate(delete);
   }
 
@@ -116,7 +82,7 @@ public class GrpcTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction 
   @Override
   public void mutate(List<? extends Mutation> mutations) throws CrudException {
     updateTransactionExpirationTime();
-    ScalarDbUtils.setTargetToIfNot(mutations, namespace, tableName);
+    mutations = copyAndSetTargetToIfNot(mutations);
     stream.mutate(mutations);
   }
 

--- a/core/src/test/java/com/scalar/db/api/DeleteTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteTest.java
@@ -77,7 +77,24 @@ public class DeleteTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Delete(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Delete((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_DeleteGiven_ShouldCopyProperly() {
+    // Arrange
+    Delete del =
+        prepareDelete()
+            .withCondition(new DeleteIfExists())
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Delete actual = new Delete(del);
+
+    // Assert
+    assertThat(actual).isEqualTo(del);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/GetTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetTest.java
@@ -136,7 +136,24 @@ public class GetTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Get(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Get((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_GetGiven_ShouldCopyProperly() {
+    // Arrange
+    Get get =
+        prepareGet()
+            .withProjection("c1")
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Get actual = new Get(get);
+
+    // Assert
+    assertThat(actual).isEqualTo(get);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/PutTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutTest.java
@@ -162,7 +162,25 @@ public class PutTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Put(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Put((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_PutGiven_ShouldCopyProperly() {
+    // Arrange
+    Put put =
+        preparePut()
+            .withValue("c1", 1)
+            .withCondition(new PutIfExists())
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Put actual = new Put(put);
+
+    // Assert
+    assertThat(actual).isEqualTo(put);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/api/ScanTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanTest.java
@@ -76,7 +76,24 @@ public class ScanTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new Scan(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new Scan((Key) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void constructor_ScanGiven_ShouldCopyProperly() {
+    // Arrange
+    Scan scan =
+        prepareScan()
+            .withLimit(100)
+            .withConsistency(Consistency.EVENTUAL)
+            .forNamespace("n1")
+            .forTable("t1");
+
+    // Act
+    Scan actual = new Scan(scan);
+
+    // Assert
+    assertThat(actual).isEqualTo(scan);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -25,12 +25,10 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.db.util.TableMetadataManager;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -38,8 +36,8 @@ import org.mockito.MockitoAnnotations;
 
 public class OperationCheckerTest {
 
-  private static final Optional<String> NAMESPACE = Optional.of("s1");
-  private static final Optional<String> TABLE_NAME = Optional.of("t1");
+  private static final String NAMESPACE = "s1";
+  private static final String TABLE_NAME = "t1";
   private static final String PKEY1 = "p1";
   private static final String PKEY2 = "p2";
   private static final String CKEY1 = "c1";
@@ -83,8 +81,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Returning null means table not found
     when(metadataManager.getTableMetadata(any())).thenReturn(null);
@@ -100,8 +101,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
@@ -113,8 +117,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, "v4");
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -128,8 +135,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -143,8 +153,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, "1", PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -158,8 +171,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, "c3", "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -173,8 +189,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, "2", CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -188,8 +207,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -211,8 +233,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -233,8 +256,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -255,8 +279,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -277,8 +302,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -299,8 +325,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -320,8 +347,9 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -340,8 +368,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withEnd(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -363,8 +392,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -387,8 +417,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -411,8 +442,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -435,8 +467,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -459,8 +492,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -482,8 +516,9 @@ public class OperationCheckerTest {
             .withProjections(projections)
             .withLimit(limit)
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.DESC))
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.DESC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -505,8 +540,9 @@ public class OperationCheckerTest {
             .withEnd(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY2, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -522,8 +558,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfNotExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -538,8 +578,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = null;
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(put)).doesNotThrowAnyException();
@@ -555,8 +599,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -573,8 +621,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -591,8 +643,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfNotExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -608,8 +664,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue("v4", true));
     MutationCondition condition = new PutIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -625,8 +685,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new TextValue(COL1, "1"), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new PutIfNotExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -645,8 +709,12 @@ public class OperationCheckerTest {
     MutationCondition condition =
         new PutIf(
             new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -663,8 +731,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new DeleteIfExists();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -680,8 +752,12 @@ public class OperationCheckerTest {
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
     MutationCondition condition = new DeleteIf();
-    Put put = new Put(partitionKey, clusteringKey).withValues(values).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -697,8 +773,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -714,8 +793,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -731,8 +813,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -748,8 +833,11 @@ public class OperationCheckerTest {
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -776,8 +864,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, (byte[]) null);
     Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -804,8 +895,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, new byte[0]);
     Key clusteringKey = new Key(CKEY1, new byte[] {1, 1, 1});
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -832,8 +926,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = new Key(CKEY1, (byte[]) null);
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -860,8 +957,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, new byte[] {1, 1, 1});
     Key clusteringKey = new Key(CKEY1, new byte[0]);
     List<Value<?>> values = Collections.singletonList(new IntValue(COL1, 1));
-    Put put = new Put(partitionKey, clusteringKey).withValues(values);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValues(values)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(put))
@@ -876,8 +976,11 @@ public class OperationCheckerTest {
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new IntValue(1), ConditionalExpression.Operator.EQ));
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(delete)).doesNotThrowAnyException();
@@ -889,8 +992,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = null;
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(delete)).doesNotThrowAnyException();
@@ -903,8 +1009,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, "p3", "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new DeleteIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -918,8 +1027,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, "c3", "val1");
     MutationCondition condition = new DeleteIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -933,8 +1045,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = null;
     MutationCondition condition = new DeleteIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -947,8 +1062,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIf();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -962,8 +1080,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -977,8 +1098,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     MutationCondition condition = new PutIfNotExists();
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -994,8 +1118,11 @@ public class OperationCheckerTest {
     MutationCondition condition =
         new DeleteIf(
             new ConditionalExpression(COL1, new TextValue("1"), ConditionalExpression.Operator.EQ));
-    Delete delete = new Delete(partitionKey, clusteringKey).withCondition(condition);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey)
+            .withCondition(condition)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(delete))
@@ -1007,10 +1134,13 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
-    Put put = new Put(partitionKey, clusteringKey).withValue(COL1, 1);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-    Delete delete = new Delete(partitionKey, clusteringKey);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(COL1, 1)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey, clusteringKey).forNamespace(NAMESPACE).forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1033,10 +1163,13 @@ public class OperationCheckerTest {
     Key partitionKey1 = new Key(PKEY1, 1, PKEY2, "val1");
     Key partitionKey2 = new Key(PKEY1, 2, PKEY2, "val2");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
-    Put put = new Put(partitionKey1, clusteringKey).withValue(COL1, 1);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-    Delete delete = new Delete(partitionKey2, clusteringKey);
-    ScalarDbUtils.setTargetToIfNot(delete, NAMESPACE, TABLE_NAME);
+    Put put =
+        new Put(partitionKey1, clusteringKey)
+            .withValue(COL1, 1)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
+    Delete delete =
+        new Delete(partitionKey2, clusteringKey).forNamespace(NAMESPACE).forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1049,10 +1182,12 @@ public class OperationCheckerTest {
     // Arrange
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val3");
-    Put put = new Put(partitionKey, clusteringKey).withValue(COL1, 1);
-    ScalarDbUtils.setTargetToIfNot(put, NAMESPACE, TABLE_NAME);
-    Delete delete = new Delete(partitionKey, clusteringKey);
-    ScalarDbUtils.setTargetToIfNot(delete, Optional.of("s2"), TABLE_NAME);
+    Put put =
+        new Put(partitionKey, clusteringKey)
+            .withValue(COL1, 1)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
+    Delete delete = new Delete(partitionKey, clusteringKey).forNamespace("s2").forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
@@ -1065,8 +1200,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL1, 1);
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
@@ -1079,8 +1217,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL2, 0.1d);
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1094,8 +1235,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL1, "1");
     Key clusteringKey = null;
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1109,8 +1253,11 @@ public class OperationCheckerTest {
     Key partitionKey = new Key(COL1, 1);
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    Get get = new Get(partitionKey, clusteringKey).withProjections(projections);
-    ScalarDbUtils.setTargetToIfNot(get, NAMESPACE, TABLE_NAME);
+    Get get =
+        new Get(partitionKey, clusteringKey)
+            .withProjections(projections)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(get))
@@ -1131,8 +1278,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
@@ -1152,8 +1300,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1174,8 +1323,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1196,8 +1346,9 @@ public class OperationCheckerTest {
             .withStart(startClusteringKey)
             .withStart(endClusteringKey)
             .withProjections(projections)
-            .withLimit(limit);
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withLimit(limit)
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))
@@ -1219,8 +1370,9 @@ public class OperationCheckerTest {
             .withStart(endClusteringKey)
             .withProjections(projections)
             .withLimit(limit)
-            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC));
-    ScalarDbUtils.setTargetToIfNot(scan, NAMESPACE, TABLE_NAME);
+            .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE_NAME);
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -29,6 +29,9 @@ import org.mockito.MockitoAnnotations;
 
 public class JdbcDatabaseTest {
 
+  private static final String NAMESPACE = "ns";
+  private static final String TABLE = "tbl";
+
   @Mock private BasicDataSource dataSource;
   @Mock private BasicDataSource tableMetadataDataSource;
   @Mock private JdbcService jdbcService;
@@ -44,10 +47,11 @@ public class JdbcDatabaseTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
+
+    // Arrange
+    when(dataSource.getConnection()).thenReturn(connection);
     jdbcDatabase =
         new JdbcDatabase(dataSource, tableMetadataDataSource, RdbEngine.MYSQL, jdbcService);
-
-    when(dataSource.getConnection()).thenReturn(connection);
   }
 
   @Test
@@ -55,11 +59,11 @@ public class JdbcDatabaseTest {
     // Arrange
 
     // Act
-    Get get = new Get(new Key("p1", "val"));
+    Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcDatabase.get(get);
 
     // Assert
-    verify(jdbcService).get(any(), any(), any(), any());
+    verify(jdbcService).get(any(), any());
     verify(connection).close();
   }
 
@@ -68,12 +72,12 @@ public class JdbcDatabaseTest {
       whenGetOperationExecutedAndJdbcServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
     // Arrange
-    when(jdbcService.get(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.get(any(), any())).thenThrow(sqlException);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Get get = new Get(new Key("p1", "val"));
+              Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.get(get);
             })
         .isInstanceOf(ExecutionException.class);
@@ -83,16 +87,16 @@ public class JdbcDatabaseTest {
   @Test
   public void whenScanOperationExecutedAndScannerClosed_shouldCallJdbcService() throws Exception {
     // Arrange
-    when(jdbcService.getScanner(any(), any(), any(), any()))
+    when(jdbcService.getScanner(any(), any()))
         .thenReturn(new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet));
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val"));
+    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     Scanner scanner = jdbcDatabase.scan(scan);
     scanner.close();
 
     // Assert
-    verify(jdbcService).getScanner(any(), any(), any(), any());
+    verify(jdbcService).getScanner(any(), any());
     verify(connection).close();
   }
 
@@ -101,12 +105,12 @@ public class JdbcDatabaseTest {
       whenScanOperationExecutedAndJdbcServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
     // Arrange
-    when(jdbcService.getScanner(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.getScanner(any(), any())).thenThrow(sqlException);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Scan scan = new Scan(new Key("p1", "val"));
+              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(ExecutionException.class);
@@ -116,14 +120,18 @@ public class JdbcDatabaseTest {
   @Test
   public void whenPutOperationExecuted_shouldCallJdbcService() throws Exception {
     // Arrange
-    when(jdbcService.put(any(), any(), any(), any())).thenReturn(true);
+    when(jdbcService.put(any(), any())).thenReturn(true);
 
     // Act
-    Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
+    Put put =
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
     jdbcDatabase.put(put);
 
     // Assert
-    verify(jdbcService).put(any(), any(), any(), any());
+    verify(jdbcService).put(any(), any());
     verify(connection).close();
   }
 
@@ -132,7 +140,7 @@ public class JdbcDatabaseTest {
       whenPutOperationWithConditionExecutedAndJdbcServiceReturnsFalse_shouldThrowNoMutationException()
           throws Exception {
     // Arrange
-    when(jdbcService.put(any(), any(), any(), any())).thenReturn(false);
+    when(jdbcService.put(any(), any())).thenReturn(false);
 
     // Act Assert
     assertThatThrownBy(
@@ -140,7 +148,9 @@ public class JdbcDatabaseTest {
               Put put =
                   new Put(new Key("p1", "val1"))
                       .withValue("v1", "val2")
-                      .withCondition(new PutIfNotExists());
+                      .withCondition(new PutIfNotExists())
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
               jdbcDatabase.put(put);
             })
         .isInstanceOf(NoMutationException.class);
@@ -152,12 +162,16 @@ public class JdbcDatabaseTest {
       whenPutOperationExecutedAndJdbcServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
     // Arrange
-    when(jdbcService.put(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.put(any(), any())).thenThrow(sqlException);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
+              Put put =
+                  new Put(new Key("p1", "val1"))
+                      .withValue("v1", "val2")
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
               jdbcDatabase.put(put);
             })
         .isInstanceOf(ExecutionException.class);
@@ -167,14 +181,14 @@ public class JdbcDatabaseTest {
   @Test
   public void whenDeleteOperationExecuted_shouldCallJdbcService() throws Exception {
     // Arrange
-    when(jdbcService.delete(any(), any(), any(), any())).thenReturn(true);
+    when(jdbcService.delete(any(), any())).thenReturn(true);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1"));
+    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcDatabase.delete(delete);
 
     // Assert
-    verify(jdbcService).delete(any(), any(), any(), any());
+    verify(jdbcService).delete(any(), any());
     verify(connection).close();
   }
 
@@ -183,12 +197,16 @@ public class JdbcDatabaseTest {
       whenDeleteOperationWithConditionExecutedAndJdbcServiceReturnsFalse_shouldThrowNoMutationException()
           throws Exception {
     // Arrange
-    when(jdbcService.delete(any(), any(), any(), any())).thenReturn(false);
+    when(jdbcService.delete(any(), any())).thenReturn(false);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Delete delete = new Delete(new Key("p1", "val1")).withCondition(new DeleteIfExists());
+              Delete delete =
+                  new Delete(new Key("p1", "val1"))
+                      .withCondition(new DeleteIfExists())
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
               jdbcDatabase.delete(delete);
             })
         .isInstanceOf(NoMutationException.class);
@@ -200,12 +218,13 @@ public class JdbcDatabaseTest {
       whenDeleteOperationExecutedAndJdbcServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
     // Arrange
-    when(jdbcService.delete(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.delete(any(), any())).thenThrow(sqlException);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Delete delete = new Delete(new Key("p1", "val1"));
+              Delete delete =
+                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.delete(delete);
             })
         .isInstanceOf(ExecutionException.class);
@@ -215,15 +234,19 @@ public class JdbcDatabaseTest {
   @Test
   public void whenMutateOperationExecuted_shouldCallJdbcService() throws Exception {
     // Arrange
-    when(jdbcService.mutate(any(), any(), any(), any())).thenReturn(true);
+    when(jdbcService.mutate(any(), any())).thenReturn(true);
 
     // Act
-    Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-    Delete delete = new Delete(new Key("p1", "val1"));
+    Put put =
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
     jdbcDatabase.mutate(Arrays.asList(put, delete));
 
     // Assert
-    verify(jdbcService).mutate(any(), any(), any(), any());
+    verify(jdbcService).mutate(any(), any());
     verify(connection).close();
   }
 
@@ -232,7 +255,7 @@ public class JdbcDatabaseTest {
       whenMutateOperationWithConditionExecutedAndJdbcServiceReturnsFalse_shouldThrowNoMutationException()
           throws Exception {
     // Arrange
-    when(jdbcService.mutate(any(), any(), any(), any())).thenReturn(false);
+    when(jdbcService.mutate(any(), any())).thenReturn(false);
 
     // Act Assert
     assertThatThrownBy(
@@ -240,8 +263,14 @@ public class JdbcDatabaseTest {
               Put put =
                   new Put(new Key("p1", "val1"))
                       .withValue("v1", "val2")
-                      .withCondition(new PutIfNotExists());
-              Delete delete = new Delete(new Key("p1", "val1")).withCondition(new DeleteIfExists());
+                      .withCondition(new PutIfNotExists())
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
+              Delete delete =
+                  new Delete(new Key("p1", "val1"))
+                      .withCondition(new DeleteIfExists())
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(NoMutationException.class);
@@ -253,13 +282,18 @@ public class JdbcDatabaseTest {
       whenMutateOperationExecutedAndJdbcServiceThrowsSQLException_shouldThrowExecutionException()
           throws Exception {
     // Arrange
-    when(jdbcService.mutate(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.mutate(any(), any())).thenThrow(sqlException);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-              Delete delete = new Delete(new Key("p1", "val1"));
+              Put put =
+                  new Put(new Key("p1", "val1"))
+                      .withValue("v1", "val2")
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
+              Delete delete =
+                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(ExecutionException.class);
@@ -270,14 +304,19 @@ public class JdbcDatabaseTest {
   public void mutate_withConflictError_shouldThrowRetriableExecutionException()
       throws SQLException, ExecutionException {
     // Arrange
-    when(jdbcService.mutate(any(), any(), any(), any())).thenThrow(sqlException);
+    when(jdbcService.mutate(any(), any())).thenThrow(sqlException);
     when(sqlException.getErrorCode()).thenReturn(1213);
 
     // Act Assert
     assertThatThrownBy(
             () -> {
-              Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-              Delete delete = new Delete(new Key("p1", "val1"));
+              Put put =
+                  new Put(new Key("p1", "val1"))
+                      .withValue("v1", "val2")
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
+              Delete delete =
+                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(RetriableExecutionException.class);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -37,7 +37,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -46,8 +45,8 @@ import org.mockito.MockitoAnnotations;
 @SuppressFBWarnings({"RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", "OBL_UNSATISFIED_OBLIGATION"})
 public class JdbcServiceTest {
 
-  private static final Optional<String> NAMESPACE = Optional.of("s1");
-  private static final Optional<String> TABLE = Optional.of("t1");
+  private static final String NAMESPACE = "ns";
+  private static final String TABLE = "tbl";
 
   @Mock private QueryBuilder queryBuilder;
   @Mock private OperationChecker operationChecker;
@@ -99,8 +98,8 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Get get = new Get(new Key("p1", "val"));
-    jdbcService.get(get, connection, NAMESPACE, TABLE);
+    Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    jdbcService.get(get, connection);
 
     // Assert
     verify(operationChecker).check(any(Get.class));
@@ -125,8 +124,8 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val"));
-    jdbcService.getScanner(scan, connection, NAMESPACE, TABLE);
+    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    jdbcService.getScanner(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(Scan.class));
@@ -151,8 +150,8 @@ public class JdbcServiceTest {
     when(resultSet.next()).thenReturn(false);
 
     // Act
-    Scan scan = new Scan(new Key("p1", "val"));
-    jdbcService.scan(scan, connection, NAMESPACE, TABLE);
+    Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+    jdbcService.scan(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(Scan.class));
@@ -168,8 +167,12 @@ public class JdbcServiceTest {
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
 
     // Act
-    Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+    Put put =
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -195,8 +198,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new PutIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -222,8 +227,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new PutIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -244,8 +251,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -266,8 +277,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -287,8 +302,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfNotExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfNotExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -310,8 +329,12 @@ public class JdbcServiceTest {
 
     // Act
     Put put =
-        new Put(new Key("p1", "val1")).withValue("v1", "val2").withCondition(new PutIfNotExists());
-    boolean ret = jdbcService.put(put, connection, NAMESPACE, TABLE);
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .withCondition(new PutIfNotExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.put(put, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -328,8 +351,8 @@ public class JdbcServiceTest {
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1"));
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -353,8 +376,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new DeleteIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -378,8 +403,10 @@ public class JdbcServiceTest {
             .withCondition(
                 new DeleteIf(
                     new ConditionalExpression(
-                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)));
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+                        "v1", new TextValue("val2"), ConditionalExpression.Operator.EQ)))
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -399,8 +426,12 @@ public class JdbcServiceTest {
     when(preparedStatement.executeUpdate()).thenReturn(1);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1")).withCondition(new DeleteIfExists());
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+    Delete delete =
+        new Delete(new Key("p1", "val1"))
+            .withCondition(new DeleteIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isTrue();
@@ -420,8 +451,12 @@ public class JdbcServiceTest {
     when(preparedStatement.executeUpdate()).thenReturn(0);
 
     // Act
-    Delete delete = new Delete(new Key("p1", "val1")).withCondition(new DeleteIfExists());
-    boolean ret = jdbcService.delete(delete, connection, NAMESPACE, TABLE);
+    Delete delete =
+        new Delete(new Key("p1", "val1"))
+            .withCondition(new DeleteIfExists())
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    boolean ret = jdbcService.delete(delete, connection);
 
     // Assert
     assertThat(ret).isFalse();
@@ -443,9 +478,13 @@ public class JdbcServiceTest {
     when(deleteQueryBuilder.build()).thenReturn(deleteQuery);
 
     // Act
-    Put put = new Put(new Key("p1", "val1")).withValue("v1", "val2");
-    Delete delete = new Delete(new Key("p1", "val1"));
-    boolean ret = jdbcService.mutate(Arrays.asList(put, delete), connection, NAMESPACE, TABLE);
+    Put put =
+        new Put(new Key("p1", "val1"))
+            .withValue("v1", "val2")
+            .forNamespace(NAMESPACE)
+            .forTable(TABLE);
+    Delete delete = new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+    boolean ret = jdbcService.mutate(Arrays.asList(put, delete), connection);
 
     // Assert
     assertThat(ret).isTrue();

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageTest.java
@@ -32,6 +32,7 @@ public class MultiStorageTest {
   protected static final String COL_NAME2 = "c2";
   protected static final String COL_NAME3 = "c3";
 
+  @Mock private MultiStorageConfig config;
   @Mock private DistributedStorage storage1;
   @Mock private DistributedStorage storage2;
   @Mock private DistributedStorage storage3;
@@ -49,7 +50,7 @@ public class MultiStorageTest {
     Map<String, DistributedStorage> namespaceStorageMap = new HashMap<>();
     namespaceStorageMap.put(NAMESPACE2, storage2);
     DistributedStorage defaultStorage = storage3;
-    multiStorage = new MultiStorage(tableStorageMap, namespaceStorageMap, defaultStorage);
+    multiStorage = new MultiStorage(config, tableStorageMap, namespaceStorageMap, defaultStorage);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
@@ -1,0 +1,109 @@
+package com.scalar.db.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+
+@SuppressWarnings("ReferenceEquality")
+public class ScalarDbUtilsTest {
+
+  private static final Optional<String> NAMESPACE = Optional.of("ns");
+  private static final Optional<String> TABLE = Optional.of("tbl");
+
+  @Test
+  public void copyAndSetTargetToIfNot_GetGiven_ShouldReturnDifferentInstance() {
+    // Arrange
+    Get get = new Get(new Key("c1", "v1"));
+
+    // Act
+    Get actual = ScalarDbUtils.copyAndSetTargetToIfNot(get, NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual == get).isFalse();
+    assertThat(get.forNamespace()).isNotPresent();
+    assertThat(get.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void copyAndSetTargetToIfNot_ScanGiven_ShouldReturnDifferentInstance() {
+    // Arrange
+    Scan scan = new Scan(new Key("c1", "v1"));
+
+    // Act
+    Scan actual = ScalarDbUtils.copyAndSetTargetToIfNot(scan, NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual == scan).isFalse();
+    assertThat(scan.forNamespace()).isNotPresent();
+    assertThat(scan.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void copyAndSetTargetToIfNot_PutGiven_ShouldReturnDifferentInstance() {
+    // Arrange
+    Put put = new Put(new Key("c1", "v1"));
+
+    // Act
+    Put actual = ScalarDbUtils.copyAndSetTargetToIfNot(put, NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual == put).isFalse();
+    assertThat(put.forNamespace()).isNotPresent();
+    assertThat(put.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void copyAndSetTargetToIfNot_DeleteGiven_ShouldReturnDifferentInstance() {
+    // Arrange
+    Delete delete = new Delete(new Key("c1", "v1"));
+
+    // Act
+    Delete actual = ScalarDbUtils.copyAndSetTargetToIfNot(delete, NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual == delete).isFalse();
+    assertThat(delete.forNamespace()).isNotPresent();
+    assertThat(delete.forTable()).isNotPresent();
+    assertThat(actual.forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void copyAndSetTargetToIfNot_MutationsGiven_ShouldReturnDifferentInstance() {
+    // Arrange
+    Put put = new Put(new Key("c1", "v1"));
+    Delete delete = new Delete(new Key("c1", "v1"));
+    List<Mutation> mutations = Arrays.asList(put, delete);
+
+    // Act
+    List<Mutation> actual = ScalarDbUtils.copyAndSetTargetToIfNot(mutations, NAMESPACE, TABLE);
+
+    // Assert
+    assertThat(actual == mutations).isFalse();
+    assertThat(actual.get(0) == put).isFalse();
+    assertThat(actual.get(1) == delete).isFalse();
+    assertThat(put.forNamespace()).isNotPresent();
+    assertThat(put.forTable()).isNotPresent();
+    assertThat(delete.forNamespace()).isNotPresent();
+    assertThat(delete.forTable()).isNotPresent();
+    assertThat(actual.get(0).forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.get(0).forTable()).isEqualTo(TABLE);
+    assertThat(actual.get(1).forNamespace()).isEqualTo(NAMESPACE);
+    assertThat(actual.get(1).forTable()).isEqualTo(TABLE);
+  }
+}


### PR DESCRIPTION
Currently, we change the states of operation instances (`Get`/`Scan`/`Put`/`Delete`) passed as arguments, which could be confusing and might be causing a bug. To address issue, we can copy the operation instances at the begging of the methods (`get()`, `scan()`, `put()`, `delete()`, and `mutate()`) of `DistributedStorage` and `DistributedTransaction` and `TwoPhaseCommitTransaction`, and use them.

The difference from #495 is the new configuration `scalar.db.need_operation_copy` is removed. This is because I think the operation copy cost is very small but introducing the new configuration makes the code more complicated, so it's not worth it.

Please take a look!