### PR TITLE
Support parameterized statement in SQL API

### DIFF
--- a/core/src/main/java/com/scalar/db/sql/Assignment.java
+++ b/core/src/main/java/com/scalar/db/sql/Assignment.java
@@ -8,11 +8,15 @@ import javax.annotation.concurrent.Immutable;
 public class Assignment {
 
   public final String columnName;
-  public final Value value;
+  public final Term value;
 
-  private Assignment(String columnName, Value value) {
+  private Assignment(String columnName, Term value) {
     this.columnName = Objects.requireNonNull(columnName);
     this.value = Objects.requireNonNull(value);
+  }
+
+  public Assignment replaceValue(Term newValue) {
+    return new Assignment(columnName, newValue);
   }
 
   @Override
@@ -51,7 +55,7 @@ public class Assignment {
       this.columnName = columnName;
     }
 
-    public Assignment value(Value value) {
+    public Assignment value(Term value) {
       return new Assignment(columnName, value);
     }
   }

--- a/core/src/main/java/com/scalar/db/sql/BindMarker.java
+++ b/core/src/main/java/com/scalar/db/sql/BindMarker.java
@@ -2,11 +2,11 @@ package com.scalar.db.sql;
 
 public interface BindMarker extends Term {
 
-  static BindMarker of() {
+  static BindMarker positional() {
     return PositionalBindMarker.INSTANCE;
   }
 
-  static BindMarker of(String name) {
+  static BindMarker named(String name) {
     return new NamedBindMarker(name);
   }
 }

--- a/core/src/main/java/com/scalar/db/sql/BindMarker.java
+++ b/core/src/main/java/com/scalar/db/sql/BindMarker.java
@@ -1,0 +1,12 @@
+package com.scalar.db.sql;
+
+public interface BindMarker extends Term {
+
+  static BindMarker of() {
+    return PositionalBindMarker.INSTANCE;
+  }
+
+  static BindMarker of(String name) {
+    return new NamedBindMarker(name);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/NamedBindMarker.java
+++ b/core/src/main/java/com/scalar/db/sql/NamedBindMarker.java
@@ -1,0 +1,37 @@
+package com.scalar.db.sql;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class NamedBindMarker implements BindMarker {
+
+  public final String name;
+
+  NamedBindMarker(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("name", name).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof NamedBindMarker)) {
+      return false;
+    }
+    NamedBindMarker that = (NamedBindMarker) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/PositionalBindMarker.java
+++ b/core/src/main/java/com/scalar/db/sql/PositionalBindMarker.java
@@ -1,0 +1,27 @@
+package com.scalar.db.sql;
+
+import com.google.common.base.MoreObjects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class PositionalBindMarker implements BindMarker {
+
+  static final PositionalBindMarker INSTANCE = new PositionalBindMarker();
+
+  private PositionalBindMarker() {}
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/Predicate.java
+++ b/core/src/main/java/com/scalar/db/sql/Predicate.java
@@ -9,12 +9,16 @@ public class Predicate {
 
   public final String columnName;
   public final Operator operator;
-  public final Value value;
+  public final Term value;
 
-  private Predicate(String columnName, Operator operator, Value value) {
+  private Predicate(String columnName, Operator operator, Term value) {
     this.columnName = Objects.requireNonNull(columnName);
     this.operator = Objects.requireNonNull(operator);
     this.value = Objects.requireNonNull(value);
+  }
+
+  public Predicate replaceValue(Term newValue) {
+    return new Predicate(columnName, operator, newValue);
   }
 
   @Override
@@ -56,23 +60,23 @@ public class Predicate {
       this.columnName = columnName;
     }
 
-    public Predicate isEqualTo(Value value) {
+    public Predicate isEqualTo(Term value) {
       return new Predicate(columnName, Operator.EQUAL_TO, value);
     }
 
-    public Predicate isGreaterThan(Value value) {
+    public Predicate isGreaterThan(Term value) {
       return new Predicate(columnName, Operator.GREATER_THAN, value);
     }
 
-    public Predicate isGreaterThanOrEqualTo(Value value) {
+    public Predicate isGreaterThanOrEqualTo(Term value) {
       return new Predicate(columnName, Operator.GREATER_THAN_OR_EQUAL_TO, value);
     }
 
-    public Predicate isLessThan(Value value) {
+    public Predicate isLessThan(Term value) {
       return new Predicate(columnName, Operator.LESS_THAN, value);
     }
 
-    public Predicate isLessThanOrEqualTo(Value value) {
+    public Predicate isLessThanOrEqualTo(Term value) {
       return new Predicate(columnName, Operator.LESS_THAN_OR_EQUAL_TO, value);
     }
   }

--- a/core/src/main/java/com/scalar/db/sql/SqlStatementSession.java
+++ b/core/src/main/java/com/scalar/db/sql/SqlStatementSession.java
@@ -1,7 +1,11 @@
 package com.scalar.db.sql;
 
 import com.scalar.db.sql.metadata.Metadata;
+import com.scalar.db.sql.statement.BindableStatement;
 import com.scalar.db.sql.statement.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public interface SqlStatementSession {
   void begin();
@@ -11,6 +15,19 @@ public interface SqlStatementSession {
   void resume(String transactionId);
 
   ResultSet execute(Statement statement);
+
+  default ResultSet execute(BindableStatement<?> statement, Value... positionalValues) {
+    return execute(statement, Arrays.asList(positionalValues));
+  }
+
+  default ResultSet execute(BindableStatement<?> bindableStatement, List<Value> positionalValues) {
+    return execute(bindableStatement.bind(positionalValues));
+  }
+
+  default ResultSet execute(
+      BindableStatement<?> bindableStatement, Map<String, Value> namedValues) {
+    return execute(bindableStatement.bind(namedValues));
+  }
 
   void prepare();
 

--- a/core/src/main/java/com/scalar/db/sql/SqlUtils.java
+++ b/core/src/main/java/com/scalar/db/sql/SqlUtils.java
@@ -6,6 +6,8 @@ import com.scalar.db.sql.Predicate.Operator;
 import com.scalar.db.sql.exception.TableNotFoundException;
 import com.scalar.db.sql.metadata.Metadata;
 import com.scalar.db.sql.metadata.TableMetadata;
+import java.util.Iterator;
+import java.util.Map;
 
 public final class SqlUtils {
 
@@ -34,5 +36,83 @@ public final class SqlUtils {
         .orElseThrow(() -> new TableNotFoundException(namespaceName, tableName))
         .getTable(tableName)
         .orElseThrow(() -> new TableNotFoundException(namespaceName, tableName));
+  }
+
+  public static ImmutableList<Predicate> bindPredicates(
+      ImmutableList<Predicate> predicates, Iterator<Value> positionalValueIterator) {
+    ImmutableList.Builder<Predicate> builder = ImmutableList.builder();
+    predicates.forEach(
+        p -> {
+          if (positionalValueIterator.hasNext() && p.value instanceof BindMarker) {
+            if (p.value instanceof NamedBindMarker) {
+              throw new IllegalArgumentException("A named bind marker is not allowed");
+            }
+            builder.add(p.replaceValue(positionalValueIterator.next()));
+          } else {
+            builder.add(p);
+          }
+        });
+    return builder.build();
+  }
+
+  public static ImmutableList<Predicate> bindPredicates(
+      ImmutableList<Predicate> predicates, Map<String, Value> namedValues) {
+    ImmutableList.Builder<Predicate> builder = ImmutableList.builder();
+    predicates.forEach(
+        p -> {
+          if (p.value instanceof BindMarker) {
+            if (p.value instanceof PositionalBindMarker) {
+              throw new IllegalArgumentException("A positional bind marker is not allowed");
+            }
+            String name = ((NamedBindMarker) p.value).name;
+            if (namedValues.containsKey(name)) {
+              builder.add(p.replaceValue(namedValues.get(name)));
+            } else {
+              builder.add(p);
+            }
+          } else {
+            builder.add(p);
+          }
+        });
+    return builder.build();
+  }
+
+  public static ImmutableList<Assignment> bindAssignments(
+      ImmutableList<Assignment> assignments, Iterator<Value> positionalValueIterator) {
+    ImmutableList.Builder<Assignment> builder = ImmutableList.builder();
+    assignments.forEach(
+        a -> {
+          if (positionalValueIterator.hasNext() && a.value instanceof BindMarker) {
+            if (a.value instanceof NamedBindMarker) {
+              throw new IllegalArgumentException("a named bind marker is not allowed");
+            }
+            builder.add(a.replaceValue(positionalValueIterator.next()));
+          } else {
+            builder.add(a);
+          }
+        });
+    return builder.build();
+  }
+
+  public static ImmutableList<Assignment> bindAssignments(
+      ImmutableList<Assignment> assignments, Map<String, Value> namedValues) {
+    ImmutableList.Builder<Assignment> builder = ImmutableList.builder();
+    assignments.forEach(
+        a -> {
+          if (a.value instanceof BindMarker) {
+            if (a.value instanceof PositionalBindMarker) {
+              throw new IllegalArgumentException("a positional bind marker is not allowed");
+            }
+            String name = ((NamedBindMarker) a.value).name;
+            if (namedValues.containsKey(name)) {
+              builder.add(a.replaceValue(namedValues.get(name)));
+            } else {
+              builder.add(a);
+            }
+          } else {
+            builder.add(a);
+          }
+        });
+    return builder.build();
   }
 }

--- a/core/src/main/java/com/scalar/db/sql/StatementValidator.java
+++ b/core/src/main/java/com/scalar/db/sql/StatementValidator.java
@@ -25,6 +25,7 @@ import com.scalar.db.sql.statement.TruncateCoordinatorTableStatement;
 import com.scalar.db.sql.statement.TruncateTableStatement;
 import com.scalar.db.sql.statement.UpdateStatement;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.ThreadSafe;
@@ -94,6 +95,9 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
 
   @Override
   public Void visit(SelectStatement statement, Void context) {
+    validatePredicates(statement.predicates);
+    validateLimit(statement.limit);
+
     TableMetadata tableMetadata =
         SqlUtils.getTableMetadata(metadata, statement.namespaceName, statement.tableName);
 
@@ -141,7 +145,7 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
                 n ->
                     predicatesMap.get(n).size() == 1
                         && predicatesMap.get(n).get(0).operator == Predicate.Operator.EQUAL_TO
-                        && predicatesMap.get(n).get(0).value.type != Value.Type.NULL);
+                        && ((Value) predicatesMap.get(n).get(0).value).type != Value.Type.NULL);
     if (!areAllPartitionKeyColumnsSpecifiedProperly) {
       throw new IllegalArgumentException("Partition key columns are not specified properly");
     }
@@ -193,6 +197,8 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
 
   @Override
   public Void visit(InsertStatement statement, Void context) {
+    validateAssignments(statement.assignments);
+
     TableMetadata tableMetadata =
         SqlUtils.getTableMetadata(metadata, statement.namespaceName, statement.tableName);
 
@@ -216,7 +222,7 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
             .allMatch(
                 n ->
                     assignmentsMap.containsKey(n)
-                        && assignmentsMap.get(n).value.type != Value.Type.NULL);
+                        && ((Value) assignmentsMap.get(n).value).type != Value.Type.NULL);
     if (!areAllPrimaryKeyColumnsSpecifiedProperly) {
       throw new IllegalArgumentException("Primary key columns are not specified properly");
     }
@@ -225,6 +231,9 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
 
   @Override
   public Void visit(UpdateStatement statement, Void context) {
+    validateAssignments(statement.assignments);
+    validatePredicates(statement.predicates);
+
     TableMetadata tableMetadata =
         SqlUtils.getTableMetadata(metadata, statement.namespaceName, statement.tableName);
     validatePredicatesForPrimaryKey(statement.predicates, tableMetadata);
@@ -233,6 +242,8 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
 
   @Override
   public Void visit(DeleteStatement statement, Void context) {
+    validatePredicates(statement.predicates);
+
     TableMetadata tableMetadata =
         SqlUtils.getTableMetadata(metadata, statement.namespaceName, statement.tableName);
     validatePredicatesForPrimaryKey(statement.predicates, tableMetadata);
@@ -268,10 +279,38 @@ public class StatementValidator implements StatementVisitor<Void, Void> {
                 n ->
                     predicatesMap.containsKey(n)
                         && predicatesMap.get(n).operator == Predicate.Operator.EQUAL_TO
-                        && predicatesMap.get(n).value.type != Value.Type.NULL);
+                        && ((Value) predicatesMap.get(n).value).type != Value.Type.NULL);
     if (!areAllPrimaryKeyColumnsSpecifiedProperly) {
       throw new IllegalArgumentException("Primary key columns are not specified properly");
     }
+  }
+
+  private void validatePredicates(List<Predicate> predicates) {
+    predicates.forEach(
+        p -> {
+          if (p.value instanceof BindMarker) {
+            throw new IllegalArgumentException("An unbound bind marker is still in the predicates");
+          }
+        });
+  }
+
+  private void validateLimit(Term limit) {
+    if (limit instanceof BindMarker) {
+      throw new IllegalArgumentException("An unbound bind marker is still in the limit clause");
+    }
+    if (((Value) limit).type != Value.Type.INT) {
+      throw new IllegalArgumentException("A limit should be a INT type");
+    }
+  }
+
+  private void validateAssignments(List<Assignment> assignments) {
+    assignments.forEach(
+        a -> {
+          if (a.value instanceof BindMarker) {
+            throw new IllegalArgumentException(
+                "An unbound bind marker is still in the assignments");
+          }
+        });
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/sql/Term.java
+++ b/core/src/main/java/com/scalar/db/sql/Term.java
@@ -1,0 +1,3 @@
+package com.scalar.db.sql;
+
+public interface Term {}

--- a/core/src/main/java/com/scalar/db/sql/Value.java
+++ b/core/src/main/java/com/scalar/db/sql/Value.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-public class Value {
+public class Value implements Term {
 
   public final Type type;
   @Nullable public final Object value;

--- a/core/src/main/java/com/scalar/db/sql/builder/SelectStatementBuilder.java
+++ b/core/src/main/java/com/scalar/db/sql/builder/SelectStatementBuilder.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableList;
 import com.scalar.db.sql.ClusteringOrdering;
 import com.scalar.db.sql.Predicate;
 import com.scalar.db.sql.Projection;
+import com.scalar.db.sql.Term;
+import com.scalar.db.sql.Value;
 import com.scalar.db.sql.statement.SelectStatement;
 import java.util.List;
 
@@ -69,7 +71,7 @@ public final class SelectStatementBuilder {
     private final String tableName;
     protected final ImmutableList.Builder<Predicate> predicatesBuilder;
     private ImmutableList<ClusteringOrdering> clusteringOrderings = ImmutableList.of();
-    private int limit;
+    private Term limit;
 
     private Buildable(
         ImmutableList<Projection> projections,
@@ -93,6 +95,11 @@ public final class SelectStatementBuilder {
     }
 
     public Buildable limit(int limit) {
+      this.limit = Value.ofInt(limit);
+      return this;
+    }
+
+    public Buildable limit(Term limit) {
       this.limit = limit;
       return this;
     }

--- a/core/src/main/java/com/scalar/db/sql/statement/BindableStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/BindableStatement.java
@@ -1,0 +1,11 @@
+package com.scalar.db.sql.statement;
+
+import com.scalar.db.sql.Value;
+import java.util.List;
+import java.util.Map;
+
+public interface BindableStatement<T extends Statement> extends Statement {
+  T bind(List<Value> positionalValues);
+
+  T bind(Map<String, Value> namedValues);
+}

--- a/core/src/main/java/com/scalar/db/sql/statement/DeleteStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/DeleteStatement.java
@@ -3,11 +3,15 @@ package com.scalar.db.sql.statement;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.SqlUtils;
+import com.scalar.db.sql.Value;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-public class DeleteStatement implements DmlStatement {
+public class DeleteStatement implements DmlStatement, BindableStatement<DeleteStatement> {
 
   public final String namespaceName;
   public final String tableName;
@@ -18,6 +22,18 @@ public class DeleteStatement implements DmlStatement {
     this.namespaceName = Objects.requireNonNull(namespaceName);
     this.tableName = Objects.requireNonNull(tableName);
     this.predicates = Objects.requireNonNull(predicates);
+  }
+
+  @Override
+  public DeleteStatement bind(List<Value> positionalValues) {
+    return new DeleteStatement(
+        namespaceName, tableName, SqlUtils.bindPredicates(predicates, positionalValues.iterator()));
+  }
+
+  @Override
+  public DeleteStatement bind(Map<String, Value> namedValues) {
+    return new DeleteStatement(
+        namespaceName, tableName, SqlUtils.bindPredicates(predicates, namedValues));
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/sql/statement/InsertStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/InsertStatement.java
@@ -3,11 +3,15 @@ package com.scalar.db.sql.statement;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.sql.Assignment;
+import com.scalar.db.sql.SqlUtils;
+import com.scalar.db.sql.Value;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-public class InsertStatement implements DmlStatement {
+public class InsertStatement implements DmlStatement, BindableStatement<InsertStatement> {
 
   public final String namespaceName;
   public final String tableName;
@@ -18,6 +22,20 @@ public class InsertStatement implements DmlStatement {
     this.namespaceName = Objects.requireNonNull(namespaceName);
     this.tableName = Objects.requireNonNull(tableName);
     this.assignments = Objects.requireNonNull(assignments);
+  }
+
+  @Override
+  public InsertStatement bind(List<Value> positionalValues) {
+    return new InsertStatement(
+        namespaceName,
+        tableName,
+        SqlUtils.bindAssignments(assignments, positionalValues.iterator()));
+  }
+
+  @Override
+  public InsertStatement bind(Map<String, Value> namedValues) {
+    return new InsertStatement(
+        namespaceName, tableName, SqlUtils.bindAssignments(assignments, namedValues));
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/sql/statement/SelectStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/SelectStatement.java
@@ -2,21 +2,30 @@ package com.scalar.db.sql.statement;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.scalar.db.sql.BindMarker;
 import com.scalar.db.sql.ClusteringOrdering;
+import com.scalar.db.sql.NamedBindMarker;
+import com.scalar.db.sql.PositionalBindMarker;
 import com.scalar.db.sql.Predicate;
 import com.scalar.db.sql.Projection;
+import com.scalar.db.sql.SqlUtils;
+import com.scalar.db.sql.Term;
+import com.scalar.db.sql.Value;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-public class SelectStatement implements DmlStatement {
+public class SelectStatement implements DmlStatement, BindableStatement<SelectStatement> {
 
   public final String namespaceName;
   public final String tableName;
   public final ImmutableList<Projection> projections;
   public final ImmutableList<Predicate> predicates;
   public final ImmutableList<ClusteringOrdering> clusteringOrderings;
-  public final int limit;
+  public final Term limit;
 
   private SelectStatement(
       String namespaceName,
@@ -24,13 +33,61 @@ public class SelectStatement implements DmlStatement {
       ImmutableList<Projection> projections,
       ImmutableList<Predicate> predicates,
       ImmutableList<ClusteringOrdering> clusteringOrderings,
-      int limit) {
+      Term limit) {
     this.namespaceName = Objects.requireNonNull(namespaceName);
     this.tableName = Objects.requireNonNull(tableName);
     this.projections = Objects.requireNonNull(projections);
     this.predicates = Objects.requireNonNull(predicates);
     this.clusteringOrderings = Objects.requireNonNull(clusteringOrderings);
-    this.limit = limit;
+    this.limit = Objects.requireNonNull(limit);
+  }
+
+  @Override
+  public SelectStatement bind(List<Value> positionalValues) {
+    Iterator<Value> positionalValueIterator = positionalValues.iterator();
+    return new SelectStatement(
+        namespaceName,
+        tableName,
+        projections,
+        SqlUtils.bindPredicates(predicates, positionalValueIterator),
+        clusteringOrderings,
+        bindLimit(limit, positionalValueIterator));
+  }
+
+  private Term bindLimit(Term limit, Iterator<Value> positionalValueIterator) {
+    if (positionalValueIterator.hasNext() && limit instanceof BindMarker) {
+      if (limit instanceof NamedBindMarker) {
+        throw new IllegalArgumentException("A named bind marker is not allowed");
+      }
+      return positionalValueIterator.next();
+    }
+    return limit;
+  }
+
+  @Override
+  public SelectStatement bind(Map<String, Value> namedValues) {
+    return new SelectStatement(
+        namespaceName,
+        tableName,
+        projections,
+        SqlUtils.bindPredicates(predicates, namedValues),
+        clusteringOrderings,
+        bindLimit(limit, namedValues));
+  }
+
+  private Term bindLimit(Term limit, Map<String, Value> namedValues) {
+    if (limit instanceof BindMarker) {
+      if (limit instanceof PositionalBindMarker) {
+        throw new IllegalArgumentException("A positional bind marker is not allowed");
+      }
+      String name = ((NamedBindMarker) limit).name;
+      if (namedValues.containsKey(name)) {
+        return namedValues.get(name);
+      } else {
+        return limit;
+      }
+    }
+    return limit;
   }
 
   @Override
@@ -64,12 +121,12 @@ public class SelectStatement implements DmlStatement {
       return false;
     }
     SelectStatement that = (SelectStatement) o;
-    return limit == that.limit
-        && Objects.equals(namespaceName, that.namespaceName)
+    return Objects.equals(namespaceName, that.namespaceName)
         && Objects.equals(tableName, that.tableName)
         && Objects.equals(projections, that.projections)
         && Objects.equals(predicates, that.predicates)
-        && Objects.equals(clusteringOrderings, that.clusteringOrderings);
+        && Objects.equals(clusteringOrderings, that.clusteringOrderings)
+        && Objects.equals(limit, that.limit);
   }
 
   @Override
@@ -84,7 +141,7 @@ public class SelectStatement implements DmlStatement {
       ImmutableList<Projection> projections,
       ImmutableList<Predicate> predicates,
       ImmutableList<ClusteringOrdering> clusteringOrderings,
-      int limit) {
+      Term limit) {
     return new SelectStatement(
         namespaceName, tableName, projections, predicates, clusteringOrderings, limit);
   }

--- a/core/src/main/java/com/scalar/db/sql/statement/TruncateCoordinatorTableStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/TruncateCoordinatorTableStatement.java
@@ -28,10 +28,7 @@ public class TruncateCoordinatorTableStatement implements DdlStatement {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    return o instanceof TruncateCoordinatorTableStatement;
+    return this == o;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/sql/statement/UpdateStatement.java
+++ b/core/src/main/java/com/scalar/db/sql/statement/UpdateStatement.java
@@ -4,11 +4,16 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.sql.Assignment;
 import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.SqlUtils;
+import com.scalar.db.sql.Value;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-public class UpdateStatement implements DmlStatement {
+public class UpdateStatement implements DmlStatement, BindableStatement<UpdateStatement> {
 
   public final String namespaceName;
   public final String tableName;
@@ -24,6 +29,25 @@ public class UpdateStatement implements DmlStatement {
     this.tableName = Objects.requireNonNull(tableName);
     this.assignments = Objects.requireNonNull(assignments);
     this.predicates = Objects.requireNonNull(predicates);
+  }
+
+  @Override
+  public UpdateStatement bind(List<Value> positionalValues) {
+    Iterator<Value> positionalValueIterator = positionalValues.iterator();
+    return new UpdateStatement(
+        namespaceName,
+        tableName,
+        SqlUtils.bindAssignments(assignments, positionalValueIterator),
+        SqlUtils.bindPredicates(predicates, positionalValueIterator));
+  }
+
+  @Override
+  public UpdateStatement bind(Map<String, Value> namedValues) {
+    return new UpdateStatement(
+        namespaceName,
+        tableName,
+        SqlUtils.bindAssignments(assignments, namedValues),
+        SqlUtils.bindPredicates(predicates, namedValues));
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/sql/AssignmentTest.java
+++ b/core/src/test/java/com/scalar/db/sql/AssignmentTest.java
@@ -17,4 +17,17 @@ public class AssignmentTest {
     assertThat(actual.columnName).isEqualTo("col");
     assertThat(actual.value).isEqualTo(Value.ofInt(10));
   }
+
+  @Test
+  public void replaceValue_ShouldBuildProperly() {
+    // Arrange
+    Assignment assignment = Assignment.column("col").value(BindMarker.of());
+
+    // Act
+    Assignment actual = assignment.replaceValue(Value.ofInt(20));
+
+    // Assert
+    assertThat(actual.columnName).isEqualTo("col");
+    assertThat(actual.value).isEqualTo(Value.ofInt(20));
+  }
 }

--- a/core/src/test/java/com/scalar/db/sql/AssignmentTest.java
+++ b/core/src/test/java/com/scalar/db/sql/AssignmentTest.java
@@ -21,7 +21,7 @@ public class AssignmentTest {
   @Test
   public void replaceValue_ShouldBuildProperly() {
     // Arrange
-    Assignment assignment = Assignment.column("col").value(BindMarker.of());
+    Assignment assignment = Assignment.column("col").value(BindMarker.positional());
 
     // Act
     Assignment actual = assignment.replaceValue(Value.ofInt(20));

--- a/core/src/test/java/com/scalar/db/sql/DmlStatementExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/DmlStatementExecutorTest.java
@@ -86,7 +86,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.get(any())).thenReturn(Optional.of(result));
@@ -118,7 +118,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c1").isEqualTo(Value.ofText("ccc"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -161,7 +161,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c2").isLessThan(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -204,7 +204,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c1").isLessThanOrEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -247,7 +247,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c2").isGreaterThan(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -288,7 +288,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c1").isGreaterThanOrEqualTo(Value.ofText("ccc"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -330,7 +330,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c2").isLessThanOrEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -371,7 +371,7 @@ public class DmlStatementExecutorTest {
                 Predicate.column("c1").isLessThan(Value.ofText("ccc"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));
@@ -407,7 +407,7 @@ public class DmlStatementExecutorTest {
                 Projection.column("c2")),
             ImmutableList.of(Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
             ImmutableList.of(),
-            100);
+            Value.ofInt(100));
 
     Result result = mock(Result.class);
     when(transaction.scan(any())).thenReturn(Arrays.asList(result, result, result));

--- a/core/src/test/java/com/scalar/db/sql/PredicateTest.java
+++ b/core/src/test/java/com/scalar/db/sql/PredicateTest.java
@@ -35,4 +35,18 @@ public class PredicateTest {
     assertThat(predicate5.operator).isEqualTo(Operator.LESS_THAN_OR_EQUAL_TO);
     assertThat(predicate5.value).isEqualTo(Value.ofInt(50));
   }
+
+  @Test
+  public void replaceValue_ShouldBuildProperly() {
+    // Arrange
+    Predicate predicate = Predicate.column("col1").isEqualTo(BindMarker.of());
+
+    // Act
+    Predicate actual = predicate.replaceValue(Value.ofInt(20));
+
+    // Assert
+    assertThat(actual.columnName).isEqualTo("col1");
+    assertThat(actual.operator).isEqualTo(Operator.EQUAL_TO);
+    assertThat(actual.value).isEqualTo(Value.ofInt(20));
+  }
 }

--- a/core/src/test/java/com/scalar/db/sql/PredicateTest.java
+++ b/core/src/test/java/com/scalar/db/sql/PredicateTest.java
@@ -39,7 +39,7 @@ public class PredicateTest {
   @Test
   public void replaceValue_ShouldBuildProperly() {
     // Arrange
-    Predicate predicate = Predicate.column("col1").isEqualTo(BindMarker.of());
+    Predicate predicate = Predicate.column("col1").isEqualTo(BindMarker.positional());
 
     // Act
     Predicate actual = predicate.replaceValue(Value.ofInt(20));

--- a/core/src/test/java/com/scalar/db/sql/ResultIteratorResultSetTest.java
+++ b/core/src/test/java/com/scalar/db/sql/ResultIteratorResultSetTest.java
@@ -9,7 +9,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -26,15 +25,14 @@ public class ResultIteratorResultSetTest {
   private static final String COLUMN_NAME_4 = "col4";
 
   private static final com.scalar.db.api.TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
-          TableMetadata.newBuilder()
-              .addColumn(COLUMN_NAME_1, com.scalar.db.io.DataType.TEXT)
-              .addColumn(COLUMN_NAME_2, com.scalar.db.io.DataType.TEXT)
-              .addColumn(COLUMN_NAME_3, com.scalar.db.io.DataType.TEXT)
-              .addColumn(COLUMN_NAME_4, com.scalar.db.io.DataType.TEXT)
-              .addPartitionKey(COLUMN_NAME_1)
-              .addClusteringKey(COLUMN_NAME_2)
-              .build());
+      TableMetadata.newBuilder()
+          .addColumn(COLUMN_NAME_1, com.scalar.db.io.DataType.TEXT)
+          .addColumn(COLUMN_NAME_2, com.scalar.db.io.DataType.TEXT)
+          .addColumn(COLUMN_NAME_3, com.scalar.db.io.DataType.TEXT)
+          .addColumn(COLUMN_NAME_4, com.scalar.db.io.DataType.TEXT)
+          .addPartitionKey(COLUMN_NAME_1)
+          .addClusteringKey(COLUMN_NAME_2)
+          .build();
 
   private ResultIteratorResultSet resultIteratorResultSet;
 

--- a/core/src/test/java/com/scalar/db/sql/ResultRecordTest.java
+++ b/core/src/test/java/com/scalar/db/sql/ResultRecordTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.io.DoubleColumn;
 import com.scalar.db.io.FloatColumn;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.TextColumn;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.Before;
@@ -40,17 +39,16 @@ public class ResultRecordTest {
   private static final String ALIAS_7 = "alias7";
 
   private static final com.scalar.db.api.TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
-          TableMetadata.newBuilder()
-              .addColumn(COLUMN_NAME_1, com.scalar.db.io.DataType.INT)
-              .addColumn(COLUMN_NAME_2, com.scalar.db.io.DataType.BOOLEAN)
-              .addColumn(COLUMN_NAME_3, com.scalar.db.io.DataType.BIGINT)
-              .addColumn(COLUMN_NAME_4, com.scalar.db.io.DataType.FLOAT)
-              .addColumn(COLUMN_NAME_5, com.scalar.db.io.DataType.DOUBLE)
-              .addColumn(COLUMN_NAME_6, com.scalar.db.io.DataType.TEXT)
-              .addColumn(COLUMN_NAME_7, com.scalar.db.io.DataType.BLOB)
-              .addPartitionKey(COLUMN_NAME_1)
-              .build());
+      TableMetadata.newBuilder()
+          .addColumn(COLUMN_NAME_1, com.scalar.db.io.DataType.INT)
+          .addColumn(COLUMN_NAME_2, com.scalar.db.io.DataType.BOOLEAN)
+          .addColumn(COLUMN_NAME_3, com.scalar.db.io.DataType.BIGINT)
+          .addColumn(COLUMN_NAME_4, com.scalar.db.io.DataType.FLOAT)
+          .addColumn(COLUMN_NAME_5, com.scalar.db.io.DataType.DOUBLE)
+          .addColumn(COLUMN_NAME_6, com.scalar.db.io.DataType.TEXT)
+          .addColumn(COLUMN_NAME_7, com.scalar.db.io.DataType.BLOB)
+          .addPartitionKey(COLUMN_NAME_1)
+          .build();
 
   private ResultRecord resultRecord;
 

--- a/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
@@ -863,12 +863,12 @@ public class StatementValidatorTest {
             NAMESPACE_NAME,
             TABLE_NAME,
             ImmutableList.of(
-                Assignment.column("p1").value(BindMarker.of()),
-                Assignment.column("p2").value(BindMarker.of()),
-                Assignment.column("c1").value(BindMarker.of("name1")),
-                Assignment.column("c2").value(BindMarker.of("name2")),
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of())));
+                Assignment.column("p1").value(BindMarker.positional()),
+                Assignment.column("p2").value(BindMarker.positional()),
+                Assignment.column("c1").value(BindMarker.named("name1")),
+                Assignment.column("c2").value(BindMarker.named("name2")),
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.positional())));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -883,8 +883,8 @@ public class StatementValidatorTest {
             NAMESPACE_NAME,
             TABLE_NAME,
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of("name1"))),
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.named("name1"))),
             ImmutableList.of(
                 Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
                 Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
@@ -899,10 +899,10 @@ public class StatementValidatorTest {
                 Assignment.column("col1").value(Value.ofText("aaa")),
                 Assignment.column("col2").value(Value.ofText("bbb"))),
             ImmutableList.of(
-                Predicate.column("p1").isEqualTo(BindMarker.of()),
-                Predicate.column("p2").isEqualTo(BindMarker.of()),
-                Predicate.column("c1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("c2").isEqualTo(BindMarker.of("name2"))));
+                Predicate.column("p1").isEqualTo(BindMarker.positional()),
+                Predicate.column("p2").isEqualTo(BindMarker.positional()),
+                Predicate.column("c1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("c2").isEqualTo(BindMarker.named("name2"))));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement1))
@@ -919,10 +919,10 @@ public class StatementValidatorTest {
             NAMESPACE_NAME,
             TABLE_NAME,
             ImmutableList.of(
-                Predicate.column("p1").isEqualTo(BindMarker.of()),
-                Predicate.column("p2").isEqualTo(BindMarker.of()),
-                Predicate.column("c1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("c2").isEqualTo(BindMarker.of("name2"))));
+                Predicate.column("p1").isEqualTo(BindMarker.positional()),
+                Predicate.column("p2").isEqualTo(BindMarker.positional()),
+                Predicate.column("c1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("c2").isEqualTo(BindMarker.named("name2"))));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -943,10 +943,10 @@ public class StatementValidatorTest {
                 Projection.column("c2"),
                 Projection.column("col1")),
             ImmutableList.of(
-                Predicate.column("p1").isEqualTo(BindMarker.of()),
-                Predicate.column("p2").isEqualTo(BindMarker.of()),
-                Predicate.column("c1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("c2").isEqualTo(BindMarker.of("name2"))),
+                Predicate.column("p1").isEqualTo(BindMarker.positional()),
+                Predicate.column("p2").isEqualTo(BindMarker.positional()),
+                Predicate.column("c1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("c2").isEqualTo(BindMarker.named("name2"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
             Value.ofInt(100));
@@ -968,7 +968,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            BindMarker.of());
+            BindMarker.positional());
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement1))

--- a/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
@@ -72,7 +72,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement2 =
         SelectStatement.of(
@@ -85,7 +85,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isEqualTo(Value.ofText("ccc"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement3 =
         SelectStatement.of(
@@ -105,7 +105,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isLessThan(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement4 =
         SelectStatement.of(
@@ -124,7 +124,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isLessThanOrEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement5 =
         SelectStatement.of(
@@ -143,7 +143,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isGreaterThan(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement6 =
         SelectStatement.of(
@@ -161,7 +161,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isGreaterThanOrEqualTo(Value.ofText("ccc"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement7 =
         SelectStatement.of(
@@ -180,7 +180,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isLessThanOrEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement8 =
         SelectStatement.of(
@@ -198,7 +198,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isLessThan(Value.ofText("ccc"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatCode(() -> statementValidator.validate(statement1)).doesNotThrowAnyException();
@@ -233,7 +233,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -257,7 +257,7 @@ public class StatementValidatorTest {
                 Predicate.column("co2").isEqualTo(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -281,7 +281,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -304,7 +304,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -327,7 +327,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -349,7 +349,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement2 =
         SelectStatement.of(
@@ -364,7 +364,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isEqualTo(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement3 =
         SelectStatement.of(
@@ -378,7 +378,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement4 =
         SelectStatement.of(
@@ -392,7 +392,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isGreaterThanOrEqualTo(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement5 =
         SelectStatement.of(
@@ -406,7 +406,7 @@ public class StatementValidatorTest {
                 Predicate.column("c1").isLessThan(Value.ofText("ddd"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement6 =
         SelectStatement.of(
@@ -421,7 +421,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement7 =
         SelectStatement.of(
@@ -435,7 +435,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isGreaterThanOrEqualTo(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement8 =
         SelectStatement.of(
@@ -450,7 +450,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isGreaterThan(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement9 =
         SelectStatement.of(
@@ -465,7 +465,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isLessThanOrEqualTo(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement10 =
         SelectStatement.of(
@@ -480,7 +480,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("eee"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     SelectStatement statement11 =
         SelectStatement.of(
@@ -496,7 +496,7 @@ public class StatementValidatorTest {
                 Predicate.column("c2").isEqualTo(Value.ofText("fff"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement1))
@@ -538,7 +538,7 @@ public class StatementValidatorTest {
                 Projection.column("c2")),
             ImmutableList.of(Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
             ImmutableList.of(),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatCode(() -> statementValidator.validate(statement)).doesNotThrowAnyException();
@@ -561,7 +561,7 @@ public class StatementValidatorTest {
             ImmutableList.of(Predicate.column("col2").isEqualTo(Value.ofText("aaa"))),
             ImmutableList.of(
                 ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
-            100);
+            Value.ofInt(100));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))
@@ -672,7 +672,7 @@ public class StatementValidatorTest {
 
   @Test
   public void
-      validate_UpdateStatementWithNonPrimaryKeyColumnsInPredicateGiven_ShouldNotThrowAnyException() {
+      validate_UpdateStatementWithNonPrimaryKeyColumnsInPredicateGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     UpdateStatement statement =
         UpdateStatement.of(
@@ -695,7 +695,7 @@ public class StatementValidatorTest {
 
   @Test
   public void
-      validate_UpdateStatementWithDuplicatePrimaryKeyColumnsGiven_ShouldNotThrowAnyException() {
+      validate_UpdateStatementWithDuplicatePrimaryKeyColumnsGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     UpdateStatement statement =
         UpdateStatement.of(
@@ -718,7 +718,7 @@ public class StatementValidatorTest {
 
   @Test
   public void
-      validate_UpdateStatementWithSpecifyingPrimaryKeyColumnsWithNonIsEqualToPredicateGiven_ShouldNotThrowAnyException() {
+      validate_UpdateStatementWithSpecifyingPrimaryKeyColumnsWithNonIsEqualToPredicateGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     UpdateStatement statement =
         UpdateStatement.of(
@@ -739,7 +739,8 @@ public class StatementValidatorTest {
   }
 
   @Test
-  public void validate_UpdateStatementWithNullPrimaryKeyColumnGiven_ShouldNotThrowAnyException() {
+  public void
+      validate_UpdateStatementWithNullPrimaryKeyColumnGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     UpdateStatement statement =
         UpdateStatement.of(
@@ -778,7 +779,7 @@ public class StatementValidatorTest {
 
   @Test
   public void
-      validate_DeleteStatementWithNonPrimaryKeyColumnsInPredicateGiven_ShouldNotThrowAnyException() {
+      validate_DeleteStatementWithNonPrimaryKeyColumnsInPredicateGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     DeleteStatement statement =
         DeleteStatement.of(
@@ -798,7 +799,7 @@ public class StatementValidatorTest {
 
   @Test
   public void
-      validate_DeleteStatementWithDuplicatePrimaryKeyColumnsGiven_ShouldNotThrowAnyException() {
+      validate_DeleteStatementWithDuplicatePrimaryKeyColumnsGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     DeleteStatement statement =
         DeleteStatement.of(
@@ -818,7 +819,7 @@ public class StatementValidatorTest {
 
   @Test
   public void
-      validate_DeleteStatementWithSpecifyingPrimaryKeyColumnsWithNonIsEqualToPredicateGiven_ShouldNotThrowAnyException() {
+      validate_DeleteStatementWithSpecifyingPrimaryKeyColumnsWithNonIsEqualToPredicateGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     DeleteStatement statement =
         DeleteStatement.of(
@@ -836,7 +837,8 @@ public class StatementValidatorTest {
   }
 
   @Test
-  public void validate_DeleteStatementWithNullPrimaryKeyColumnGiven_ShouldNotThrowAnyException() {
+  public void
+      validate_DeleteStatementWithNullPrimaryKeyColumnGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     DeleteStatement statement =
         DeleteStatement.of(
@@ -847,6 +849,155 @@ public class StatementValidatorTest {
                 Predicate.column("p2").isEqualTo(Value.ofNull()),
                 Predicate.column("c1").isEqualTo(Value.ofText("ccc")),
                 Predicate.column("c2").isEqualTo(Value.ofText("ddd"))));
+
+    // Act Assert
+    assertThatThrownBy(() -> statementValidator.validate(statement))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void validate_InsertStatementWithBindMarkerGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    InsertStatement statement =
+        InsertStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Assignment.column("p1").value(BindMarker.of()),
+                Assignment.column("p2").value(BindMarker.of()),
+                Assignment.column("c1").value(BindMarker.of("name1")),
+                Assignment.column("c2").value(BindMarker.of("name2")),
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of())));
+
+    // Act Assert
+    assertThatThrownBy(() -> statementValidator.validate(statement))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void validate_UpdateStatementWithBindMarkerGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    UpdateStatement statement1 =
+        UpdateStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of("name1"))),
+            ImmutableList.of(
+                Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
+                Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
+                Predicate.column("c1").isEqualTo(Value.ofText("ccc")),
+                Predicate.column("c2").isEqualTo(Value.ofText("ddd"))));
+
+    UpdateStatement statement2 =
+        UpdateStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Assignment.column("col1").value(Value.ofText("aaa")),
+                Assignment.column("col2").value(Value.ofText("bbb"))),
+            ImmutableList.of(
+                Predicate.column("p1").isEqualTo(BindMarker.of()),
+                Predicate.column("p2").isEqualTo(BindMarker.of()),
+                Predicate.column("c1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("c2").isEqualTo(BindMarker.of("name2"))));
+
+    // Act Assert
+    assertThatThrownBy(() -> statementValidator.validate(statement1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> statementValidator.validate(statement2))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void validate_DeleteStatementWithBindMarkerGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    DeleteStatement statement =
+        DeleteStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Predicate.column("p1").isEqualTo(BindMarker.of()),
+                Predicate.column("p2").isEqualTo(BindMarker.of()),
+                Predicate.column("c1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("c2").isEqualTo(BindMarker.of("name2"))));
+
+    // Act Assert
+    assertThatThrownBy(() -> statementValidator.validate(statement))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void validate_SelectStatementWithBindMarkerGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    SelectStatement statement1 =
+        SelectStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col1")),
+            ImmutableList.of(
+                Predicate.column("p1").isEqualTo(BindMarker.of()),
+                Predicate.column("p2").isEqualTo(BindMarker.of()),
+                Predicate.column("c1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("c2").isEqualTo(BindMarker.of("name2"))),
+            ImmutableList.of(
+                ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
+            Value.ofInt(100));
+
+    SelectStatement statement2 =
+        SelectStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col1")),
+            ImmutableList.of(
+                Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
+                Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
+                Predicate.column("c1").isEqualTo(Value.ofText("ccc")),
+                Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
+            ImmutableList.of(
+                ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
+            BindMarker.of());
+
+    // Act Assert
+    assertThatThrownBy(() -> statementValidator.validate(statement1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> statementValidator.validate(statement2))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void validate_SelectStatementWithNonIntTypeLimit_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    SelectStatement statement =
+        SelectStatement.of(
+            NAMESPACE_NAME,
+            TABLE_NAME,
+            ImmutableList.of(
+                Projection.column("p1"),
+                Projection.column("p2"),
+                Projection.column("c1"),
+                Projection.column("c2"),
+                Projection.column("col1")),
+            ImmutableList.of(
+                Predicate.column("p1").isEqualTo(Value.ofText("aaa")),
+                Predicate.column("p2").isEqualTo(Value.ofText("bbb")),
+                Predicate.column("c1").isEqualTo(Value.ofText("ccc")),
+                Predicate.column("c2").isEqualTo(Value.ofText("ddd"))),
+            ImmutableList.of(
+                ClusteringOrdering.column("c1").asc(), ClusteringOrdering.column("c2").desc()),
+            Value.ofText("limit"));
 
     // Act Assert
     assertThatThrownBy(() -> statementValidator.validate(statement))

--- a/core/src/test/java/com/scalar/db/sql/TransactionSessionTest.java
+++ b/core/src/test/java/com/scalar/db/sql/TransactionSessionTest.java
@@ -21,6 +21,9 @@ import com.scalar.db.sql.exception.UnknownTransactionStatusException;
 import com.scalar.db.sql.metadata.Metadata;
 import com.scalar.db.sql.statement.CreateTableStatement;
 import com.scalar.db.sql.statement.SelectStatement;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -161,6 +164,54 @@ public class TransactionSessionTest {
 
     verify(statementValidator, never()).validate(dmlStatement);
     verify(dmlStatementExecutor, never()).execute(transaction, dmlStatement);
+  }
+
+  @Test
+  public void execute_BindableStatementAndPositionalValuesGiven_ShouldThrowIllegalStateException()
+      throws TransactionException {
+    // Arrange
+    when(manager.start()).thenReturn(transaction);
+
+    SelectStatement bindableStatement = mock(SelectStatement.class);
+    List<Value> positionalValues = Collections.emptyList();
+
+    SelectStatement boundStatement = mock(SelectStatement.class);
+    when(bindableStatement.bind(positionalValues)).thenReturn(boundStatement);
+
+    ResultSet resultSet = mock(ResultSet.class);
+    when(dmlStatementExecutor.execute(transaction, boundStatement)).thenReturn(resultSet);
+
+    // Act
+    transactionSession.begin();
+    transactionSession.execute(bindableStatement, positionalValues);
+
+    // Assert
+    verify(statementValidator).validate(boundStatement);
+    verify(dmlStatementExecutor).execute(transaction, boundStatement);
+  }
+
+  @Test
+  public void execute_BindableStatementAndNamedValuesGiven_ShouldThrowIllegalStateException()
+      throws TransactionException {
+    // Arrange
+    when(manager.start()).thenReturn(transaction);
+
+    SelectStatement bindableStatement = mock(SelectStatement.class);
+    Map<String, Value> namedValues = Collections.emptyMap();
+
+    SelectStatement boundStatement = mock(SelectStatement.class);
+    when(bindableStatement.bind(namedValues)).thenReturn(boundStatement);
+
+    ResultSet resultSet = mock(ResultSet.class);
+    when(dmlStatementExecutor.execute(transaction, boundStatement)).thenReturn(resultSet);
+
+    // Act
+    transactionSession.begin();
+    transactionSession.execute(bindableStatement, namedValues);
+
+    // Assert
+    verify(statementValidator).validate(boundStatement);
+    verify(dmlStatementExecutor).execute(transaction, boundStatement);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/sql/builder/StatementBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/sql/builder/StatementBuilderTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.sql.Assignment;
+import com.scalar.db.sql.BindMarker;
 import com.scalar.db.sql.ClusteringOrder;
 import com.scalar.db.sql.ClusteringOrdering;
 import com.scalar.db.sql.DataType;
@@ -325,6 +326,18 @@ public class StatementBuilderTest {
                     Predicate.column("col2").isEqualTo(Value.ofText("bbb"))))
             .build();
 
+    DeleteStatement statement3 =
+        StatementBuilder.deleteFrom("ns1", "tbl1")
+            .where(Predicate.column("col1").isEqualTo(BindMarker.of()))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.of()))
+            .build();
+
+    DeleteStatement statement4 =
+        StatementBuilder.deleteFrom("ns1", "tbl1")
+            .where(Predicate.column("col1").isEqualTo(BindMarker.of("name1")))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.of("name2")))
+            .build();
+
     // Assert
     assertThat(statement1)
         .isEqualTo(
@@ -343,6 +356,24 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(20)),
                     Predicate.column("col2").isEqualTo(Value.ofText("bbb")))));
+
+    assertThat(statement3)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns1",
+                "tbl1",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of()),
+                    Predicate.column("col2").isEqualTo(BindMarker.of()))));
+
+    assertThat(statement4)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns1",
+                "tbl1",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                    Predicate.column("col2").isEqualTo(BindMarker.of("name2")))));
   }
 
   @Test
@@ -433,6 +464,20 @@ public class StatementBuilderTest {
                     Assignment.column("col2").value(Value.ofText("bbb"))))
             .build();
 
+    InsertStatement statement3 =
+        StatementBuilder.insertInto("ns2", "tbl2")
+            .values(
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of()))
+            .build();
+
+    InsertStatement statement4 =
+        StatementBuilder.insertInto("ns2", "tbl2")
+            .values(
+                Assignment.column("col1").value(BindMarker.of("name1")),
+                Assignment.column("col2").value(BindMarker.of("name2")))
+            .build();
+
     // Assert
     assertThat(statement1)
         .isEqualTo(
@@ -451,6 +496,24 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     Assignment.column("col1").value(Value.ofInt(20)),
                     Assignment.column("col2").value(Value.ofText("bbb")))));
+
+    assertThat(statement3)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns2",
+                "tbl2",
+                ImmutableList.of(
+                    Assignment.column("col1").value(BindMarker.of()),
+                    Assignment.column("col2").value(BindMarker.of()))));
+
+    assertThat(statement4)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns2",
+                "tbl2",
+                ImmutableList.of(
+                    Assignment.column("col1").value(BindMarker.of("name1")),
+                    Assignment.column("col2").value(BindMarker.of("name2")))));
   }
 
   @Test
@@ -499,6 +562,28 @@ public class StatementBuilderTest {
             .limit(10)
             .build();
 
+    SelectStatement statement4 =
+        StatementBuilder.select("col1", "col2", "col3")
+            .from("ns1", "tbl1")
+            .where(Predicate.column("col1").isEqualTo(BindMarker.of()))
+            .and(Predicate.column("col2").isGreaterThan(BindMarker.of()))
+            .and(Predicate.column("col2").isLessThan(BindMarker.of()))
+            .orderBy(
+                ClusteringOrdering.column("col2").desc(), ClusteringOrdering.column("col3").desc())
+            .limit(BindMarker.of())
+            .build();
+
+    SelectStatement statement5 =
+        StatementBuilder.select("col1", "col2", "col3")
+            .from("ns1", "tbl1")
+            .where(Predicate.column("col1").isEqualTo(BindMarker.of("name1")))
+            .and(Predicate.column("col2").isGreaterThan(BindMarker.of("name2")))
+            .and(Predicate.column("col2").isLessThan(BindMarker.of("name3")))
+            .orderBy(
+                ClusteringOrdering.column("col2").desc(), ClusteringOrdering.column("col3").desc())
+            .limit(BindMarker.of("name4"))
+            .build();
+
     // Assert
     assertThat(statement1)
         .isEqualTo(
@@ -516,7 +601,7 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     ClusteringOrdering.column("col2").desc(),
                     ClusteringOrdering.column("col3").desc()),
-                10));
+                Value.ofInt(10)));
 
     assertThat(statement2)
         .isEqualTo(
@@ -531,7 +616,7 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     ClusteringOrdering.column("col2").desc(),
                     ClusteringOrdering.column("col3").asc()),
-                10));
+                Value.ofInt(10)));
 
     assertThat(statement3)
         .isEqualTo(
@@ -546,7 +631,43 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     ClusteringOrdering.column("col2").desc(),
                     ClusteringOrdering.column("col3").desc()),
-                10));
+                Value.ofInt(10)));
+
+    assertThat(statement4)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns1",
+                "tbl1",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of()),
+                    Predicate.column("col2").isGreaterThan(BindMarker.of()),
+                    Predicate.column("col2").isLessThan(BindMarker.of())),
+                ImmutableList.of(
+                    ClusteringOrdering.column("col2").desc(),
+                    ClusteringOrdering.column("col3").desc()),
+                BindMarker.of()));
+
+    assertThat(statement5)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns1",
+                "tbl1",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                    Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
+                    Predicate.column("col2").isLessThan(BindMarker.of("name3"))),
+                ImmutableList.of(
+                    ClusteringOrdering.column("col2").desc(),
+                    ClusteringOrdering.column("col3").desc()),
+                BindMarker.of("name4")));
   }
 
   @Test
@@ -598,6 +719,24 @@ public class StatementBuilderTest {
                     Predicate.column("col2").isEqualTo(Value.ofText("ccc"))))
             .build();
 
+    UpdateStatement statement3 =
+        StatementBuilder.update("ns1", "tbl1")
+            .set(
+                Assignment.column("col3").value(BindMarker.of()),
+                Assignment.column("col4").value(BindMarker.of()))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.of()))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.of()))
+            .build();
+
+    UpdateStatement statement4 =
+        StatementBuilder.update("ns1", "tbl1")
+            .set(
+                Assignment.column("col3").value(BindMarker.of("name1")),
+                Assignment.column("col4").value(BindMarker.of("name2")))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.of("name3")))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.of("name4")))
+            .build();
+
     // Assert
     assertThat(statement1)
         .isEqualTo(
@@ -622,5 +761,29 @@ public class StatementBuilderTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(40)),
                     Predicate.column("col2").isEqualTo(Value.ofText("ccc")))));
+
+    assertThat(statement3)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns1",
+                "tbl1",
+                ImmutableList.of(
+                    Assignment.column("col3").value(BindMarker.of()),
+                    Assignment.column("col4").value(BindMarker.of())),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of()),
+                    Predicate.column("col2").isEqualTo(BindMarker.of()))));
+
+    assertThat(statement4)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns1",
+                "tbl1",
+                ImmutableList.of(
+                    Assignment.column("col3").value(BindMarker.of("name1")),
+                    Assignment.column("col4").value(BindMarker.of("name2"))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of("name3")),
+                    Predicate.column("col2").isEqualTo(BindMarker.of("name4")))));
   }
 }

--- a/core/src/test/java/com/scalar/db/sql/builder/StatementBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/sql/builder/StatementBuilderTest.java
@@ -328,14 +328,14 @@ public class StatementBuilderTest {
 
     DeleteStatement statement3 =
         StatementBuilder.deleteFrom("ns1", "tbl1")
-            .where(Predicate.column("col1").isEqualTo(BindMarker.of()))
-            .and(Predicate.column("col2").isEqualTo(BindMarker.of()))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.positional()))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.positional()))
             .build();
 
     DeleteStatement statement4 =
         StatementBuilder.deleteFrom("ns1", "tbl1")
-            .where(Predicate.column("col1").isEqualTo(BindMarker.of("name1")))
-            .and(Predicate.column("col2").isEqualTo(BindMarker.of("name2")))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.named("name1")))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.named("name2")))
             .build();
 
     // Assert
@@ -363,8 +363,8 @@ public class StatementBuilderTest {
                 "ns1",
                 "tbl1",
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of()),
-                    Predicate.column("col2").isEqualTo(BindMarker.of()))));
+                    Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                    Predicate.column("col2").isEqualTo(BindMarker.positional()))));
 
     assertThat(statement4)
         .isEqualTo(
@@ -372,8 +372,8 @@ public class StatementBuilderTest {
                 "ns1",
                 "tbl1",
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                    Predicate.column("col2").isEqualTo(BindMarker.of("name2")))));
+                    Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                    Predicate.column("col2").isEqualTo(BindMarker.named("name2")))));
   }
 
   @Test
@@ -467,15 +467,15 @@ public class StatementBuilderTest {
     InsertStatement statement3 =
         StatementBuilder.insertInto("ns2", "tbl2")
             .values(
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of()))
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.positional()))
             .build();
 
     InsertStatement statement4 =
         StatementBuilder.insertInto("ns2", "tbl2")
             .values(
-                Assignment.column("col1").value(BindMarker.of("name1")),
-                Assignment.column("col2").value(BindMarker.of("name2")))
+                Assignment.column("col1").value(BindMarker.named("name1")),
+                Assignment.column("col2").value(BindMarker.named("name2")))
             .build();
 
     // Assert
@@ -503,8 +503,8 @@ public class StatementBuilderTest {
                 "ns2",
                 "tbl2",
                 ImmutableList.of(
-                    Assignment.column("col1").value(BindMarker.of()),
-                    Assignment.column("col2").value(BindMarker.of()))));
+                    Assignment.column("col1").value(BindMarker.positional()),
+                    Assignment.column("col2").value(BindMarker.positional()))));
 
     assertThat(statement4)
         .isEqualTo(
@@ -512,8 +512,8 @@ public class StatementBuilderTest {
                 "ns2",
                 "tbl2",
                 ImmutableList.of(
-                    Assignment.column("col1").value(BindMarker.of("name1")),
-                    Assignment.column("col2").value(BindMarker.of("name2")))));
+                    Assignment.column("col1").value(BindMarker.named("name1")),
+                    Assignment.column("col2").value(BindMarker.named("name2")))));
   }
 
   @Test
