### PR TITLE
Add ConfigUtils.getStringArray()

### DIFF
--- a/core/src/main/java/com/scalar/db/config/ConfigUtils.java
+++ b/core/src/main/java/com/scalar/db/config/ConfigUtils.java
@@ -51,4 +51,12 @@ public final class ConfigUtils {
           "the specified value of '" + name + "' is not a boolean value");
     }
   }
+
+  public static String[] getStringArray(Properties properties, String name, String[] defaultValue) {
+    String value = properties.getProperty(name);
+    if (Strings.isNullOrEmpty(value)) {
+      return defaultValue;
+    }
+    return value.split("\\s*,\\s*");
+  }
 }

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.scalar.db.config.ConfigUtils.getInt;
 import static com.scalar.db.config.ConfigUtils.getLong;
 import static com.scalar.db.config.ConfigUtils.getString;
+import static com.scalar.db.config.ConfigUtils.getStringArray;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
@@ -121,7 +122,7 @@ public class DatabaseConfig {
     if (storageClass != MultiStorage.class) {
       contactPoints =
           Arrays.asList(
-              Objects.requireNonNull(getString(getProperties(), CONTACT_POINTS, null)).split(","));
+              Objects.requireNonNull(getStringArray(getProperties(), CONTACT_POINTS, null)));
       contactPort = getInt(getProperties(), CONTACT_PORT, 0);
       checkArgument(contactPort >= 0);
       username = getString(getProperties(), USERNAME, null);

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.multistorage;
 
 import static com.scalar.db.config.ConfigUtils.getString;
+import static com.scalar.db.config.ConfigUtils.getStringArray;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.config.DatabaseConfig;
@@ -73,13 +74,13 @@ public class MultiStorageConfig {
   }
 
   private void loadDatabaseConfigs() {
-    String storages = getString(getProperties(), STORAGES, null);
+    String[] storages = getStringArray(getProperties(), STORAGES, null);
     if (storages == null) {
       databaseConfigMap = Collections.emptyMap();
       return;
     }
     ImmutableMap.Builder<String, DatabaseConfig> builder = ImmutableMap.builder();
-    for (String storage : storages.split(",", -1)) {
+    for (String storage : storages) {
       Properties dbProps = new Properties();
       for (String propertyName : props.stringPropertyNames()) {
         if (propertyName.startsWith(STORAGES + "." + storage + ".")) {
@@ -99,13 +100,13 @@ public class MultiStorageConfig {
   }
 
   private void loadTableStorageMapping() {
-    String tableMapping = getString(getProperties(), TABLE_MAPPING, null);
+    String[] tableMapping = getStringArray(getProperties(), TABLE_MAPPING, null);
     if (tableMapping == null) {
       tableStorageMap = Collections.emptyMap();
       return;
     }
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    for (String tableAndStorage : tableMapping.split(",", -1)) {
+    for (String tableAndStorage : tableMapping) {
       String[] s = tableAndStorage.split(":", -1);
       String table = s[0];
       String storage = s[1];
@@ -116,13 +117,13 @@ public class MultiStorageConfig {
   }
 
   private void loadNamespaceStorageMapping() {
-    String namespaceMapping = getString(getProperties(), NAMESPACE_MAPPING, null);
+    String[] namespaceMapping = getStringArray(getProperties(), NAMESPACE_MAPPING, null);
     if (namespaceMapping == null) {
       namespaceStorageMap = Collections.emptyMap();
       return;
     }
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    for (String namespaceAndStorage : namespaceMapping.split(",", -1)) {
+    for (String namespaceAndStorage : namespaceMapping) {
       String[] s = namespaceAndStorage.split(":", -1);
       String namespace = s[0];
       String storage = s[1];


### PR DESCRIPTION
This PR adds `ConfigUtils.getStringArray()` utility method that is for getting a string array property from a comma-separated string in a properties file.

It is applied to the existing `DatabaseConfig` and `MultiStorageConfig`. Note that there is a slight difference in how a trailing _regex_ in a property is treated between `split(regex, -1)` and `split(regex)` (equivalent to `split(regex, 0)`). In the latter case, trailing empty strings will be discarded (e.g., `scalar.db.contact_points = server1, , ,` is parsed into a one-element array). This should not be a problem.