### PR TITLE
Introduce DistributedTransactionAdmin

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,6 +57,8 @@ sourceSets {
             include '**/com/scalar/db/storage/jdbc/*.java'
             include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java'
             include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitWithJdbcDatabaseIntegrationTest.java'
+            include '**/com/scalar/db/transaction/TransactionAdminIntegrationTestBase.java'
+            include '**/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithJdbcDatabaseIntegrationTest.java'
             include '**/com/scalar/db/transaction/jdbc/*.java'
         }
         resources.srcDir file('src/integration-test/resources')

--- a/core/src/integration-test/java/com/scalar/db/storage/StorageAdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/StorageAdminIntegrationTestBase.java
@@ -1,0 +1,449 @@
+package com.scalar.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.StorageFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
+public abstract class StorageAdminIntegrationTestBase {
+
+  private static final String TEST_NAME = "storage_admin";
+  private static final String NAMESPACE1 = "integration_testing_" + TEST_NAME + "1";
+  private static final String NAMESPACE2 = "integration_testing_" + TEST_NAME + "2";
+  private static final String NAMESPACE3 = "integration_testing_" + TEST_NAME + "3";
+  private static final String TABLE1 = "test_table1";
+  private static final String TABLE2 = "test_table2";
+  private static final String TABLE3 = "test_table3";
+  private static final String TABLE4 = "test_table4";
+  private static final String COL_NAME1 = "c1";
+  private static final String COL_NAME2 = "c2";
+  private static final String COL_NAME3 = "c3";
+  private static final String COL_NAME4 = "c4";
+  private static final String COL_NAME5 = "c5";
+  private static final String COL_NAME6 = "c6";
+  private static final String COL_NAME7 = "c7";
+  private static final String COL_NAME8 = "c8";
+  private static final String COL_NAME9 = "c9";
+  private static final String COL_NAME10 = "c10";
+  private static final String COL_NAME11 = "c11";
+
+  private static final TableMetadata TABLE_METADATA =
+      TableMetadata.newBuilder()
+          .addColumn(COL_NAME1, DataType.INT)
+          .addColumn(COL_NAME2, DataType.TEXT)
+          .addColumn(COL_NAME3, DataType.TEXT)
+          .addColumn(COL_NAME4, DataType.INT)
+          .addColumn(COL_NAME5, DataType.INT)
+          .addColumn(COL_NAME6, DataType.TEXT)
+          .addColumn(COL_NAME7, DataType.BIGINT)
+          .addColumn(COL_NAME8, DataType.FLOAT)
+          .addColumn(COL_NAME9, DataType.DOUBLE)
+          .addColumn(COL_NAME10, DataType.BOOLEAN)
+          .addColumn(COL_NAME11, DataType.BLOB)
+          .addPartitionKey(COL_NAME2)
+          .addPartitionKey(COL_NAME1)
+          .addClusteringKey(COL_NAME4, Scan.Ordering.Order.ASC)
+          .addClusteringKey(COL_NAME3, Scan.Ordering.Order.DESC)
+          .addSecondaryIndex(COL_NAME5)
+          .addSecondaryIndex(COL_NAME6)
+          .build();
+
+  private static boolean initialized;
+  private static DistributedStorageAdmin admin;
+  private static DistributedStorage storage;
+  private static String namespace1;
+  private static String namespace2;
+  private static String namespace3;
+
+  @Before
+  public void setUp() throws Exception {
+    if (!initialized) {
+      initialize();
+      StorageFactory factory =
+          new StorageFactory(TestUtils.addSuffix(getDatabaseConfig(), TEST_NAME));
+      admin = factory.getAdmin();
+      namespace1 = getNamespace1();
+      namespace2 = getNamespace2();
+      namespace3 = getNamespace3();
+      createTables();
+      storage = factory.getStorage();
+      initialized = true;
+    }
+  }
+
+  protected void initialize() throws Exception {}
+
+  protected abstract DatabaseConfig getDatabaseConfig();
+
+  protected String getNamespace1() {
+    return NAMESPACE1;
+  }
+
+  protected String getNamespace2() {
+    return NAMESPACE2;
+  }
+
+  protected String getNamespace3() {
+    return NAMESPACE3;
+  }
+
+  private void createTables() throws ExecutionException {
+    Map<String, String> options = getCreateOptions();
+    for (String namespace : Arrays.asList(namespace1, namespace2)) {
+      admin.createNamespace(namespace, true, options);
+      for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
+        admin.createTable(namespace, table, TABLE_METADATA, true, options);
+      }
+    }
+  }
+
+  protected Map<String, String> getCreateOptions() {
+    return Collections.emptyMap();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws ExecutionException {
+    dropTables();
+    admin.close();
+  }
+
+  private static void dropTables() throws ExecutionException {
+    for (String namespace : Arrays.asList(namespace1, namespace2)) {
+      for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
+        admin.dropTable(namespace, table);
+      }
+      admin.dropNamespace(namespace, true);
+    }
+  }
+
+  @Test
+  public void getTableMetadata_CorrectTableGiven_ShouldReturnCorrectMetadata()
+      throws ExecutionException {
+    // Arrange
+
+    // Act
+    TableMetadata tableMetadata = admin.getTableMetadata(namespace1, TABLE1);
+
+    // Assert
+    assertThat(tableMetadata).isNotNull();
+
+    assertThat(tableMetadata.getPartitionKeyNames().size()).isEqualTo(2);
+    Iterator<String> iterator = tableMetadata.getPartitionKeyNames().iterator();
+    assertThat(iterator.next()).isEqualTo(COL_NAME2);
+    assertThat(iterator.next()).isEqualTo(COL_NAME1);
+
+    assertThat(tableMetadata.getClusteringKeyNames().size()).isEqualTo(2);
+    iterator = tableMetadata.getClusteringKeyNames().iterator();
+    assertThat(iterator.next()).isEqualTo(COL_NAME4);
+    assertThat(iterator.next()).isEqualTo(COL_NAME3);
+
+    assertThat(tableMetadata.getColumnNames().size()).isEqualTo(11);
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME1)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME2)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME3)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME4)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME5)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME6)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME7)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME8)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME9)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME10)).isTrue();
+    assertThat(tableMetadata.getColumnNames().contains(COL_NAME11)).isTrue();
+
+    assertThat(tableMetadata.getColumnDataType(COL_NAME1)).isEqualTo(DataType.INT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME2)).isEqualTo(DataType.TEXT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME3)).isEqualTo(DataType.TEXT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME4)).isEqualTo(DataType.INT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME5)).isEqualTo(DataType.INT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME6)).isEqualTo(DataType.TEXT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME7)).isEqualTo(DataType.BIGINT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME8)).isEqualTo(DataType.FLOAT);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME9)).isEqualTo(DataType.DOUBLE);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME10)).isEqualTo(DataType.BOOLEAN);
+    assertThat(tableMetadata.getColumnDataType(COL_NAME11)).isEqualTo(DataType.BLOB);
+
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME1)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME2)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME3)).isEqualTo(Scan.Ordering.Order.DESC);
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME4)).isEqualTo(Scan.Ordering.Order.ASC);
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME5)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME6)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME7)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME8)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME9)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME10)).isNull();
+    assertThat(tableMetadata.getClusteringOrder(COL_NAME11)).isNull();
+
+    assertThat(tableMetadata.getSecondaryIndexNames().size()).isEqualTo(2);
+    assertThat(tableMetadata.getSecondaryIndexNames().contains(COL_NAME5)).isTrue();
+    assertThat(tableMetadata.getSecondaryIndexNames().contains(COL_NAME6)).isTrue();
+  }
+
+  @Test
+  public void getTableMetadata_WrongTableGiven_ShouldReturnNull() throws ExecutionException {
+    // Arrange
+
+    // Act
+    TableMetadata tableMetadata = admin.getTableMetadata("wrong_ns", "wrong_table");
+
+    // Assert
+    assertThat(tableMetadata).isNull();
+  }
+
+  @Test
+  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
+      throws ExecutionException {
+    try {
+      // Arrange
+
+      // Act
+      admin.createNamespace(namespace3);
+
+      // Assert
+      assertThat(admin.namespaceExists(namespace3)).isTrue();
+    } finally {
+      admin.dropNamespace(namespace3, true);
+    }
+  }
+
+  @Test
+  public void createNamespace_ForExistingNamespace_ShouldExecutionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.createNamespace(namespace1))
+        .isInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void createNamespace_IfNotExists_ForExistingNamespace_ShouldNotThrowAnyException() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.createNamespace(namespace1, true)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void dropNamespace_ForNonExistingNamespace_ShouldDropNamespaceProperly()
+      throws ExecutionException {
+    try {
+      // Arrange
+      admin.createNamespace(namespace3);
+
+      // Act
+      admin.dropNamespace(namespace3);
+
+      // Assert
+      assertThat(admin.namespaceExists(namespace3)).isFalse();
+    } finally {
+      admin.dropNamespace(namespace3, true);
+    }
+  }
+
+  @Test
+  public void dropNamespace_ForNonExistingNamespace_ShouldExecutionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.dropNamespace(namespace3))
+        .isInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void dropNamespace_IfExists_ForNonExistingNamespace_ShouldNotThrowAnyException() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.dropNamespace(namespace3, true)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void createTable_ForNonExistingTable_ShouldCreateTableProperly()
+      throws ExecutionException {
+    try {
+      // Arrange
+      Map<String, String> options = getCreateOptions();
+
+      // Act
+      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+
+      // Assert
+      assertThat(admin.tableExists(namespace1, TABLE4)).isTrue();
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  public void createTable_ForExistingTable_ShouldExecutionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.createTable(namespace1, TABLE1, TABLE_METADATA))
+        .isInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void createTable_IfNotExists_ForExistingNamespace_ShouldNotThrowAnyException() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.createTable(namespace1, TABLE1, TABLE_METADATA, true))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void dropTable_ForExistingTable_ShouldDropTableProperly() throws ExecutionException {
+    try {
+      // Arrange
+      Map<String, String> options = getCreateOptions();
+      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+
+      // Act
+      admin.dropTable(namespace1, TABLE4);
+
+      // Assert
+      assertThat(admin.tableExists(namespace1, TABLE4)).isFalse();
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  public void dropTable_ForNonExistingTable_ShouldExecutionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.dropTable(namespace1, TABLE4))
+        .isInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void dropTable_IfExists_ForNonExistingTable_ShouldNotThrowAnyException() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.dropTable(namespace1, TABLE4, true)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void truncateTable_ShouldTruncateProperly() throws ExecutionException, IOException {
+    // Arrange
+    Key partitionKey = new Key(COL_NAME2, "aaa", COL_NAME1, 1);
+    Key clusteringKey = new Key(COL_NAME4, 2, COL_NAME3, "bbb");
+    storage.put(
+        new Put(partitionKey, clusteringKey)
+            .withValue(COL_NAME5, 3)
+            .withValue(COL_NAME6, "ccc")
+            .withValue(COL_NAME7, 4L)
+            .withValue(COL_NAME8, 1.0f)
+            .withValue(COL_NAME9, 1.0d)
+            .withValue(COL_NAME10, true)
+            .withValue(COL_NAME11, "ddd".getBytes(StandardCharsets.UTF_8))
+            .forNamespace(namespace1)
+            .forTable(TABLE1));
+
+    // Act
+    admin.truncateTable(namespace1, TABLE1);
+
+    // Assert
+    Scanner scanner =
+        storage.scan(new Scan(partitionKey).forNamespace(namespace1).forTable(TABLE1));
+    assertThat(scanner.all()).isEmpty();
+    scanner.close();
+  }
+
+  @Test
+  public void getNamespaceTableNames_ShouldReturnCorrectTables() throws ExecutionException {
+    // Arrange
+
+    // Act
+    Set<String> actual = admin.getNamespaceTableNames(namespace1);
+
+    // Assert
+    assertThat(actual).isEqualTo(new HashSet<>(Arrays.asList(TABLE1, TABLE2, TABLE3)));
+  }
+
+  @Test
+  public void namespaceExists_ShouldReturnCorrectResults() throws ExecutionException {
+    // Arrange
+
+    // Act Assert
+    assertThat(admin.namespaceExists(namespace1)).isTrue();
+    assertThat(admin.namespaceExists(namespace2)).isTrue();
+    assertThat(admin.namespaceExists(namespace3)).isFalse();
+  }
+
+  @Test
+  public void tableExists_ShouldReturnCorrectResults() throws ExecutionException {
+    // Arrange
+
+    // Act Assert
+    assertThat(admin.tableExists(namespace1, TABLE1)).isTrue();
+    assertThat(admin.tableExists(namespace1, TABLE2)).isTrue();
+    assertThat(admin.tableExists(namespace1, TABLE3)).isTrue();
+    assertThat(admin.tableExists(namespace1, TABLE4)).isFalse();
+  }
+
+  @Test
+  public void createIndex_ShouldCreateIndexCorrectly() throws ExecutionException {
+    try {
+      // Arrange
+      Map<String, String> options = getCreateOptions();
+      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+
+      // Act
+      admin.createIndex(namespace1, TABLE4, COL_NAME7, options);
+
+      // Assert
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isTrue();
+      assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
+          .contains(COL_NAME7);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+
+  @Test
+  public void dropIndex_ShouldDropIndexCorrectly() throws ExecutionException {
+    try {
+      // Arrange
+      Map<String, String> options = getCreateOptions();
+      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+
+      // Act
+      admin.dropIndex(namespace1, TABLE4, COL_NAME6);
+
+      // Assert
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME6)).isFalse();
+      assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
+          .doesNotContain(COL_NAME6);
+    } finally {
+      admin.dropTable(namespace1, TABLE4, true);
+    }
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
@@ -1,9 +1,9 @@
 package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.AdminIntegrationTestBase;
+import com.scalar.db.storage.StorageAdminIntegrationTestBase;
 
-public class CassandraAdminIntegrationTest extends AdminIntegrationTestBase {
+public class CassandraAdminIntegrationTest extends StorageAdminIntegrationTestBase {
   @Override
   protected DatabaseConfig getDatabaseConfig() {
     return CassandraEnv.getDatabaseConfig();

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -1,11 +1,11 @@
 package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.AdminIntegrationTestBase;
+import com.scalar.db.storage.StorageAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Optional;
 
-public class CosmosAdminIntegrationTest extends AdminIntegrationTestBase {
+public class CosmosAdminIntegrationTest extends StorageAdminIntegrationTestBase {
 
   @Override
   protected DatabaseConfig getDatabaseConfig() {

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -1,12 +1,12 @@
 package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.AdminIntegrationTestBase;
+import com.scalar.db.storage.StorageAdminIntegrationTestBase;
 import java.util.Map;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class DynamoAdminIntegrationTest extends AdminIntegrationTestBase {
+public class DynamoAdminIntegrationTest extends StorageAdminIntegrationTestBase {
 
   @Override
   protected DatabaseConfig getDatabaseConfig() {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -1,9 +1,9 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.AdminIntegrationTestBase;
+import com.scalar.db.storage.StorageAdminIntegrationTestBase;
 
-public class JdbcAdminIntegrationTest extends AdminIntegrationTestBase {
+public class JdbcAdminIntegrationTest extends StorageAdminIntegrationTestBase {
 
   @Override
   protected DatabaseConfig getDatabaseConfig() {

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithJdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithJdbcDatabaseIntegrationTest.java
@@ -1,0 +1,14 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcEnv;
+import com.scalar.db.transaction.TransactionAdminIntegrationTestBase;
+
+public class ConsensusCommitAdminWithJdbcDatabaseIntegrationTest
+    extends TransactionAdminIntegrationTestBase {
+
+  @Override
+  protected DatabaseConfig getDatabaseConfig() {
+    return JdbcEnv.getJdbcConfig();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -131,13 +131,11 @@ public abstract class ConsensusCommitIntegrationTestBase {
             .addPartitionKey(ACCOUNT_ID)
             .addClusteringKey(ACCOUNT_TYPE)
             .build();
-    admin.createNamespace(namespace1, true, options);
-    consensusCommitAdmin.createTransactionalTable(
-        namespace1, TABLE_1, tableMetadata, true, options);
-    admin.createNamespace(namespace2, true, options);
-    consensusCommitAdmin.createTransactionalTable(
-        namespace2, TABLE_2, tableMetadata, true, options);
-    consensusCommitAdmin.createCoordinatorTable(options);
+    consensusCommitAdmin.createNamespace(namespace1, true, options);
+    consensusCommitAdmin.createTable(namespace1, TABLE_1, tableMetadata, true, options);
+    consensusCommitAdmin.createNamespace(namespace2, true, options);
+    consensusCommitAdmin.createTable(namespace2, TABLE_2, tableMetadata, true, options);
+    consensusCommitAdmin.createCoordinatorNamespaceAndTable(options);
   }
 
   protected Map<String, String> getCreateOptions() {
@@ -145,25 +143,25 @@ public abstract class ConsensusCommitIntegrationTestBase {
   }
 
   private void truncateTables() throws ExecutionException {
-    admin.truncateTable(namespace1, TABLE_1);
-    admin.truncateTable(namespace2, TABLE_2);
+    consensusCommitAdmin.truncateTable(namespace1, TABLE_1);
+    consensusCommitAdmin.truncateTable(namespace2, TABLE_2);
     consensusCommitAdmin.truncateCoordinatorTable();
   }
 
   @AfterClass
   public static void tearDownAfterClass() throws ExecutionException {
     deleteTables();
-    admin.close();
+    consensusCommitAdmin.close();
     originalStorage.close();
     parallelExecutor.close();
   }
 
   private static void deleteTables() throws ExecutionException {
-    admin.dropTable(namespace1, TABLE_1);
-    admin.dropNamespace(namespace1);
-    admin.dropTable(namespace2, TABLE_2);
-    admin.dropNamespace(namespace2);
-    consensusCommitAdmin.dropCoordinatorTable();
+    consensusCommitAdmin.dropTable(namespace1, TABLE_1);
+    consensusCommitAdmin.dropNamespace(namespace1);
+    consensusCommitAdmin.dropTable(namespace2, TABLE_2);
+    consensusCommitAdmin.dropNamespace(namespace2);
+    consensusCommitAdmin.dropCoordinatorNamespaceAndTable();
   }
 
   @Test

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTest.java
@@ -111,9 +111,9 @@ public class TwoPhaseConsensusCommitIntegrationTest {
             .addClusteringKey(ACCOUNT_TYPE)
             .build();
     admin.createNamespace(NAMESPACE, true);
-    consensusCommitAdmin.createTransactionalTable(NAMESPACE, TABLE_1, tableMetadata, true);
-    consensusCommitAdmin.createTransactionalTable(NAMESPACE, TABLE_2, tableMetadata, true);
-    consensusCommitAdmin.createCoordinatorTable();
+    consensusCommitAdmin.createTable(NAMESPACE, TABLE_1, tableMetadata, true);
+    consensusCommitAdmin.createTable(NAMESPACE, TABLE_2, tableMetadata, true);
+    consensusCommitAdmin.createCoordinatorNamespaceAndTable();
   }
 
   private static void initManagerAndCoordinator(DatabaseConfig config) {
@@ -145,7 +145,7 @@ public class TwoPhaseConsensusCommitIntegrationTest {
     admin.dropTable(NAMESPACE, TABLE_1);
     admin.dropTable(NAMESPACE, TABLE_2);
     admin.dropNamespace(NAMESPACE);
-    consensusCommitAdmin.dropCoordinatorTable();
+    consensusCommitAdmin.dropCoordinatorNamespaceAndTable();
   }
 
   @Test

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -1,0 +1,19 @@
+package com.scalar.db.transaction.jdbc;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcConfig;
+import com.scalar.db.storage.jdbc.JdbcEnv;
+import com.scalar.db.transaction.TransactionAdminIntegrationTestBase;
+import java.util.Properties;
+
+public class JdbcTransactionAdminIntegrationTest extends TransactionAdminIntegrationTestBase {
+
+  @Override
+  protected DatabaseConfig getDatabaseConfig() {
+    JdbcConfig jdbcConfig = JdbcEnv.getJdbcConfig();
+    Properties properties = new Properties();
+    properties.putAll(jdbcConfig.getProperties());
+    properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
+    return new DatabaseConfig(properties);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionAdmin.java
@@ -1,0 +1,427 @@
+package com.scalar.db.api;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An administrative interface for distributed transaction implementations. The user can execute
+ * administrative operations with it like createNamespace/createTable/getTableMetadata.
+ */
+public interface DistributedTransactionAdmin {
+
+  /**
+   * Creates a namespace.
+   *
+   * @param namespace the namespace to create
+   * @param options namespace creation options
+   * @throws ExecutionException if the operation failed
+   */
+  void createNamespace(String namespace, Map<String, String> options) throws ExecutionException;
+
+  /**
+   * Creates a namespace.
+   *
+   * @param namespace the namespace to create
+   * @param options namespace creation options
+   * @param ifNotExists if set to true, the namespace will be created only if it does not exist
+   *     already. If set to false, it will try to create the namespace but may throw an exception if
+   *     it already exists
+   * @throws ExecutionException if the namespace already exists among other
+   */
+  default void createNamespace(String namespace, boolean ifNotExists, Map<String, String> options)
+      throws ExecutionException {
+    if (ifNotExists && namespaceExists(namespace)) {
+      return;
+    }
+    createNamespace(namespace, options);
+  }
+
+  /**
+   * Creates a namespace.
+   *
+   * @param namespace the namespace to create
+   * @param ifNotExists if set to true, the namespace will be created only if it does not exist
+   *     already. If set to false, it will try to create the namespace but may throw an exception if
+   *     it already exists
+   * @throws ExecutionException if the operation failed
+   */
+  default void createNamespace(String namespace, boolean ifNotExists) throws ExecutionException {
+    createNamespace(namespace, ifNotExists, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a namespace.
+   *
+   * @param namespace the namespace to create
+   * @throws ExecutionException if the namespace already exits among other
+   */
+  default void createNamespace(String namespace) throws ExecutionException {
+    createNamespace(namespace, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a new table.
+   *
+   * @param namespace a namespace already created
+   * @param table a table to create
+   * @param metadata a metadata to create
+   * @param options options to create
+   * @throws ExecutionException if the operation failed
+   */
+  void createTable(
+      String namespace, String table, TableMetadata metadata, Map<String, String> options)
+      throws ExecutionException;
+
+  /**
+   * Creates a new table.
+   *
+   * @param namespace an existing namespace
+   * @param table a table to create
+   * @param metadata a metadata to create
+   * @param ifNotExists if set to true, the table will be created only if it does not exist already.
+   *     If set to false, it will try to create the table but may throw an exception if it already
+   *     exists
+   * @param options options to create
+   * @throws ExecutionException if the operation failed
+   */
+  default void createTable(
+      String namespace,
+      String table,
+      TableMetadata metadata,
+      boolean ifNotExists,
+      Map<String, String> options)
+      throws ExecutionException {
+    if (ifNotExists && tableExists(namespace, table)) {
+      return;
+    }
+    createTable(namespace, table, metadata, options);
+  }
+
+  /**
+   * Creates a new table.
+   *
+   * @param namespace an existing namespace
+   * @param table a table to create
+   * @param metadata a metadata to create
+   * @param ifNotExists if set to true, the table will be created only if it does not exist already.
+   *     If set to false, it will try to create the table but may throw an exception if it already
+   *     exists
+   * @throws ExecutionException if the operation failed
+   */
+  default void createTable(
+      String namespace, String table, TableMetadata metadata, boolean ifNotExists)
+      throws ExecutionException {
+    createTable(namespace, table, metadata, ifNotExists, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a new table.
+   *
+   * @param namespace an existing namespace
+   * @param table a table to create
+   * @param metadata a metadata to create
+   * @throws ExecutionException if the operation failed
+   */
+  default void createTable(String namespace, String table, TableMetadata metadata)
+      throws ExecutionException {
+    createTable(namespace, table, metadata, Collections.emptyMap());
+  }
+
+  /**
+   * Drops the specified table.
+   *
+   * @param namespace a namespace to drop
+   * @param table a table to drop
+   * @throws ExecutionException if the operation failed
+   */
+  void dropTable(String namespace, String table) throws ExecutionException;
+
+  /**
+   * Drops the specified table.
+   *
+   * @param namespace a namespace to drop
+   * @param table a table to drop
+   * @param ifExists if set to true, the table will be dropped only if it exists. If set to false,
+   *     it will try to drop the table but may throw an exception if it does not exist
+   * @throws ExecutionException if the operation failed
+   */
+  default void dropTable(String namespace, String table, boolean ifExists)
+      throws ExecutionException {
+    if (ifExists && !tableExists(namespace, table)) {
+      return;
+    }
+    dropTable(namespace, table);
+  }
+
+  /**
+   * Drops the specified namespace.
+   *
+   * @param namespace a namespace to drop
+   * @throws ExecutionException if the operation failed
+   */
+  void dropNamespace(String namespace) throws ExecutionException;
+
+  /**
+   * Drops the specified namespace.
+   *
+   * @param namespace a namespace to drop
+   * @param ifExists if set to true, the namespace will be dropped only if it exists. If set to
+   *     false, it will try to drop the namespace but may throw an exception if it does not exist
+   * @throws ExecutionException if the operation failed
+   */
+  default void dropNamespace(String namespace, boolean ifExists) throws ExecutionException {
+    if (ifExists && !namespaceExists(namespace)) {
+      return;
+    }
+    dropNamespace(namespace);
+  }
+
+  /**
+   * Truncates the specified table.
+   *
+   * @param namespace a namespace to truncate
+   * @param table a table to truncate
+   * @throws ExecutionException if the operation failed
+   */
+  void truncateTable(String namespace, String table) throws ExecutionException;
+
+  /**
+   * Creates a secondary index for the specified column of the specified table.
+   *
+   * @param namespace a namespace to create a secondary index
+   * @param table a table to create a secondary index
+   * @param columnName a name of the target column
+   * @param options options to create a secondary index
+   * @throws ExecutionException if the operation failed
+   */
+  void createIndex(String namespace, String table, String columnName, Map<String, String> options)
+      throws ExecutionException;
+
+  /**
+   * Creates a secondary index for the specified column of the specified table.
+   *
+   * @param namespace a namespace to create a secondary index
+   * @param table a table to create a secondary index
+   * @param columnName a name of the target column
+   * @param ifNotExists if set to true, the secondary index will be created only if it does not
+   *     exist already. If set to false, it will try to create the secondary index but may throw an
+   *     exception if it already exists
+   * @param options options to create a secondary index
+   * @throws ExecutionException if the operation failed
+   */
+  default void createIndex(
+      String namespace,
+      String table,
+      String columnName,
+      boolean ifNotExists,
+      Map<String, String> options)
+      throws ExecutionException {
+    if (ifNotExists && indexExists(namespace, table, columnName)) {
+      return;
+    }
+    createIndex(namespace, table, columnName, options);
+  }
+
+  /**
+   * Creates a secondary index for the specified column of the specified table.
+   *
+   * @param namespace a namespace to create a secondary index
+   * @param table a table to create a secondary index
+   * @param columnName a name of the target column
+   * @param ifNotExists if set to true, the secondary index will be created only if it does not
+   *     exist already. If set to false, it will try to create the secondary index but may throw an
+   *     exception if it already exists
+   * @throws ExecutionException if the operation failed
+   */
+  default void createIndex(String namespace, String table, String columnName, boolean ifNotExists)
+      throws ExecutionException {
+    createIndex(namespace, table, columnName, ifNotExists, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a secondary index for the specified column of the specified table.
+   *
+   * @param namespace a namespace to create a secondary index
+   * @param table a table to create a secondary index
+   * @param columnName a name of the target column
+   * @throws ExecutionException if the operation failed
+   */
+  default void createIndex(String namespace, String table, String columnName)
+      throws ExecutionException {
+    createIndex(namespace, table, columnName, Collections.emptyMap());
+  }
+
+  /**
+   * Drops a secondary index for the specified column of the specified table.
+   *
+   * @param namespace a namespace to drop a secondary index
+   * @param table a table to drop a secondary index
+   * @param columnName a name of the target column
+   * @throws ExecutionException if the operation failed
+   */
+  void dropIndex(String namespace, String table, String columnName) throws ExecutionException;
+
+  /**
+   * Drops a secondary index for the specified column of the specified table.
+   *
+   * @param namespace a namespace to drop a secondary index
+   * @param table a table to drop a secondary index
+   * @param columnName a name of the target column
+   * @param ifExists if set to true, the secondary index will be dropped only if it exists. If set
+   *     to false, it will try to drop the secondary index but may throw an exception if it does not
+   *     exist
+   * @throws ExecutionException if the operation failed
+   */
+  default void dropIndex(String namespace, String table, String columnName, boolean ifExists)
+      throws ExecutionException {
+    if (ifExists && !indexExists(namespace, table, columnName)) {
+      return;
+    }
+    dropIndex(namespace, table, columnName);
+  }
+
+  /**
+   * Returns true if the secondary index exists.
+   *
+   * @param namespace a namespace
+   * @param table a table
+   * @param columnName a name of the target column
+   * @return true if the secondary index exists, false otherwise
+   * @throws ExecutionException if the operation failed
+   */
+  default boolean indexExists(String namespace, String table, String columnName)
+      throws ExecutionException {
+    return getTableMetadata(namespace, table).getSecondaryIndexNames().contains(columnName);
+  }
+
+  /**
+   * Creates a coordinator namespace and table if it does not exist.
+   *
+   * @param options options to create namespace and table
+   * @throws ExecutionException if the operation failed
+   */
+  void createCoordinatorNamespaceAndTable(Map<String, String> options) throws ExecutionException;
+
+  /**
+   * Creates a coordinator namespace and table if it does not exist.
+   *
+   * @param ifNotExists if set to true, the coordinator table will be created only if it does not
+   *     exist already. If set to false, it will try to create the coordinator table but may throw
+   *     an exception if it already exists
+   * @param options options to create namespace and table
+   * @throws ExecutionException if the operation failed
+   */
+  default void createCoordinatorNamespaceAndTable(boolean ifNotExists, Map<String, String> options)
+      throws ExecutionException {
+    if (ifNotExists && coordinatorTableExists()) {
+      return;
+    }
+    createCoordinatorNamespaceAndTable(options);
+  }
+
+  /**
+   * Creates a coordinator namespace and table if it does not exist.
+   *
+   * @param ifNotExists if set to true, the coordinator table will be created only if it does not
+   *     exist already. If set to false, it will try to create the coordinator table but may throw
+   *     an exception if it already exists
+   * @throws ExecutionException if the operation failed
+   */
+  default void createCoordinatorNamespaceAndTable(boolean ifNotExists) throws ExecutionException {
+    if (ifNotExists && coordinatorTableExists()) {
+      return;
+    }
+    createCoordinatorNamespaceAndTable(Collections.emptyMap());
+  }
+
+  /**
+   * Creates a coordinator namespace and table if it does not exist.
+   *
+   * @throws ExecutionException if the operation failed
+   */
+  default void createCoordinatorNamespaceAndTable() throws ExecutionException {
+    createCoordinatorNamespaceAndTable(Collections.emptyMap());
+  }
+
+  /**
+   * Drops a coordinator namespace and table.
+   *
+   * @throws ExecutionException if the operation failed
+   */
+  void dropCoordinatorNamespaceAndTable() throws ExecutionException;
+
+  /**
+   * Drops a coordinator namespace and table.
+   *
+   * @param ifExists if set to true, the coordinator table will be dropped only if it exists. If set
+   *     to false, it will try to drop the coordinator table but may throw an exception if it does
+   *     not exist
+   * @throws ExecutionException if the operation failed
+   */
+  default void dropCoordinatorNamespaceAndTable(boolean ifExists) throws ExecutionException {
+    if (ifExists && !coordinatorTableExists()) {
+      return;
+    }
+    dropCoordinatorNamespaceAndTable();
+  }
+
+  /**
+   * Truncates a coordinator table.
+   *
+   * @throws ExecutionException if the operation failed
+   */
+  void truncateCoordinatorTable() throws ExecutionException;
+
+  /**
+   * Returns true if a coordinator table exists.
+   *
+   * @return true if a coordinator table exists, false otherwise
+   * @throws ExecutionException if the operation failed
+   */
+  boolean coordinatorTableExists() throws ExecutionException;
+
+  /**
+   * Retrieves the table metadata of the specified table.
+   *
+   * @param namespace a namespace to retrieve
+   * @param table a table to retrieve
+   * @return the table metadata of the specified table. null if the table is not found.
+   * @throws ExecutionException if the operation failed
+   */
+  TableMetadata getTableMetadata(String namespace, String table) throws ExecutionException;
+
+  /**
+   * Returns the names of the table belonging to the given namespace.
+   *
+   * @param namespace a namespace
+   * @return a set of table names, an empty list if the namespace doesn't exist
+   * @throws ExecutionException if the operation failed
+   */
+  Set<String> getNamespaceTableNames(String namespace) throws ExecutionException;
+
+  /**
+   * Returns true if the namespace exists.
+   *
+   * @param namespace a namespace
+   * @return true if the namespace exists, false otherwise
+   * @throws ExecutionException if the operation failed
+   */
+  boolean namespaceExists(String namespace) throws ExecutionException;
+
+  /**
+   * Returns true if the table exists.
+   *
+   * @param namespace a namespace
+   * @param table a table
+   * @return true if the table exists, false otherwise
+   * @throws ExecutionException if the operation failed
+   */
+  default boolean tableExists(String namespace, String table) throws ExecutionException {
+    return getNamespaceTableNames(namespace).contains(table);
+  }
+
+  /** Closes connections to the storage. */
+  void close();
+}

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -8,6 +8,7 @@ import static com.scalar.db.config.ConfigUtils.getStringArray;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.storage.cassandra.Cassandra;
@@ -22,8 +23,10 @@ import com.scalar.db.storage.multistorage.MultiStorage;
 import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcStorage;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdmin;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitManager;
+import com.scalar.db.transaction.jdbc.JdbcTransactionAdmin;
 import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
 import com.scalar.db.transaction.rpc.GrpcTwoPhaseCommitTransactionManager;
@@ -49,8 +52,9 @@ public class DatabaseConfig {
   @Nullable private String username;
   @Nullable private String password;
   private Class<? extends DistributedStorage> storageClass;
-  private Class<? extends DistributedStorageAdmin> adminClass;
+  private Class<? extends DistributedStorageAdmin> storageAdminClass;
   private Class<? extends DistributedTransactionManager> transactionManagerClass;
+  private Class<? extends DistributedTransactionAdmin> transactionAdminClass;
   private Class<? extends TwoPhaseCommitTransactionManager> twoPhaseCommitTransactionManagerClass;
   private long tableMetadataCacheExpirationTimeSecs;
 
@@ -93,27 +97,27 @@ public class DatabaseConfig {
     switch (storage.toLowerCase()) {
       case "cassandra":
         storageClass = Cassandra.class;
-        adminClass = CassandraAdmin.class;
+        storageAdminClass = CassandraAdmin.class;
         break;
       case "cosmos":
         storageClass = Cosmos.class;
-        adminClass = CosmosAdmin.class;
+        storageAdminClass = CosmosAdmin.class;
         break;
       case "dynamo":
         storageClass = Dynamo.class;
-        adminClass = DynamoAdmin.class;
+        storageAdminClass = DynamoAdmin.class;
         break;
       case "jdbc":
         storageClass = JdbcDatabase.class;
-        adminClass = JdbcAdmin.class;
+        storageAdminClass = JdbcAdmin.class;
         break;
       case "multi-storage":
         storageClass = MultiStorage.class;
-        adminClass = MultiStorageAdmin.class;
+        storageAdminClass = MultiStorageAdmin.class;
         break;
       case "grpc":
         storageClass = GrpcStorage.class;
-        adminClass = GrpcAdmin.class;
+        storageAdminClass = GrpcAdmin.class;
         break;
       default:
         throw new IllegalArgumentException("storage '" + storage + "' isn't supported");
@@ -133,6 +137,7 @@ public class DatabaseConfig {
     switch (transactionManager.toLowerCase()) {
       case "consensus-commit":
         transactionManagerClass = ConsensusCommitManager.class;
+        transactionAdminClass = ConsensusCommitAdmin.class;
         twoPhaseCommitTransactionManagerClass = TwoPhaseConsensusCommitManager.class;
         break;
       case "jdbc":
@@ -145,6 +150,7 @@ public class DatabaseConfig {
                   + ")");
         }
         transactionManagerClass = JdbcTransactionManager.class;
+        transactionAdminClass = JdbcTransactionAdmin.class;
         twoPhaseCommitTransactionManagerClass = null;
         break;
       case "grpc":
@@ -157,6 +163,7 @@ public class DatabaseConfig {
                   + ")");
         }
         transactionManagerClass = GrpcTransactionManager.class;
+        transactionAdminClass = null;
         twoPhaseCommitTransactionManagerClass = GrpcTwoPhaseCommitTransactionManager.class;
         break;
       default:
@@ -188,17 +195,21 @@ public class DatabaseConfig {
     return storageClass;
   }
 
-  public Class<? extends DistributedStorageAdmin> getAdminClass() {
-    return adminClass;
+  public Class<? extends DistributedStorageAdmin> getStorageAdminClass() {
+    return storageAdminClass;
+  }
+
+  public Class<? extends DistributedTransactionManager> getTransactionManagerClass() {
+    return transactionManagerClass;
+  }
+
+  public Class<? extends DistributedTransactionAdmin> getTransactionAdminClass() {
+    return transactionAdminClass;
   }
 
   public Class<? extends TwoPhaseCommitTransactionManager>
       getTwoPhaseCommitTransactionManagerClass() {
     return twoPhaseCommitTransactionManagerClass;
-  }
-
-  public Class<? extends DistributedTransactionManager> getTransactionManagerClass() {
-    return transactionManagerClass;
   }
 
   public long getTableMetadataCacheExpirationTimeSecs() {

--- a/core/src/main/java/com/scalar/db/service/StorageModule.java
+++ b/core/src/main/java/com/scalar/db/service/StorageModule.java
@@ -22,7 +22,7 @@ public class StorageModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(DistributedStorage.class).to(config.getStorageClass()).in(Singleton.class);
-    bind(DistributedStorageAdmin.class).to(config.getAdminClass()).in(Singleton.class);
+    bind(DistributedStorageAdmin.class).to(config.getStorageAdminClass()).in(Singleton.class);
   }
 
   @Singleton

--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -2,6 +2,7 @@ package com.scalar.db.service;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -24,6 +25,15 @@ public class TransactionFactory {
    */
   public DistributedTransactionManager getTransactionManager() {
     return injector.getInstance(DistributedTransactionManager.class);
+  }
+
+  /**
+   * Returns a {@link DistributedTransactionAdmin} instance
+   *
+   * @return a {@link DistributedTransactionAdmin} instance
+   */
+  public DistributedTransactionAdmin getTransactionAdmin() {
+    return injector.getInstance(DistributedTransactionAdmin.class);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/service/TransactionModule.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionModule.java
@@ -5,6 +5,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -25,9 +26,12 @@ public class TransactionModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(DistributedStorage.class).to(config.getStorageClass()).in(Singleton.class);
-    bind(DistributedStorageAdmin.class).to(config.getAdminClass()).in(Singleton.class);
+    bind(DistributedStorageAdmin.class).to(config.getStorageAdminClass()).in(Singleton.class);
     bind(DistributedTransactionManager.class)
         .to(config.getTransactionManagerClass())
+        .in(Singleton.class);
+    bind(DistributedTransactionAdmin.class)
+        .to(config.getTransactionAdminClass())
         .in(Singleton.class);
     if (config.getTwoPhaseCommitTransactionManagerClass() != null) {
       bind(TwoPhaseCommitTransactionManager.class)

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -15,9 +15,13 @@ import com.scalar.db.storage.multistorage.MultiStorage;
 import com.scalar.db.storage.multistorage.MultiStorageAdmin;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcStorage;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdmin;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
+import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitManager;
+import com.scalar.db.transaction.jdbc.JdbcTransactionAdmin;
 import com.scalar.db.transaction.jdbc.JdbcTransactionManager;
 import com.scalar.db.transaction.rpc.GrpcTransactionManager;
+import com.scalar.db.transaction.rpc.GrpcTwoPhaseCommitTransactionManager;
 import java.util.Collections;
 import java.util.Properties;
 import org.junit.Test;
@@ -47,8 +51,11 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
+    assertThat(config.getTransactionAdminClass()).isEqualTo(ConsensusCommitAdmin.class);
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass())
+        .isEqualTo(TwoPhaseConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -70,8 +77,11 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
+    assertThat(config.getTransactionAdminClass()).isEqualTo(ConsensusCommitAdmin.class);
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass())
+        .isEqualTo(TwoPhaseConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -93,8 +103,11 @@ public class DatabaseConfigTest {
     assertThat(config.getUsername().get()).isEqualTo(ANY_USERNAME);
     assertThat(config.getPassword().isPresent()).isFalse();
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
+    assertThat(config.getTransactionAdminClass()).isEqualTo(ConsensusCommitAdmin.class);
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass())
+        .isEqualTo(TwoPhaseConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -118,8 +131,11 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
+    assertThat(config.getTransactionAdminClass()).isEqualTo(ConsensusCommitAdmin.class);
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass())
+        .isEqualTo(TwoPhaseConsensusCommitManager.class);
     assertThat(config.getTableMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
   }
 
@@ -166,7 +182,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CassandraAdmin.class);
   }
 
   @Test
@@ -189,7 +205,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
-    assertThat(config.getAdminClass()).isEqualTo(CosmosAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CosmosAdmin.class);
   }
 
   @Test
@@ -212,7 +228,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
-    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(DynamoAdmin.class);
   }
 
   @Test
@@ -235,7 +251,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(JdbcAdmin.class);
   }
 
   @Test
@@ -253,7 +269,7 @@ public class DatabaseConfigTest {
     assertThat(config.getUsername().isPresent()).isFalse();
     assertThat(config.getPassword().isPresent()).isFalse();
     assertThat(config.getStorageClass()).isEqualTo(MultiStorage.class);
-    assertThat(config.getAdminClass()).isEqualTo(MultiStorageAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(MultiStorageAdmin.class);
   }
 
   @Test
@@ -276,7 +292,7 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(GrpcStorage.class);
-    assertThat(config.getAdminClass()).isEqualTo(GrpcAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(GrpcAdmin.class);
   }
 
   @Test
@@ -314,8 +330,11 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(Cassandra.class);
-    assertThat(config.getAdminClass()).isEqualTo(CassandraAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CassandraAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(ConsensusCommitManager.class);
+    assertThat(config.getTransactionAdminClass()).isEqualTo(ConsensusCommitAdmin.class);
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass())
+        .isEqualTo(TwoPhaseConsensusCommitManager.class);
   }
 
   @Test
@@ -340,8 +359,10 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(JdbcTransactionManager.class);
+    assertThat(config.getTransactionAdminClass()).isEqualTo(JdbcTransactionAdmin.class);
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass()).isNull();
   }
 
   @Test
@@ -382,8 +403,11 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(GrpcStorage.class);
-    assertThat(config.getAdminClass()).isEqualTo(GrpcAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(GrpcAdmin.class);
     assertThat(config.getTransactionManagerClass()).isEqualTo(GrpcTransactionManager.class);
+    assertThat(config.getTransactionAdminClass()).isNull();
+    assertThat(config.getTwoPhaseCommitTransactionManagerClass())
+        .isEqualTo(GrpcTwoPhaseCommitTransactionManager.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
@@ -32,7 +32,7 @@ public class CosmosConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_KEY);
     assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
-    assertThat(config.getAdminClass()).isEqualTo(CosmosAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CosmosAdmin.class);
     assertThat(config.getTableMetadataDatabase()).isPresent();
     assertThat(config.getTableMetadataDatabase().get()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
   }
@@ -65,7 +65,7 @@ public class CosmosConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_KEY);
     assertThat(config.getStorageClass()).isEqualTo(Cosmos.class);
-    assertThat(config.getAdminClass()).isEqualTo(CosmosAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(CosmosAdmin.class);
     assertThat(config.getTableMetadataDatabase()).isNotPresent();
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
@@ -39,7 +39,7 @@ public class DynamoConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_SECRET_ACCESS_ID);
     assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
-    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(DynamoAdmin.class);
     assertThat(config.getEndpointOverride().isPresent()).isTrue();
     assertThat(config.getEndpointOverride().get()).isEqualTo(ANY_ENDPOINT_OVERRIDE);
     assertThat(config.getTableMetadataNamespace()).isPresent();
@@ -81,7 +81,7 @@ public class DynamoConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_SECRET_ACCESS_ID);
     assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
-    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(DynamoAdmin.class);
     assertThat(config.getEndpointOverride().isPresent()).isFalse();
     assertThat(config.getTableMetadataNamespace()).isPresent();
     assertThat(config.getTableMetadataNamespace().get()).isEqualTo(ANY_TABLE_METADATA_NAMESPACE);
@@ -108,7 +108,7 @@ public class DynamoConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_SECRET_ACCESS_ID);
     assertThat(config.getStorageClass()).isEqualTo(Dynamo.class);
-    assertThat(config.getAdminClass()).isEqualTo(DynamoAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(DynamoAdmin.class);
     assertThat(config.getEndpointOverride().isPresent()).isTrue();
     assertThat(config.getEndpointOverride().get()).isEqualTo(ANY_ENDPOINT_OVERRIDE);
     assertThat(config.getTableMetadataNamespace()).isNotPresent();

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -49,7 +49,7 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getConnectionPoolMinIdle()).isEqualTo(1);
     assertThat(config.getConnectionPoolMaxIdle()).isEqualTo(100);
     assertThat(config.getConnectionPoolMaxTotal()).isEqualTo(500);
@@ -88,7 +88,7 @@ public class JdbcConfigTest {
     assertThat(config.getPassword().isPresent()).isTrue();
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorageClass()).isEqualTo(JdbcDatabase.class);
-    assertThat(config.getAdminClass()).isEqualTo(JdbcAdmin.class);
+    assertThat(config.getStorageAdminClass()).isEqualTo(JdbcAdmin.class);
     assertThat(config.getConnectionPoolMinIdle())
         .isEqualTo(JdbcConfig.DEFAULT_CONNECTION_POOL_MIN_IDLE);
     assertThat(config.getConnectionPoolMaxIdle())

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
@@ -2,10 +2,12 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -13,6 +15,7 @@ import com.scalar.db.io.DataType;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -34,19 +37,20 @@ public class ConsensusCommitAdminTest {
   }
 
   @Test
-  public void createCoordinatorTable_shouldCreateCoordinatorTableProperly()
+  public void createCoordinatorNamespaceAndTable_shouldCreateCoordinatorTableProperly()
       throws ExecutionException {
-    createCoordinatorTable_shouldCreateCoordinatorTableProperly(Optional.empty());
+    createCoordinatorNamespaceAndTable_shouldCreateCoordinatorTableProperly(Optional.empty());
   }
 
   @Test
   public void
-      createCoordinatorTable_WithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
+      createCoordinatorNamespaceAndTable_WithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
           throws ExecutionException {
-    createCoordinatorTable_shouldCreateCoordinatorTableProperly(Optional.of("changed_coordinator"));
+    createCoordinatorNamespaceAndTable_shouldCreateCoordinatorTableProperly(
+        Optional.of("changed_coordinator"));
   }
 
-  private void createCoordinatorTable_shouldCreateCoordinatorTableProperly(
+  private void createCoordinatorNamespaceAndTable_shouldCreateCoordinatorTableProperly(
       Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
     String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
@@ -56,29 +60,35 @@ public class ConsensusCommitAdminTest {
     }
 
     // Act
-    admin.createCoordinatorTable();
+    admin.createCoordinatorNamespaceAndTable();
 
     // Assert
-    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true);
     verify(distributedStorageAdmin)
-        .createTable(coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, true);
+        .createNamespace(coordinatorNamespaceName, Collections.emptyMap());
+    verify(distributedStorageAdmin)
+        .createTable(
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA,
+            Collections.emptyMap());
   }
 
   @Test
-  public void createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly()
+  public void createCoordinatorNamespaceAndTable_WithOptions_shouldCreateCoordinatorTableProperly()
       throws ExecutionException {
-    createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly(Optional.empty());
+    createCoordinatorNamespaceAndTable_WithOptions_shouldCreateCoordinatorTableProperly(
+        Optional.empty());
   }
 
   @Test
   public void
-      createCoordinatorTable_WithOptionsWithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
+      createCoordinatorNamespaceAndTable_WithOptionsWithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
           throws ExecutionException {
-    createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly(
+    createCoordinatorNamespaceAndTable_WithOptions_shouldCreateCoordinatorTableProperly(
         Optional.of("changed_coordinator"));
   }
 
-  private void createCoordinatorTable_WithOptions_shouldCreateCoordinatorTableProperly(
+  private void createCoordinatorNamespaceAndTable_WithOptions_shouldCreateCoordinatorTableProperly(
       Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
     String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
@@ -90,13 +100,13 @@ public class ConsensusCommitAdminTest {
     Map<String, String> options = ImmutableMap.of("name", "value");
 
     // Act
-    admin.createCoordinatorTable(options);
+    admin.createCoordinatorNamespaceAndTable(options);
 
     // Assert
-    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, true, options);
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, options);
     verify(distributedStorageAdmin)
         .createTable(
-            coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, true, options);
+            coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, options);
   }
 
   @Test
@@ -130,18 +140,20 @@ public class ConsensusCommitAdminTest {
   }
 
   @Test
-  public void dropCoordinatorTable_shouldDropCoordinatorTableProperly() throws ExecutionException {
-    dropCoordinatorTable_shouldDropCoordinatorTableProperly(Optional.empty());
+  public void dropCoordinatorNamespaceAndTable_shouldDropCoordinatorTableProperly()
+      throws ExecutionException {
+    dropCoordinatorNamespaceAndTable_shouldDropCoordinatorTableProperly(Optional.empty());
   }
 
   @Test
   public void
-      dropCoordinatorTable_WithCoordinatorNamespaceChanged_shouldDropCoordinatorTableProperly()
+      dropCoordinatorNamespaceAndTable_WithCoordinatorNamespaceChanged_shouldDropCoordinatorTableProperly()
           throws ExecutionException {
-    dropCoordinatorTable_shouldDropCoordinatorTableProperly(Optional.of("changed_coordinator"));
+    dropCoordinatorNamespaceAndTable_shouldDropCoordinatorTableProperly(
+        Optional.of("changed_coordinator"));
   }
 
-  private void dropCoordinatorTable_shouldDropCoordinatorTableProperly(
+  private void dropCoordinatorNamespaceAndTable_shouldDropCoordinatorTableProperly(
       Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
     String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
@@ -151,7 +163,7 @@ public class ConsensusCommitAdminTest {
     }
 
     // Act
-    admin.dropCoordinatorTable();
+    admin.dropCoordinatorNamespaceAndTable();
 
     // Assert
     verify(distributedStorageAdmin).dropTable(coordinatorNamespaceName, Coordinator.TABLE);
@@ -189,7 +201,7 @@ public class ConsensusCommitAdminTest {
   }
 
   @Test
-  public void createTransactionalTable_tableMetadataGiven_shouldCreateTransactionalTableProperly()
+  public void createTable_tableMetadataGiven_shouldCreateTransactionalTableProperly()
       throws ExecutionException {
     // Arrange
     final String ACCOUNT_ID = "account_id";
@@ -226,7 +238,7 @@ public class ConsensusCommitAdminTest {
             .build();
 
     // Act
-    admin.createTransactionalTable(NAMESPACE, TABLE, tableMetadata);
+    admin.createTable(NAMESPACE, TABLE, tableMetadata);
 
     // Assert
     verify(distributedStorageAdmin).createTable(NAMESPACE, TABLE, expected, Collections.emptyMap());
@@ -234,13 +246,13 @@ public class ConsensusCommitAdminTest {
 
   @Test
   public void
-      createTransactionalTable_tableMetadataThatHasTransactionMetaColumnGiven_shouldThrowIllegalArgumentException() {
+      createTable_tableMetadataThatHasTransactionMetaColumnGiven_shouldThrowIllegalArgumentException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(
             () ->
-                admin.createTransactionalTable(
+                admin.createTable(
                     NAMESPACE,
                     TABLE,
                     TableMetadata.newBuilder()
@@ -254,13 +266,13 @@ public class ConsensusCommitAdminTest {
 
   @Test
   public void
-      createTransactionalTable_tableMetadataThatHasNonPrimaryKeyColumnWithBeforePrefixGiven_shouldThrowIllegalArgumentException() {
+      createTable_tableMetadataThatHasNonPrimaryKeyColumnWithBeforePrefixGiven_shouldThrowIllegalArgumentException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(
             () ->
-                admin.createTransactionalTable(
+                admin.createTable(
                     NAMESPACE,
                     TABLE,
                     TableMetadata.newBuilder()
@@ -272,5 +284,144 @@ public class ConsensusCommitAdminTest {
                         .addPartitionKey("col1")
                         .build()))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void createNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.createNamespace("ns", Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).createNamespace("ns", Collections.emptyMap());
+  }
+
+  @Test
+  public void dropTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropTable("ns", "tbl");
+
+    // Assert
+    verify(distributedStorageAdmin).dropTable("ns", "tbl");
+  }
+
+  @Test
+  public void dropNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropNamespace("ns");
+
+    // Assert
+    verify(distributedStorageAdmin).dropNamespace("ns");
+  }
+
+  @Test
+  public void truncateTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.truncateTable("ns", "tbl");
+
+    // Assert
+    verify(distributedStorageAdmin).truncateTable("ns", "tbl");
+  }
+
+  @Test
+  public void createIndex_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.createIndex("ns", "tbl", "col", Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).createIndex("ns", "tbl", "col", Collections.emptyMap());
+  }
+
+  @Test
+  public void dropIndex_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropIndex("ns", "tbl", "col");
+
+    // Assert
+    verify(distributedStorageAdmin).dropIndex("ns", "tbl", "col");
+  }
+
+  @Test
+  public void getTableMetadata_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String BALANCE = "balance";
+
+    TableMetadata tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_PREFIX + BALANCE, DataType.INT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .build();
+
+    TableMetadata expected =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .build();
+
+    when(distributedStorageAdmin.getTableMetadata(any(), any())).thenReturn(tableMetadata);
+
+    // Act
+    TableMetadata actual = admin.getTableMetadata("ns", "tbl");
+
+    // Assert
+    verify(distributedStorageAdmin).getTableMetadata("ns", "tbl");
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void getNamespaceTableNames_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    Set<String> tableNames = ImmutableSet.of("tbl1", "tbl2", "tbl3");
+    when(distributedStorageAdmin.getNamespaceTableNames(any())).thenReturn(tableNames);
+
+    // Act
+    Set<String> actual = admin.getNamespaceTableNames("ns");
+
+    // Assert
+    verify(distributedStorageAdmin).getNamespaceTableNames("ns");
+    assertThat(actual).isEqualTo(tableNames);
+  }
+
+  @Test
+  public void namespaceExists_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.namespaceExists(any())).thenReturn(true);
+
+    // Act
+    boolean actual = admin.namespaceExists("ns");
+
+    // Assert
+    verify(distributedStorageAdmin).namespaceExists("ns");
+    assertThat(actual).isTrue();
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -1,0 +1,188 @@
+package com.scalar.db.transaction.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.storage.jdbc.JdbcAdmin;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class JdbcTransactionAdminTest {
+
+  @Mock private JdbcAdmin jdbcAdmin;
+  private JdbcTransactionAdmin admin;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    admin = new JdbcTransactionAdmin(jdbcAdmin);
+  }
+
+  @Test
+  public void createNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.createNamespace("ns", Collections.emptyMap());
+
+    // Assert
+    verify(jdbcAdmin).createNamespace("ns", Collections.emptyMap());
+  }
+
+  @Test
+  public void createTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
+
+    // Act
+    admin.createTable("ns", "tbl", metadata, Collections.emptyMap());
+
+    // Assert
+    verify(jdbcAdmin).createTable("ns", "tbl", metadata, Collections.emptyMap());
+  }
+
+  @Test
+  public void dropTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropTable("ns", "tbl");
+
+    // Assert
+    verify(jdbcAdmin).dropTable("ns", "tbl");
+  }
+
+  @Test
+  public void dropNamespace_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropNamespace("ns");
+
+    // Assert
+    verify(jdbcAdmin).dropNamespace("ns");
+  }
+
+  @Test
+  public void truncateTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.truncateTable("ns", "tbl");
+
+    // Assert
+    verify(jdbcAdmin).truncateTable("ns", "tbl");
+  }
+
+  @Test
+  public void createIndex_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.createIndex("ns", "tbl", "col", Collections.emptyMap());
+
+    // Assert
+    verify(jdbcAdmin).createIndex("ns", "tbl", "col", Collections.emptyMap());
+  }
+
+  @Test
+  public void dropIndex_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropIndex("ns", "tbl", "col");
+
+    // Assert
+    verify(jdbcAdmin).dropIndex("ns", "tbl", "col");
+  }
+
+  @Test
+  public void getTableMetadata_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
+    when(jdbcAdmin.getTableMetadata(any(), any())).thenReturn(metadata);
+
+    // Act
+    TableMetadata actual = admin.getTableMetadata("ns", "tbl");
+
+    // Assert
+    verify(jdbcAdmin).getTableMetadata("ns", "tbl");
+    assertThat(actual).isEqualTo(metadata);
+  }
+
+  @Test
+  public void getNamespaceTableNames_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    Set<String> tableNames = ImmutableSet.of("tbl1", "tbl2", "tbl3");
+    when(jdbcAdmin.getNamespaceTableNames(any())).thenReturn(tableNames);
+
+    // Act
+    Set<String> actual = admin.getNamespaceTableNames("ns");
+
+    // Assert
+    verify(jdbcAdmin).getNamespaceTableNames("ns");
+    assertThat(actual).isEqualTo(tableNames);
+  }
+
+  @Test
+  public void namespaceExists_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    when(jdbcAdmin.namespaceExists(any())).thenReturn(true);
+
+    // Act
+    boolean actual = admin.namespaceExists("ns");
+
+    // Assert
+    verify(jdbcAdmin).namespaceExists("ns");
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void createCoordinatorNamespaceAndTable_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.createCoordinatorNamespaceAndTable(Collections.emptyMap()))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void dropCoordinatorNamespaceAndTable_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.dropCoordinatorNamespaceAndTable())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void truncateCoordinatorTable_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.truncateCoordinatorTable())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void coordinatorTableExists_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.coordinatorTableExists())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -50,8 +50,7 @@ public class SchemaOperatorTest {
     // Assert
     verify(admin, times(3)).createNamespace("ns", true, options);
     verify(admin, times(3)).tableExists("ns", "tb");
-    verify(consensusCommitAdmin, times(3))
-        .createTransactionalTable("ns", "tb", tableMetadata, options);
+    verify(consensusCommitAdmin, times(3)).createTable("ns", "tb", tableMetadata, options);
   }
 
   @Test
@@ -85,7 +84,7 @@ public class SchemaOperatorTest {
 
     // Assert
     verify(consensusCommitAdmin).coordinatorTableExists();
-    verify(consensusCommitAdmin).createCoordinatorTable(options);
+    verify(consensusCommitAdmin).createCoordinatorNamespaceAndTable(options);
   }
 
   @Test
@@ -99,7 +98,7 @@ public class SchemaOperatorTest {
 
     // Assert
     verify(consensusCommitAdmin).coordinatorTableExists();
-    verify(consensusCommitAdmin, never()).createCoordinatorTable(options);
+    verify(consensusCommitAdmin, never()).createCoordinatorNamespaceAndTable(options);
   }
 
   @Test
@@ -134,7 +133,7 @@ public class SchemaOperatorTest {
 
     // Assert
     verify(consensusCommitAdmin).coordinatorTableExists();
-    verify(consensusCommitAdmin).dropCoordinatorTable();
+    verify(consensusCommitAdmin).dropCoordinatorNamespaceAndTable();
   }
 
   @Test
@@ -148,6 +147,6 @@ public class SchemaOperatorTest {
 
     // Assert
     verify(consensusCommitAdmin).coordinatorTableExists();
-    verify(consensusCommitAdmin, never()).dropCoordinatorTable();
+    verify(consensusCommitAdmin, never()).dropCoordinatorNamespaceAndTable();
   }
 }

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminServiceIntegrationTest.java
@@ -2,11 +2,11 @@ package com.scalar.db.server;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.storage.AdminIntegrationTestBase;
+import com.scalar.db.storage.StorageAdminIntegrationTestBase;
 import java.io.IOException;
 import org.junit.AfterClass;
 
-public class DistributedStorageAdminServiceIntegrationTest extends AdminIntegrationTestBase {
+public class DistributedStorageAdminServiceIntegrationTest extends StorageAdminIntegrationTestBase {
 
   private static ScalarDbServer server;
 
@@ -26,7 +26,7 @@ public class DistributedStorageAdminServiceIntegrationTest extends AdminIntegrat
 
   @AfterClass
   public static void tearDownAfterClass() throws ExecutionException {
-    AdminIntegrationTestBase.tearDownAfterClass();
+    StorageAdminIntegrationTestBase.tearDownAfterClass();
     if (server != null) {
       server.shutdown();
       server.blockUntilShutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedTransactionServiceWithConsensusCommitIntegrationTest.java
@@ -84,9 +84,9 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
             .addClusteringKey(ACCOUNT_TYPE)
             .build();
     admin.createNamespace(NAMESPACE, true);
-    consensusCommitAdmin.createTransactionalTable(NAMESPACE, TABLE_1, tableMetadata, true);
-    consensusCommitAdmin.createTransactionalTable(NAMESPACE, TABLE_2, tableMetadata, true);
-    consensusCommitAdmin.createCoordinatorTable();
+    consensusCommitAdmin.createTable(NAMESPACE, TABLE_1, tableMetadata, true);
+    consensusCommitAdmin.createTable(NAMESPACE, TABLE_2, tableMetadata, true);
+    consensusCommitAdmin.createCoordinatorNamespaceAndTable();
   }
 
   @Before
@@ -118,7 +118,7 @@ public class DistributedTransactionServiceWithConsensusCommitIntegrationTest {
     admin.dropTable(NAMESPACE, TABLE_1);
     admin.dropTable(NAMESPACE, TABLE_2);
     admin.dropNamespace(NAMESPACE);
-    consensusCommitAdmin.dropCoordinatorTable();
+    consensusCommitAdmin.dropCoordinatorNamespaceAndTable();
   }
 
   @Test


### PR DESCRIPTION
This PR introduces a new `DistributedTransactionAdmin` class that abstracts the administrative operations for distributed transactions like createNamespace/createTable/getTableMetadata. This PR also adds the implementation classes of `DistributedTransactionAdmin`, `ConsensusCommitAdmin` and `JdbcTransactionAdmin`. I will add inline comment for more details. Please take a look!