@@ -565,23 +565,23 @@ public class StatementBuilderTest {
     SelectStatement statement4 =
         StatementBuilder.select("col1", "col2", "col3")
             .from("ns1", "tbl1")
-            .where(Predicate.column("col1").isEqualTo(BindMarker.of()))
-            .and(Predicate.column("col2").isGreaterThan(BindMarker.of()))
-            .and(Predicate.column("col2").isLessThan(BindMarker.of()))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.positional()))
+            .and(Predicate.column("col2").isGreaterThan(BindMarker.positional()))
+            .and(Predicate.column("col2").isLessThan(BindMarker.positional()))
             .orderBy(
                 ClusteringOrdering.column("col2").desc(), ClusteringOrdering.column("col3").desc())
-            .limit(BindMarker.of())
+            .limit(BindMarker.positional())
             .build();
 
     SelectStatement statement5 =
         StatementBuilder.select("col1", "col2", "col3")
             .from("ns1", "tbl1")
-            .where(Predicate.column("col1").isEqualTo(BindMarker.of("name1")))
-            .and(Predicate.column("col2").isGreaterThan(BindMarker.of("name2")))
-            .and(Predicate.column("col2").isLessThan(BindMarker.of("name3")))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.named("name1")))
+            .and(Predicate.column("col2").isGreaterThan(BindMarker.named("name2")))
+            .and(Predicate.column("col2").isLessThan(BindMarker.named("name3")))
             .orderBy(
                 ClusteringOrdering.column("col2").desc(), ClusteringOrdering.column("col3").desc())
