### PR TITLE
Change Key builder

### DIFF
--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -308,132 +308,97 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
     private Builder() {}
 
     /**
+     * Adds Boolean value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
-     *     boolean)} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addBoolean(String name, boolean value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, boolean value) {
       values.add(new BooleanValue(name, value));
       return this;
     }
 
     /**
+     * Adds Int value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
-     *     int)} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addInt(String name, int value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, int value) {
       values.add(new IntValue(name, value));
       return this;
     }
 
     /**
+     * Adds BigInt value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
-     *     long)} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addBigInt(String name, long value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, long value) {
       values.add(new BigIntValue(name, value));
       return this;
     }
 
     /**
+     * Adds Float value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
-     *     float)} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addFloat(String name, float value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, float value) {
       values.add(new FloatValue(name, value));
       return this;
     }
 
     /**
+     * Adds Double value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
-     *     double)} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addDouble(String name, double value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, double value) {
       values.add(new DoubleValue(name, value));
       return this;
     }
 
     /**
+     * Adds Text value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use @{@link #add(String,
-     *     String)} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addText(String name, String value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, String value) {
       values.add(new TextValue(name, value));
       return this;
     }
 
     /**
+     * Adds Blob value.
+     *
      * @param name name of the {@code Value}
      * @param value content of the {@code Value}
      * @return a builder object
-     * @deprecated As of release 2.5.0. Will be removed in release 4.0.0. Use {@link #add(String,
-     *     byte[])} instead
      */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
     public Builder addBlob(String name, byte[] value) {
-      return add(name, value);
-    }
-
-    public Builder add(String name, byte[] value) {
       values.add(new BlobValue(name, value));
       return this;
     }
 
-    public Builder add(String name, ByteBuffer value) {
+    /**
+     * Adds Blob value.
+     *
+     * @param name name of the {@code Value}
+     * @param value content of the {@code Value}
+     * @return a builder object
+     */
+    public Builder addBlob(String name, ByteBuffer value) {
       values.add(new BlobValue(name, value));
       return this;
     }

--- a/core/src/test/java/com/scalar/db/io/KeyTest.java
+++ b/core/src/test/java/com/scalar/db/io/KeyTest.java
@@ -218,14 +218,14 @@ public class KeyTest {
     // Arrange
     Key key =
         Key.newBuilder()
-            .add("key1", true)
-            .add("key2", 5678)
-            .add("key3", 1234L)
-            .add("key4", 4.56f)
-            .add("key5", 1.23)
-            .add("key6", "string_key")
-            .add("key7", "blob_key".getBytes(StandardCharsets.UTF_8))
-            .add("key8", ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)))
+            .addBoolean("key1", true)
+            .addInt("key2", 5678)
+            .addBigInt("key3", 1234L)
+            .addFloat("key4", 4.56f)
+            .addDouble("key5", 1.23)
+            .addText("key6", "string_key")
+            .addBlob("key7", "blob_key".getBytes(StandardCharsets.UTF_8))
+            .addBlob("key8", ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)))
             .add(new IntValue("key9", 1357))
             .addAll(Arrays.asList(new IntValue("key10", 2468), new BigIntValue("key11", 1111L)))
             .build();

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -692,7 +692,7 @@ public class OperationCheckerTest {
   public void
       whenCheckingPutOperationWithPartitionKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
-    Key partitionKey = Key.newBuilder().add(PKEY1, 1).add(PKEY2, (String) null).build();
+    Key partitionKey = Key.newBuilder().addInt(PKEY1, 1).addText(PKEY2, null).build();
     Key clusteringKey = new Key(CKEY1, 2, CKEY2, "val2");
     List<Value<?>> values =
         Arrays.asList(
@@ -727,7 +727,7 @@ public class OperationCheckerTest {
       whenCheckingPutOperationWithClusteringKeyWithNullTextValue_shouldThrowIllegalArgumentException() {
     // Arrange
     Key partitionKey = new Key(PKEY1, 1, PKEY2, "val1");
-    Key clusteringKey = Key.newBuilder().add(CKEY1, 2).add(CKEY2, (String) null).build();
+    Key clusteringKey = Key.newBuilder().addInt(CKEY1, 2).addText(CKEY2, null).build();
     List<Value<?>> values =
         Arrays.asList(
             new IntValue(COL1, 1), new DoubleValue(COL2, 0.1), new BooleanValue(COL3, true));


### PR DESCRIPTION
This PR actually reverts some of the changes in #447.

It seems like the current standard of Java API is more explicit method names rather than using overload.

After this reverting, We can use the Key builder as follows:
```java
Key key = Key.newBuilder()
            .addInt("col1", 1)
            .addBigInt("col2", 100L)
            .addDouble("col3", 1.3d)
            .addText("col4", "value")
            .addBoolean("col5", false)
            .addInt("col6", 100)
            .build();
```

Note that we don't need to consider its compatibility since we have not yet released the changes in #447.