### PR TITLE
Move the rollbackRecords method from RecoveryHandler to CommitHandler

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -78,6 +78,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   private DistributedStorage storage;
   private Coordinator coordinator;
   private RecoveryHandler recovery;
+  private CommitHandler commit;
 
   @Before
   public void setUp() throws Exception {
@@ -99,14 +100,10 @@ public abstract class ConsensusCommitIntegrationTestBase {
     truncateTables();
     storage = spy(originalStorage);
     coordinator = spy(new Coordinator(storage, consensusCommitConfig));
-    recovery =
-        spy(
-            new RecoveryHandler(
-                storage,
-                coordinator,
-                new TransactionalTableMetadataManager(admin, -1),
-                parallelExecutor));
-    CommitHandler commit = spy(new CommitHandler(storage, coordinator, recovery, parallelExecutor));
+    TransactionalTableMetadataManager tableMetadataManager =
+        new TransactionalTableMetadataManager(admin, -1);
+    recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
+    commit = spy(new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor));
     manager =
         new ConsensusCommitManager(
             storage, admin, consensusCommitConfig, coordinator, parallelExecutor, recovery, commit);
@@ -1183,7 +1180,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     assertThatThrownBy(transaction::commit).isInstanceOf(CommitException.class);
 
     // Assert
-    verify(recovery).rollbackRecords(any(Snapshot.class));
+    verify(commit).rollbackRecords(any(Snapshot.class));
     List<Get> gets1 = prepareGets(namespace1, table1);
     List<Get> gets2 = differentTables ? prepareGets(namespace2, table2) : gets1;
 
@@ -1200,7 +1197,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   @Test
   public void
       commit_ConflictingPutsForSameTableGivenForNonExisting_ShouldCommitOneAndAbortTheOther()
-          throws CrudException, CommitConflictException {
+          throws CrudException {
     commit_ConflictingPutsGivenForNonExisting_ShouldCommitOneAndAbortTheOther(
         namespace1, TABLE_1, namespace1, TABLE_1);
   }
@@ -1208,7 +1205,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
   @Test
   public void
       commit_ConflictingPutsForDifferentTablesGivenForNonExisting_ShouldCommitOneAndAbortTheOther()
-          throws CrudException, CommitConflictException {
+          throws CrudException {
     commit_ConflictingPutsGivenForNonExisting_ShouldCommitOneAndAbortTheOther(
         namespace1, TABLE_1, namespace2, TABLE_2);
   }
@@ -1259,7 +1256,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     assertThatThrownBy(transaction::commit).isInstanceOf(CommitException.class);
 
     // Assert
-    verify(recovery).rollbackRecords(any(Snapshot.class));
+    verify(commit).rollbackRecords(any(Snapshot.class));
     ConsensusCommit another = manager.start();
     Optional<Result> fromResult = another.get(gets1.get(from));
     assertThat(fromResult).isPresent();
@@ -1327,7 +1324,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     assertThatThrownBy(transaction::commit).isInstanceOf(CommitException.class);
 
     // Assert
-    verify(recovery).rollbackRecords(any(Snapshot.class));
+    verify(commit).rollbackRecords(any(Snapshot.class));
     List<Get> gets1 = prepareGets(namespace1, table1);
     List<Get> gets2 = prepareGets(namespace2, table2);
 
@@ -1560,7 +1557,7 @@ public abstract class ConsensusCommitIntegrationTestBase {
     assertThatThrownBy(transaction::commit).isInstanceOf(CommitException.class);
 
     // Assert
-    verify(recovery).rollbackRecords(any(Snapshot.class));
+    verify(commit).rollbackRecords(any(Snapshot.class));
     List<Get> gets1 = prepareGets(namespace1, table1);
     List<Get> gets2 = differentTables ? prepareGets(namespace2, table2) : gets1;
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -43,8 +43,8 @@ public class ConsensusCommitManager implements DistributedTransactionManager {
     tableMetadataManager =
         new TransactionalTableMetadataManager(
             admin, config.getTableMetadataCacheExpirationTimeSecs());
-    recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
-    commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
+    recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
+    commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     namespace = storage.getNamespace();
     tableName = storage.getTable();
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -54,8 +54,8 @@ public class TwoPhaseConsensusCommitManager implements TwoPhaseCommitTransaction
             admin, config.getTableMetadataCacheExpirationTimeSecs());
     coordinator = new Coordinator(storage, config);
     parallelExecutor = new ParallelExecutor(config);
-    recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
-    commit = new CommitHandler(storage, coordinator, recovery, parallelExecutor);
+    recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
+    commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
 
     if (config.isActiveTransactionsManagementEnabled()) {
       activeTransactions =

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -30,7 +30,6 @@ public class RecoveryHandlerTest {
   @Mock private Coordinator coordinator;
   @Mock private TransactionalTableMetadataManager tableMetadataManager;
   @Mock private Selection selection;
-  @Mock private ConsensusCommitConfig config;
 
   private RecoveryHandler handler;
 
@@ -39,10 +38,7 @@ public class RecoveryHandlerTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    handler =
-        spy(
-            new RecoveryHandler(
-                storage, coordinator, tableMetadataManager, new ParallelExecutor(config)));
+    handler = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
   }
 
   private void configureResult(Result mock, long preparedAt, TransactionState transactionState) {


### PR DESCRIPTION
This is a PR for refactoring. I think it's better to move the `RecoveryHandler.rollbackRecords()` method to `CommitHandler` because the method is only used in `CommitHandler`. Please take a look!