-            .limit(BindMarker.of("name4"))
+            .limit(BindMarker.named("name4"))
             .build();
 
     // Assert
@@ -643,13 +643,13 @@ public class StatementBuilderTest {
                     Projection.column("col2"),
                     Projection.column("col3")),
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of()),
-                    Predicate.column("col2").isGreaterThan(BindMarker.of()),
-                    Predicate.column("col2").isLessThan(BindMarker.of())),
+                    Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                    Predicate.column("col2").isGreaterThan(BindMarker.positional()),
+                    Predicate.column("col2").isLessThan(BindMarker.positional())),
                 ImmutableList.of(
                     ClusteringOrdering.column("col2").desc(),
                     ClusteringOrdering.column("col3").desc()),
-                BindMarker.of()));
+                BindMarker.positional()));
 
     assertThat(statement5)
         .isEqualTo(
@@ -661,13 +661,13 @@ public class StatementBuilderTest {
                     Projection.column("col2"),
                     Projection.column("col3")),
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                    Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
-                    Predicate.column("col2").isLessThan(BindMarker.of("name3"))),
+                    Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                    Predicate.column("col2").isGreaterThan(BindMarker.named("name2")),
+                    Predicate.column("col2").isLessThan(BindMarker.named("name3"))),
                 ImmutableList.of(
                     ClusteringOrdering.column("col2").desc(),
                     ClusteringOrdering.column("col3").desc()),
