### PR TITLE
Add factory methods to Key

### DIFF
--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -3,7 +3,6 @@ package com.scalar.db.io;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -56,7 +55,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param booleanValue a BOOLEAN value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
+   *     #ofBoolean(String, boolean)} instead
    */
+  @Deprecated
   public Key(String columnName, boolean booleanValue) {
     values = Collections.singletonList(new BooleanValue(columnName, booleanValue));
   }
@@ -65,8 +67,11 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * Constructs a {@code Key} with a single column with an INT type
    *
    * @param columnName a column name
-   * @param intValue a INT value of the column
+   * @param intValue an INT value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofInt(String,
+   *     int)} instead
    */
+  @Deprecated
   public Key(String columnName, int intValue) {
     values = Collections.singletonList(new IntValue(columnName, intValue));
   }
@@ -76,7 +81,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param bigIntValue a BIGINT value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofBigInt(String,
+   *     long)} instead
    */
+  @Deprecated
   public Key(String columnName, long bigIntValue) {
     values = Collections.singletonList(new BigIntValue(columnName, bigIntValue));
   }
@@ -86,7 +94,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param floatValue a FLOAT value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofFloat(String,
+   *     float)} instead
    */
+  @Deprecated
   public Key(String columnName, float floatValue) {
     values = Collections.singletonList(new FloatValue(columnName, floatValue));
   }
@@ -96,7 +107,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param doubleValue a DOUBLE value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofDouble(String,
+   *     double)} instead
    */
+  @Deprecated
   public Key(String columnName, double doubleValue) {
     values = Collections.singletonList(new DoubleValue(columnName, doubleValue));
   }
@@ -106,7 +120,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param textValue a TEXT value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofText(String,
+   *     String)} instead
    */
+  @Deprecated
   public Key(String columnName, String textValue) {
     values = Collections.singletonList(new TextValue(columnName, textValue));
   }
@@ -116,7 +133,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param blobValue a BLOB value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofBlob(String,
+   *     byte[])} instead
    */
+  @Deprecated
   public Key(String columnName, byte[] blobValue) {
     values = Collections.singletonList(new BlobValue(columnName, blobValue));
   }
@@ -126,7 +146,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    *
    * @param columnName a column name
    * @param blobValue a BLOB value of the column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #ofBlob(String,
+   *     ByteBuffer)} instead
    */
+  @Deprecated
   public Key(String columnName, ByteBuffer blobValue) {
     values = Collections.singletonList(new BlobValue(columnName, blobValue));
   }
@@ -138,7 +161,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v1 a value of the 1st column
    * @param n2 a column name of the 2nd column
    * @param v2 a value of the 2nd column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   *     Object, String, Object)} instead
    */
+  @Deprecated
   public Key(String n1, Object v1, String n2, Object v2) {
     values = Arrays.asList(toValue(n1, v1), toValue(n2, v2));
   }
@@ -152,7 +178,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v2 a value of the 2nd column
    * @param n3 a column name of the 3rd column
    * @param v3 a value of the 3rd column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   *     Object, String, Object, String, Object)} instead
    */
+  @Deprecated
   public Key(String n1, Object v1, String n2, Object v2, String n3, Object v3) {
     values = Arrays.asList(toValue(n1, v1), toValue(n2, v2), toValue(n3, v3));
   }
@@ -168,7 +197,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v3 a value of the 3rd column
    * @param n4 a column of the 4th column
    * @param v4 a value of the 4th column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   *     Object, String, Object, String, Object, String, Object)} instead
    */
+  @Deprecated
   public Key(
       String n1, Object v1, String n2, Object v2, String n3, Object v3, String n4, Object v4) {
     values = Arrays.asList(toValue(n1, v1), toValue(n2, v2), toValue(n3, v3), toValue(n4, v4));
@@ -187,7 +219,10 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
    * @param v4 a value of the 4th column
    * @param n5 a column of the 5th column
    * @param v5 a value of the 5th column
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #of(String,
+   *     Object, String, Object, String, Object, String, Object, String, Object)} instead
    */
