### PR TITLE
Support alias in SQL API

### DIFF
--- a/core/src/main/java/com/scalar/db/sql/Projection.java
+++ b/core/src/main/java/com/scalar/db/sql/Projection.java
@@ -1,0 +1,51 @@
+package com.scalar.db.sql;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class Projection {
+
+  public final String columnName;
+  @Nullable public final String alias;
+
+  private Projection(String columnName, @Nullable String alias) {
+    this.columnName = Objects.requireNonNull(columnName);
+    this.alias = alias;
+  }
+
+  public Projection as(String alias) {
+    return new Projection(columnName, alias);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("columnName", columnName)
+        .add("alias", alias)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Projection)) {
+      return false;
+    }
+    Projection that = (Projection) o;
+    return Objects.equals(columnName, that.columnName) && Objects.equals(alias, that.alias);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(columnName, alias);
+  }
+
+  public static Projection column(String columnName) {
+    return new Projection(columnName, null);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/ResultIteratorResultSet.java
+++ b/core/src/main/java/com/scalar/db/sql/ResultIteratorResultSet.java
@@ -1,8 +1,8 @@
 package com.scalar.db.sql;
 
-import com.google.common.collect.ImmutableList;
 import com.scalar.db.api.Result;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -11,34 +11,34 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class ResultIteratorResultSet implements ResultSet {
 
   private final Iterator<Result> iterator;
-  private final ImmutableList<String> projectedColumnNames;
+  private final List<Projection> projections;
 
-  ResultIteratorResultSet(Iterator<Result> iterator, ImmutableList<String> projectedColumnNames) {
+  ResultIteratorResultSet(Iterator<Result> iterator, List<Projection> projections) {
     this.iterator = Objects.requireNonNull(iterator);
-    this.projectedColumnNames = Objects.requireNonNull(projectedColumnNames);
+    this.projections = Objects.requireNonNull(projections);
   }
 
   @Override
   public Optional<Record> one() {
     if (iterator.hasNext()) {
-      return Optional.of(new ResultRecord(iterator.next(), projectedColumnNames));
+      return Optional.of(new ResultRecord(iterator.next(), projections));
     }
     return Optional.empty();
   }
 
   @Override
   public Iterator<Record> iterator() {
-    return new ResultIterator(iterator, projectedColumnNames);
+    return new ResultIterator(iterator, projections);
   }
 
   private static class ResultIterator implements Iterator<Record> {
 
     private final Iterator<Result> iterator;
-    private final ImmutableList<String> projectedColumnNames;
+    private final List<Projection> projections;
 
-    public ResultIterator(Iterator<Result> iterator, ImmutableList<String> projectedColumnNames) {
+    public ResultIterator(Iterator<Result> iterator, List<Projection> projections) {
       this.iterator = iterator;
-      this.projectedColumnNames = projectedColumnNames;
+      this.projections = projections;
     }
 
     @Override
@@ -48,7 +48,7 @@ public class ResultIteratorResultSet implements ResultSet {
 
     @Override
     public Record next() {
-      return new ResultRecord(iterator.next(), projectedColumnNames);
+      return new ResultRecord(iterator.next(), projections);
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/sql/StatementValidator.java
+++ b/core/src/main/java/com/scalar/db/sql/StatementValidator.java
@@ -100,10 +100,9 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
     ImmutableListMultimap<String, Predicate> predicatesMap =
         Multimaps.index(statement.predicates, c -> c.columnName);
 
-    // duplication check for projected column names
-    ImmutableSet<String> projectedColumnNamesSet =
-        ImmutableSet.copyOf(statement.projectedColumnNames);
-    if (statement.projectedColumnNames.size() != projectedColumnNamesSet.size()) {
+    // duplication check for projections
+    ImmutableSet<Projection> projectionSet = ImmutableSet.copyOf(statement.projections);
+    if (statement.projections.size() != projectionSet.size()) {
       throw new IllegalArgumentException(
           "Specifying duplicated projected column names is not allowed");
     }

--- a/core/src/main/java/com/scalar/db/sql/builder/SelectStatementBuilder.java
+++ b/core/src/main/java/com/scalar/db/sql/builder/SelectStatementBuilder.java
@@ -3,6 +3,7 @@ package com.scalar.db.sql.builder;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.sql.ClusteringOrdering;
 import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.Projection;
 import com.scalar.db.sql.statement.SelectStatement;
 import java.util.List;
 
@@ -11,25 +12,25 @@ public final class SelectStatementBuilder {
   private SelectStatementBuilder() {}
 
   public static class Start {
-    private final ImmutableList<String> projectedColumnNames;
+    private final ImmutableList<Projection> projections;
 
-    Start(List<String> projectedColumnNames) {
-      this.projectedColumnNames = ImmutableList.copyOf(projectedColumnNames);
+    Start(List<Projection> projections) {
+      this.projections = ImmutableList.copyOf(projections);
     }
 
     public WhereStart from(String namespaceName, String tableName) {
-      return new WhereStart(projectedColumnNames, namespaceName, tableName);
+      return new WhereStart(projections, namespaceName, tableName);
     }
   }
 
   public static class WhereStart {
-    private final ImmutableList<String> projectedColumnNames;
+    private final ImmutableList<Projection> projections;
     private final String namespaceName;
     private final String tableName;
 
     private WhereStart(
-        ImmutableList<String> projectedColumnNames, String namespaceName, String tableName) {
-      this.projectedColumnNames = projectedColumnNames;
+        ImmutableList<Projection> projections, String namespaceName, String tableName) {
+      this.projections = projections;
       this.namespaceName = namespaceName;
       this.tableName = tableName;
     }
@@ -37,23 +38,23 @@ public final class SelectStatementBuilder {
     public OngoingWhere where(Predicate predicate) {
       ImmutableList.Builder<Predicate> predicatesBuilder = ImmutableList.builder();
       predicatesBuilder.add(predicate);
-      return new OngoingWhere(projectedColumnNames, namespaceName, tableName, predicatesBuilder);
+      return new OngoingWhere(projections, namespaceName, tableName, predicatesBuilder);
     }
 
     public Buildable where(List<Predicate> predicates) {
       ImmutableList.Builder<Predicate> predicatesBuilder = ImmutableList.builder();
       predicatesBuilder.addAll(predicates);
-      return new Buildable(projectedColumnNames, namespaceName, tableName, predicatesBuilder);
+      return new Buildable(projections, namespaceName, tableName, predicatesBuilder);
     }
   }
 
   public static class OngoingWhere extends Buildable {
     private OngoingWhere(
-        ImmutableList<String> projectedColumnNames,
+        ImmutableList<Projection> projections,
         String namespaceName,
         String tableName,
         ImmutableList.Builder<Predicate> predicatesBuilder) {
-      super(projectedColumnNames, namespaceName, tableName, predicatesBuilder);
+      super(projections, namespaceName, tableName, predicatesBuilder);
     }
 
     public OngoingWhere and(Predicate predicate) {
@@ -63,7 +64,7 @@ public final class SelectStatementBuilder {
   }
 
   public static class Buildable {
-    private final ImmutableList<String> projectedColumnNames;
+    private final ImmutableList<Projection> projections;
     private final String namespaceName;
     private final String tableName;
     protected final ImmutableList.Builder<Predicate> predicatesBuilder;
@@ -71,11 +72,11 @@ public final class SelectStatementBuilder {
     private int limit;
 
     private Buildable(
-        ImmutableList<String> projectedColumnNames,
+        ImmutableList<Projection> projections,
         String namespaceName,
         String tableName,
         ImmutableList.Builder<Predicate> predicatesBuilder) {
-      this.projectedColumnNames = projectedColumnNames;
+      this.projections = projections;
       this.namespaceName = namespaceName;
       this.tableName = tableName;
       this.predicatesBuilder = predicatesBuilder;
@@ -100,7 +101,7 @@ public final class SelectStatementBuilder {
       return SelectStatement.of(
           namespaceName,
           tableName,
-          projectedColumnNames,
+          projections,
           predicatesBuilder.build(),
           clusteringOrderings,
           limit);

--- a/core/src/main/java/com/scalar/db/sql/builder/StatementBuilder.java
+++ b/core/src/main/java/com/scalar/db/sql/builder/StatementBuilder.java
@@ -1,7 +1,9 @@
 package com.scalar.db.sql.builder;
 
+import com.scalar.db.sql.Projection;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class StatementBuilder {
 
@@ -50,11 +52,16 @@ public final class StatementBuilder {
   }
 
   public static SelectStatementBuilder.Start select(String... projectedColumnNames) {
-    return new SelectStatementBuilder.Start(Arrays.asList(projectedColumnNames));
+    return new SelectStatementBuilder.Start(
+        Arrays.stream(projectedColumnNames).map(Projection::column).collect(Collectors.toList()));
   }
 
-  public static SelectStatementBuilder.Start select(List<String> projectedColumnNames) {
-    return new SelectStatementBuilder.Start(projectedColumnNames);
+  public static SelectStatementBuilder.Start select(Projection... projections) {
+    return new SelectStatementBuilder.Start(Arrays.asList(projections));
+  }
+
+  public static SelectStatementBuilder.Start select(List<Projection> projections) {
+    return new SelectStatementBuilder.Start(projections);
   }
 
   public static InsertStatementBuilder.Start insertInto(String namespaceName, String tableName) {

--- a/core/src/main/java/com/scalar/db/sql/statement/SelectStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/SelectStatement.java
@@ -4,6 +4,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.sql.ClusteringOrdering;
 import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.Projection;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
@@ -12,7 +13,7 @@ public class SelectStatement implements DmlStatement {
 
   public final String namespaceName;
   public final String tableName;
-  public final ImmutableList<String> projectedColumnNames;
+  public final ImmutableList<Projection> projections;
   public final ImmutableList<Predicate> predicates;
   public final ImmutableList<ClusteringOrdering> clusteringOrderings;
   public final int limit;
@@ -20,13 +21,13 @@ public class SelectStatement implements DmlStatement {
   private SelectStatement(
       String namespaceName,
       String tableName,
-      ImmutableList<String> projectedColumnNames,
+      ImmutableList<Projection> projections,
       ImmutableList<Predicate> predicates,
       ImmutableList<ClusteringOrdering> clusteringOrderings,
       int limit) {
     this.namespaceName = Objects.requireNonNull(namespaceName);
     this.tableName = Objects.requireNonNull(tableName);
-    this.projectedColumnNames = Objects.requireNonNull(projectedColumnNames);
+    this.projections = Objects.requireNonNull(projections);
     this.predicates = Objects.requireNonNull(predicates);
     this.clusteringOrderings = Objects.requireNonNull(clusteringOrderings);
     this.limit = limit;
@@ -47,7 +48,7 @@ public class SelectStatement implements DmlStatement {
     return MoreObjects.toStringHelper(this)
         .add("namespaceName", namespaceName)
         .add("tableName", tableName)
-        .add("projectedColumnNames", projectedColumnNames)
+        .add("projectedColumnNames", projections)
         .add("predicates", predicates)
         .add("clusteringOrderings", clusteringOrderings)
         .add("limit", limit)
@@ -66,7 +67,7 @@ public class SelectStatement implements DmlStatement {
     return limit == that.limit
         && Objects.equals(namespaceName, that.namespaceName)
         && Objects.equals(tableName, that.tableName)
-        && Objects.equals(projectedColumnNames, that.projectedColumnNames)
+        && Objects.equals(projections, that.projections)
         && Objects.equals(predicates, that.predicates)
         && Objects.equals(clusteringOrderings, that.clusteringOrderings);
   }
@@ -74,17 +75,17 @@ public class SelectStatement implements DmlStatement {
   @Override
   public int hashCode() {
     return Objects.hash(
-        namespaceName, tableName, projectedColumnNames, predicates, clusteringOrderings, limit);
+        namespaceName, tableName, projections, predicates, clusteringOrderings, limit);
   }
 
   public static SelectStatement of(
       String namespaceName,
       String tableName,
-      ImmutableList<String> projectedColumnNames,
+      ImmutableList<Projection> projections,
       ImmutableList<Predicate> predicates,
       ImmutableList<ClusteringOrdering> clusteringOrderings,
       int limit) {
     return new SelectStatement(
-        namespaceName, tableName, projectedColumnNames, predicates, clusteringOrderings, limit);
+        namespaceName, tableName, projections, predicates, clusteringOrderings, limit);
   }
 }

--- a/core/src/test/java/com/scalar/db/sql/DmlStatementExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/DmlStatementExecutorTest.java
@@ -72,7 +72,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col1"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col1")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -141,7 +146,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1").as("a"),
+                Projection.column("p2").as("b"),
+                Projection.column("c1").as("c"),
+                Projection.column("c2").as("d"),
+                Projection.column("col2").as("e")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -180,7 +190,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -218,7 +233,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -255,7 +275,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -291,7 +316,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -328,7 +358,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -363,7 +398,12 @@ public class DmlStatementExecutorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("col2", "p1", "p2", "c1", "c2"),
+            ImmutableList.of(
+                Projection.column("col2"),
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2")),
             ImmutableList.of(Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
             ImmutableList.of(),
             100);

--- a/core/src/test/java/com/scalar/db/sql/ProjectionTest.java
+++ b/core/src/test/java/com/scalar/db/sql/ProjectionTest.java
@@ -1,0 +1,32 @@
+package com.scalar.db.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ProjectionTest {
+
+  @Test
+  public void column_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    Projection actual = Projection.column("col");
+
+    // Assert
+    assertThat(actual.columnName).isEqualTo("col");
+    assertThat(actual.alias).isNull();
+  }
+
+  @Test
+  public void as_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    Projection actual = Projection.column("col1").as("col2");
+
+    // Assert
+    assertThat(actual.columnName).isEqualTo("col1");
+    assertThat(actual.alias).isEqualTo("col2");
+  }
+}

--- a/core/src/test/java/com/scalar/db/sql/ResultIteratorResultSetTest.java
+++ b/core/src/test/java/com/scalar/db/sql/ResultIteratorResultSetTest.java
@@ -71,7 +71,11 @@ public class ResultIteratorResultSetTest {
     resultIteratorResultSet =
         new ResultIteratorResultSet(
             Arrays.asList(result1, result2, result3).iterator(),
-            ImmutableList.of(COLUMN_NAME_1, COLUMN_NAME_2, COLUMN_NAME_3, COLUMN_NAME_4));
+            ImmutableList.of(
+                Projection.column(COLUMN_NAME_1),
+                Projection.column(COLUMN_NAME_2),
+                Projection.column(COLUMN_NAME_3),
+                Projection.column(COLUMN_NAME_4)));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/sql/ResultRecordTest.java
+++ b/core/src/test/java/com/scalar/db/sql/ResultRecordTest.java
@@ -31,6 +31,14 @@ public class ResultRecordTest {
   private static final String COLUMN_NAME_6 = "col6";
   private static final String COLUMN_NAME_7 = "col7";
 
+  private static final String ALIAS_1 = "alias1";
+  private static final String ALIAS_2 = "alias2";
+  private static final String ALIAS_3 = "alias3";
+  private static final String ALIAS_4 = "alias4";
+  private static final String ALIAS_5 = "alias5";
+  private static final String ALIAS_6 = "alias6";
+  private static final String ALIAS_7 = "alias7";
+
   private static final com.scalar.db.api.TableMetadata TABLE_METADATA =
       ConsensusCommitUtils.buildTransactionalTableMetadata(
           TableMetadata.newBuilder()
@@ -65,13 +73,13 @@ public class ResultRecordTest {
                     .build(),
                 TABLE_METADATA),
             ImmutableList.of(
-                COLUMN_NAME_4,
-                COLUMN_NAME_7,
-                COLUMN_NAME_6,
-                COLUMN_NAME_2,
-                COLUMN_NAME_3,
-                COLUMN_NAME_1,
-                COLUMN_NAME_5));
+                Projection.column(COLUMN_NAME_4),
+                Projection.column(COLUMN_NAME_7),
+                Projection.column(COLUMN_NAME_6),
+                Projection.column(COLUMN_NAME_2),
+                Projection.column(COLUMN_NAME_3),
+                Projection.column(COLUMN_NAME_1),
+                Projection.column(COLUMN_NAME_5)));
   }
 
   @Test
@@ -96,6 +104,46 @@ public class ResultRecordTest {
     assertThat(resultRecord.getDouble(COLUMN_NAME_5)).isEqualTo(4.56);
     assertThat(resultRecord.getText(COLUMN_NAME_6)).isEqualTo("text");
     assertThat(resultRecord.getBlob(COLUMN_NAME_7))
+        .isEqualTo(ByteBuffer.wrap("blob".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  public void getXXX_NameGiven_WithAlias_ShouldReturnCorrectResult() {
+    // Arrange
+    resultRecord =
+        new ResultRecord(
+            new ResultImpl(
+                ImmutableMap.<String, Column<?>>builder()
+                    .put(COLUMN_NAME_1, IntColumn.of(COLUMN_NAME_1, 10))
+                    .put(COLUMN_NAME_2, BooleanColumn.of(COLUMN_NAME_2, true))
+                    .put(COLUMN_NAME_3, BigIntColumn.of(COLUMN_NAME_3, 100L))
+                    .put(COLUMN_NAME_4, FloatColumn.of(COLUMN_NAME_4, 1.23F))
+                    .put(COLUMN_NAME_5, DoubleColumn.of(COLUMN_NAME_5, 4.56))
+                    .put(COLUMN_NAME_6, TextColumn.of(COLUMN_NAME_6, "text"))
+                    .put(
+                        COLUMN_NAME_7,
+                        BlobColumn.of(COLUMN_NAME_7, "blob".getBytes(StandardCharsets.UTF_8)))
+                    .build(),
+                TABLE_METADATA),
+            ImmutableList.of(
+                Projection.column(COLUMN_NAME_4).as(ALIAS_4),
+                Projection.column(COLUMN_NAME_7).as(ALIAS_7),
+                Projection.column(COLUMN_NAME_6).as(ALIAS_6),
+                Projection.column(COLUMN_NAME_2).as(ALIAS_2),
+                Projection.column(COLUMN_NAME_3).as(ALIAS_3),
+                Projection.column(COLUMN_NAME_1).as(ALIAS_1),
+                Projection.column(COLUMN_NAME_5).as(ALIAS_5)));
+
+    // Act Assert
+    assertThat(resultRecord.getContainedColumnNames())
+        .isEqualTo(ImmutableSet.of(ALIAS_1, ALIAS_2, ALIAS_3, ALIAS_4, ALIAS_5, ALIAS_6, ALIAS_7));
+    assertThat(resultRecord.getInt(ALIAS_1)).isEqualTo(10);
+    assertThat(resultRecord.getBoolean(ALIAS_2)).isTrue();
+    assertThat(resultRecord.getBigInt(ALIAS_3)).isEqualTo(100L);
+    assertThat(resultRecord.getFloat(ALIAS_4)).isEqualTo(1.23F);
+    assertThat(resultRecord.getDouble(ALIAS_5)).isEqualTo(4.56);
+    assertThat(resultRecord.getText(ALIAS_6)).isEqualTo("text");
+    assertThat(resultRecord.getBlob(ALIAS_7))
         .isEqualTo(ByteBuffer.wrap("blob".getBytes(StandardCharsets.UTF_8)));
   }
 
@@ -132,13 +180,13 @@ public class ResultRecordTest {
                     .build(),
                 TABLE_METADATA),
             ImmutableList.of(
-                COLUMN_NAME_4,
-                COLUMN_NAME_7,
-                COLUMN_NAME_6,
-                COLUMN_NAME_2,
-                COLUMN_NAME_3,
-                COLUMN_NAME_1,
-                COLUMN_NAME_5));
+                Projection.column(COLUMN_NAME_4),
+                Projection.column(COLUMN_NAME_7),
+                Projection.column(COLUMN_NAME_6),
+                Projection.column(COLUMN_NAME_2),
+                Projection.column(COLUMN_NAME_3),
+                Projection.column(COLUMN_NAME_1),
+                Projection.column(COLUMN_NAME_5)));
 
     // Act Assert
     assertThat(resultRecord.getContainedColumnNames())
@@ -161,6 +209,43 @@ public class ResultRecordTest {
   }
 
   @Test
+  public void isNull_NameGiven_WithAlias_ShouldReturnCorrectResult() {
+    // Arrange
+    resultRecord =
+        new ResultRecord(
+            new ResultImpl(
+                ImmutableMap.<String, Column<?>>builder()
+                    .put(COLUMN_NAME_1, IntColumn.ofNull(COLUMN_NAME_1))
+                    .put(COLUMN_NAME_2, BooleanColumn.ofNull(COLUMN_NAME_2))
+                    .put(COLUMN_NAME_3, BigIntColumn.ofNull(COLUMN_NAME_3))
+                    .put(COLUMN_NAME_4, FloatColumn.ofNull(COLUMN_NAME_4))
+                    .put(COLUMN_NAME_5, DoubleColumn.ofNull(COLUMN_NAME_5))
+                    .put(COLUMN_NAME_6, TextColumn.ofNull(COLUMN_NAME_6))
+                    .put(COLUMN_NAME_7, BlobColumn.ofNull(COLUMN_NAME_7))
+                    .build(),
+                TABLE_METADATA),
+            ImmutableList.of(
+                Projection.column(COLUMN_NAME_4).as(ALIAS_4),
+                Projection.column(COLUMN_NAME_7).as(ALIAS_7),
+                Projection.column(COLUMN_NAME_6).as(ALIAS_6),
+                Projection.column(COLUMN_NAME_2).as(ALIAS_2),
+                Projection.column(COLUMN_NAME_3).as(ALIAS_3),
+                Projection.column(COLUMN_NAME_1).as(ALIAS_1),
+                Projection.column(COLUMN_NAME_5).as(ALIAS_5)));
+
+    // Act Assert
+    assertThat(resultRecord.getContainedColumnNames())
+        .isEqualTo(ImmutableSet.of(ALIAS_1, ALIAS_2, ALIAS_3, ALIAS_4, ALIAS_5, ALIAS_6, ALIAS_7));
+    assertThat(resultRecord.isNull(ALIAS_1)).isTrue();
+    assertThat(resultRecord.isNull(ALIAS_2)).isTrue();
+    assertThat(resultRecord.isNull(ALIAS_3)).isTrue();
+    assertThat(resultRecord.isNull(ALIAS_4)).isTrue();
+    assertThat(resultRecord.isNull(ALIAS_5)).isTrue();
+    assertThat(resultRecord.isNull(ALIAS_6)).isTrue();
+    assertThat(resultRecord.isNull(ALIAS_7)).isTrue();
+  }
+
+  @Test
   public void isNull_IndexGiven_ShouldReturnCorrectResult() {
     // Arrange
     resultRecord =
@@ -177,13 +262,13 @@ public class ResultRecordTest {
                     .build(),
                 TABLE_METADATA),
             ImmutableList.of(
-                COLUMN_NAME_4,
-                COLUMN_NAME_7,
-                COLUMN_NAME_6,
-                COLUMN_NAME_2,
-                COLUMN_NAME_3,
-                COLUMN_NAME_1,
-                COLUMN_NAME_5));
+                Projection.column(COLUMN_NAME_4),
+                Projection.column(COLUMN_NAME_7),
+                Projection.column(COLUMN_NAME_6),
+                Projection.column(COLUMN_NAME_2),
+                Projection.column(COLUMN_NAME_3),
+                Projection.column(COLUMN_NAME_1),
+                Projection.column(COLUMN_NAME_5)));
 
     // Act Assert
     assertThat(resultRecord.size()).isEqualTo(7);

--- a/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
@@ -58,7 +58,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col1"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col1")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -85,7 +90,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -100,7 +110,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -114,7 +129,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -128,7 +148,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -141,7 +166,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col2")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -155,7 +185,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p2", "c1", "c2", "col2"),
+            ImmutableList.of(
+                Projection.column("p1").as("a"),
+                Projection.column("p2").as("b"),
+                Projection.column("c1").as("c"),
+                Projection.column("c2").as("d"),
+                Projection.column("col2").as("e")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -183,7 +218,13 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("p1", "p1", "p2", "c1", "c2", "col1"),
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col1")),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -488,7 +529,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("col2", "p1", "p2", "c1", "c2"),
+            ImmutableList.of(
+                Projection.column("col2"),
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2")),
             ImmutableList.of(Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
             ImmutableList.of(),
             100);
@@ -505,7 +551,12 @@ public class StatementValidatorTest {
         SelectStatement.of(
             NAMESPACE_NAME,
             TABLE_NAME,
-            ImmutableList.of("col2", "p1", "p2", "c1", "c2"),
+            ImmutableList.of(
+                Projection.column("col2"),
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2")),
             ImmutableList.of(Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),

--- a/core/src/test/java/com/scalar/db/sql/builder/StatementBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/sql/builder/StatementBuilderTest.java
@@ -10,6 +10,7 @@ import com.scalar.db.sql.ClusteringOrder;
 import com.scalar.db.sql.ClusteringOrdering;
 import com.scalar.db.sql.DataType;
 import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.Projection;
 import com.scalar.db.sql.Value;
 import com.scalar.db.sql.statement.CreateCoordinatorTableStatement;
 import com.scalar.db.sql.statement.CreateIndexStatement;
@@ -469,7 +470,7 @@ public class StatementBuilderTest {
             .build();
 
     SelectStatement statement2 =
-        StatementBuilder.select(Arrays.asList("col2", "col3"))
+        StatementBuilder.select(Projection.column("col2"), Projection.column("col3"))
             .from("ns2", "tbl2")
             .where(
                 Arrays.asList(
@@ -483,13 +484,31 @@ public class StatementBuilderTest {
             .limit(10)
             .build();
 
+    SelectStatement statement3 =
+        StatementBuilder.select(
+                Arrays.asList(Projection.column("col2").as("a"), Projection.column("col3").as("b")))
+            .from("ns3", "tbl3")
+            .where(
+                Arrays.asList(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(20)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa"))))
+            .orderBy(
+                Arrays.asList(
+                    ClusteringOrdering.column("col2").desc(),
+                    ClusteringOrdering.column("col3").desc()))
+            .limit(10)
+            .build();
+
     // Assert
     assertThat(statement1)
         .isEqualTo(
             SelectStatement.of(
                 "ns1",
                 "tbl1",
-                ImmutableList.of("col1", "col2", "col3"),
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
@@ -504,7 +523,7 @@ public class StatementBuilderTest {
             SelectStatement.of(
                 "ns2",
                 "tbl2",
-                ImmutableList.of("col2", "col3"),
+                ImmutableList.of(Projection.column("col2"), Projection.column("col3")),
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(20)),
                     Predicate.column("col2").isGreaterThan(Value.ofText("ddd")),
@@ -512,6 +531,21 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     ClusteringOrdering.column("col2").desc(),
                     ClusteringOrdering.column("col3").asc()),
+                10));
+
+    assertThat(statement3)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns3",
+                "tbl3",
+                ImmutableList.of(
+                    Projection.column("col2").as("a"), Projection.column("col3").as("b")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(20)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
+                ImmutableList.of(
+                    ClusteringOrdering.column("col2").desc(),
+                    ClusteringOrdering.column("col3").desc()),
                 10));
   }
 


### PR DESCRIPTION
This PR supports alias in SQL API.

After this change, we can specify projections with aliases (with the `as()` method) as follows:
```java
SelectStatement statement =
  StatementBuilder.select(Projection.column("col2").as("a"), Projection.column("col3").as("b"))
      .from("ns", "tbl")
      .where(Predicate.column("col1").isEqualTo(Value.ofInt(10)))
      .and(Predicate.column("col2").isGreaterThan(Value.ofText("aaa")))
      .and(Predicate.column("col2").isLessThan(Value.ofText("ccc")))
      .orderBy(
          ClusteringOrdering.column("col2").desc(), ClusteringOrdering.column("col3").desc())
      .limit(10)
      .build();
```

Please take a look!