-                BindMarker.of("name4")));
+                BindMarker.named("name4")));
   }
 
   @Test
@@ -722,19 +722,19 @@ public class StatementBuilderTest {
     UpdateStatement statement3 =
         StatementBuilder.update("ns1", "tbl1")
             .set(
-                Assignment.column("col3").value(BindMarker.of()),
-                Assignment.column("col4").value(BindMarker.of()))
-            .where(Predicate.column("col1").isEqualTo(BindMarker.of()))
-            .and(Predicate.column("col2").isEqualTo(BindMarker.of()))
+                Assignment.column("col3").value(BindMarker.positional()),
+                Assignment.column("col4").value(BindMarker.positional()))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.positional()))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.positional()))
             .build();
 
     UpdateStatement statement4 =
         StatementBuilder.update("ns1", "tbl1")
             .set(
-                Assignment.column("col3").value(BindMarker.of("name1")),
-                Assignment.column("col4").value(BindMarker.of("name2")))
-            .where(Predicate.column("col1").isEqualTo(BindMarker.of("name3")))
-            .and(Predicate.column("col2").isEqualTo(BindMarker.of("name4")))
+                Assignment.column("col3").value(BindMarker.named("name1")),
+                Assignment.column("col4").value(BindMarker.named("name2")))
+            .where(Predicate.column("col1").isEqualTo(BindMarker.named("name3")))
+            .and(Predicate.column("col2").isEqualTo(BindMarker.named("name4")))
             .build();
 
     // Assert
