### PR TITLE
Hide `Value` from users

### DIFF
--- a/core/src/main/java/com/scalar/db/api/ConditionalExpression.java
+++ b/core/src/main/java/com/scalar/db/api/ConditionalExpression.java
@@ -19,137 +19,266 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public class ConditionalExpression {
-  private final String name;
+  private final String columnName;
   private final Value<?> value;
   private final Operator operator;
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator. A
-   * conditional expression will be "{@code <name> <operator> <value's content>}". {@code Value}'s
-   * name won't be used to create an expression, so giving anonymous {@code Value} makes more sense
-   * and is more readable.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
+   * A conditional expression will be "{@code <columnName> <operator> <value>}".
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * <p>{@code Value}'s name won't be used to create an expression, so giving anonymous {@code
+   * Value} makes more sense and is more readable.
+   *
+   * @param columnName a name of target column
+   * @param value a value used to compare with the target column
+   * @param operator an operator used to compare the target column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
-  public ConditionalExpression(String name, Value<?> value, Operator operator) {
-    this.name = name;
+  @Deprecated
+  public ConditionalExpression(String columnName, Value<?> value, Operator operator) {
+    this.columnName = columnName;
     this.value = value;
     this.operator = operator;
-    checkOperator(operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param booleanValue a BOOLEAN value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, boolean value, Operator operator) {
-    this(name, new BooleanValue(value), operator);
+  public ConditionalExpression(String columnName, boolean booleanValue, Operator operator) {
+    this(columnName, new BooleanValue(booleanValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param intValue an INT value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, int value, Operator operator) {
-    this(name, new IntValue(value), operator);
+  public ConditionalExpression(String columnName, int intValue, Operator operator) {
+    this(columnName, new IntValue(intValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param bigIntValue a BIGINT value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, long value, Operator operator) {
-    this(name, new BigIntValue(value), operator);
+  public ConditionalExpression(String columnName, long bigIntValue, Operator operator) {
+    this(columnName, new BigIntValue(bigIntValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param floatValue a FLOAT value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, float value, Operator operator) {
-    this(name, new FloatValue(value), operator);
+  public ConditionalExpression(String columnName, float floatValue, Operator operator) {
+    this(columnName, new FloatValue(floatValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param doubleValue a DOUBLE value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, double value, Operator operator) {
-    this(name, new DoubleValue(value), operator);
+  public ConditionalExpression(String columnName, double doubleValue, Operator operator) {
+    this(columnName, new DoubleValue(doubleValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param textValue a TEXT value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, String value, Operator operator) {
-    this(name, new TextValue(value), operator);
+  public ConditionalExpression(String columnName, String textValue, Operator operator) {
+    this(columnName, new TextValue(textValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param blobValue a BLOB value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, byte[] value, Operator operator) {
-    this(name, new BlobValue(value), operator);
+  public ConditionalExpression(String columnName, byte[] blobValue, Operator operator) {
+    this(columnName, new BlobValue(blobValue), operator);
   }
 
   /**
-   * Constructs a {@code ConditionalExpression} with the specified name, value and operator.
+   * Constructs a {@code ConditionalExpression} with the specified column name, value and operator.
    *
-   * @param name name of target value
-   * @param value value used to compare with the target value
-   * @param operator operator used to compare the target value specified with the name and the value
+   * @param columnName a name of target column
+   * @param blobValue a BLOB value used to compare with the target column
+   * @param operator an operator used to compare the target column
    */
-  public ConditionalExpression(String name, ByteBuffer value, Operator operator) {
-    this(name, new BlobValue(value), operator);
+  public ConditionalExpression(String columnName, ByteBuffer blobValue, Operator operator) {
+    this(columnName, new BlobValue(blobValue), operator);
   }
 
   /**
-   * Returns the name of target value
+   * Returns the column name of target column.
    *
-   * @return the name of target value
+   * @return the column name of target column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   public String getName() {
-    return name;
+    return columnName;
   }
 
   /**
-   * Return the value used to compare with the target value
+   * Returns the column name of target column.
    *
-   * @return the value used to compare with the target value
+   * @return the column name of target column
+   */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  /**
+   * Return the value used to compare with the target column.
+   *
+   * <p>This method is primarily for internal use. Breaking changes can and will be introduced to
+   * this method. Users should not depend on it.
+   *
+   * @return the value used to compare with the target column
    */
   public Value<?> getValue() {
     return value;
   }
 
   /**
-   * Returns the operator used to compare the target value specified with the name and the value
+   * Returns the BOOLEAN value to compare with the target column.
    *
-   * @return the operator used to compare the target value specified with the name and the value
+   * @return the BOOLEAN value to compare with the target column
+   */
+  public boolean getBooleanValue() {
+    return value.getAsBoolean();
+  }
+
+  /**
+   * Returns the INT value to compare with the target column.
+   *
+   * @return the INT value to compare with the target column
+   */
+  public int getIntValue() {
+    return value.getAsInt();
+  }
+
+  /**
+   * Returns the BIGINT value to compare with the target column.
+   *
+   * @return the BIGINT value to compare with the target column
+   */
+  public long getBigIntValue() {
+    return value.getAsLong();
+  }
+
+  /**
+   * Returns the FLOAT value to compare with the target column.
+   *
+   * @return the FLOAT value to compare with the target column
+   */
+  public float getFloatValue() {
+    return value.getAsFloat();
+  }
+
+  /**
+   * Returns the DOUBLE value to compare with the target column.
+   *
+   * @return the DOUBLE value to compare with the target column
+   */
+  public double getDoubleValue() {
+    return value.getAsDouble();
+  }
+
+  /**
+   * Returns the TEXT value to compare with the target column.
+   *
+   * @return the TEXT value to compare with the target column
+   */
+  public String getTextValue() {
+    return value.getAsString().orElse(null);
+  }
+
+  /**
+   * Returns the BLOB value to compare with the target column as a ByteBuffer type.
+   *
+   * @return the BLOB value to compare with the target column as a ByteBuffer type
+   */
+  public ByteBuffer getBlobValue() {
+    return getBlobValueAsByteBuffer();
+  }
+
+  /**
+   * Returns the BLOB value to compare with the target column as a ByteBuffer type.
+   *
+   * @return the BLOB value to compare with the target column as a ByteBuffer type
+   */
+  public ByteBuffer getBlobValueAsByteBuffer() {
+    return value.getAsByteBuffer().orElse(null);
+  }
+
+  /**
+   * Returns the BLOB value to compare with the target column as a byte array type.
+   *
+   * @return the BLOB value to compare with the target column as a byte array type
+   */
+  public byte[] getBlobValueAsBytes() {
+    return value.getAsBytes().orElse(null);
+  }
+
+  /**
+   * Returns the value to compare with the target column as an Object type.
+   *
+   * <p>If the columns is a BOOLEAN type, it returns a {@code Boolean} object. If the columns is an
+   * INT type, it returns an {@code Integer} object. If the columns is a BIGINT type, it returns a
+   * {@code LONG} object. If the columns is a FLOAT type, it returns a {@code FLOAT} object. If the
+   * columns is a DOUBLE type, it returns a {@code DOUBLE} object. If the columns is a TEXT type, it
+   * returns a {@code String} object. If the columns is a BLOB type, it returns a {@code ByteBuffer}
+   * object.
+   *
+   * @return the value to compare with the target column as an Object type
+   */
+  public Object getValueAsObject() {
+    if (value instanceof BooleanValue) {
+      return getBooleanValue();
+    } else if (value instanceof IntValue) {
+      return getIntValue();
+    } else if (value instanceof BigIntValue) {
+      return getBigIntValue();
+    } else if (value instanceof FloatValue) {
+      return getFloatValue();
+    } else if (value instanceof DoubleValue) {
+      return getDoubleValue();
+    } else if (value instanceof TextValue) {
+      return getTextValue();
+    } else if (value instanceof BlobValue) {
+      return getBlobValue();
+    } else {
+      throw new AssertionError();
+    }
+  }
+
+  /**
+   * Returns the operator used to compare the target column.
+   *
+   * @return the operator used to compare the target column
    */
   public Operator getOperator() {
     return operator;
@@ -161,7 +290,7 @@ public class ConditionalExpression {
    *
    * <ul>
    *   <li>it is also an {@code ConditionalExpression} and
-   *   <li>both instances have the same name, value and operator.
+   *   <li>both instances have the same column name, value and operator.
    * </ul>
    *
    * @param o an object to be tested for equality
@@ -176,26 +305,14 @@ public class ConditionalExpression {
       return false;
     }
     ConditionalExpression other = (ConditionalExpression) o;
-    return name.equals(other.name) && value.equals(other.value) && operator.equals(other.operator);
+    return columnName.equals(other.columnName)
+        && value.equals(other.value)
+        && operator.equals(other.operator);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, value, operator);
-  }
-
-  private void checkOperator(Operator op) {
-    switch (op) {
-      case EQ:
-      case NE:
-      case GT:
-      case GTE:
-      case LT:
-      case LTE:
-        return;
-      default:
-        throw new IllegalArgumentException(op + " is not supported.");
-    }
+    return Objects.hash(columnName, value, operator);
   }
 
   public enum Operator {

--- a/core/src/main/java/com/scalar/db/api/DeleteIfExists.java
+++ b/core/src/main/java/com/scalar/db/api/DeleteIfExists.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.scalar.db.io.Value;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -18,9 +17,10 @@ public class DeleteIfExists implements MutationCondition {
   public DeleteIfExists() {}
 
   /**
-   * Returns an empty list of {@link Value}s since any conditions are not given to this object.
+   * Returns an empty list of {@link ConditionalExpression}s since any conditions are not given to
+   * this object.
    *
-   * @return an empty list of {@code Value}s
+   * @return an empty list of {@code ConditionalExpression}s
    */
   @Override
   @Nonnull

--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -12,10 +12,10 @@ import java.util.Optional;
  *
  * <p>The data model behind this abstraction is a multi-dimensional map based on key-value data
  * model. A logical record (or entry) is composed of partition key, clustering key and a set of
- * values. The value is uniquely mapped by a primary key composed of partition key, clustering key
- * and value name as described in the following scheme.
+ * columns. The column value is uniquely mapped by a primary key composed of partition key,
+ * clustering key and column name as described in the following scheme.
  *
- * <p>(partition key, clustering key, value name) {@code =>} value content
+ * <p>(partition key, clustering key, column name) {@code =>} column value
  *
  * <p>The physical data model is a multi-dimensional map distributed to multiple nodes by key-based
  * hash partitioning. Entries are assumed to be hash-partitioned by partition key (even though an
@@ -38,7 +38,7 @@ import java.util.Optional;
  * storage.with(NAMESPACE, TABLE);
  *
  * // Inserts a new entry which has the primary key value 0 to the storage.
- * // Assumes that the primary key is composed of a integer value named COL_NAME.
+ * // Assumes that the primary key is composed of a integer column named COL_NAME.
  * Put put = new Put(new Key(COL_NAME, 0);
  * storage.put(put);
  *

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -63,116 +63,118 @@ public class Put extends Mutation {
    *
    * @param value a {@code Value} to put
    * @return this object
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   public Put withValue(Value<?> value) {
     values.put(value.getName(), Optional.of(value));
     return this;
   }
 
   /**
-   * Adds the specified Boolean value to the list of put values.
+   * Adds the specified BOOLEAN value to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param booleanValue a BOOLEAN value to put
    * @return this object
    */
-  public Put withValue(String name, boolean value) {
-    values.put(name, Optional.of(new BooleanValue(name, value)));
+  public Put withValue(String columnName, boolean booleanValue) {
+    values.put(columnName, Optional.of(new BooleanValue(columnName, booleanValue)));
     return this;
   }
 
   /**
-   * Adds the specified Int value to the list of put values.
+   * Adds the specified INT value to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param intValue a INT value to put
    * @return this object
    */
-  public Put withValue(String name, int value) {
-    values.put(name, Optional.of(new IntValue(name, value)));
+  public Put withValue(String columnName, int intValue) {
+    values.put(columnName, Optional.of(new IntValue(columnName, intValue)));
     return this;
   }
 
   /**
-   * Adds the specified BigInt value to the list of put values.
+   * Adds the specified BIGINT value to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param bigIntValue a BIGINT value to put
    * @return this object
    */
-  public Put withValue(String name, long value) {
-    values.put(name, Optional.of(new BigIntValue(name, value)));
+  public Put withValue(String columnName, long bigIntValue) {
+    values.put(columnName, Optional.of(new BigIntValue(columnName, bigIntValue)));
     return this;
   }
 
   /**
-   * Adds the specified Float value to the list of put values.
+   * Adds the specified FLOAT value to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param floatValue a value to put
    * @return this object
    */
-  public Put withValue(String name, float value) {
-    values.put(name, Optional.of(new FloatValue(name, value)));
+  public Put withValue(String columnName, float floatValue) {
+    values.put(columnName, Optional.of(new FloatValue(columnName, floatValue)));
     return this;
   }
 
   /**
-   * Adds the specified Double value to the list of put values.
+   * Adds the specified DOUBLE value to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param doubleValue a DOUBLE value to put
    * @return this object
    */
-  public Put withValue(String name, double value) {
-    values.put(name, Optional.of(new DoubleValue(name, value)));
+  public Put withValue(String columnName, double doubleValue) {
+    values.put(columnName, Optional.of(new DoubleValue(columnName, doubleValue)));
     return this;
   }
 
   /**
-   * Adds the specified Text value to the list of put values.
+   * Adds the specified TEXT value to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param textValue a TEXT value to put
    * @return this object
    */
-  public Put withValue(String name, @Nullable String value) {
-    if (value == null) {
-      withNullValue(name);
+  public Put withValue(String columnName, @Nullable String textValue) {
+    if (textValue == null) {
+      withNullValue(columnName);
     } else {
-      values.put(name, Optional.of(new TextValue(name, value)));
+      values.put(columnName, Optional.of(new TextValue(columnName, textValue)));
     }
     return this;
   }
 
   /**
-   * Adds the specified Blob value to the list of put values.
+   * Adds the specified BLOB value as a byte array to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param blobValue a BLOB value to put
    * @return this object
    */
-  public Put withValue(String name, @Nullable byte[] value) {
-    if (value == null) {
-      withNullValue(name);
+  public Put withValue(String columnName, @Nullable byte[] blobValue) {
+    if (blobValue == null) {
+      withNullValue(columnName);
     } else {
-      values.put(name, Optional.of(new BlobValue(name, value)));
+      values.put(columnName, Optional.of(new BlobValue(columnName, blobValue)));
     }
     return this;
   }
 
   /**
-   * Adds the specified Blob value to the list of put values.
+   * Adds the specified Blob value as a ByteBuffer to the list of put values.
    *
-   * @param name a name of the value
-   * @param value a value to put
+   * @param columnName a column name of the value
+   * @param blobValue a BLOB value to put
    * @return this object
    */
-  public Put withValue(String name, @Nullable ByteBuffer value) {
-    if (value == null) {
-      withNullValue(name);
+  public Put withValue(String columnName, @Nullable ByteBuffer blobValue) {
+    if (blobValue == null) {
+      withNullValue(columnName);
     } else {
-      values.put(name, Optional.of(new BlobValue(name, value)));
+      values.put(columnName, Optional.of(new BlobValue(columnName, blobValue)));
     }
     return this;
   }
@@ -182,20 +184,22 @@ public class Put extends Mutation {
    *
    * @param values a collection of {@code Value}s to put
    * @return this object
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   public Put withValues(Collection<Value<?>> values) {
     values.forEach(v -> this.values.put(v.getName(), Optional.of(v)));
     return this;
   }
 
   /**
-   * Adds NULL value for the specified name of the value.
+   * Adds NULL value to the list of put values.
    *
-   * @param name a name of the value
+   * @param columnName a column name of the value
    * @return this object
    */
-  public Put withNullValue(String name) {
-    values.put(name, Optional.empty());
+  public Put withNullValue(String columnName) {
+    values.put(columnName, Optional.empty());
     return this;
   }
 
@@ -215,6 +219,9 @@ public class Put extends Mutation {
   /**
    * Returns a map of {@link Value}s.
    *
+   * <p>This method is primarily for internal use. Breaking changes can and will be introduced to
+   * this method. Users should not depend on it.
+   *
    * @return a map of {@code Value}s
    */
   public Map<String, Optional<Value<?>>> getNullableValues() {
@@ -222,15 +229,15 @@ public class Put extends Mutation {
   }
 
   /**
-   * Indicates whether the value for the specified name added to the list of put values is NULL.
+   * Indicates whether the value of the specified column added to the list of put values is NULL.
    *
-   * @param name a name
-   * @return whether the value for the specified name is NULL
+   * @param columnName a column name of the value
+   * @return whether the value of the specified column is NULL
    */
-  public boolean isNullValue(String name) {
-    checkIfExists(name);
+  public boolean isNullValue(String columnName) {
+    checkIfExists(columnName);
 
-    Optional<Value<?>> value = values.get(name);
+    Optional<Value<?>> value = values.get(columnName);
     if (value.isPresent()) {
       if (value.get() instanceof TextValue) {
         return !value.get().getAsString().isPresent();
@@ -243,180 +250,180 @@ public class Put extends Mutation {
   }
 
   /**
-   * Returns the BOOLEAN value for the specified name added to the list of put values.
+   * Returns the BOOLEAN value of the specified column added to the list of put values.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0. If this doesn't work for you, either call {@link #isNullValue(String)} before
    * calling this method, or use {@link #getValueAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the BOOLEAN value for the specified name
+   * @param columnName a column name of the value
+   * @return the BOOLEAN value of the specified column
    */
-  public boolean getBooleanValue(String name) {
-    checkIfExists(name);
+  public boolean getBooleanValue(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return false;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsBoolean();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsBoolean();
   }
 
   /**
-   * Returns the INT value for the specified name added to the list of put values.
+   * Returns the INT value of the specified column added to the list of put values.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0. If this doesn't work for you, either call {@link #isNullValue(String)} before
    * calling this method, or use {@link #getValueAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the INT value for the specified name
+   * @param columnName a column name of the value
+   * @return the INT value of the specified column
    */
-  public int getIntValue(String name) {
-    checkIfExists(name);
+  public int getIntValue(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return 0;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsInt();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsInt();
   }
 
   /**
-   * Returns the BIGINT value for the specified name added to the list of put values.
+   * Returns the BIGINT value of the specified column added to the list of put values.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0. If this doesn't work for you, either call {@link #isNullValue(String)} before
    * calling this method, or use {@link #getValueAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the BIGINT value for the specified name
+   * @param columnName a column name of the value
+   * @return the BIGINT value of the specified column
    */
-  public long getBigIntValue(String name) {
-    checkIfExists(name);
+  public long getBigIntValue(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return 0L;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsLong();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsLong();
   }
 
   /**
-   * Returns the FLOAT value for the specified name added to the list of put values.
+   * Returns the FLOAT value of the specified column added to the list of put values.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0.0. If this doesn't work for you, either call {@link #isNullValue(String)} before
    * calling this method, or use {@link #getValueAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the FLOAT value for the specified name
+   * @param columnName a column name of the value
+   * @return the FLOAT value of the specified column
    */
-  public float getFloatValue(String name) {
-    checkIfExists(name);
+  public float getFloatValue(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return 0.0F;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsFloat();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsFloat();
   }
 
   /**
-   * Returns the DOUBLE value for the specified name added to the list of put values.
+   * Returns the DOUBLE value of the specified column added to the list of put values.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0.0. If this doesn't work for you, either call {@link #isNullValue(String)} before
    * calling this method, or use {@link #getValueAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the DOUBLE value for the specified name
+   * @param columnName a column name of the value
+   * @return the DOUBLE value of the specified column
    */
-  public double getDoubleValue(String name) {
-    checkIfExists(name);
+  public double getDoubleValue(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return 0.0D;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsDouble();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsDouble();
   }
 
   /**
-   * Returns the TEXT value for the specified name added to the list of put values.
+   * Returns the TEXT value of the specified column added to the list of put values.
    *
-   * @param name a name
-   * @return the TEXT value for the specified name. If the value is NULL, null
+   * @param columnName a column name of the value
+   * @return the TEXT value of the specified column. If the value is NULL, null
    */
   @Nullable
-  public String getTextValue(String name) {
-    checkIfExists(name);
+  public String getTextValue(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return null;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsString().orElse(null);
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsString().orElse(null);
   }
 
   /**
-   * Returns the BLOB value as a ByteBuffer type for the specified name added to the list of put
-   * values.
+   * Returns the BLOB value of the specified column added to the list of put values as a ByteBuffer
+   * type.
    *
-   * @param name a name
-   * @return the BLOB value for the specified name. If the value is NULL, null
+   * @param columnName a column name of the value
+   * @return the BLOB value of the specified column. If the value is NULL, null
    */
   @Nullable
-  public ByteBuffer getBlobValue(String name) {
-    return getBlobValueAsByteBuffer(name);
+  public ByteBuffer getBlobValue(String columnName) {
+    return getBlobValueAsByteBuffer(columnName);
   }
 
   /**
-   * Returns the BLOB value as a ByteBuffer type for the specified name added to the list of put
-   * values.
+   * Returns the BLOB value of the specified column added to the list of put values as a ByteBuffer
+   * type.
    *
-   * @param name a name
-   * @return the BLOB value for the specified name. If the value is NULL, null
+   * @param columnName a column name of the value
+   * @return the BLOB value of the specified column. If the value is NULL, null
    */
   @Nullable
-  public ByteBuffer getBlobValueAsByteBuffer(String name) {
-    checkIfExists(name);
+  public ByteBuffer getBlobValueAsByteBuffer(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return null;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsByteBuffer().orElse(null);
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsByteBuffer().orElse(null);
   }
 
   /**
-   * Returns the BLOB value as a byte array type for the specified name added to the list of put
-   * values.
+   * Returns the BLOB value of the specified column added to the list of put values as a byte array
+   * type.
    *
-   * @param name a name
-   * @return the BLOB value for the specified name. If the value is NULL, null
+   * @param columnName a column name of the value
+   * @return the BLOB value of the specified column. If the value is NULL, null
    */
   @Nullable
-  public byte[] getBlobValueAsBytes(String name) {
-    checkIfExists(name);
+  public byte[] getBlobValueAsBytes(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNullValue(name)) {
+    if (isNullValue(columnName)) {
       // default value
       return null;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsBytes().orElse(null);
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsBytes().orElse(null);
   }
 
   /**
-   * Returns the value as an Object type for the specified name added to the list of put values.
+   * Returns the value of the specified column added to the list of put values as an Object type.
    *
    * <p>If the columns is a BOOLEAN type, it returns a {@code Boolean} object. If the columns is an
    * INT type, it returns an {@code Integer} object. If the columns is a BIGINT type, it returns a
@@ -425,32 +432,32 @@ public class Put extends Mutation {
    * returns a {@code String} object. If the columns is a BLOB type, it returns a {@code ByteBuffer}
    * object.
    *
-   * @param name a name
-   * @return the value for the specified name. If the value is NULL, null
+   * @param columnName a column name of the value
+   * @return the value of the specified column. If the value is NULL, null
    */
   @Nullable
-  public Object getValueAsObject(String name) {
-    checkIfExists(name);
-    if (isNullValue(name)) {
+  public Object getValueAsObject(String columnName) {
+    checkIfExists(columnName);
+    if (isNullValue(columnName)) {
       return null;
     }
 
-    Optional<Value<?>> value = values.get(name);
+    Optional<Value<?>> value = values.get(columnName);
     assert value.isPresent();
     if (value.get() instanceof BooleanValue) {
-      return getBooleanValue(name);
+      return getBooleanValue(columnName);
     } else if (value.get() instanceof IntValue) {
-      return getIntValue(name);
+      return getIntValue(columnName);
     } else if (value.get() instanceof BigIntValue) {
-      return getBigIntValue(name);
+      return getBigIntValue(columnName);
     } else if (value.get() instanceof FloatValue) {
-      return getFloatValue(name);
+      return getFloatValue(columnName);
     } else if (value.get() instanceof DoubleValue) {
-      return getDoubleValue(name);
+      return getDoubleValue(columnName);
     } else if (value.get() instanceof TextValue) {
-      return getTextValue(name);
+      return getTextValue(columnName);
     } else if (value.get() instanceof BlobValue) {
-      return getBlobValue(name);
+      return getBlobValue(columnName);
     } else {
       throw new AssertionError();
     }
@@ -459,11 +466,11 @@ public class Put extends Mutation {
   /**
    * Indicates whether the list of put values contains the specified column.
    *
-   * @param name a name
+   * @param columnName a column name of the value
    * @return whether the result contains the specified column name
    */
-  public boolean containsColumn(String name) {
-    return values.containsKey(name);
+  public boolean containsColumn(String columnName) {
+    return values.containsKey(columnName);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/api/PutIfExists.java
+++ b/core/src/main/java/com/scalar/db/api/PutIfExists.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.scalar.db.io.Value;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -18,9 +17,10 @@ public class PutIfExists implements MutationCondition {
   public PutIfExists() {}
 
   /**
-   * Returns an empty list of {@link Value}s since any conditions are not given to this object.
+   * Returns an empty list of {@link ConditionalExpression}s since any conditions are not given to
+   * this object.
    *
-   * @return an empty list of {@code Value}s
+   * @return an empty list of {@code ConditionalExpression}s
    */
   @Override
   @Nonnull

--- a/core/src/main/java/com/scalar/db/api/PutIfNotExists.java
+++ b/core/src/main/java/com/scalar/db/api/PutIfNotExists.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.scalar.db.io.Value;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -18,9 +17,10 @@ public class PutIfNotExists implements MutationCondition {
   public PutIfNotExists() {}
 
   /**
-   * Returns an empty list of {@link Value}s since any conditions are not given to this object.
+   * Returns an empty list of {@link ConditionalExpression}s since any conditions are not given to
+   * this object.
    *
-   * @return an empty list of {@code Value}s
+   * @return an empty list of {@code ConditionalExpression}s
    */
   @Override
   @Nonnull

--- a/core/src/main/java/com/scalar/db/api/Result.java
+++ b/core/src/main/java/com/scalar/db/api/Result.java
@@ -30,14 +30,16 @@ public interface Result {
   Optional<Key> getClusteringKey();
 
   /**
-   * Returns the {@link Value} which the specified name is mapped to
+   * Returns the {@link Value} which the specified column name is mapped to
    *
    * <p>Note that if the value is NULL, it will return a {@code Value} object with a default value.
    *
-   * @param name name of the {@code Value}
+   * @param columnName a column name of the {@code Value}
    * @return an {@code Optional} with the {@code Value}
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
-  Optional<Value<?>> getValue(String name);
+  @Deprecated
+  Optional<Value<?>> getValue(String columnName);
 
   /**
    * Returns a map of {@link Value}s
@@ -46,120 +48,123 @@ public interface Result {
    * default value.
    *
    * @return a map of {@code Value}s
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   Map<String, Value<?>> getValues();
 
   /**
-   * Indicates whether the value for the specified name is NULL.
+   * Indicates whether the value of the specified column is NULL.
    *
-   * @param name a name
-   * @return whether the value for the specified name is NULL
+   * @param columnName a column name of the value
+   * @return whether the value of the specified column is NULL
    */
-  boolean isNull(String name);
+  boolean isNull(String columnName);
 
   /**
-   * Returns the BOOLEAN value for the specified name as a Java boolean type.
+   * Returns the BOOLEAN value of the specified column as a Java boolean type.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0. If this doesn't work for you, either call {@link #isNull(String)} before calling
    * this method, or use {@link #getAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the BOOLEAN value for the specified name as a Java boolean type
+   * @param columnName a column name of the value
+   * @return the BOOLEAN value of the specified column as a Java boolean type
    */
-  boolean getBoolean(String name);
+  boolean getBoolean(String columnName);
 
   /**
-   * Returns the INT value for the specified name as a Java int type.
+   * Returns the INT value of the specified column as a Java int type.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0. If this doesn't work for you, either call {@link #isNull(String)} before calling
    * this method, or use {@link #getAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the INT value for the specified name as a Java int type
+   * @param columnName a column name of the value
+   * @return the INT value of the specified column as a Java int type
    */
-  int getInt(String name);
+  int getInt(String columnName);
 
   /**
-   * Returns the BIGINT value for the specified name as a Java long type.
+   * Returns the BIGINT value of the specified column as a Java long type.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0. If this doesn't work for you, either call {@link #isNull(String)} before calling
    * this method, or use {@link #getAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the BIGINT value for the specified name as a Java long type
+   * @param columnName a column name of the value
+   * @return the BIGINT value of the specified column as a Java long type
    */
-  long getBigInt(String name);
+  long getBigInt(String columnName);
 
   /**
-   * Returns the FLOAT value for the specified name as a Java float type.
+   * Returns the FLOAT value of the specified column as a Java float type.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0.0. If this doesn't work for you, either call {@link #isNull(String)} before
    * calling this method, or use {@link #getAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the FLOAT value for the specified name as a Java float type
+   * @param columnName a column name of the value
+   * @return the FLOAT value of the specified column as a Java float type
    */
-  float getFloat(String name);
+  float getFloat(String columnName);
 
   /**
-   * Returns the DOUBLE value for the specified name as a Java double type.
+   * Returns the DOUBLE value of the specified column as a Java double type.
    *
    * <p>Note that, due to its signature, this method cannot return null. If the value is NULL, it
    * will return 0.0. If this doesn't work for you, either call {@link #isNull(String)} before
    * calling this method, or use {@link #getAsObject(String)} instead.
    *
-   * @param name a name
-   * @return the DOUBLE value for the specified name as a Java double type
+   * @param columnName a column name of the value
+   * @return the DOUBLE value of the specified column as a Java double type
    */
-  double getDouble(String name);
+  double getDouble(String columnName);
 
   /**
-   * Returns the TEXT value for the specified name as a Java String type.
+   * Returns the TEXT value of the specified column as a Java String type.
    *
-   * @param name a name
-   * @return the TEXT value for the specified name as a Java String type. If the value is NULL, null
-   */
-  @Nullable
-  String getText(String name);
-
-  /**
-   * Returns the BLOB value for the specified name as a Java ByteBuffer type.
-   *
-   * @param name a name
-   * @return the BLOB value for the specified name as a Java ByteBuffer type. If the value is NULL,
+   * @param columnName a column name of the value
+   * @return the TEXT value of the specified column as a Java String type. If the value is NULL,
    *     null
    */
   @Nullable
-  default ByteBuffer getBlob(String name) {
-    return getBlobAsByteBuffer(name);
+  String getText(String columnName);
+
+  /**
+   * Returns the BLOB value of the specified column as a Java ByteBuffer type.
+   *
+   * @param columnName a column name of the value
+   * @return the BLOB value of the specified column as a Java ByteBuffer type. If the value is NULL,
+   *     null
+   */
+  @Nullable
+  default ByteBuffer getBlob(String columnName) {
+    return getBlobAsByteBuffer(columnName);
   }
 
   /**
-   * Returns the BLOB value for the specified name as a Java ByteBuffer type.
+   * Returns the BLOB value of the specified column as a Java ByteBuffer type.
    *
-   * @param name a name
-   * @return the BLOB value for the specified name as a Java ByteBuffer type. If the value is NULL,
+   * @param columnName a column name of the value
+   * @return the BLOB value of the specified column as a Java ByteBuffer type. If the value is NULL,
    *     null
    */
   @Nullable
-  ByteBuffer getBlobAsByteBuffer(String name);
+  ByteBuffer getBlobAsByteBuffer(String columnName);
 
   /**
-   * Returns the BLOB value for the specified name as a Java byte array type.
+   * Returns the BLOB value of the specified column as a Java byte array type.
    *
-   * @param name a name
-   * @return the BLOB value for the specified name as a Java byte array type. If the value is NULL,
+   * @param columnName a column name of the value
+   * @return the BLOB value of the specified column as a Java byte array type. If the value is NULL,
    *     null
    */
   @Nullable
-  byte[] getBlobAsBytes(String name);
+  byte[] getBlobAsBytes(String columnName);
 
   /**
-   * Returns the value for the specified name as a Java Object type.
+   * Returns the value of the specified column as a Java Object type.
    *
    * <p>If the columns is a BOOLEAN type, it returns a {@code Boolean} object. If the columns is an
    * INT type, it returns an {@code Integer} object. If the columns is a BIGINT type, it returns a
@@ -168,19 +173,19 @@ public interface Result {
    * returns a {@code String} object. If the columns is a BLOB type, it returns a {@code ByteBuffer}
    * object.
    *
-   * @param name a name
-   * @return the value for the specified name as a Java Object type. If the value is NULL, null
+   * @param columnName a column name of the value
+   * @return the value of the specified column as a Java Object type. If the value is NULL, null
    */
   @Nullable
-  Object getAsObject(String name);
+  Object getAsObject(String columnName);
 
   /**
    * Indicates whether it contains the specified column.
    *
-   * @param name a name
+   * @param columnName a column name of the value
    * @return whether the result contains the specified column name
    */
-  boolean contains(String name);
+  boolean contains(String columnName);
 
   /**
    * Returns a set of the contained column names.

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -268,28 +268,39 @@ public class Scan extends Selection {
   /** An optional parameter of {@link Scan} command to specify ordering of returned results. */
   @Immutable
   public static class Ordering {
-    private final String name;
+    private final String columnName;
     private final Order order;
 
     /**
      * Constructs a {@code Ordering} with the specified name of a clustering key of an entry and the
      * given order
      *
-     * @param name the name of a clustering key in an entry to order
+     * @param columnName the column name of a clustering key in an entry to order
      * @param order the {@code Order} of results
      */
-    public Ordering(String name, Order order) {
-      this.name = name;
+    public Ordering(String columnName, Order order) {
+      this.columnName = columnName;
       this.order = order;
     }
 
     /**
-     * Returns the name of the ordering clustering key
+     * Returns the column name of the ordering clustering key
      *
-     * @return the name of the ordering clustering key
+     * @return the column name of the ordering clustering key
+     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
      */
+    @Deprecated
     public String getName() {
-      return name;
+      return columnName;
+    }
+
+    /**
+     * Returns the column name of the ordering clustering key
+     *
+     * @return the column name of the ordering clustering key
+     */
+    public String getColumnName() {
+      return columnName;
     }
 
     /**
@@ -307,7 +318,7 @@ public class Scan extends Selection {
      *
      * <ul>
      *   <li>it is also an {@code Ordering}
-     *   <li>both instances have the same name and order
+     *   <li>both instances have the same column name and order
      * </ul>
      *
      * @param o an object to be tested for equality
@@ -322,17 +333,17 @@ public class Scan extends Selection {
         return false;
       }
       Ordering other = (Ordering) o;
-      return (name.equals(other.name) && order.equals(other.order));
+      return (columnName.equals(other.columnName) && order.equals(other.order));
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, order);
+      return Objects.hash(columnName, order);
     }
 
     @Override
     public String toString() {
-      return name + "-" + order;
+      return columnName + "-" + order;
     }
 
     public enum Order {

--- a/core/src/main/java/com/scalar/db/api/Selection.java
+++ b/core/src/main/java/com/scalar/db/api/Selection.java
@@ -2,7 +2,6 @@ package com.scalar.db.api;
 
 import com.google.common.base.MoreObjects;
 import com.scalar.db.io.Key;
-import com.scalar.db.io.Value;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -31,9 +30,9 @@ public abstract class Selection extends Operation {
   }
 
   /**
-   * Appends the specified name of {@link Value} to the list of projections.
+   * Appends the specified column name to the list of projections.
    *
-   * @param projection a name of {@code Value} to project
+   * @param projection a column name to project
    * @return this object
    */
   public Selection withProjection(String projection) {
@@ -42,10 +41,9 @@ public abstract class Selection extends Operation {
   }
 
   /**
-   * Appends the specified collection of the specified names of {@code Value}s to the list of
-   * projections.
+   * Appends the specified collection of the specified column names to the list of projections.
    *
-   * @param projections a collection of the name of {@code Value}s to project
+   * @param projections a collection of the column names to project
    * @return this object
    */
   public Selection withProjections(Collection<String> projections) {

--- a/core/src/main/java/com/scalar/db/io/BigIntValue.java
+++ b/core/src/main/java/com/scalar/db/io/BigIntValue.java
@@ -10,8 +10,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a signed integer from -2^53 to 2^53. The range is determined by the numbers
- * Double-precision floating-point format can exactly represent.
+ * A {@code Value} (column) for a signed integer from -2^53 to 2^53. The range is determined by the
+ * numbers Double-precision floating-point format can exactly represent.
  *
  * @author Hiroyuki Yamada
  */
@@ -28,8 +28,8 @@ public final class BigIntValue implements Value<Long> {
   /**
    * Constructs a {@code BigIntValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public BigIntValue(String name, long value) {
     this.name = checkNotNull(name);
@@ -38,9 +38,10 @@ public final class BigIntValue implements Value<Long> {
   }
 
   /**
-   * Constructs a {@code BigIntValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code BigIntValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public BigIntValue(long value) {
     this(ANONYMOUS, value);

--- a/core/src/main/java/com/scalar/db/io/BlobValue.java
+++ b/core/src/main/java/com/scalar/db/io/BlobValue.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a binary data
+ * A {@code Value} (column) for a binary data
  *
  * @author Hiroyuki Yamada
  */
@@ -27,8 +27,8 @@ public final class BlobValue implements Value<Optional<byte[]>> {
   /**
    * Constructs a {@code BlobValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public BlobValue(String name, @Nullable byte[] value) {
     this.name = checkNotNull(name);
@@ -42,9 +42,10 @@ public final class BlobValue implements Value<Optional<byte[]>> {
   }
 
   /**
-   * Constructs a {@code BlobValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code BlobValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public BlobValue(@Nullable byte[] value) {
     this(ANONYMOUS, value);
@@ -53,8 +54,8 @@ public final class BlobValue implements Value<Optional<byte[]>> {
   /**
    * Constructs a {@code BlobValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public BlobValue(String name, @Nullable ByteBuffer value) {
     this.name = checkNotNull(name);
@@ -68,9 +69,10 @@ public final class BlobValue implements Value<Optional<byte[]>> {
   }
 
   /**
-   * Constructs a {@code BlobValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code BlobValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public BlobValue(@Nullable ByteBuffer value) {
     this(ANONYMOUS, value);

--- a/core/src/main/java/com/scalar/db/io/BooleanValue.java
+++ b/core/src/main/java/com/scalar/db/io/BooleanValue.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a boolean data
+ * A {@code Value} (column) for a boolean data
  *
  * @author Hiroyuki Yamada
  */
@@ -22,8 +22,8 @@ public final class BooleanValue implements Value<Boolean> {
   /**
    * Constructs a {@code BooleanValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public BooleanValue(String name, boolean value) {
     this.name = checkNotNull(name);
@@ -31,10 +31,10 @@ public final class BooleanValue implements Value<Boolean> {
   }
 
   /**
-   * Constructs a {@code BooleanValue} with the specified value. The name of this value is
+   * Constructs a {@code BooleanValue} with the specified value. The name of this value (column) is
    * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public BooleanValue(boolean value) {
     this(ANONYMOUS, value);

--- a/core/src/main/java/com/scalar/db/io/DoubleValue.java
+++ b/core/src/main/java/com/scalar/db/io/DoubleValue.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a double precision floating point number
+ * A {@code Value} (column) for a double precision floating point number
  *
  * @author Hiroyuki Yamada
  */
@@ -22,8 +22,8 @@ public final class DoubleValue implements Value<Double> {
   /**
    * Constructs a {@code DoubleValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public DoubleValue(String name, double value) {
     this.name = checkNotNull(name);
@@ -31,9 +31,10 @@ public final class DoubleValue implements Value<Double> {
   }
 
   /**
-   * Constructs a {@code DoubleValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code DoubleValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public DoubleValue(double value) {
     this(ANONYMOUS, value);

--- a/core/src/main/java/com/scalar/db/io/FloatValue.java
+++ b/core/src/main/java/com/scalar/db/io/FloatValue.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a single precision floating point number
+ * A {@code Value} (column) for a single precision floating point number
  *
  * @author Hiroyuki Yamada
  */
@@ -22,8 +22,8 @@ public final class FloatValue implements Value<Float> {
   /**
    * Constructs a {@code FloatValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public FloatValue(String name, float value) {
     this.name = checkNotNull(name);
@@ -31,9 +31,10 @@ public final class FloatValue implements Value<Float> {
   }
 
   /**
-   * Constructs a {@code FloatValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code FloatValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public FloatValue(float value) {
     this(ANONYMOUS, value);

--- a/core/src/main/java/com/scalar/db/io/IntValue.java
+++ b/core/src/main/java/com/scalar/db/io/IntValue.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a 32-bit signed integer
+ * A {@code Value} (column) for a 32-bit signed integer
  *
  * @author Hiroyuki Yamada
  */
@@ -22,8 +22,8 @@ public final class IntValue implements Value<Integer> {
   /**
    * Constructs a {@code IntValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column)
    */
   public IntValue(String name, int value) {
     this.name = checkNotNull(name);
@@ -31,9 +31,10 @@ public final class IntValue implements Value<Integer> {
   }
 
   /**
-   * Constructs a {@code IntValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code IntValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public IntValue(int value) {
     this(ANONYMOUS, value);

--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -29,7 +29,9 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * Constructs a {@code Key} with the specified {@link Value}s
    *
    * @param values one or more {@link Value}s which this key is composed of
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   public Key(Value<?>... values) {
     checkNotNull(values);
     this.values = new ArrayList<>(values.length);
@@ -40,7 +42,9 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * Constructs a {@code Key} with the specified list of {@link Value}s
    *
    * @param values a list of {@link Value}s which this key is composed of
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   public Key(List<Value<?>> values) {
     checkNotNull(values);
     this.values = new ArrayList<>(values.size());
@@ -48,122 +52,122 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a boolean type
+   * Constructs a {@code Key} with a single column with a BOOLEAN type
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param booleanValue a BOOLEAN value of the column
    */
-  public Key(String name, boolean value) {
-    values = Collections.singletonList(new BooleanValue(name, value));
+  public Key(String columnName, boolean booleanValue) {
+    values = Collections.singletonList(new BooleanValue(columnName, booleanValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as an integer type
+   * Constructs a {@code Key} with a single column with an INT type
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param intValue a INT value of the column
    */
-  public Key(String name, int value) {
-    values = Collections.singletonList(new IntValue(name, value));
+  public Key(String columnName, int intValue) {
+    values = Collections.singletonList(new IntValue(columnName, intValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a long type
+   * Constructs a {@code Key} with a single column with a BIGINT type
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param bigIntValue a BIGINT value of the column
    */
-  public Key(String name, long value) {
-    values = Collections.singletonList(new BigIntValue(name, value));
+  public Key(String columnName, long bigIntValue) {
+    values = Collections.singletonList(new BigIntValue(columnName, bigIntValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a float type
+   * Constructs a {@code Key} with a single column with a FLOAT type
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param floatValue a FLOAT value of the column
    */
-  public Key(String name, float value) {
-    values = Collections.singletonList(new FloatValue(name, value));
+  public Key(String columnName, float floatValue) {
+    values = Collections.singletonList(new FloatValue(columnName, floatValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a double type
+   * Constructs a {@code Key} with a single column with a DOUBLE type
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param doubleValue a DOUBLE value of the column
    */
-  public Key(String name, double value) {
-    values = Collections.singletonList(new DoubleValue(name, value));
+  public Key(String columnName, double doubleValue) {
+    values = Collections.singletonList(new DoubleValue(columnName, doubleValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a string type
+   * Constructs a {@code Key} with a single column with a TEXT type
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param textValue a TEXT value of the column
    */
-  public Key(String name, String value) {
-    values = Collections.singletonList(new TextValue(name, value));
+  public Key(String columnName, String textValue) {
+    values = Collections.singletonList(new TextValue(columnName, textValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a byte array type
+   * Constructs a {@code Key} with a single column with a BLOB type from a byte array
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param blobValue a BLOB value of the column
    */
-  public Key(String name, byte[] value) {
-    values = Collections.singletonList(new BlobValue(name, value));
+  public Key(String columnName, byte[] blobValue) {
+    values = Collections.singletonList(new BlobValue(columnName, blobValue));
   }
 
   /**
-   * Constructs a {@code Key} with a single {@link Value} as a byte buffer type
+   * Constructs a {@code Key} with a single column with a BLOB type from a ByteBuffer
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value}
+   * @param columnName a column name
+   * @param blobValue a BLOB value of the column
    */
-  public Key(String name, ByteBuffer value) {
-    values = Collections.singletonList(new BlobValue(name, value));
+  public Key(String columnName, ByteBuffer blobValue) {
+    values = Collections.singletonList(new BlobValue(columnName, blobValue));
   }
 
   /**
-   * Constructs a {@code Key} with multiple {@link Value}s
+   * Constructs a {@code Key} with two columns
    *
-   * @param n1 name of the 1st {@code Value}
-   * @param v1 content of the 1st {@code Value}
-   * @param n2 name of the 2nd {@code Value}
-   * @param v2 content of the 2nd {@code Value}
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
    */
   public Key(String n1, Object v1, String n2, Object v2) {
     values = Arrays.asList(toValue(n1, v1), toValue(n2, v2));
   }
 
   /**
-   * Constructs a {@code Key} with multiple {@link Value}s
+   * Constructs a {@code Key} with three columns
    *
-   * @param n1 name of the 1st {@code Value}
-   * @param v1 content of the 1st {@code Value}
-   * @param n2 name of the 2nd {@code Value}
-   * @param v2 content of the 2nd {@code Value}
-   * @param n3 name of the 3rd {@code Value}
-   * @param v3 content of the 3rd {@code Value}
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @param n3 a column name of the 3rd column
+   * @param v3 a value of the 3rd column
    */
   public Key(String n1, Object v1, String n2, Object v2, String n3, Object v3) {
     values = Arrays.asList(toValue(n1, v1), toValue(n2, v2), toValue(n3, v3));
   }
 
   /**
-   * Constructs a {@code Key} with multiple {@link Value}s
+   * Constructs a {@code Key} with four columns
    *
-   * @param n1 name of the 1st {@code Value}
-   * @param v1 content of the 1st {@code Value}
-   * @param n2 name of the 2nd {@code Value}
-   * @param v2 content of the 2nd {@code Value}
-   * @param n3 name of the 3rd {@code Value}
-   * @param v3 content of the 3rd {@code Value}
-   * @param n4 name of the 4th {@code Value}
-   * @param v4 content of the 4th {@code Value}
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @param n3 a column name of the 3rd column
+   * @param v3 a value of the 3rd column
+   * @param n4 a column of the 4th column
+   * @param v4 a value of the 4th column
    */
   public Key(
       String n1, Object v1, String n2, Object v2, String n3, Object v3, String n4, Object v4) {
@@ -171,18 +175,18 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
   }
 
   /**
-   * Constructs a {@code Key} with multiple {@link Value}s
+   * Constructs a {@code Key} with five columns
    *
-   * @param n1 name of the 1st {@code Value}
-   * @param v1 content of the 1st {@code Value}
-   * @param n2 name of the 2nd {@code Value}
-   * @param v2 content of the 2nd {@code Value}
-   * @param n3 name of the 3rd {@code Value}
-   * @param v3 content of the 3rd {@code Value}
-   * @param n4 name of the 4th {@code Value}
-   * @param v4 content of the 4th {@code Value}
-   * @param n5 name of the 5th {@code Value}
-   * @param v5 content of the 5th {@code Value}
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @param n3 a column name of the 3rd column
+   * @param v3 a value of the 3rd column
+   * @param n4 a column of the 4th column
+   * @param v4 a value of the 4th column
+   * @param n5 a column of the 5th column
+   * @param v5 a value of the 5th column
    */
   public Key(
       String n1,
@@ -224,7 +228,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
   }
 
   /**
-   * Returns the list of {@code Value} which this key is composed of
+   * Returns the list of {@code Value} which this key is composed of.
+   *
+   * <p>This method is primarily for internal use. Breaking changes can and will be introduced to
+   * this method. Users should not depend on it.
    *
    * @return list of {@code Value} which this key is composed of
    */
@@ -234,12 +241,145 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
   }
 
   /**
-   * Returns the size of the list of {@code Value} which this key is composed of
+   * Returns the size of the list of columns which this key is composed of.
    *
-   * @return the size of list of {@code Value} which this key is composed of
+   * @return the size of list of columns which this key is composed of
    */
   public int size() {
     return values.size();
+  }
+
+  /**
+   * Return the column name of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the column name of the i-th column which this key is composed of
+   */
+  public String getColumnName(int i) {
+    return values.get(i).getName();
+  }
+
+  /**
+   * Returns the BOOLEAN value of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the BOOLEAN value of the i-th column which this key is composed of
+   */
+  public boolean getBoolean(int i) {
+    return values.get(i).getAsBoolean();
+  }
+
+  /**
+   * Returns the INT value of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the INT value of the i-th column which this key is composed of
+   */
+  public int getInt(int i) {
+    return values.get(i).getAsInt();
+  }
+
+  /**
+   * Returns the BIGINT value of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the BIGINT value of the i-th column which this key is composed of
+   */
+  public long getBigInt(int i) {
+    return values.get(i).getAsLong();
+  }
+
+  /**
+   * Returns the FLOAT value of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the FLOAT value of the i-th column which this key is composed of
+   */
+  public float getFloat(int i) {
+    return values.get(i).getAsFloat();
+  }
+
+  /**
+   * Returns the DOUBLE value of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the DOUBLE value of the i-th column which this key is composed of
+   */
+  public double getDouble(int i) {
+    return values.get(i).getAsDouble();
+  }
+
+  /**
+   * Returns the TEXT value of the i-th column which this key is composed of.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the TEXT value of the i-th column which this key is composed of
+   */
+  public String getText(int i) {
+    return values.get(i).getAsString().orElse(null);
+  }
+
+  /**
+   * Returns the BLOB value of the i-th column which this key is composed of as a ByteBuffer type.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the BLOB value of the i-th column which this key is composed of as a ByteBuffer type
+   */
+  public ByteBuffer getBlob(int i) {
+    return getBlobAsByteBuffer(i);
+  }
+
+  /**
+   * Returns the BLOB value of the i-th column which this key is composed of as a ByteBuffer type.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the BLOB value of the i-th column which this key is composed of as a ByteBuffer type
+   */
+  public ByteBuffer getBlobAsByteBuffer(int i) {
+    return values.get(i).getAsByteBuffer().orElse(null);
+  }
+
+  /**
+   * Returns the BLOB value of the i-th column which this key is composed of as a byte array type.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the BLOB value of the i-th column which this key is composed of as a byte array type
+   */
+  public byte[] getBlobAsBytes(int i) {
+    return values.get(i).getAsBytes().orElse(null);
+  }
+
+  /**
+   * Returns the value of the i-th column which this key is composed of as an Object type.
+   *
+   * <p>If the columns is a BOOLEAN type, it returns a {@code Boolean} object. If the columns is an
+   * INT type, it returns an {@code Integer} object. If the columns is a BIGINT type, it returns a
+   * {@code LONG} object. If the columns is a FLOAT type, it returns a {@code FLOAT} object. If the
+   * columns is a DOUBLE type, it returns a {@code DOUBLE} object. If the columns is a TEXT type, it
+   * returns a {@code String} object. If the columns is a BLOB type, it returns a {@code ByteBuffer}
+   * object.
+   *
+   * @param i the position of the column which this key is composed of
+   * @return the value of the i-th column which this key is composed of as an Object type
+   */
+  public Object getAsObject(int i) {
+    if (values.get(i) instanceof BooleanValue) {
+      return getBoolean(i);
+    } else if (values.get(i) instanceof IntValue) {
+      return getInt(i);
+    } else if (values.get(i) instanceof BigIntValue) {
+      return getBigInt(i);
+    } else if (values.get(i) instanceof FloatValue) {
+      return getFloat(i);
+    } else if (values.get(i) instanceof DoubleValue) {
+      return getDouble(i);
+    } else if (values.get(i) instanceof TextValue) {
+      return getText(i);
+    } else if (values.get(i) instanceof BlobValue) {
+      return getBlob(i);
+    } else {
+      throw new AssertionError();
+    }
   }
 
   @Override
@@ -308,106 +448,118 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
     private Builder() {}
 
     /**
-     * Adds Boolean value.
+     * Adds BOOLEAN value as an element of Key.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a BOOLEAN value to add
      * @return a builder object
      */
-    public Builder addBoolean(String name, boolean value) {
-      values.add(new BooleanValue(name, value));
+    public Builder addBoolean(String columnName, boolean value) {
+      values.add(new BooleanValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds Int value.
+     * Adds INT value as an element of Key.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a INT value to add
      * @return a builder object
      */
-    public Builder addInt(String name, int value) {
-      values.add(new IntValue(name, value));
+    public Builder addInt(String columnName, int value) {
+      values.add(new IntValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds BigInt value.
+     * Adds BIGINT value as an element of Key.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a BIGINT value to add
      * @return a builder object
      */
-    public Builder addBigInt(String name, long value) {
-      values.add(new BigIntValue(name, value));
+    public Builder addBigInt(String columnName, long value) {
+      values.add(new BigIntValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds Float value.
+     * Adds FLOAT value as an element of Key.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a FLOAT value to add
      * @return a builder object
      */
-    public Builder addFloat(String name, float value) {
-      values.add(new FloatValue(name, value));
+    public Builder addFloat(String columnName, float value) {
+      values.add(new FloatValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds Double value.
+     * Adds DOUBLE value as an element of Key.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a DOUBLE value to add
      * @return a builder object
      */
-    public Builder addDouble(String name, double value) {
-      values.add(new DoubleValue(name, value));
+    public Builder addDouble(String columnName, double value) {
+      values.add(new DoubleValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds Text value.
+     * Adds TEXT value as an element of Key.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a TEXT value to add
      * @return a builder object
      */
-    public Builder addText(String name, String value) {
-      values.add(new TextValue(name, value));
+    public Builder addText(String columnName, String value) {
+      values.add(new TextValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds Blob value.
+     * Adds BLOB value as an element of Key with a byte array.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a BLOB value to add
      * @return a builder object
      */
-    public Builder addBlob(String name, byte[] value) {
-      values.add(new BlobValue(name, value));
+    public Builder addBlob(String columnName, byte[] value) {
+      values.add(new BlobValue(columnName, value));
       return this;
     }
 
     /**
-     * Adds Blob value.
+     * Adds BLOB value as an element of Key with a ByteBuffer.
      *
-     * @param name name of the {@code Value}
-     * @param value content of the {@code Value}
+     * @param columnName a column name to add
+     * @param value a BLOB value to add
      * @return a builder object
      */
-    public Builder addBlob(String name, ByteBuffer value) {
-      values.add(new BlobValue(name, value));
+    public Builder addBlob(String columnName, ByteBuffer value) {
+      values.add(new BlobValue(columnName, value));
       return this;
     }
 
+    /**
+     * @param value a value to add
+     * @return a builder object
+     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+     */
+    @Deprecated
     public Builder add(Value<?> value) {
       values.add(value);
       return this;
     }
 
+    /**
+     * @param values a list of values to add
+     * @return a builder object
+     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0
+     */
+    @Deprecated
     public Builder addAll(Collection<? extends Value<?>> values) {
       this.values.addAll(values);
       return this;

--- a/core/src/main/java/com/scalar/db/io/TextValue.java
+++ b/core/src/main/java/com/scalar/db/io/TextValue.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code Value} for a string
+ * A {@code Value} (column) for a string
  *
  * @author Hiroyuki Yamada
  */
@@ -26,8 +26,8 @@ public final class TextValue implements Value<Optional<String>> {
   /**
    * Constructs a {@code TextValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value} in byte array
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column) in byte array
    * @deprecated As of release 3.5.0. Will be removed in release 5.0.0
    */
   @Deprecated
@@ -41,9 +41,10 @@ public final class TextValue implements Value<Optional<String>> {
   }
 
   /**
-   * Constructs a {@code TextValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code TextValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    * @deprecated As of release 3.5.0. Will be removed in release 5.0.0
    */
   @Deprecated
@@ -54,8 +55,8 @@ public final class TextValue implements Value<Optional<String>> {
   /**
    * Constructs a {@code TextValue} with the specified name and value
    *
-   * @param name name of the {@code Value}
-   * @param value content of the {@code Value} in {@code String}
+   * @param name name of the {@code Value} (column)
+   * @param value value of the {@code Value} (column) in {@code String}
    */
   public TextValue(String name, @Nullable String value) {
     checkNotNull(name);
@@ -68,9 +69,10 @@ public final class TextValue implements Value<Optional<String>> {
   }
 
   /**
-   * Constructs a {@code TextValue} with the specified value. The name of this value is anonymous.
+   * Constructs a {@code TextValue} with the specified value. The name of this value (column) is
+   * anonymous.
    *
-   * @param value content of the {@code Value}
+   * @param value value of the {@code Value} (column)
    */
   public TextValue(@Nullable String value) {
     this(ANONYMOUS, value);
@@ -83,7 +85,7 @@ public final class TextValue implements Value<Optional<String>> {
   }
 
   /**
-   * Returns the content of this {@code Value}
+   * Returns the value of this {@code Value} (column)
    *
    * @return an {@code Optional} of the content of this {@code Value} in byte array
    * @deprecated As of release 3.2.0, replaced by {@link #getAsBytes()}. Will be removed in release
@@ -97,7 +99,7 @@ public final class TextValue implements Value<Optional<String>> {
   }
 
   /**
-   * Returns the content of this {@code Value}
+   * Returns the value of this {@code Value} (column)
    *
    * @return an {@code Optional} of the content of this {@code Value} in {@code String}
    * @deprecated As of release 3.2.0, replaced by {@link #getAsString()}. Will be removed in release

--- a/core/src/main/java/com/scalar/db/io/Value.java
+++ b/core/src/main/java/com/scalar/db/io/Value.java
@@ -5,21 +5,26 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 
 /**
- * An abstraction for storage entry's value
+ * An abstraction for storage entry's value (column).
+ *
+ * <p>This class and the implementation classes of it are primarily for internal use. Breaking
+ * changes can and will be introduced to them. Users should not depend on them. And maybe we will
+ * rename this class to {@code Column} in the future because it is a more proper name for this
+ * abstraction.
  *
  * @author Hiroyuki Yamada
  */
 public interface Value<T> extends Comparable<Value<T>> {
 
   /**
-   * Returns the name of the value
+   * Returns the name of the value (column)
    *
-   * @return the name of this value
+   * @return the name of this value (column)
    */
   String getName();
 
   /**
-   * Creates a copy of the value with the specified name
+   * Creates a copy of the value (column) with the specified name
    *
    * @param name name of a {@code Value}
    * @return a {@code Value} which has the same content of this value
@@ -29,85 +34,85 @@ public interface Value<T> extends Comparable<Value<T>> {
   /**
    * Accepts a {@link ValueVisitor} to be able to be traversed
    *
-   * @param v a visitor class used for traversing {@code Value}s
+   * @param v a visitor class used for traversing {@code Value}s (columns)
    */
   void accept(ValueVisitor v);
 
   /**
-   * Returns the content of this {@code Value}
+   * Returns the value of this {@code Value} (column)
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   @Nonnull
   T get();
 
   /**
-   * Returns the content of this {@code Value} as a boolean type
+   * Returns the value of this {@code Value} (column) as a boolean type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default boolean getAsBoolean() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as an integer type
+   * Returns the value of this {@code Value} (column) as an integer type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default int getAsInt() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as a long type
+   * Returns the value of this {@code Value} (column) as a long type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default long getAsLong() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as a float type
+   * Returns the value of this {@code Value} (column) as a float type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default float getAsFloat() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as a double type
+   * Returns the value of this {@code Value} (column) as a double type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default double getAsDouble() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as a string type
+   * Returns the value of this {@code Value} (column) as a string type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default Optional<String> getAsString() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as a byte array type
+   * Returns the value of this {@code Value} (column) as a byte array type
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default Optional<byte[]> getAsBytes() {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Returns the content of this {@code Value} as a byte buffer
+   * Returns the value of this {@code Value} (column) as a byte buffer
    *
-   * @return the content of this {@code Value}
+   * @return the value of this {@code Value} (column)
    */
   default Optional<ByteBuffer> getAsByteBuffer() {
     throw new UnsupportedOperationException();

--- a/core/src/main/java/com/scalar/db/storage/cassandra/ConditionSetter.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ConditionSetter.java
@@ -107,7 +107,7 @@ public class ConditionSetter implements MutationConditionVisitor {
   }
 
   private Clause createClauseWith(ConditionalExpression e) {
-    String name = quoteIfNecessary(e.getName());
+    String name = quoteIfNecessary(e.getColumnName());
     switch (e.getOperator()) {
       case EQ:
         return eq(name, bindMarker());

--- a/core/src/main/java/com/scalar/db/storage/cassandra/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/SelectStatementHandler.java
@@ -261,12 +261,12 @@ public class SelectStatementHandler extends StatementHandler {
   private Ordering getOrdering(Scan.Ordering ordering) {
     switch (ordering.getOrder()) {
       case ASC:
-        return QueryBuilder.asc(quoteIfNecessary(ordering.getName()));
+        return QueryBuilder.asc(quoteIfNecessary(ordering.getColumnName()));
       case DESC:
-        return QueryBuilder.desc(quoteIfNecessary(ordering.getName()));
+        return QueryBuilder.desc(quoteIfNecessary(ordering.getColumnName()));
       default:
         LOGGER.warn("Unsupported ordering specified. Using Order.ASC.");
-        return QueryBuilder.asc(quoteIfNecessary(ordering.getName()));
+        return QueryBuilder.asc(quoteIfNecessary(ordering.getColumnName()));
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/common/checker/ConditionChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/ConditionChecker.java
@@ -38,7 +38,7 @@ class ConditionChecker implements MutationConditionVisitor {
     for (ConditionalExpression expression : condition.getExpressions()) {
       isValid =
           new ColumnChecker(tableMetadata, false, false, true)
-              .check(expression.getName(), expression.getValue());
+              .check(expression.getColumnName(), expression.getValue());
       if (!isValid) {
         break;
       }
@@ -66,7 +66,7 @@ class ConditionChecker implements MutationConditionVisitor {
     for (ConditionalExpression expression : condition.getExpressions()) {
       isValid =
           new ColumnChecker(tableMetadata, false, false, true)
-              .check(expression.getName(), expression.getValue());
+              .check(expression.getColumnName(), expression.getValue());
       if (!isValid) {
         break;
       }

--- a/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
@@ -160,11 +160,12 @@ public class OperationChecker {
     Iterator<String> iterator = metadata.getClusteringKeyNames().iterator();
     for (Scan.Ordering ordering : orderings) {
       String clusteringKeyName = iterator.next();
-      if (!ordering.getName().equals(clusteringKeyName)) {
+      if (!ordering.getColumnName().equals(clusteringKeyName)) {
         throw new IllegalArgumentException(message.get());
       }
 
-      boolean rightOrder = ordering.getOrder() != metadata.getClusteringOrder(ordering.getName());
+      boolean rightOrder =
+          ordering.getOrder() != metadata.getClusteringOrder(ordering.getColumnName());
       if (reverse == null) {
         reverse = rightOrder;
       } else {

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilder.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilder.java
@@ -99,7 +99,7 @@ public class ConditionalQueryBuilder implements MutationConditionVisitor {
 
   private <T> Consumer<T> createConditionWith(ConditionalExpression e) {
     // TODO: for a clustering key?
-    Field<Object> field = DSL.field("r.values" + quoteKeyword(e.getName()));
+    Field<Object> field = DSL.field("r.values" + quoteKeyword(e.getColumnName()));
     switch (e.getOperator()) {
       case EQ:
         return v -> select.and(field.equal(v));

--- a/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
@@ -188,7 +188,7 @@ public class SelectStatementHandler extends StatementHandler {
     boolean reverse = false;
     if (!scanOrderings.isEmpty()) {
       reverse =
-          tableMetadata.getClusteringOrder(scanOrderings.get(0).getName())
+          tableMetadata.getClusteringOrder(scanOrderings.get(0).getColumnName())
               != scanOrderings.get(0).getOrder();
     }
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -245,7 +245,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       }
       if (metadata.getColumnDataType(partitionKeyName) == DataType.BLOB) {
         throw new IllegalArgumentException(
-            "BLOB type is supported only for the last value in partition key in DynamoDB: "
+            "BLOB type is supported only for the last column in partition key in DynamoDB: "
                 + partitionKeyName);
       }
     }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoMutation.java
@@ -132,7 +132,7 @@ public class DynamoMutation extends DynamoOperation {
     if (mutation.getCondition().isPresent()) {
       int index = 0;
       for (ConditionalExpression expression : mutation.getCondition().get().getExpressions()) {
-        ret.put(CONDITION_COLUMN_NAME_ALIAS + index, expression.getName());
+        ret.put(CONDITION_COLUMN_NAME_ALIAS + index, expression.getColumnName());
         index++;
       }
     }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -145,7 +145,7 @@ public class SelectStatementHandler extends StatementHandler {
 
     if (!scan.getOrderings().isEmpty()) {
       Ordering ordering = scan.getOrderings().get(0);
-      if (ordering.getOrder() != tableMetadata.getClusteringOrder(ordering.getName())) {
+      if (ordering.getOrder() != tableMetadata.getClusteringOrder(ordering.getColumnName())) {
         // reverse scan
         builder.scanIndexForward(false);
       }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/DeleteQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/DeleteQuery.java
@@ -54,7 +54,7 @@ public class DeleteQuery implements Query {
     otherConditions.forEach(
         c ->
             conditions.add(
-                enclose(c.getName(), rdbEngine) + getOperatorString(c.getOperator()) + "?"));
+                enclose(c.getColumnName(), rdbEngine) + getOperatorString(c.getOperator()) + "?"));
     return String.join(" AND ", conditions);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
@@ -98,7 +98,8 @@ public class SimpleSelectQuery implements SelectQuery {
       if (i < orderings.size()) {
         Scan.Ordering ordering = orderings.get(i++);
         if (reverse == null) {
-          reverse = ordering.getOrder() != tableMetadata.getClusteringOrder(ordering.getName());
+          reverse =
+              ordering.getOrder() != tableMetadata.getClusteringOrder(ordering.getColumnName());
         }
       } else {
         Scan.Ordering.Order order = tableMetadata.getClusteringOrder(clusteringKeyName);
@@ -116,7 +117,7 @@ public class SimpleSelectQuery implements SelectQuery {
 
     return " ORDER BY "
         + orderingList.stream()
-            .map(o -> enclose(o.getName(), rdbEngine) + " " + o.getOrder())
+            .map(o -> enclose(o.getColumnName(), rdbEngine) + " " + o.getOrder())
             .collect(Collectors.joining(","));
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/UpdateQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/UpdateQuery.java
@@ -67,7 +67,7 @@ public class UpdateQuery implements Query {
     otherConditions.forEach(
         c ->
             conditions.add(
-                enclose(c.getName(), rdbEngine) + getOperatorString(c.getOperator()) + "?"));
+                enclose(c.getColumnName(), rdbEngine) + getOperatorString(c.getOperator()) + "?"));
     return String.join(" AND ", conditions);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
@@ -78,83 +78,85 @@ public class FilteredResult extends AbstractResult {
     return key;
   }
 
+  @Deprecated
   @Override
-  public Optional<Value<?>> getValue(String name) {
-    return Optional.ofNullable(valuesWithDefaultValues.get().get(name));
+  public Optional<Value<?>> getValue(String columnName) {
+    return Optional.ofNullable(valuesWithDefaultValues.get().get(columnName));
   }
 
+  @Deprecated
   @Override
   public Map<String, Value<?>> getValues() {
     return valuesWithDefaultValues.get();
   }
 
   @Override
-  public boolean isNull(String name) {
-    checkIfExists(name);
-    return original.isNull(name);
+  public boolean isNull(String columnName) {
+    checkIfExists(columnName);
+    return original.isNull(columnName);
   }
 
   @Override
-  public boolean getBoolean(String name) {
-    checkIfExists(name);
-    return original.getBoolean(name);
+  public boolean getBoolean(String columnName) {
+    checkIfExists(columnName);
+    return original.getBoolean(columnName);
   }
 
   @Override
-  public int getInt(String name) {
-    checkIfExists(name);
-    return original.getInt(name);
+  public int getInt(String columnName) {
+    checkIfExists(columnName);
+    return original.getInt(columnName);
   }
 
   @Override
-  public long getBigInt(String name) {
-    checkIfExists(name);
-    return original.getBigInt(name);
+  public long getBigInt(String columnName) {
+    checkIfExists(columnName);
+    return original.getBigInt(columnName);
   }
 
   @Override
-  public float getFloat(String name) {
-    checkIfExists(name);
-    return original.getFloat(name);
+  public float getFloat(String columnName) {
+    checkIfExists(columnName);
+    return original.getFloat(columnName);
   }
 
   @Override
-  public double getDouble(String name) {
-    checkIfExists(name);
-    return original.getDouble(name);
-  }
-
-  @Nullable
-  @Override
-  public String getText(String name) {
-    checkIfExists(name);
-    return original.getText(name);
+  public double getDouble(String columnName) {
+    checkIfExists(columnName);
+    return original.getDouble(columnName);
   }
 
   @Nullable
   @Override
-  public ByteBuffer getBlobAsByteBuffer(String name) {
-    checkIfExists(name);
-    return original.getBlobAsByteBuffer(name);
+  public String getText(String columnName) {
+    checkIfExists(columnName);
+    return original.getText(columnName);
   }
 
   @Nullable
   @Override
-  public byte[] getBlobAsBytes(String name) {
-    checkIfExists(name);
-    return original.getBlobAsBytes(name);
+  public ByteBuffer getBlobAsByteBuffer(String columnName) {
+    checkIfExists(columnName);
+    return original.getBlobAsByteBuffer(columnName);
   }
 
   @Nullable
   @Override
-  public Object getAsObject(String name) {
-    checkIfExists(name);
-    return original.getAsObject(name);
+  public byte[] getBlobAsBytes(String columnName) {
+    checkIfExists(columnName);
+    return original.getBlobAsBytes(columnName);
+  }
+
+  @Nullable
+  @Override
+  public Object getAsObject(String columnName) {
+    checkIfExists(columnName);
+    return original.getAsObject(columnName);
   }
 
   @Override
-  public boolean contains(String name) {
-    return containedColumnNames.contains(name);
+  public boolean contains(String columnName) {
+    return containedColumnNames.contains(columnName);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
@@ -26,7 +26,7 @@ public class MergedResult extends AbstractResult {
   private final Supplier<Map<String, Value<?>>> valuesWithDefaultValues;
 
   public MergedResult(Optional<TransactionResult> result, Put put, TableMetadata metadata) {
-    // assume that all the values are projected to the result
+    // assume that all the columns are projected to the result
     this.result = result;
     this.put = put;
 
@@ -83,133 +83,135 @@ public class MergedResult extends AbstractResult {
     return put.getClusteringKey();
   }
 
+  @Deprecated
   @Override
-  public Optional<Value<?>> getValue(String name) {
-    return Optional.of(valuesWithDefaultValues.get().get(name));
+  public Optional<Value<?>> getValue(String columnName) {
+    return Optional.of(valuesWithDefaultValues.get().get(columnName));
   }
 
+  @Deprecated
   @Override
   public Map<String, Value<?>> getValues() {
     return valuesWithDefaultValues.get();
   }
 
   @Override
-  public boolean isNull(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return !putValues.get(name).isPresent();
+  public boolean isNull(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return !putValues.get(columnName).isPresent();
     }
-    return result.map(transactionResult -> transactionResult.isNull(name)).orElse(true);
+    return result.map(transactionResult -> transactionResult.isNull(columnName)).orElse(true);
   }
 
   @Override
-  public boolean getBoolean(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).map(Value::getAsBoolean).orElse(false);
+  public boolean getBoolean(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).map(Value::getAsBoolean).orElse(false);
     }
-    return result.map(r -> r.getBoolean(name)).orElse(false);
+    return result.map(r -> r.getBoolean(columnName)).orElse(false);
   }
 
   @Override
-  public int getInt(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).map(Value::getAsInt).orElse(0);
+  public int getInt(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).map(Value::getAsInt).orElse(0);
     }
-    return result.map(r -> r.getInt(name)).orElse(0);
+    return result.map(r -> r.getInt(columnName)).orElse(0);
   }
 
   @Override
-  public long getBigInt(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).map(Value::getAsLong).orElse(0L);
+  public long getBigInt(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).map(Value::getAsLong).orElse(0L);
     }
-    return result.map(r -> r.getBigInt(name)).orElse(0L);
+    return result.map(r -> r.getBigInt(columnName)).orElse(0L);
   }
 
   @Override
-  public float getFloat(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).map(Value::getAsFloat).orElse(0.0F);
+  public float getFloat(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).map(Value::getAsFloat).orElse(0.0F);
     }
-    return result.map(r -> r.getFloat(name)).orElse(0.0F);
+    return result.map(r -> r.getFloat(columnName)).orElse(0.0F);
   }
 
   @Override
-  public double getDouble(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).map(Value::getAsDouble).orElse(0.0D);
+  public double getDouble(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).map(Value::getAsDouble).orElse(0.0D);
     }
-    return result.map(r -> r.getDouble(name)).orElse(0.0D);
-  }
-
-  @Nullable
-  @Override
-  public String getText(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).flatMap(Value::getAsString).orElse(null);
-    }
-    return result.map(r -> r.getText(name)).orElse(null);
+    return result.map(r -> r.getDouble(columnName)).orElse(0.0D);
   }
 
   @Nullable
   @Override
-  public ByteBuffer getBlobAsByteBuffer(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).flatMap(Value::getAsByteBuffer).orElse(null);
+  public String getText(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).flatMap(Value::getAsString).orElse(null);
     }
-    return result.map(r -> r.getBlobAsByteBuffer(name)).orElse(null);
+    return result.map(r -> r.getText(columnName)).orElse(null);
   }
 
   @Nullable
   @Override
-  public byte[] getBlobAsBytes(String name) {
-    checkIfExists(name);
-    if (putValues.containsKey(name)) {
-      return putValues.get(name).flatMap(Value::getAsBytes).orElse(null);
+  public ByteBuffer getBlobAsByteBuffer(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).flatMap(Value::getAsByteBuffer).orElse(null);
     }
-    return result.map(r -> r.getBlobAsBytes(name)).orElse(null);
+    return result.map(r -> r.getBlobAsByteBuffer(columnName)).orElse(null);
   }
 
   @Nullable
   @Override
-  public Object getAsObject(String name) {
-    checkIfExists(name);
-    if (isNull(name)) {
+  public byte[] getBlobAsBytes(String columnName) {
+    checkIfExists(columnName);
+    if (putValues.containsKey(columnName)) {
+      return putValues.get(columnName).flatMap(Value::getAsBytes).orElse(null);
+    }
+    return result.map(r -> r.getBlobAsBytes(columnName)).orElse(null);
+  }
+
+  @Nullable
+  @Override
+  public Object getAsObject(String columnName) {
+    checkIfExists(columnName);
+    if (isNull(columnName)) {
       return null;
     }
 
-    switch (metadata.getColumnDataType(name)) {
+    switch (metadata.getColumnDataType(columnName)) {
       case BOOLEAN:
-        return getBoolean(name);
+        return getBoolean(columnName);
       case INT:
-        return getInt(name);
+        return getInt(columnName);
       case BIGINT:
-        return getBigInt(name);
+        return getBigInt(columnName);
       case FLOAT:
-        return getFloat(name);
+        return getFloat(columnName);
       case DOUBLE:
-        return getDouble(name);
+        return getDouble(columnName);
       case TEXT:
-        return getText(name);
+        return getText(columnName);
       case BLOB:
-        return getBlob(name);
+        return getBlob(columnName);
       default:
         throw new AssertionError();
     }
   }
 
   @Override
-  public boolean contains(String name) {
+  public boolean contains(String columnName) {
     return result
-        .map(r -> r.getContainedColumnNames().contains(name))
-        .orElse(metadata.getColumnNames().contains(name));
+        .map(r -> r.getContainedColumnNames().contains(columnName))
+        .orElse(metadata.getColumnNames().contains(columnName));
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
@@ -11,7 +11,6 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -20,7 +19,7 @@ public class TransactionResult extends AbstractResult {
   private final Result result;
 
   public TransactionResult(Result result) {
-    // assume that all the values are projected to the result
+    // assume that all the columns are projected to the result
     this.result = checkNotNull(result);
   }
 
@@ -34,74 +33,75 @@ public class TransactionResult extends AbstractResult {
     return result.getClusteringKey();
   }
 
+  @Deprecated
   @Override
-  public Optional<Value<?>> getValue(String name) {
-    return result.getValue(name);
+  public Optional<Value<?>> getValue(String columnName) {
+    return result.getValue(columnName);
   }
 
+  @Deprecated
   @Override
-  @Nonnull
   public Map<String, Value<?>> getValues() {
     return result.getValues();
   }
 
   @Override
-  public boolean isNull(String name) {
-    return result.isNull(name);
+  public boolean isNull(String columnName) {
+    return result.isNull(columnName);
   }
 
   @Override
-  public boolean getBoolean(String name) {
-    return result.getBoolean(name);
+  public boolean getBoolean(String columnName) {
+    return result.getBoolean(columnName);
   }
 
   @Override
-  public int getInt(String name) {
-    return result.getInt(name);
+  public int getInt(String columnName) {
+    return result.getInt(columnName);
   }
 
   @Override
-  public long getBigInt(String name) {
-    return result.getBigInt(name);
+  public long getBigInt(String columnName) {
+    return result.getBigInt(columnName);
   }
 
   @Override
-  public float getFloat(String name) {
-    return result.getFloat(name);
+  public float getFloat(String columnName) {
+    return result.getFloat(columnName);
   }
 
   @Override
-  public double getDouble(String name) {
-    return result.getDouble(name);
-  }
-
-  @Nullable
-  @Override
-  public String getText(String name) {
-    return result.getText(name);
+  public double getDouble(String columnName) {
+    return result.getDouble(columnName);
   }
 
   @Nullable
   @Override
-  public ByteBuffer getBlobAsByteBuffer(String name) {
-    return result.getBlobAsByteBuffer(name);
+  public String getText(String columnName) {
+    return result.getText(columnName);
   }
 
   @Nullable
   @Override
-  public byte[] getBlobAsBytes(String name) {
-    return result.getBlobAsBytes(name);
+  public ByteBuffer getBlobAsByteBuffer(String columnName) {
+    return result.getBlobAsByteBuffer(columnName);
   }
 
   @Nullable
   @Override
-  public Object getAsObject(String name) {
-    return result.getAsObject(name);
+  public byte[] getBlobAsBytes(String columnName) {
+    return result.getBlobAsBytes(columnName);
+  }
+
+  @Nullable
+  @Override
+  public Object getAsObject(String columnName) {
+    return result.getAsObject(columnName);
   }
 
   @Override
-  public boolean contains(String name) {
-    return result.contains(name);
+  public boolean contains(String columnName) {
+    return result.contains(columnName);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/util/ProtoUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ProtoUtils.java
@@ -226,7 +226,7 @@ public final class ProtoUtils {
 
   private static com.scalar.db.rpc.Ordering toOrdering(Scan.Ordering ordering) {
     return com.scalar.db.rpc.Ordering.newBuilder()
-        .setName(ordering.getName())
+        .setName(ordering.getColumnName())
         .setOrder(toOrder(ordering.getOrder()))
         .build();
   }
@@ -370,7 +370,7 @@ public final class ProtoUtils {
   private static com.scalar.db.rpc.ConditionalExpression toExpression(
       ConditionalExpression expression) {
     return com.scalar.db.rpc.ConditionalExpression.newBuilder()
-        .setName(expression.getName())
+        .setName(expression.getColumnName())
         .setValue(toValue(expression.getValue()))
         .setOperator(toOperator(expression.getOperator()))
         .build();

--- a/core/src/main/java/com/scalar/db/util/ResultImpl.java
+++ b/core/src/main/java/com/scalar/db/util/ResultImpl.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
@@ -76,22 +75,23 @@ public class ResultImpl extends AbstractResult {
     return Optional.of(builder.build());
   }
 
+  @Deprecated
   @Override
-  public Optional<Value<?>> getValue(String name) {
-    return Optional.ofNullable(valuesWithDefaultValues.get().get(name));
+  public Optional<Value<?>> getValue(String columnName) {
+    return Optional.ofNullable(valuesWithDefaultValues.get().get(columnName));
   }
 
+  @Deprecated
   @Override
-  @Nonnull
   public Map<String, Value<?>> getValues() {
     return valuesWithDefaultValues.get();
   }
 
   @Override
-  public boolean isNull(String name) {
-    checkIfExists(name);
+  public boolean isNull(String columnName) {
+    checkIfExists(columnName);
 
-    Optional<Value<?>> value = values.get(name);
+    Optional<Value<?>> value = values.get(columnName);
     if (value.isPresent()) {
       if (value.get() instanceof TextValue) {
         return !value.get().getAsString().isPresent();
@@ -104,135 +104,135 @@ public class ResultImpl extends AbstractResult {
   }
 
   @Override
-  public boolean getBoolean(String name) {
-    checkIfExists(name);
+  public boolean getBoolean(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return false;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsBoolean();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsBoolean();
   }
 
   @Override
-  public int getInt(String name) {
-    checkIfExists(name);
+  public int getInt(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return 0;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsInt();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsInt();
   }
 
   @Override
-  public long getBigInt(String name) {
-    checkIfExists(name);
+  public long getBigInt(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return 0L;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsLong();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsLong();
   }
 
   @Override
-  public float getFloat(String name) {
-    checkIfExists(name);
+  public float getFloat(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return 0.0F;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsFloat();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsFloat();
   }
 
   @Override
-  public double getDouble(String name) {
-    checkIfExists(name);
+  public double getDouble(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return 0.0D;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsDouble();
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsDouble();
   }
 
   @Nullable
   @Override
-  public String getText(String name) {
-    checkIfExists(name);
+  public String getText(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return null;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsString().orElse(null);
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsString().orElse(null);
   }
 
   @Nullable
   @Override
-  public ByteBuffer getBlobAsByteBuffer(String name) {
-    checkIfExists(name);
+  public ByteBuffer getBlobAsByteBuffer(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return null;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsByteBuffer().orElse(null);
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsByteBuffer().orElse(null);
   }
 
   @Nullable
   @Override
-  public byte[] getBlobAsBytes(String name) {
-    checkIfExists(name);
+  public byte[] getBlobAsBytes(String columnName) {
+    checkIfExists(columnName);
 
-    if (isNull(name)) {
+    if (isNull(columnName)) {
       // default value
       return null;
     }
-    assert values.get(name).isPresent();
-    return values.get(name).get().getAsBytes().orElse(null);
+    assert values.get(columnName).isPresent();
+    return values.get(columnName).get().getAsBytes().orElse(null);
   }
 
   @Nullable
   @Override
-  public Object getAsObject(String name) {
-    checkIfExists(name);
-    if (isNull(name)) {
+  public Object getAsObject(String columnName) {
+    checkIfExists(columnName);
+    if (isNull(columnName)) {
       return null;
     }
 
-    switch (metadata.getColumnDataType(name)) {
+    switch (metadata.getColumnDataType(columnName)) {
       case BOOLEAN:
-        return getBoolean(name);
+        return getBoolean(columnName);
       case INT:
-        return getInt(name);
+        return getInt(columnName);
       case BIGINT:
-        return getBigInt(name);
+        return getBigInt(columnName);
       case FLOAT:
-        return getFloat(name);
+        return getFloat(columnName);
       case DOUBLE:
-        return getDouble(name);
+        return getDouble(columnName);
       case TEXT:
-        return getText(name);
+        return getText(columnName);
       case BLOB:
-        return getBlob(name);
+        return getBlob(columnName);
       default:
         throw new AssertionError();
     }
   }
 
   @Override
-  public boolean contains(String name) {
-    return values.containsKey(name);
+  public boolean contains(String columnName) {
+    return values.containsKey(columnName);
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/api/ConditionExpressionTest.java
+++ b/core/src/test/java/com/scalar/db/api/ConditionExpressionTest.java
@@ -1,0 +1,107 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.ConditionalExpression.Operator;
+import com.scalar.db.io.BigIntValue;
+import com.scalar.db.io.BlobValue;
+import com.scalar.db.io.BooleanValue;
+import com.scalar.db.io.DoubleValue;
+import com.scalar.db.io.FloatValue;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.io.TextValue;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class ConditionExpressionTest {
+
+  @Test
+  public void constructor_ProperArgsGiven_ShouldConstructProperly() {
+    // Arrange
+
+    // Act
+    ConditionalExpression expression1 =
+        new ConditionalExpression("col1", new TextValue("aaa"), Operator.EQ);
+    ConditionalExpression expression2 = new ConditionalExpression("col2", true, Operator.EQ);
+    ConditionalExpression expression3 = new ConditionalExpression("col3", 123, Operator.NE);
+    ConditionalExpression expression4 = new ConditionalExpression("col4", 456L, Operator.GT);
+    ConditionalExpression expression5 = new ConditionalExpression("col5", 1.23F, Operator.GTE);
+    ConditionalExpression expression6 = new ConditionalExpression("col6", 4.56D, Operator.LT);
+    ConditionalExpression expression7 = new ConditionalExpression("col7", "text", Operator.LTE);
+    ConditionalExpression expression8 =
+        new ConditionalExpression("col8", "blob".getBytes(StandardCharsets.UTF_8), Operator.EQ);
+    ConditionalExpression expression9 =
+        new ConditionalExpression(
+            "col9", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.NE);
+
+    // Assert
+    assertThat(expression1.getColumnName()).isEqualTo("col1");
+    assertThat(expression1.getValue()).isEqualTo(new TextValue("aaa"));
+    assertThat(expression1.getTextValue()).isEqualTo("aaa");
+    assertThat(expression1.getValueAsObject()).isEqualTo("aaa");
+    assertThat(expression1.getOperator()).isEqualTo(Operator.EQ);
+
+    assertThat(expression2.getColumnName()).isEqualTo("col2");
+    assertThat(expression2.getValue()).isEqualTo(new BooleanValue(true));
+    assertThat(expression2.getBooleanValue()).isTrue();
+    assertThat(expression2.getValueAsObject()).isEqualTo(true);
+    assertThat(expression2.getOperator()).isEqualTo(Operator.EQ);
+
+    assertThat(expression3.getColumnName()).isEqualTo("col3");
+    assertThat(expression3.getValue()).isEqualTo(new IntValue(123));
+    assertThat(expression3.getIntValue()).isEqualTo(123);
+    assertThat(expression3.getValueAsObject()).isEqualTo(123);
+    assertThat(expression3.getOperator()).isEqualTo(Operator.NE);
+
+    assertThat(expression4.getColumnName()).isEqualTo("col4");
+    assertThat(expression4.getValue()).isEqualTo(new BigIntValue(456L));
+    assertThat(expression4.getBigIntValue()).isEqualTo(456L);
+    assertThat(expression4.getValueAsObject()).isEqualTo(456L);
+    assertThat(expression4.getOperator()).isEqualTo(Operator.GT);
+
+    assertThat(expression5.getColumnName()).isEqualTo("col5");
+    assertThat(expression5.getValue()).isEqualTo(new FloatValue(1.23F));
+    assertThat(expression5.getFloatValue()).isEqualTo(1.23F);
+    assertThat(expression5.getValueAsObject()).isEqualTo(1.23F);
+    assertThat(expression5.getOperator()).isEqualTo(Operator.GTE);
+
+    assertThat(expression6.getColumnName()).isEqualTo("col6");
+    assertThat(expression6.getValue()).isEqualTo(new DoubleValue(4.56D));
+    assertThat(expression6.getDoubleValue()).isEqualTo(4.56D);
+    assertThat(expression6.getValueAsObject()).isEqualTo(4.56D);
+    assertThat(expression6.getOperator()).isEqualTo(Operator.LT);
+
+    assertThat(expression7.getColumnName()).isEqualTo("col7");
+    assertThat(expression7.getValue()).isEqualTo(new TextValue("text"));
+    assertThat(expression7.getTextValue()).isEqualTo("text");
+    assertThat(expression7.getValueAsObject()).isEqualTo("text");
+    assertThat(expression7.getOperator()).isEqualTo(Operator.LTE);
+
+    assertThat(expression8.getColumnName()).isEqualTo("col8");
+    assertThat(expression8.getValue())
+        .isEqualTo(new BlobValue("blob".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression8.getBlobValue())
+        .isEqualTo(ByteBuffer.wrap("blob".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression8.getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.wrap("blob".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression8.getBlobValueAsBytes())
+        .isEqualTo("blob".getBytes(StandardCharsets.UTF_8));
+    assertThat(expression8.getValueAsObject())
+        .isEqualTo(ByteBuffer.wrap("blob".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression8.getOperator()).isEqualTo(Operator.EQ);
+
+    assertThat(expression9.getColumnName()).isEqualTo("col9");
+    assertThat(expression9.getValue())
+        .isEqualTo(new BlobValue("blob2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression9.getBlobValue())
+        .isEqualTo(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression9.getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression9.getBlobValueAsBytes())
+        .isEqualTo("blob2".getBytes(StandardCharsets.UTF_8));
+    assertThat(expression9.getValueAsObject())
+        .isEqualTo(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(expression9.getOperator()).isEqualTo(Operator.NE);
+  }
+}

--- a/core/src/test/java/com/scalar/db/io/KeyTest.java
+++ b/core/src/test/java/com/scalar/db/io/KeyTest.java
@@ -28,13 +28,15 @@ public class KeyTest {
     boolean value = true;
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(values.get(0).getAsBoolean()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBoolean(0)).isEqualTo(value);
   }
 
   @Test
@@ -44,13 +46,15 @@ public class KeyTest {
     int value = 100;
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(values.get(0).getAsInt()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getInt(0)).isEqualTo(value);
   }
 
   @Test
@@ -60,13 +64,15 @@ public class KeyTest {
     long value = 1000L;
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(values.get(0).getAsLong()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBigInt(0)).isEqualTo(value);
   }
 
   @Test
@@ -76,13 +82,15 @@ public class KeyTest {
     float value = 1.0f;
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(values.get(0).getAsFloat()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getFloat(0)).isEqualTo(value);
   }
 
   @Test
@@ -92,13 +100,15 @@ public class KeyTest {
     double value = 1.01d;
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(values.get(0).getAsDouble()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getDouble(0)).isEqualTo(value);
   }
 
   @Test
@@ -108,13 +118,15 @@ public class KeyTest {
     String value = "value";
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(values.get(0).getAsString().get()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getText(0)).isEqualTo(value);
   }
 
   @Test
@@ -124,13 +136,17 @@ public class KeyTest {
     byte[] value = "value".getBytes(StandardCharsets.UTF_8);
     Key key = new Key(name, value);
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(Arrays.equals(values.get(0).getAsBytes().get(), value)).isTrue();
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBlob(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsByteBuffer(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsBytes(0)).isEqualTo(value);
   }
 
   @Test
@@ -140,13 +156,17 @@ public class KeyTest {
     byte[] value = "value".getBytes(StandardCharsets.UTF_8);
     Key key = new Key(name, ByteBuffer.wrap(value));
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(1);
     assertThat(values.get(0).getName()).isEqualTo(name);
     assertThat(Arrays.equals(values.get(0).getAsBytes().get(), value)).isTrue();
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBlob(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsByteBuffer(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsBytes(0)).isEqualTo(value);
   }
 
   @Test
@@ -166,22 +186,33 @@ public class KeyTest {
             2468);
     Key key4 = new Key("key1", true, "key2", 5678, "key3", 1234L, "key4", 4.56f, "key5", 1.23);
 
-    // Act
+    // Act Assert
     List<Value<?>> values1 = key1.get();
-    List<Value<?>> values2 = key2.get();
-    List<Value<?>> values3 = key3.get();
-    List<Value<?>> values4 = key4.get();
-
-    // Assert
     assertThat(values1.size()).isEqualTo(2);
     assertThat(values1.get(0)).isEqualTo(new BooleanValue("key1", true));
     assertThat(values1.get(1)).isEqualTo(new IntValue("key2", 5678));
 
+    assertThat(key1.size()).isEqualTo(2);
+    assertThat(key1.getColumnName(0)).isEqualTo("key1");
+    assertThat(key1.getBoolean(0)).isEqualTo(true);
+    assertThat(key1.getColumnName(1)).isEqualTo("key2");
+    assertThat(key1.getInt(1)).isEqualTo(5678);
+
+    List<Value<?>> values2 = key2.get();
     assertThat(values2.size()).isEqualTo(3);
     assertThat(values2.get(0)).isEqualTo(new BigIntValue("key3", 1234L));
     assertThat(values2.get(1)).isEqualTo(new FloatValue("key4", 4.56f));
     assertThat(values2.get(2)).isEqualTo(new DoubleValue("key5", 1.23));
 
+    assertThat(key2.size()).isEqualTo(3);
+    assertThat(key2.getColumnName(0)).isEqualTo("key3");
+    assertThat(key2.getBigInt(0)).isEqualTo(1234L);
+    assertThat(key2.getColumnName(1)).isEqualTo("key4");
+    assertThat(key2.getFloat(1)).isEqualTo(4.56f);
+    assertThat(key2.getColumnName(2)).isEqualTo("key5");
+    assertThat(key2.getDouble(2)).isEqualTo(1.23);
+
+    List<Value<?>> values3 = key3.get();
     assertThat(values3.size()).isEqualTo(4);
     assertThat(values3.get(0)).isEqualTo(new TextValue("key6", "string_key"));
     assertThat(values3.get(1))
@@ -191,12 +222,43 @@ public class KeyTest {
             new BlobValue("key8", ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8))));
     assertThat(values3.get(3)).isEqualTo(new IntValue("key9", 2468));
 
+    assertThat(key3.size()).isEqualTo(4);
+    assertThat(key3.getColumnName(0)).isEqualTo("key6");
+    assertThat(key3.getText(0)).isEqualTo("string_key");
+    assertThat(key3.getColumnName(1)).isEqualTo("key7");
+    assertThat(key3.getBlob(1))
+        .isEqualTo(ByteBuffer.wrap("blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsByteBuffer(1))
+        .isEqualTo(ByteBuffer.wrap("blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsBytes(1)).isEqualTo("blob_key".getBytes(StandardCharsets.UTF_8));
+    assertThat(key3.getColumnName(2)).isEqualTo("key8");
+    assertThat(key3.getBlob(2))
+        .isEqualTo(ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsByteBuffer(2))
+        .isEqualTo(ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsBytes(2)).isEqualTo("blob_key2".getBytes(StandardCharsets.UTF_8));
+    assertThat(key3.getColumnName(3)).isEqualTo("key9");
+    assertThat(key3.getInt(3)).isEqualTo(2468);
+
+    List<Value<?>> values4 = key4.get();
     assertThat(values4.size()).isEqualTo(5);
     assertThat(values4.get(0)).isEqualTo(new BooleanValue("key1", true));
     assertThat(values4.get(1)).isEqualTo(new IntValue("key2", 5678));
     assertThat(values4.get(2)).isEqualTo(new BigIntValue("key3", 1234L));
     assertThat(values4.get(3)).isEqualTo(new FloatValue("key4", 4.56f));
     assertThat(values4.get(4)).isEqualTo(new DoubleValue("key5", 1.23));
+
+    assertThat(key4.size()).isEqualTo(5);
+    assertThat(key1.getColumnName(0)).isEqualTo("key1");
+    assertThat(key1.getBoolean(0)).isEqualTo(true);
+    assertThat(key1.getColumnName(1)).isEqualTo("key2");
+    assertThat(key1.getInt(1)).isEqualTo(5678);
+    assertThat(key4.getColumnName(2)).isEqualTo("key3");
+    assertThat(key4.getBigInt(2)).isEqualTo(1234L);
+    assertThat(key4.getColumnName(3)).isEqualTo("key4");
+    assertThat(key4.getFloat(3)).isEqualTo(4.56f);
+    assertThat(key4.getColumnName(4)).isEqualTo("key5");
+    assertThat(key4.getDouble(4)).isEqualTo(1.23);
   }
 
   @Test
@@ -230,10 +292,8 @@ public class KeyTest {
             .addAll(Arrays.asList(new IntValue("key10", 2468), new BigIntValue("key11", 1111L)))
             .build();
 
-    // Act
+    // Act Assert
     List<Value<?>> values = key.get();
-
-    // Assert
     assertThat(values.size()).isEqualTo(11);
     assertThat(values.get(0)).isEqualTo(new BooleanValue("key1", true));
     assertThat(values.get(1)).isEqualTo(new IntValue("key2", 5678));
@@ -249,6 +309,38 @@ public class KeyTest {
     assertThat(values.get(8)).isEqualTo(new IntValue("key9", 1357));
     assertThat(values.get(9)).isEqualTo(new IntValue("key10", 2468));
     assertThat(values.get(10)).isEqualTo(new BigIntValue("key11", 1111L));
+
+    assertThat(key.size()).isEqualTo(11);
+    assertThat(key.getColumnName(0)).isEqualTo("key1");
+    assertThat(key.getBoolean(0)).isEqualTo(true);
+    assertThat(key.getColumnName(1)).isEqualTo("key2");
+    assertThat(key.getInt(1)).isEqualTo(5678);
+    assertThat(key.getColumnName(2)).isEqualTo("key3");
+    assertThat(key.getBigInt(2)).isEqualTo(1234L);
+    assertThat(key.getColumnName(3)).isEqualTo("key4");
+    assertThat(key.getFloat(3)).isEqualTo(4.56f);
+    assertThat(key.getColumnName(4)).isEqualTo("key5");
+    assertThat(key.getDouble(4)).isEqualTo(1.23);
+    assertThat(key.getColumnName(5)).isEqualTo("key6");
+    assertThat(key.getText(5)).isEqualTo("string_key");
+    assertThat(key.getColumnName(6)).isEqualTo("key7");
+    assertThat(key.getBlob(6))
+        .isEqualTo(ByteBuffer.wrap("blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key.getBlobAsByteBuffer(6))
+        .isEqualTo(ByteBuffer.wrap("blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key.getBlobAsBytes(6)).isEqualTo("blob_key".getBytes(StandardCharsets.UTF_8));
+    assertThat(key.getColumnName(7)).isEqualTo("key8");
+    assertThat(key.getBlob(7))
+        .isEqualTo(ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key.getBlobAsByteBuffer(7))
+        .isEqualTo(ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key.getBlobAsBytes(7)).isEqualTo("blob_key2".getBytes(StandardCharsets.UTF_8));
+    assertThat(key.getColumnName(8)).isEqualTo("key9");
+    assertThat(key.getInt(8)).isEqualTo(1357);
+    assertThat(key.getColumnName(9)).isEqualTo("key10");
+    assertThat(key.getInt(9)).isEqualTo(2468);
+    assertThat(key.getColumnName(10)).isEqualTo("key11");
+    assertThat(key.getBigInt(10)).isEqualTo(1111L);
   }
 
   @Test


### PR DESCRIPTION
This PR hides the `Value` class from users. After this change, users basically no longer need to use `Value` directly.

What exactly this PR does is as follows:

- Change the terms, from `value` to `column`, and from `value content` to `column value`
- Make some methods to access the `Value` class deprecated or internal use
- Rename the argument name `name` to `columnName` to make it more explicit
- Rename the argument name `value` to `xxxValue` (like `booleanValue` and `intValue`) to make it more explicit
- Add several methods to get values in `ConditionalExpression` and `Key` so that users can access the values without the `Value` class

I will also add inline comments later. Please take a look!