### PR TITLE
Fix typo in the javadoc

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Operation.java
+++ b/core/src/main/java/com/scalar/db/api/Operation.java
@@ -89,7 +89,7 @@ public abstract class Operation {
   }
 
   /**
-   * Sets the specified target namespace for this operation
+   * Sets the specified target table for this operation
    *
    * @param tableName target table name for this operation
    * @return this object


### PR DESCRIPTION
It seems that javadoc of com.scalar.db.api.Operation Class has a typo.
I think that "table" is correct in the description of the Operation.forTable() method.
Please take a look!