@@ -768,11 +768,11 @@ public class StatementBuilderTest {
                 "ns1",
                 "tbl1",
                 ImmutableList.of(
-                    Assignment.column("col3").value(BindMarker.of()),
-                    Assignment.column("col4").value(BindMarker.of())),
+                    Assignment.column("col3").value(BindMarker.positional()),
+                    Assignment.column("col4").value(BindMarker.positional())),
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of()),
-                    Predicate.column("col2").isEqualTo(BindMarker.of()))));
+                    Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                    Predicate.column("col2").isEqualTo(BindMarker.positional()))));
 
     assertThat(statement4)
         .isEqualTo(
@@ -780,10 +780,10 @@ public class StatementBuilderTest {
                 "ns1",
                 "tbl1",
                 ImmutableList.of(
-                    Assignment.column("col3").value(BindMarker.of("name1")),
-                    Assignment.column("col4").value(BindMarker.of("name2"))),
+                    Assignment.column("col3").value(BindMarker.named("name1")),
+                    Assignment.column("col4").value(BindMarker.named("name2"))),
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of("name3")),
-                    Predicate.column("col2").isEqualTo(BindMarker.of("name4")))));
+                    Predicate.column("col1").isEqualTo(BindMarker.named("name3")),
+                    Predicate.column("col2").isEqualTo(BindMarker.named("name4")))));
   }
 }

--- a/core/src/test/java/com/scalar/db/sql/statement/DeleteStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/DeleteStatementTest.java
@@ -25,9 +25,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues1 =
         Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
 
@@ -36,9 +36,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues2 = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"));
 
     DeleteStatement statement3 =
@@ -46,9 +46,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues3 =
         Arrays.asList(
             Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofText("ccc"));