+  @Deprecated
   public Key(
       String n1,
       Object v1,
@@ -427,9 +462,170 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
 
   @Override
   public int compareTo(Key o) {
-    return ComparisonChain.start()
-        .compare(values, o.values, Ordering.<Value<?>>natural().lexicographical())
-        .result();
+    return Ordering.<Value<?>>natural().lexicographical().compare(values, o.values);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a BOOLEAN type
+   *
+   * @param columnName a column name
+   * @param value a BOOLEAN value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofBoolean(String columnName, boolean value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with an INT type
+   *
+   * @param columnName a column name
+   * @param value an INT value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofInt(String columnName, int value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a BIGINT type
+   *
+   * @param columnName a column name
+   * @param value a BIGINT value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofBigInt(String columnName, long value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a FLOAT type
+   *
+   * @param columnName a column name
+   * @param value a FLOAT value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofFloat(String columnName, float value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a DOUBLE type
+   *
+   * @param columnName a column name
+   * @param value a DOUBLE value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofDouble(String columnName, double value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a TEXT type
+   *
+   * @param columnName a column name
+   * @param value a TEXT value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofText(String columnName, String value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a BLOB type from a byte array
+   *
+   * @param columnName a column name
+   * @param value a TEXT value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofBlob(String columnName, byte[] value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Creates a {@code Key} object with a single column with a BLOB type from a ByteBuffer
+   *
+   * @param columnName a column name
+   * @param value a TEXT value of the column
+   * @return a {@code Key} object
+   */
+  public static Key ofBlob(String columnName, ByteBuffer value) {
+    return new Key(columnName, value);
+  }
+
+  /**
+   * Create a {@code Key} object with two columns
+   *
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @return a {@code Key} object
+   */
+  public static Key of(String n1, Object v1, String n2, Object v2) {
+    return new Key(n1, v1, n2, v2);
+  }
+
+  /**
+   * Create a {@code Key} object with three columns
+   *
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @param n3 a column name of the 3rd column
+   * @param v3 a value of the 3rd column
+   * @return a {@code Key} object
+   */
+  public static Key of(String n1, Object v1, String n2, Object v2, String n3, Object v3) {
+    return new Key(n1, v1, n2, v2, n3, v3);
+  }
+
+  /**
+   * Create a {@code Key} object with four columns
+   *
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @param n3 a column name of the 3rd column
+   * @param v3 a value of the 3rd column
+   * @param n4 a column of the 4th column
+   * @param v4 a value of the 4th column
+   * @return a {@code Key} object
+   */
+  public static Key of(
+      String n1, Object v1, String n2, Object v2, String n3, Object v3, String n4, Object v4) {
+    return new Key(n1, v1, n2, v2, n3, v3, n4, v4);
+  }
+
+  /**
+   * Create a {@code Key} object with five columns
+   *
+   * @param n1 a column name of the 1st column
+   * @param v1 a value of the 1st column
+   * @param n2 a column name of the 2nd column
+   * @param v2 a value of the 2nd column
+   * @param n3 a column name of the 3rd column
+   * @param v3 a value of the 3rd column
+   * @param n4 a column of the 4th column
+   * @param v4 a value of the 4th column
+   * @param n5 a column of the 5th column
+   * @param v5 a value of the 5th column
+   * @return a {@code Key} object
+   */
+  public static Key of(
+      String n1,
+      Object v1,
+      String n2,
+      Object v2,
+      String n3,
+      Object v3,
+      String n4,
+      Object v4,
+      String n5,
+      Object v5) {
+    return new Key(n1, v1, n2, v2, n3, v3, n4, v4, n5, v5);
   }
 
   /**

--- a/core/src/test/java/com/scalar/db/io/KeyTest.java
+++ b/core/src/test/java/com/scalar/db/io/KeyTest.java
@@ -262,17 +262,261 @@ public class KeyTest {
   }
 
   @Test
-  public void get_ProperKeysGivenInConstructor_ShouldReturnWhatsSet() {
+  public void ofBoolean_ShouldReturnWhatsSet() {
     // Arrange
-    TextValue key1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue key2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key key = new Key(key1, key2);
+    String name = ANY_NAME_1;
+    boolean value = true;
+    Key key = Key.ofBoolean(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsBoolean()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBoolean(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofInt_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    int value = 100;
+    Key key = Key.ofInt(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsInt()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getInt(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofBigInt_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    long value = 1000L;
+    Key key = Key.ofBigInt(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsLong()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBigInt(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofFloat_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    float value = 1.0f;
+    Key key = Key.ofFloat(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsFloat()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getFloat(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofDouble_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    double value = 1.01d;
+    Key key = Key.ofDouble(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsDouble()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getDouble(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofText_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    String value = "value";
+    Key key = Key.ofText(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsString().isPresent()).isTrue();
+    assertThat(values.get(0).getAsString().get()).isEqualTo(value);
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getText(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofBlob_ByteArrayValueGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+    Key key = Key.ofBlob(name, value);
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsBytes().isPresent()).isTrue();
+    assertThat(Arrays.equals(values.get(0).getAsBytes().get(), value)).isTrue();
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBlob(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsByteBuffer(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsBytes(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void ofBlob_ByteBufferValueGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    String name = ANY_NAME_1;
+    byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+    Key key = Key.ofBlob(name, ByteBuffer.wrap(value));
+
+    // Act Assert
+    List<Value<?>> values = key.get();
+    assertThat(values.size()).isEqualTo(1);
+    assertThat(values.get(0).getName()).isEqualTo(name);
+    assertThat(values.get(0).getAsBytes().isPresent()).isTrue();
+    assertThat(Arrays.equals(values.get(0).getAsBytes().get(), value)).isTrue();
+
+    assertThat(key.size()).isEqualTo(1);
+    assertThat(key.getColumnName(0)).isEqualTo(name);
+    assertThat(key.getBlob(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsByteBuffer(0)).isEqualTo(ByteBuffer.wrap(value));
+    assertThat(key.getBlobAsBytes(0)).isEqualTo(value);
+  }
+
+  @Test
+  public void of_ShouldReturnWhatsSet() {
+    // Arrange
+    Key key1 = Key.of("key1", true, "key2", 5678);
+    Key key2 = Key.of("key3", 1234L, "key4", 4.56f, "key5", 1.23);
+    Key key3 =
+        Key.of(
+            "key6",
+            "string_key",
+            "key7",
+            "blob_key".getBytes(StandardCharsets.UTF_8),
+            "key8",
+            ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)),
+            "key9",
+            2468);
+    Key key4 = Key.of("key1", true, "key2", 5678, "key3", 1234L, "key4", 4.56f, "key5", 1.23);
+
+    // Act Assert
+    List<Value<?>> values1 = key1.get();
+    assertThat(values1.size()).isEqualTo(2);
+    assertThat(values1.get(0)).isEqualTo(new BooleanValue("key1", true));
+    assertThat(values1.get(1)).isEqualTo(new IntValue("key2", 5678));
+
+    assertThat(key1.size()).isEqualTo(2);
+    assertThat(key1.getColumnName(0)).isEqualTo("key1");
+    assertThat(key1.getBoolean(0)).isEqualTo(true);
+    assertThat(key1.getColumnName(1)).isEqualTo("key2");
+    assertThat(key1.getInt(1)).isEqualTo(5678);
+
+    List<Value<?>> values2 = key2.get();
+    assertThat(values2.size()).isEqualTo(3);
+    assertThat(values2.get(0)).isEqualTo(new BigIntValue("key3", 1234L));
+    assertThat(values2.get(1)).isEqualTo(new FloatValue("key4", 4.56f));
+    assertThat(values2.get(2)).isEqualTo(new DoubleValue("key5", 1.23));
+
+    assertThat(key2.size()).isEqualTo(3);
+    assertThat(key2.getColumnName(0)).isEqualTo("key3");
+    assertThat(key2.getBigInt(0)).isEqualTo(1234L);
+    assertThat(key2.getColumnName(1)).isEqualTo("key4");
+    assertThat(key2.getFloat(1)).isEqualTo(4.56f);
+    assertThat(key2.getColumnName(2)).isEqualTo("key5");
+    assertThat(key2.getDouble(2)).isEqualTo(1.23);
+
+    List<Value<?>> values3 = key3.get();
+    assertThat(values3.size()).isEqualTo(4);
+    assertThat(values3.get(0)).isEqualTo(new TextValue("key6", "string_key"));
+    assertThat(values3.get(1))
+        .isEqualTo(new BlobValue("key7", "blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(values3.get(2))
+        .isEqualTo(
+            new BlobValue("key8", ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8))));
+    assertThat(values3.get(3)).isEqualTo(new IntValue("key9", 2468));
+
+    assertThat(key3.size()).isEqualTo(4);
+    assertThat(key3.getColumnName(0)).isEqualTo("key6");
+    assertThat(key3.getText(0)).isEqualTo("string_key");
+    assertThat(key3.getColumnName(1)).isEqualTo("key7");
+    assertThat(key3.getBlob(1))
+        .isEqualTo(ByteBuffer.wrap("blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsByteBuffer(1))
+        .isEqualTo(ByteBuffer.wrap("blob_key".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsBytes(1)).isEqualTo("blob_key".getBytes(StandardCharsets.UTF_8));
+    assertThat(key3.getColumnName(2)).isEqualTo("key8");
+    assertThat(key3.getBlob(2))
+        .isEqualTo(ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsByteBuffer(2))
+        .isEqualTo(ByteBuffer.wrap("blob_key2".getBytes(StandardCharsets.UTF_8)));
+    assertThat(key3.getBlobAsBytes(2)).isEqualTo("blob_key2".getBytes(StandardCharsets.UTF_8));
+    assertThat(key3.getColumnName(3)).isEqualTo("key9");
+    assertThat(key3.getInt(3)).isEqualTo(2468);
+
+    List<Value<?>> values4 = key4.get();
+    assertThat(values4.size()).isEqualTo(5);
+    assertThat(values4.get(0)).isEqualTo(new BooleanValue("key1", true));
+    assertThat(values4.get(1)).isEqualTo(new IntValue("key2", 5678));
+    assertThat(values4.get(2)).isEqualTo(new BigIntValue("key3", 1234L));
+    assertThat(values4.get(3)).isEqualTo(new FloatValue("key4", 4.56f));
+    assertThat(values4.get(4)).isEqualTo(new DoubleValue("key5", 1.23));
+
+    assertThat(key4.size()).isEqualTo(5);
+    assertThat(key1.getColumnName(0)).isEqualTo("key1");
+    assertThat(key1.getBoolean(0)).isEqualTo(true);
+    assertThat(key1.getColumnName(1)).isEqualTo("key2");
+    assertThat(key1.getInt(1)).isEqualTo(5678);
+    assertThat(key4.getColumnName(2)).isEqualTo("key3");
+    assertThat(key4.getBigInt(2)).isEqualTo(1234L);
+    assertThat(key4.getColumnName(3)).isEqualTo("key4");
+    assertThat(key4.getFloat(3)).isEqualTo(4.56f);
+    assertThat(key4.getColumnName(4)).isEqualTo("key5");
+    assertThat(key4.getDouble(4)).isEqualTo(1.23);
+  }
+
+  @Test
+  public void get_ProperKeysGivenInFactoryMethod_ShouldReturnWhatsSet() {
+    // Arrange
+    Key key = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
 
     // Act
     List<Value<?>> values = key.get();
 
     // Assert
-    assertThat(values).isEqualTo(Arrays.asList(key1, key2));
+    assertThat(values)
+        .isEqualTo(
+            Arrays.asList(
+                new TextValue(ANY_NAME_1, ANY_TEXT_1), new TextValue(ANY_NAME_2, ANY_TEXT_2)));
   }
 
   @Test
@@ -346,9 +590,7 @@ public class KeyTest {
   @Test
   public void get_TryToModifyReturned_ShouldThrowException() {
     // Arrange
-    TextValue key1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue key2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key key = new Key(key1, key2);
+    Key key = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
 
     // Act Assert
     List<Value<?>> values = key.get();
@@ -359,12 +601,8 @@ public class KeyTest {
   @Test
   public void equals_DifferentObjectsSameValuesGiven_ShouldReturnTrue() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue oneKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    TextValue anotherKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue anotherKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
+    Key anotherKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
 
     // Act
     boolean result = oneKey.equals(anotherKey);
@@ -376,9 +614,7 @@ public class KeyTest {
   @Test
   public void equals_SameObjectsGiven_ShouldReturnTrue() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue oneKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
 
     // Act
     @SuppressWarnings("SelfEquals")
@@ -391,12 +627,8 @@ public class KeyTest {
   @Test
   public void equals_DifferentObjectsDifferentValuesGiven_ShouldReturnFalse() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue oneKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    TextValue anotherKey1 = new TextValue(ANY_NAME_3, ANY_TEXT_3);
-    TextValue anotherKey2 = new TextValue(ANY_NAME_4, ANY_TEXT_4);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
+    Key anotherKey = Key.of(ANY_NAME_3, ANY_TEXT_3, ANY_NAME_4, ANY_TEXT_4);
 
     // Act
     boolean result = oneKey.equals(anotherKey);
@@ -408,12 +640,13 @@ public class KeyTest {
   @Test
   public void equals_DifferentTypesSameValuesGiven_ShouldReturnFalse() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue oneKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    BlobValue anotherKey1 = new BlobValue(ANY_NAME_1, ANY_TEXT_1.getBytes(StandardCharsets.UTF_8));
-    BlobValue anotherKey2 = new BlobValue(ANY_NAME_2, ANY_TEXT_2.getBytes(StandardCharsets.UTF_8));
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
+    Key anotherKey =
+        Key.of(
+            ANY_NAME_1,
+            ANY_TEXT_1.getBytes(StandardCharsets.UTF_8),
+            ANY_NAME_2,
+            ANY_TEXT_2.getBytes(StandardCharsets.UTF_8));
 
     // Act
     boolean result = oneKey.equals(anotherKey);
@@ -425,12 +658,8 @@ public class KeyTest {
   @Test
   public void compareTo_ThisTextBiggerThanGiven_ShouldReturnPositive() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_3, ANY_TEXT_3);
-    TextValue oneKey2 = new TextValue(ANY_NAME_4, ANY_TEXT_4);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    TextValue anotherKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue anotherKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_3, ANY_TEXT_3, ANY_NAME_4, ANY_TEXT_4);
+    Key anotherKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
 
     // Act
     int actual = oneKey.compareTo(anotherKey);
@@ -442,12 +671,8 @@ public class KeyTest {
   @Test
   public void compareTo_ThisNumberBiggerThanGiven_ShouldReturnPositive() {
     // Arrange
-    IntValue oneKey1 = new IntValue(ANY_NAME_1, ANY_INT_1);
-    IntValue oneKey2 = new IntValue(ANY_NAME_2, ANY_INT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    IntValue anotherKey1 = new IntValue(ANY_NAME_1, ANY_INT_1);
-    IntValue anotherKey2 = new IntValue(ANY_NAME_2, ANY_INT_1);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_INT_1, ANY_NAME_2, ANY_INT_2);
+    Key anotherKey = Key.of(ANY_NAME_1, ANY_INT_1, ANY_NAME_2, ANY_INT_1);
 
     // Act
     int actual = oneKey.compareTo(anotherKey);
@@ -459,12 +684,8 @@ public class KeyTest {
   @Test
   public void compareTo_ThisEqualsToGiven_ShouldReturnZero() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    IntValue oneKey2 = new IntValue(ANY_NAME_2, ANY_INT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    TextValue anotherKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    IntValue anotherKey2 = new IntValue(ANY_NAME_2, ANY_INT_2);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_INT_2);
+    Key anotherKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_INT_2);
 
     // Act
     int actual = oneKey.compareTo(anotherKey);
@@ -476,12 +697,8 @@ public class KeyTest {
   @Test
   public void compareTo_ThisTextSmallerThanGiven_ShouldReturnNegative() {
     // Arrange
-    TextValue oneKey1 = new TextValue(ANY_NAME_1, ANY_TEXT_1);
-    TextValue oneKey2 = new TextValue(ANY_NAME_2, ANY_TEXT_2);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    TextValue anotherKey1 = new TextValue(ANY_NAME_3, ANY_TEXT_3);
-    TextValue anotherKey2 = new TextValue(ANY_NAME_4, ANY_TEXT_4);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_TEXT_1, ANY_NAME_2, ANY_TEXT_2);
+    Key anotherKey = Key.of(ANY_NAME_3, ANY_TEXT_3, ANY_NAME_4, ANY_TEXT_4);
 
     // Act
     int actual = oneKey.compareTo(anotherKey);
@@ -493,12 +710,8 @@ public class KeyTest {
   @Test
   public void compareTo_ThisNumberSmallerThanGiven_ShouldReturnNegative() {
     // Arrange
-    IntValue oneKey1 = new IntValue(ANY_NAME_1, ANY_INT_1);
-    IntValue oneKey2 = new IntValue(ANY_NAME_2, ANY_INT_1);
-    Key oneKey = new Key(oneKey1, oneKey2);
-    IntValue anotherKey1 = new IntValue(ANY_NAME_1, ANY_INT_1);
-    IntValue anotherKey2 = new IntValue(ANY_NAME_2, ANY_INT_2);
-    Key anotherKey = new Key(anotherKey1, anotherKey2);
+    Key oneKey = Key.of(ANY_NAME_1, ANY_INT_1, ANY_NAME_2, ANY_INT_1);
+    Key anotherKey = Key.of(ANY_NAME_1, ANY_INT_1, ANY_NAME_2, ANY_INT_2);
 
     // Act
     int actual = oneKey.compareTo(anotherKey);


### PR DESCRIPTION
This PR adds factory methods to the `Key` class.

We can use the factory methods as follows:
```java
// for a key that consists of a single column of Int
Key key1 = Key.ofInt("col1", 1);

// for a key that consists of a single column of BigInt
Key key2 = Key.ofBigInt("col1", 100L);

// for a key that consists of a single column of Double
Key key3 = Key.ofDouble("col1", 1.3d);

// for a key that consists of a single column of Text
Key key4 = Key.ofText("col1", "value");

// for a key that consists of 2 - 5 columns
Key key5 = Key.of("col1", 1, "col2", 100L);
Key key6 = Key.of("col1", 1, "col2", 100L, "col3", 1.3d);
Key key7 = Key.of("col1", 1, "col2", 100L, "col3", 1.3d, "col4", "value");
Key key8 = Key.of("col1", 1, "col2", 100L, "col3", 1.3d, "col4", "value", "col5", false);
```

We can still use the Key Builder class when we create a key that consists of more than 5 columns.

This PR also deprecates some existing constructors. Please take a look!