### PR TITLE
Fix `Query condition missed key schema element` error in DynamoDB

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.dynamo;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.UnsignedBytes;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Get;
@@ -85,7 +84,9 @@ public class SelectStatementHandler {
             .key(dynamoOperation.getKeyMap());
 
     if (!get.getProjections().isEmpty()) {
-      projectionExpression(builder, get);
+      Map<String, String> expressionAttributeNames = new HashMap<>();
+      projectionExpression(builder, get, expressionAttributeNames);
+      builder.expressionAttributeNames(expressionAttributeNames);
     }
 
     if (get.getConsistency() != Consistency.EVENTUAL) {
@@ -109,14 +110,16 @@ public class SelectStatementHandler {
     ValueBinder binder = new ValueBinder(DynamoOperation.VALUE_ALIAS);
     keyColumn.accept(binder);
     Map<String, AttributeValue> bindMap = binder.build();
-    builder
-        .keyConditionExpression(condition)
-        .expressionAttributeValues(bindMap)
-        .expressionAttributeNames(ImmutableMap.of(expressionColumnName, column));
+    builder.keyConditionExpression(condition).expressionAttributeValues(bindMap);
+
+    Map<String, String> expressionAttributeNames = new HashMap<>();
+    expressionAttributeNames.put(expressionColumnName, column);
 
     if (!selection.getProjections().isEmpty()) {
-      projectionExpression(builder, selection);
+      projectionExpression(builder, selection, expressionAttributeNames);
     }
+
+    builder.expressionAttributeNames(expressionAttributeNames);
 
     if (selection instanceof Scan) {
       Scan scan = (Scan) selection;
@@ -151,7 +154,9 @@ public class SelectStatementHandler {
     }
 
     if (!scan.getProjections().isEmpty()) {
-      projectionExpression(builder, scan);
+      Map<String, String> expressionAttributeNames = new HashMap<>();
+      projectionExpression(builder, scan, expressionAttributeNames);
+      builder.expressionAttributeNames(expressionAttributeNames);
     }
 
     if (scan.getConsistency() != Consistency.EVENTUAL) {
@@ -162,24 +167,24 @@ public class SelectStatementHandler {
         client, builder.build(), new ResultInterpreter(scan.getProjections(), tableMetadata));
   }
 
-  private void projectionExpression(DynamoDbRequest.Builder builder, Selection selection) {
+  private void projectionExpression(
+      DynamoDbRequest.Builder builder,
+      Selection selection,
+      Map<String, String> expressionAttributeNames) {
     assert builder instanceof GetItemRequest.Builder || builder instanceof QueryRequest.Builder;
 
-    Map<String, String> columnMap = new HashMap<>();
     List<String> projections = new ArrayList<>(selection.getProjections().size());
-    for (int i = 0; i < selection.getProjections().size(); i++) {
-      String alias = DynamoOperation.COLUMN_NAME_ALIAS + i;
+    for (String projection : selection.getProjections()) {
+      String alias = DynamoOperation.COLUMN_NAME_ALIAS + expressionAttributeNames.size();
       projections.add(alias);
-      columnMap.put(alias, selection.getProjections().get(i));
+      expressionAttributeNames.put(alias, projection);
     }
     String projectionExpression = String.join(",", projections);
 
     if (builder instanceof GetItemRequest.Builder) {
       ((GetItemRequest.Builder) builder).projectionExpression(projectionExpression);
-      ((GetItemRequest.Builder) builder).expressionAttributeNames(columnMap);
     } else {
       ((QueryRequest.Builder) builder).projectionExpression(projectionExpression);
-      ((QueryRequest.Builder) builder).expressionAttributeNames(columnMap);
     }
   }
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -226,6 +226,42 @@ public class SelectStatementHandlerTest {
   }
 
   @Test
+  public void handle_ScanOperationWithIndexGiven_WithProjections_ShouldCallQuery() {
+    // Arrange
+    when(client.query(any(QueryRequest.class))).thenReturn(queryResponse);
+    when(queryResponse.items()).thenReturn(Collections.singletonList(new HashMap<>()));
+
+    Key indexKey = new Key(ANY_NAME_3, ANY_TEXT_3);
+    Scan scan =
+        new Scan(indexKey)
+            .withProjection(ANY_NAME_1)
+            .withProjection(ANY_NAME_2)
+            .forNamespace(ANY_NAMESPACE_NAME)
+            .forTable(ANY_TABLE_NAME);
+    String expectedKeyCondition =
+        DynamoOperation.COLUMN_NAME_ALIAS + "0 = " + DynamoOperation.VALUE_ALIAS + "0";
+    Map<String, AttributeValue> expectedBindMap = new HashMap<>();
+    expectedBindMap.put(
+        DynamoOperation.VALUE_ALIAS + "0", AttributeValue.builder().s(ANY_TEXT_3).build());
+    Map<String, String> expectedExpressionAttributeNames = new HashMap<>();
+    expectedExpressionAttributeNames.put(DynamoOperation.COLUMN_NAME_ALIAS + "0", ANY_NAME_3);
+    expectedExpressionAttributeNames.put(DynamoOperation.COLUMN_NAME_ALIAS + "1", ANY_NAME_1);
+    expectedExpressionAttributeNames.put(DynamoOperation.COLUMN_NAME_ALIAS + "2", ANY_NAME_2);
+
+    // Act Assert
+    assertThatCode(() -> handler.handle(scan)).doesNotThrowAnyException();
+
+    // Assert
+    ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+    verify(client).query(captor.capture());
+    QueryRequest actualRequest = captor.getValue();
+    assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedKeyCondition);
+    assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.expressionAttributeNames())
+        .isEqualTo(expectedExpressionAttributeNames);
+  }
+
+  @Test
   public void handle_ScanOperationCosmosExceptionThrown_ShouldThrowExecutionException() {
     // Arrange
     DynamoDbException toThrow = mock(DynamoDbException.class);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTest.java
@@ -259,6 +259,9 @@ public class SelectStatementHandlerTest {
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.expressionAttributeNames())
         .isEqualTo(expectedExpressionAttributeNames);
+    assertThat(actualRequest.projectionExpression())
+        .isEqualTo(
+            DynamoOperation.COLUMN_NAME_ALIAS + "1," + DynamoOperation.COLUMN_NAME_ALIAS + "2");
   }
 
   @Test


### PR DESCRIPTION
`Query condition missed key schema element` error happens when executing Scan/Get operations using secondary index and specifying projections in DynamoDB. This PR fixes this bug. Please take a look!