@@ -76,7 +76,7 @@ public class DeleteStatementTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
-                    Predicate.column("col3").isEqualTo(BindMarker.of()))));
+                    Predicate.column("col3").isEqualTo(BindMarker.positional()))));
     assertThat(actual3)
         .isEqualTo(
             DeleteStatement.of(
@@ -97,9 +97,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     Map<String, Value> namedValues =
         ImmutableMap.of(
             "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
@@ -117,9 +117,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name3"))));
     Map<String, Value> namedValues1 =
         ImmutableMap.of(
             "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
@@ -129,9 +129,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name3"))));
     Map<String, Value> namedValues2 =
         ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
 
@@ -140,9 +140,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name3"))));
     Map<String, Value> namedValues3 =
         ImmutableMap.of(
             "name1",
@@ -159,9 +159,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name2"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name2"))));
     Map<String, Value> namedValues4 =
         ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
 
@@ -189,7 +189,7 @@ public class DeleteStatementTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
-                    Predicate.column("col3").isEqualTo(BindMarker.of("name3")))));
+                    Predicate.column("col3").isEqualTo(BindMarker.named("name3")))));
     assertThat(actual3)
         .isEqualTo(
             DeleteStatement.of(
@@ -219,9 +219,9 @@ public class DeleteStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name3"))));
     List<Value> positionalValues =
         Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
 

--- a/core/src/test/java/com/scalar/db/sql/statement/DeleteStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/DeleteStatementTest.java
@@ -1,0 +1,232 @@
+package com.scalar.db.sql.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.sql.BindMarker;
+import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.Value;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_INFERRED")
+public class DeleteStatementTest {
+
+  @Test
+  public void bind_positionalValuesGiven_ShouldBindProperly() {
+    // Arrange
+    DeleteStatement statement1 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues1 =
+        Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
+
+    DeleteStatement statement2 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues2 = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"));
+
+    DeleteStatement statement3 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues3 =
+        Arrays.asList(
+            Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofText("ccc"));
+
+    // Act
+    DeleteStatement actual1 = statement1.bind(positionalValues1);
+    DeleteStatement actual2 = statement2.bind(positionalValues2);
+    DeleteStatement actual3 = statement3.bind(positionalValues3);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofText("bbb")))));
+    assertThat(actual2)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(BindMarker.of()))));
+    assertThat(actual3)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofText("bbb")))));
+  }
+
+  @Test
+  public void
+      bind_namedValuesGiven_ButStatementHasPositionalBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    DeleteStatement statement =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    Map<String, Value> namedValues =
+        ImmutableMap.of(
+            "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(namedValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void bind_namedValuesGiven_ShouldBindProperly() {
+    // Arrange
+    DeleteStatement statement1 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+    Map<String, Value> namedValues1 =
+        ImmutableMap.of(
+            "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
+
+    DeleteStatement statement2 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+    Map<String, Value> namedValues2 =
+        ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
+
+    DeleteStatement statement3 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+    Map<String, Value> namedValues3 =
+        ImmutableMap.of(
+            "name1",
+            Value.ofInt(10),
+            "name2",
+            Value.ofText("aaa"),
+            "name3",
+            Value.ofText("bbb"),
+            "name4",
+            Value.ofText("ccc"));
+
+    DeleteStatement statement4 =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name2"))));
+    Map<String, Value> namedValues4 =
+        ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
+
+    // Act
+    DeleteStatement actual1 = statement1.bind(namedValues1);
+    DeleteStatement actual2 = statement2.bind(namedValues2);
+    DeleteStatement actual3 = statement3.bind(namedValues3);
+    DeleteStatement actual4 = statement4.bind(namedValues4);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofText("bbb")))));
+    assertThat(actual2)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(BindMarker.of("name3")))));
+    assertThat(actual3)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofText("bbb")))));
+    assertThat(actual4)
+        .isEqualTo(
+            DeleteStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofText("aaa")))));
+  }
+
+  @Test
+  public void
+      bind_positionalValuesGiven_ButStatementHasNamedBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    DeleteStatement statement =
+        DeleteStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+    List<Value> positionalValues =
+        Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(positionalValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/sql/statement/InsertStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/InsertStatementTest.java
@@ -25,9 +25,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of()),
-                Assignment.column("col3").value(BindMarker.of())));
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.positional()),
+                Assignment.column("col3").value(BindMarker.positional())));
     List<Value> positionalValues1 =
         Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
 
@@ -36,9 +36,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of()),
-                Assignment.column("col3").value(BindMarker.of())));
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.positional()),
+                Assignment.column("col3").value(BindMarker.positional())));
     List<Value> positionalValues2 = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"));
 
     InsertStatement statement3 =
@@ -46,9 +46,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of()),
-                Assignment.column("col3").value(BindMarker.of())));
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.positional()),
+                Assignment.column("col3").value(BindMarker.positional())));
     List<Value> positionalValues3 =
         Arrays.asList(
             Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofText("ccc"));
@@ -76,7 +76,7 @@ public class InsertStatementTest {
                 ImmutableList.of(
                     Assignment.column("col1").value(Value.ofInt(10)),
                     Assignment.column("col2").value(Value.ofText("aaa")),
-                    Assignment.column("col3").value(BindMarker.of()))));
+                    Assignment.column("col3").value(BindMarker.positional()))));
     assertThat(actual3)
         .isEqualTo(
             InsertStatement.of(
@@ -97,9 +97,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of()),
-                Assignment.column("col2").value(BindMarker.of()),
-                Assignment.column("col3").value(BindMarker.of())));
+                Assignment.column("col1").value(BindMarker.positional()),
+                Assignment.column("col2").value(BindMarker.positional()),
+                Assignment.column("col3").value(BindMarker.positional())));
     Map<String, Value> namedValues =
         ImmutableMap.of(
             "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
@@ -117,9 +117,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of("name1")),
-                Assignment.column("col2").value(BindMarker.of("name2")),
-                Assignment.column("col3").value(BindMarker.of("name3"))));
+                Assignment.column("col1").value(BindMarker.named("name1")),
+                Assignment.column("col2").value(BindMarker.named("name2")),
+                Assignment.column("col3").value(BindMarker.named("name3"))));
     Map<String, Value> namedValues1 =
         ImmutableMap.of(
             "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
@@ -129,9 +129,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of("name1")),
-                Assignment.column("col2").value(BindMarker.of("name2")),
-                Assignment.column("col3").value(BindMarker.of("name3"))));
+                Assignment.column("col1").value(BindMarker.named("name1")),
+                Assignment.column("col2").value(BindMarker.named("name2")),
+                Assignment.column("col3").value(BindMarker.named("name3"))));
     Map<String, Value> namedValues2 =
         ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
 
@@ -140,9 +140,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of("name1")),
-                Assignment.column("col2").value(BindMarker.of("name2")),
-                Assignment.column("col3").value(BindMarker.of("name3"))));
+                Assignment.column("col1").value(BindMarker.named("name1")),
+                Assignment.column("col2").value(BindMarker.named("name2")),
+                Assignment.column("col3").value(BindMarker.named("name3"))));
     Map<String, Value> namedValues3 =
         ImmutableMap.of(
             "name1",
@@ -159,9 +159,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of("name1")),
-                Assignment.column("col2").value(BindMarker.of("name2")),
-                Assignment.column("col3").value(BindMarker.of("name2"))));
+                Assignment.column("col1").value(BindMarker.named("name1")),
+                Assignment.column("col2").value(BindMarker.named("name2")),
+                Assignment.column("col3").value(BindMarker.named("name2"))));
     Map<String, Value> namedValues4 =
         ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
 
@@ -189,7 +189,7 @@ public class InsertStatementTest {
                 ImmutableList.of(
                     Assignment.column("col1").value(Value.ofInt(10)),
                     Assignment.column("col2").value(Value.ofText("aaa")),
-                    Assignment.column("col3").value(BindMarker.of("name3")))));
+                    Assignment.column("col3").value(BindMarker.named("name3")))));
     assertThat(actual3)
         .isEqualTo(
             InsertStatement.of(
@@ -219,9 +219,9 @@ public class InsertStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col1").value(BindMarker.of("name1")),
-                Assignment.column("col2").value(BindMarker.of("name2")),
-                Assignment.column("col3").value(BindMarker.of("name3"))));
+                Assignment.column("col1").value(BindMarker.named("name1")),
+                Assignment.column("col2").value(BindMarker.named("name2")),
+                Assignment.column("col3").value(BindMarker.named("name3"))));
     List<Value> positionalValues =
         Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
 

--- a/core/src/test/java/com/scalar/db/sql/statement/InsertStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/InsertStatementTest.java
@@ -1,0 +1,232 @@
+package com.scalar.db.sql.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.sql.Assignment;
+import com.scalar.db.sql.BindMarker;
+import com.scalar.db.sql.Value;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_INFERRED")
+public class InsertStatementTest {
+
+  @Test
+  public void bind_positionalValuesGiven_ShouldBindProperly() {
+    // Arrange
+    InsertStatement statement1 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of()),
+                Assignment.column("col3").value(BindMarker.of())));
+    List<Value> positionalValues1 =
+        Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
+
+    InsertStatement statement2 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of()),
+                Assignment.column("col3").value(BindMarker.of())));
+    List<Value> positionalValues2 = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"));
+
+    InsertStatement statement3 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of()),
+                Assignment.column("col3").value(BindMarker.of())));
+    List<Value> positionalValues3 =
+        Arrays.asList(
+            Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofText("ccc"));
+
+    // Act
+    InsertStatement actual1 = statement1.bind(positionalValues1);
+    InsertStatement actual2 = statement2.bind(positionalValues2);
+    InsertStatement actual3 = statement3.bind(positionalValues3);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(Value.ofText("bbb")))));
+    assertThat(actual2)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(BindMarker.of()))));
+    assertThat(actual3)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(Value.ofText("bbb")))));
+  }
+
+  @Test
+  public void
+      bind_namedValuesGiven_ButStatementHasPositionalBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    InsertStatement statement =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of()),
+                Assignment.column("col2").value(BindMarker.of()),
+                Assignment.column("col3").value(BindMarker.of())));
+    Map<String, Value> namedValues =
+        ImmutableMap.of(
+            "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(namedValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void bind_namedValuesGiven_ShouldBindProperly() {
+    // Arrange
+    InsertStatement statement1 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of("name1")),
+                Assignment.column("col2").value(BindMarker.of("name2")),
+                Assignment.column("col3").value(BindMarker.of("name3"))));
+    Map<String, Value> namedValues1 =
+        ImmutableMap.of(
+            "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofText("bbb"));
+
+    InsertStatement statement2 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of("name1")),
+                Assignment.column("col2").value(BindMarker.of("name2")),
+                Assignment.column("col3").value(BindMarker.of("name3"))));
+    Map<String, Value> namedValues2 =
+        ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
+
+    InsertStatement statement3 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of("name1")),
+                Assignment.column("col2").value(BindMarker.of("name2")),
+                Assignment.column("col3").value(BindMarker.of("name3"))));
+    Map<String, Value> namedValues3 =
+        ImmutableMap.of(
+            "name1",
+            Value.ofInt(10),
+            "name2",
+            Value.ofText("aaa"),
+            "name3",
+            Value.ofText("bbb"),
+            "name4",
+            Value.ofText("ccc"));
+
+    InsertStatement statement4 =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of("name1")),
+                Assignment.column("col2").value(BindMarker.of("name2")),
+                Assignment.column("col3").value(BindMarker.of("name2"))));
+    Map<String, Value> namedValues4 =
+        ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
+
+    // Act
+    InsertStatement actual1 = statement1.bind(namedValues1);
+    InsertStatement actual2 = statement2.bind(namedValues2);
+    InsertStatement actual3 = statement3.bind(namedValues3);
+    InsertStatement actual4 = statement4.bind(namedValues4);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(Value.ofText("bbb")))));
+    assertThat(actual2)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(BindMarker.of("name3")))));
+    assertThat(actual3)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(Value.ofText("bbb")))));
+    assertThat(actual4)
+        .isEqualTo(
+            InsertStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col1").value(Value.ofInt(10)),
+                    Assignment.column("col2").value(Value.ofText("aaa")),
+                    Assignment.column("col3").value(Value.ofText("aaa")))));
+  }
+
+  @Test
+  public void
+      bind_positionalValuesGiven_ButStatementHasNamedBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    InsertStatement statement =
+        InsertStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col1").value(BindMarker.of("name1")),
+                Assignment.column("col2").value(BindMarker.of("name2")),
+                Assignment.column("col3").value(BindMarker.of("name3"))));
+    List<Value> positionalValues =
+        Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(positionalValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/sql/statement/SelectStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/SelectStatementTest.java
@@ -1,0 +1,333 @@
+package com.scalar.db.sql.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.sql.BindMarker;
+import com.scalar.db.sql.ClusteringOrdering;
+import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.Projection;
+import com.scalar.db.sql.Value;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_INFERRED")
+public class SelectStatementTest {
+
+  @Test
+  public void bind_positionalValuesGiven_ShouldBindProperly() {
+    // Arrange
+    SelectStatement statement1 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isGreaterThan(BindMarker.of()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of());
+    List<Value> positionalValues1 =
+        Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofInt(100));
+
+    SelectStatement statement2 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isGreaterThan(BindMarker.of()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of());
+    List<Value> positionalValues2 = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"));
+
+    SelectStatement statement3 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isGreaterThan(BindMarker.of()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of());
+    List<Value> positionalValues3 =
+        Arrays.asList(
+            Value.ofInt(10),
+            Value.ofText("aaa"),
+            Value.ofText("bbb"),
+            Value.ofInt(100),
+            Value.ofText("ccc"));
+
+    // Act
+    SelectStatement actual1 = statement1.bind(positionalValues1);
+    SelectStatement actual2 = statement2.bind(positionalValues2);
+    SelectStatement actual3 = statement3.bind(positionalValues3);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(Value.ofText("bbb"))),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                Value.ofInt(100)));
+    assertThat(actual2)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                BindMarker.of()));
+    assertThat(actual3)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(Value.ofText("bbb"))),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                Value.ofInt(100)));
+  }
+
+  @Test
+  public void
+      bind_namedValuesGiven_ButStatementHasPositionalBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    SelectStatement statement =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isGreaterThan(BindMarker.of()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of());
+    Map<String, Value> namedValues =
+        ImmutableMap.of(
+            "name1",
+            Value.ofInt(10),
+            "name2",
+            Value.ofText("aaa"),
+            "name3",
+            Value.ofText("bbb"),
+            "name4",
+            Value.ofInt(100));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(namedValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void bind_namedValuesGiven_ShouldBindProperly() {
+    // Arrange
+    SelectStatement statement1 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of("name4"));
+    Map<String, Value> namedValues1 =
+        ImmutableMap.of(
+            "name1",
+            Value.ofInt(10),
+            "name2",
+            Value.ofText("aaa"),
+            "name3",
+            Value.ofText("bbb"),
+            "name4",
+            Value.ofInt(100));
+
+    SelectStatement statement2 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of("name4"));
+    Map<String, Value> namedValues2 =
+        ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
+
+    SelectStatement statement3 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of("name4"));
+    Map<String, Value> namedValues3 =
+        ImmutableMap.of(
+            "name1",
+            Value.ofInt(10),
+            "name2",
+            Value.ofText("aaa"),
+            "name3",
+            Value.ofText("bbb"),
+            "name4",
+            Value.ofInt(100),
+            "name5",
+            Value.ofText("ccc"));
+
+    SelectStatement statement4 =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name2"))),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of("name3"));
+    Map<String, Value> namedValues4 =
+        ImmutableMap.of(
+            "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofInt(100));
+
+    // Act
+    SelectStatement actual1 = statement1.bind(namedValues1);
+    SelectStatement actual2 = statement2.bind(namedValues2);
+    SelectStatement actual3 = statement3.bind(namedValues3);
+    SelectStatement actual4 = statement4.bind(namedValues4);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(Value.ofText("bbb"))),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                Value.ofInt(100)));
+    assertThat(actual2)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                BindMarker.of("name4")));
+    assertThat(actual3)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(Value.ofText("bbb"))),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                Value.ofInt(100)));
+    assertThat(actual4)
+        .isEqualTo(
+            SelectStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Projection.column("col1"),
+                    Projection.column("col2"),
+                    Projection.column("col3")),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
+                    Predicate.column("col2").isLessThanOrEqualTo(Value.ofText("aaa"))),
+                ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+                Value.ofInt(100)));
+  }
+
+  @Test
+  public void
+      bind_positionalValuesGiven_ButStatementHasNamedBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    SelectStatement statement =
+        SelectStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+            ImmutableList.of(ClusteringOrdering.column("col2").desc()),
+            BindMarker.of("name4"));
+    List<Value> positionalValues =
+        Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofInt(100));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(positionalValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/sql/statement/SelectStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/SelectStatementTest.java
@@ -29,11 +29,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isGreaterThan(BindMarker.of()),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isGreaterThan(BindMarker.positional()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.positional())),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of());
+            BindMarker.positional());
     List<Value> positionalValues1 =
         Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofInt(100));
 
