### PR TITLE
Add factory methods to Scan.Ordering

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -277,7 +277,10 @@ public class Scan extends Selection {
      *
      * @param columnName the column name of a clustering key in an entry to order
      * @param order the {@code Order} of results
+     * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link #asc(String)}
+     *     or {@link #desc(String)} to create an Ordering object
      */
+    @Deprecated
     public Ordering(String columnName, Order order) {
       this.columnName = columnName;
       this.order = order;
@@ -349,6 +352,26 @@ public class Scan extends Selection {
     public enum Order {
       ASC,
       DESC,
+    }
+
+    /**
+     * Creates an Ordering object for ASC order with the specified column.
+     *
+     * @param columnName a name of a target column
+     * @return an Ordering object
+     */
+    public static Ordering asc(String columnName) {
+      return new Ordering(columnName, Order.ASC);
+    }
+
+    /**
+     * Creates an Ordering object for DESC order with the specified column.
+     *
+     * @param columnName a name of a target column
+     * @return an Ordering object
+     */
+    public static Ordering desc(String columnName) {
+      return new Ordering(columnName, Order.DESC);
     }
   }
 }

--- a/core/src/test/java/com/scalar/db/api/ScanTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanTest.java
@@ -21,7 +21,7 @@ public class ScanTest {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     Key startClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
     Key endClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
-    Scan.Ordering ordering = new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.ASC);
+    Scan.Ordering ordering = Scan.Ordering.asc(ANY_NAME_2);
 
     return new Scan(partitionKey)
         .withStart(startClusteringKey, false)
@@ -35,7 +35,7 @@ public class ScanTest {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     Key startClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
     Key endClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_4);
-    Scan.Ordering ordering = new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.ASC);
+    Scan.Ordering ordering = Scan.Ordering.asc(ANY_NAME_2);
 
     return new Scan(partitionKey)
         .withStart(startClusteringKey, false)
@@ -51,7 +51,7 @@ public class ScanTest {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     Key startClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
     Key endClusteringKey = new Key(ANY_NAME_2, ANY_TEXT_3);
-    Scan.Ordering ordering = new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.ASC);
+    Scan.Ordering ordering = Scan.Ordering.asc(ANY_NAME_2);
 
     // Act
     Scan scan =
@@ -140,9 +140,9 @@ public class ScanTest {
   public void equals_ScanWithDifferentOrderingGiven_ShouldReturnFalse() {
     // Arrange
     Scan scan = prepareScan();
-    scan.withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.DESC));
+    scan.withOrdering(Scan.Ordering.desc(ANY_NAME_2));
     Scan another = prepareScan();
-    another.withOrdering(new Scan.Ordering(ANY_NAME_2, Scan.Ordering.Order.ASC));
+    another.withOrdering(Scan.Ordering.asc(ANY_NAME_2));
 
     // Act
     boolean ret = scan.equals(another);


### PR DESCRIPTION
This PR adds factory methods to the `Scan.Ordering` class.

We can use them as follows:
```
// for asc ordering
Scan.Ordering ascOrdering = Scan.Ordering.asc("col1");

// for desc ordering
Scan.Ordering descOrdering = Scan.Ordering.desc("col2");
```

This PR also deprecates the constructor of `Scan.Ordering`. Please take a look!