@@ -44,11 +44,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isGreaterThan(BindMarker.of()),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isGreaterThan(BindMarker.positional()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.positional())),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of());
+            BindMarker.positional());
     List<Value> positionalValues2 = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"));
 
     SelectStatement statement3 =
@@ -58,11 +58,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isGreaterThan(BindMarker.of()),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isGreaterThan(BindMarker.positional()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.positional())),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of());
+            BindMarker.positional());
     List<Value> positionalValues3 =
         Arrays.asList(
             Value.ofInt(10),
@@ -104,9 +104,9 @@ public class SelectStatementTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
-                    Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+                    Predicate.column("col2").isLessThanOrEqualTo(BindMarker.positional())),
                 ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-                BindMarker.of()));
+                BindMarker.positional()));
     assertThat(actual3)
         .isEqualTo(
             SelectStatement.of(
@@ -135,11 +135,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isGreaterThan(BindMarker.of()),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of())),
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isGreaterThan(BindMarker.positional()),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.positional())),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of());
+            BindMarker.positional());
     Map<String, Value> namedValues =
         ImmutableMap.of(
             "name1",
@@ -166,11 +166,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.named("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.named("name3"))),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of("name4"));
+            BindMarker.named("name4"));
     Map<String, Value> namedValues1 =
         ImmutableMap.of(
             "name1",
@@ -189,11 +189,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.named("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.named("name3"))),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of("name4"));
+            BindMarker.named("name4"));
     Map<String, Value> namedValues2 =
         ImmutableMap.of("name1", Value.ofInt(10), "name2", Value.ofText("aaa"));
 
@@ -204,11 +204,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.named("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.named("name3"))),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of("name4"));
+            BindMarker.named("name4"));
     Map<String, Value> namedValues3 =
         ImmutableMap.of(
             "name1",
@@ -229,11 +229,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name2"))),
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.named("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.named("name2"))),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of("name3"));
+            BindMarker.named("name3"));
     Map<String, Value> namedValues4 =
         ImmutableMap.of(
             "name1", Value.ofInt(10), "name2", Value.ofText("aaa"), "name3", Value.ofInt(100));
@@ -272,9 +272,9 @@ public class SelectStatementTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isGreaterThan(Value.ofText("aaa")),
-                    Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+                    Predicate.column("col2").isLessThanOrEqualTo(BindMarker.named("name3"))),
                 ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-                BindMarker.of("name4")));
+                BindMarker.named("name4")));
     assertThat(actual3)
         .isEqualTo(
             SelectStatement.of(
@@ -318,11 +318,11 @@ public class SelectStatementTest {
             ImmutableList.of(
                 Projection.column("col1"), Projection.column("col2"), Projection.column("col3")),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isGreaterThan(BindMarker.of("name2")),
-                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.of("name3"))),
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isGreaterThan(BindMarker.named("name2")),
+                Predicate.column("col2").isLessThanOrEqualTo(BindMarker.named("name3"))),
             ImmutableList.of(ClusteringOrdering.column("col2").desc()),
-            BindMarker.of("name4"));
+            BindMarker.named("name4"));
     List<Value> positionalValues =
         Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofText("bbb"), Value.ofInt(100));
 

--- a/core/src/test/java/com/scalar/db/sql/statement/UpdateStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/UpdateStatementTest.java
@@ -1,0 +1,400 @@
+package com.scalar.db.sql.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.sql.Assignment;
+import com.scalar.db.sql.BindMarker;
+import com.scalar.db.sql.Predicate;
+import com.scalar.db.sql.Value;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_INFERRED")
+public class UpdateStatementTest {
+
+  @Test
+  public void bind_positionalValuesGiven_ShouldBindProperly() {
+    // Arrange
+    UpdateStatement statement1 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of()),
+                Assignment.column("col5").value(BindMarker.of()),
+                Assignment.column("col6").value(BindMarker.of())),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues1 =
+        Arrays.asList(
+            Value.ofBoolean(true),
+            Value.ofFloat(1.23F),
+            Value.ofDouble(4.56),
+            Value.ofInt(10),
+            Value.ofText("aaa"),
+            Value.ofBigInt(100L));
+
+    UpdateStatement statement2 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of()),
+                Assignment.column("col5").value(BindMarker.of()),
+                Assignment.column("col6").value(BindMarker.of())),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues2 =
+        Arrays.asList(
+            Value.ofBoolean(true),
+            Value.ofFloat(1.23F),
+            Value.ofDouble(4.56),
+            Value.ofInt(10),
+            Value.ofText("aaa"));
+
+    UpdateStatement statement3 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of()),
+                Assignment.column("col5").value(BindMarker.of()),
+                Assignment.column("col6").value(BindMarker.of())),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues3 = Arrays.asList(Value.ofBoolean(true), Value.ofFloat(1.23F));
+
+    UpdateStatement statement4 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of()),
+                Assignment.column("col5").value(BindMarker.of()),
+                Assignment.column("col6").value(BindMarker.of())),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    List<Value> positionalValues4 =
+        Arrays.asList(
+            Value.ofBoolean(true),
+            Value.ofFloat(1.23F),
+            Value.ofDouble(4.56),
+            Value.ofInt(10),
+            Value.ofText("aaa"),
+            Value.ofBigInt(100L),
+            Value.ofText("bbb"));
+
+    // Act
+    UpdateStatement actual1 = statement1.bind(positionalValues1);
+    UpdateStatement actual2 = statement2.bind(positionalValues2);
+    UpdateStatement actual3 = statement3.bind(positionalValues3);
+    UpdateStatement actual4 = statement4.bind(positionalValues4);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(Value.ofDouble(4.56))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofBigInt(100L)))));
+    assertThat(actual2)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(Value.ofDouble(4.56))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(BindMarker.of()))));
+    assertThat(actual3)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(BindMarker.of())),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of()),
+                    Predicate.column("col2").isEqualTo(BindMarker.of()),
+                    Predicate.column("col3").isEqualTo(BindMarker.of()))));
+    assertThat(actual4)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(Value.ofDouble(4.56))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofBigInt(100L)))));
+  }
+
+  @Test
+  public void
+      bind_namedValuesGiven_ButStatementHasPositionalBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    UpdateStatement statement =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of()),
+                Assignment.column("col5").value(BindMarker.of()),
+                Assignment.column("col6").value(BindMarker.of())),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of()),
+                Predicate.column("col2").isEqualTo(BindMarker.of()),
+                Predicate.column("col3").isEqualTo(BindMarker.of())));
+    Map<String, Value> namedValues =
+        ImmutableMap.<String, Value>builder()
+            .put("name1", Value.ofBoolean(true))
+            .put("name2", Value.ofFloat(1.23F))
+            .put("name3", Value.ofDouble(4.56))
+            .put("name4", Value.ofInt(10))
+            .put("name5", Value.ofText("aaa"))
+            .put("name6", Value.ofBigInt(100L))
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(namedValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void bind_namedValuesGiven_ShouldBindProperly() {
+    // Arrange
+    UpdateStatement statement1 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of("name1")),
+                Assignment.column("col5").value(BindMarker.of("name2")),
+                Assignment.column("col6").value(BindMarker.of("name3"))),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+    Map<String, Value> namedValues1 =
+        ImmutableMap.<String, Value>builder()
+            .put("name1", Value.ofBoolean(true))
+            .put("name2", Value.ofFloat(1.23F))
+            .put("name3", Value.ofDouble(4.56))
+            .put("name4", Value.ofInt(10))
+            .put("name5", Value.ofText("aaa"))
+            .put("name6", Value.ofBigInt(100L))
+            .build();
+
+    UpdateStatement statement2 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of("name1")),
+                Assignment.column("col5").value(BindMarker.of("name2")),
+                Assignment.column("col6").value(BindMarker.of("name3"))),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+    Map<String, Value> namedValues2 =
+        ImmutableMap.<String, Value>builder()
+            .put("name1", Value.ofBoolean(true))
+            .put("name2", Value.ofFloat(1.23F))
+            .put("name3", Value.ofDouble(4.56))
+            .put("name4", Value.ofInt(10))
+            .put("name5", Value.ofText("aaa"))
+            .build();
+
+    UpdateStatement statement3 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of("name1")),
+                Assignment.column("col5").value(BindMarker.of("name2")),
+                Assignment.column("col6").value(BindMarker.of("name3"))),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+    Map<String, Value> namedValues3 =
+        ImmutableMap.of("name1", Value.ofBoolean(true), "name2", Value.ofFloat(1.23F));
+
+    UpdateStatement statement4 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of("name1")),
+                Assignment.column("col5").value(BindMarker.of("name2")),
+                Assignment.column("col6").value(BindMarker.of("name3"))),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+    Map<String, Value> namedValues4 =
+        ImmutableMap.<String, Value>builder()
+            .put("name1", Value.ofBoolean(true))
+            .put("name2", Value.ofFloat(1.23F))
+            .put("name3", Value.ofDouble(4.56))
+            .put("name4", Value.ofInt(10))
+            .put("name5", Value.ofText("aaa"))
+            .put("name6", Value.ofBigInt(100L))
+            .put("name7", Value.ofText("bbb"))
+            .build();
+
+    UpdateStatement statement5 =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of("name1")),
+                Assignment.column("col5").value(BindMarker.of("name2")),
+                Assignment.column("col6").value(BindMarker.of("name3"))),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+    Map<String, Value> namedValues5 =
+        ImmutableMap.<String, Value>builder()
+            .put("name1", Value.ofInt(10))
+            .put("name2", Value.ofText("aaa"))
+            .put("name3", Value.ofBigInt(100L))
+            .build();
+
+    // Act
+    UpdateStatement actual1 = statement1.bind(namedValues1);
+    UpdateStatement actual2 = statement2.bind(namedValues2);
+    UpdateStatement actual3 = statement3.bind(namedValues3);
+    UpdateStatement actual4 = statement4.bind(namedValues4);
+    UpdateStatement actual5 = statement5.bind(namedValues5);
+
+    // Assert
+    assertThat(actual1)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(Value.ofDouble(4.56))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofBigInt(100L)))));
+    assertThat(actual2)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(Value.ofDouble(4.56))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(BindMarker.of("name6")))));
+    assertThat(actual3)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(BindMarker.of("name3"))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
+                    Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
+                    Predicate.column("col3").isEqualTo(BindMarker.of("name6")))));
+    assertThat(actual4)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofBoolean(true)),
+                    Assignment.column("col5").value(Value.ofFloat(1.23F)),
+                    Assignment.column("col6").value(Value.ofDouble(4.56))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofBigInt(100L)))));
+    assertThat(actual5)
+        .isEqualTo(
+            UpdateStatement.of(
+                "ns",
+                "table",
+                ImmutableList.of(
+                    Assignment.column("col4").value(Value.ofInt(10)),
+                    Assignment.column("col5").value(Value.ofText("aaa")),
+                    Assignment.column("col6").value(Value.ofBigInt(100L))),
+                ImmutableList.of(
+                    Predicate.column("col1").isEqualTo(Value.ofInt(10)),
+                    Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
+                    Predicate.column("col3").isEqualTo(Value.ofBigInt(100L)))));
+  }
+
+  @Test
+  public void
+      bind_positionalValuesGiven_ButStatementHasNamedBindMarker_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    UpdateStatement statement =
+        UpdateStatement.of(
+            "ns",
+            "table",
+            ImmutableList.of(
+                Assignment.column("col4").value(BindMarker.of("name1")),
+                Assignment.column("col5").value(BindMarker.of("name2")),
+                Assignment.column("col6").value(BindMarker.of("name3"))),
+            ImmutableList.of(
+                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+    List<Value> positionalValues =
+        Arrays.asList(
+            Value.ofBoolean(true),
+            Value.ofFloat(1.23F),
+            Value.ofDouble(4.56),
+            Value.ofInt(10),
+            Value.ofText("aaa"),
+            Value.ofBigInt(100L));
+
+    // Act Assert
+    assertThatThrownBy(() -> statement.bind(positionalValues))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/sql/statement/UpdateStatementTest.java
+++ b/core/src/test/java/com/scalar/db/sql/statement/UpdateStatementTest.java
@@ -26,13 +26,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of()),
-                Assignment.column("col5").value(BindMarker.of()),
-                Assignment.column("col6").value(BindMarker.of())),
+                Assignment.column("col4").value(BindMarker.positional()),
+                Assignment.column("col5").value(BindMarker.positional()),
+                Assignment.column("col6").value(BindMarker.positional())),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues1 =
         Arrays.asList(
             Value.ofBoolean(true),
@@ -47,13 +47,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of()),
-                Assignment.column("col5").value(BindMarker.of()),
-                Assignment.column("col6").value(BindMarker.of())),
+                Assignment.column("col4").value(BindMarker.positional()),
+                Assignment.column("col5").value(BindMarker.positional()),
+                Assignment.column("col6").value(BindMarker.positional())),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues2 =
         Arrays.asList(
             Value.ofBoolean(true),
@@ -67,13 +67,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of()),
-                Assignment.column("col5").value(BindMarker.of()),
-                Assignment.column("col6").value(BindMarker.of())),
+                Assignment.column("col4").value(BindMarker.positional()),
+                Assignment.column("col5").value(BindMarker.positional()),
+                Assignment.column("col6").value(BindMarker.positional())),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues3 = Arrays.asList(Value.ofBoolean(true), Value.ofFloat(1.23F));
 
     UpdateStatement statement4 =
@@ -81,13 +81,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of()),
-                Assignment.column("col5").value(BindMarker.of()),
-                Assignment.column("col6").value(BindMarker.of())),
+                Assignment.column("col4").value(BindMarker.positional()),
+                Assignment.column("col5").value(BindMarker.positional()),
+                Assignment.column("col6").value(BindMarker.positional())),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     List<Value> positionalValues4 =
         Arrays.asList(
             Value.ofBoolean(true),
@@ -130,7 +130,7 @@ public class UpdateStatementTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
-                    Predicate.column("col3").isEqualTo(BindMarker.of()))));
+                    Predicate.column("col3").isEqualTo(BindMarker.positional()))));
     assertThat(actual3)
         .isEqualTo(
             UpdateStatement.of(
@@ -139,11 +139,11 @@ public class UpdateStatementTest {
                 ImmutableList.of(
                     Assignment.column("col4").value(Value.ofBoolean(true)),
                     Assignment.column("col5").value(Value.ofFloat(1.23F)),
-                    Assignment.column("col6").value(BindMarker.of())),
+                    Assignment.column("col6").value(BindMarker.positional())),
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of()),
-                    Predicate.column("col2").isEqualTo(BindMarker.of()),
-                    Predicate.column("col3").isEqualTo(BindMarker.of()))));
+                    Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                    Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                    Predicate.column("col3").isEqualTo(BindMarker.positional()))));
     assertThat(actual4)
         .isEqualTo(
             UpdateStatement.of(
@@ -168,13 +168,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of()),
-                Assignment.column("col5").value(BindMarker.of()),
-                Assignment.column("col6").value(BindMarker.of())),
+                Assignment.column("col4").value(BindMarker.positional()),
+                Assignment.column("col5").value(BindMarker.positional()),
+                Assignment.column("col6").value(BindMarker.positional())),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of()),
-                Predicate.column("col2").isEqualTo(BindMarker.of()),
-                Predicate.column("col3").isEqualTo(BindMarker.of())));
+                Predicate.column("col1").isEqualTo(BindMarker.positional()),
+                Predicate.column("col2").isEqualTo(BindMarker.positional()),
+                Predicate.column("col3").isEqualTo(BindMarker.positional())));
     Map<String, Value> namedValues =
         ImmutableMap.<String, Value>builder()
             .put("name1", Value.ofBoolean(true))
@@ -198,13 +198,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of("name1")),
-                Assignment.column("col5").value(BindMarker.of("name2")),
-                Assignment.column("col6").value(BindMarker.of("name3"))),
+                Assignment.column("col4").value(BindMarker.named("name1")),
+                Assignment.column("col5").value(BindMarker.named("name2")),
+                Assignment.column("col6").value(BindMarker.named("name3"))),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name6"))));
     Map<String, Value> namedValues1 =
         ImmutableMap.<String, Value>builder()
             .put("name1", Value.ofBoolean(true))
@@ -220,13 +220,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of("name1")),
-                Assignment.column("col5").value(BindMarker.of("name2")),
-                Assignment.column("col6").value(BindMarker.of("name3"))),
+                Assignment.column("col4").value(BindMarker.named("name1")),
+                Assignment.column("col5").value(BindMarker.named("name2")),
+                Assignment.column("col6").value(BindMarker.named("name3"))),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name6"))));
     Map<String, Value> namedValues2 =
         ImmutableMap.<String, Value>builder()
             .put("name1", Value.ofBoolean(true))
@@ -241,13 +241,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of("name1")),
-                Assignment.column("col5").value(BindMarker.of("name2")),
-                Assignment.column("col6").value(BindMarker.of("name3"))),
+                Assignment.column("col4").value(BindMarker.named("name1")),
+                Assignment.column("col5").value(BindMarker.named("name2")),
+                Assignment.column("col6").value(BindMarker.named("name3"))),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name6"))));
     Map<String, Value> namedValues3 =
         ImmutableMap.of("name1", Value.ofBoolean(true), "name2", Value.ofFloat(1.23F));
 
@@ -256,13 +256,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of("name1")),
-                Assignment.column("col5").value(BindMarker.of("name2")),
-                Assignment.column("col6").value(BindMarker.of("name3"))),
+                Assignment.column("col4").value(BindMarker.named("name1")),
+                Assignment.column("col5").value(BindMarker.named("name2")),
+                Assignment.column("col6").value(BindMarker.named("name3"))),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name6"))));
     Map<String, Value> namedValues4 =
         ImmutableMap.<String, Value>builder()
             .put("name1", Value.ofBoolean(true))
@@ -279,13 +279,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of("name1")),
-                Assignment.column("col5").value(BindMarker.of("name2")),
-                Assignment.column("col6").value(BindMarker.of("name3"))),
+                Assignment.column("col4").value(BindMarker.named("name1")),
+                Assignment.column("col5").value(BindMarker.named("name2")),
+                Assignment.column("col6").value(BindMarker.named("name3"))),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name1")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name2")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name3"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name1")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name2")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name3"))));
     Map<String, Value> namedValues5 =
         ImmutableMap.<String, Value>builder()
             .put("name1", Value.ofInt(10))
@@ -326,7 +326,7 @@ public class UpdateStatementTest {
                 ImmutableList.of(
                     Predicate.column("col1").isEqualTo(Value.ofInt(10)),
                     Predicate.column("col2").isEqualTo(Value.ofText("aaa")),
-                    Predicate.column("col3").isEqualTo(BindMarker.of("name6")))));
+                    Predicate.column("col3").isEqualTo(BindMarker.named("name6")))));
     assertThat(actual3)
         .isEqualTo(
             UpdateStatement.of(
@@ -335,11 +335,11 @@ public class UpdateStatementTest {
                 ImmutableList.of(
                     Assignment.column("col4").value(Value.ofBoolean(true)),
                     Assignment.column("col5").value(Value.ofFloat(1.23F)),
-                    Assignment.column("col6").value(BindMarker.of("name3"))),
+                    Assignment.column("col6").value(BindMarker.named("name3"))),
                 ImmutableList.of(
-                    Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
-                    Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
-                    Predicate.column("col3").isEqualTo(BindMarker.of("name6")))));
+                    Predicate.column("col1").isEqualTo(BindMarker.named("name4")),
+                    Predicate.column("col2").isEqualTo(BindMarker.named("name5")),
+                    Predicate.column("col3").isEqualTo(BindMarker.named("name6")))));
     assertThat(actual4)
         .isEqualTo(
             UpdateStatement.of(
@@ -377,13 +377,13 @@ public class UpdateStatementTest {
             "ns",
             "table",
             ImmutableList.of(
-                Assignment.column("col4").value(BindMarker.of("name1")),
-                Assignment.column("col5").value(BindMarker.of("name2")),
-                Assignment.column("col6").value(BindMarker.of("name3"))),
+                Assignment.column("col4").value(BindMarker.named("name1")),
+                Assignment.column("col5").value(BindMarker.named("name2")),
+                Assignment.column("col6").value(BindMarker.named("name3"))),
             ImmutableList.of(
-                Predicate.column("col1").isEqualTo(BindMarker.of("name4")),
-                Predicate.column("col2").isEqualTo(BindMarker.of("name5")),
-                Predicate.column("col3").isEqualTo(BindMarker.of("name6"))));
+                Predicate.column("col1").isEqualTo(BindMarker.named("name4")),
+                Predicate.column("col2").isEqualTo(BindMarker.named("name5")),
+                Predicate.column("col3").isEqualTo(BindMarker.named("name6"))));
     List<Value> positionalValues =
         Arrays.asList(
             Value.ofBoolean(true),


### PR DESCRIPTION
This PR adds a Support for parameterized statements in SQL API.

There are two kinds of bind markers, `positional bind marker` and `named bind marker`.

The following code shows how to use parameterized statements:
```java
SqlStatementSession sqlStatementSession = ...;

// Select statement with positional bind markers
SelectStatement selectStatement =
    StatementBuilder.select("col1", "col2", "col3")
        .from("ns", "tbl")
        .where(Predicate.column("col1").isEqualTo(BindMarker.positional()))
        .and(Predicate.column("col2").isEqualTo(BindMarker.positional()))
        .limit(BindMarker.positional())
        .build();

// Positional values
List<Value> positionalValues = Arrays.asList(Value.ofInt(10), Value.ofText("aaa"), Value.ofInt(100));

// Execute with the parameter values
sqlStatementSession.execute(selectStatement, positionalValues);

// Update statement with named bind markers
UpdateStatement updateStatement =
    StatementBuilder.update("ns", "tbl")
        .set(Assignment.column("col3").value(BindMarker.named("name1")))
        .where(Predicate.column("col1").isEqualTo(BindMarker.named("name2")))
        .and(Predicate.column("col2").isEqualTo(BindMarker.named("name3")))
        .build();

// Named values
Map<String, Value> namedValues =
    ImmutableMap.of(
        "name1", Value.ofBigInt(200L), "name2", Value.ofInt(10), "name3", Value.ofText("aaa"));

// Execute with the parameter values
sqlStatementSession.execute(updateStatement, namedValues);
```

I will add inline comments to make this change more readable. Please take a look!