### PR TITLE
Introduce ScanAll operation

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * is defined with a starting clustering key and an ending clustering key. {@link Ordering} can also
  * be specified to return {@link Result}s in ascending order or descending order of clustering keys.
  * The number of {@link Result} can also be limited. If none of these are set, it will return all
- * the {@link Result}s with a specified partition key in some order.
+ * the {@link Result}s with a specified partition key in default clustering orders.
  *
  * @author Hiroyuki Yamada
  */

--- a/core/src/main/java/com/scalar/db/api/ScanAll.java
+++ b/core/src/main/java/com/scalar/db/api/ScanAll.java
@@ -1,0 +1,101 @@
+package com.scalar.db.api;
+
+import com.google.common.base.MoreObjects;
+import com.scalar.db.io.Key;
+import java.util.Collection;
+import java.util.Objects;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A command to retrieve all the entries of the database. The scan range of clustering key and
+ * {@link Ordering} cannot be specified for this command. The number of {@link Result} can be
+ * limited.
+ */
+@NotThreadSafe
+public class ScanAll extends Scan {
+
+  private static final Key DUMMY_PARTITION_KEY = Key.of();
+
+  public ScanAll() {
+    super(DUMMY_PARTITION_KEY);
+  }
+
+  public ScanAll(ScanAll scanAll) {
+    super(scanAll);
+  }
+
+  @Override
+  public ScanAll withStart(Key clusteringKey) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ScanAll withStart(Key clusteringKey, boolean inclusive) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Scan withEnd(Key clusteringKey) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Scan withEnd(Key clusteringKey, boolean inclusive) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ScanAll withOrdering(Ordering ordering) {
+    throw new UnsupportedOperationException();
+  }
+
+  public ScanAll withLimit(int limit) {
+    return (ScanAll) super.withLimit(limit);
+  }
+
+  @Override
+  public ScanAll forNamespace(String namespace) {
+    return (ScanAll) super.forNamespace(namespace);
+  }
+
+  @Override
+  public ScanAll forTable(String tableName) {
+    return (ScanAll) super.forTable(tableName);
+  }
+
+  @Override
+  public ScanAll withConsistency(Consistency consistency) {
+    return (ScanAll) super.withConsistency(consistency);
+  }
+
+  @Override
+  public ScanAll withProjection(String projection) {
+    return (ScanAll) super.withProjection(projection);
+  }
+
+  @Override
+  public ScanAll withProjections(Collection<String> projections) {
+    return (ScanAll) super.withProjections(projections);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    return o instanceof ScanAll;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + MoreObjects.toStringHelper(this);
+  }
+}

--- a/core/src/main/java/com/scalar/db/io/Key.java
+++ b/core/src/main/java/com/scalar/db/io/Key.java
@@ -587,6 +587,15 @@ public final class Key implements Comparable<Key>, Iterable<Value<?>> {
   }
 
   /**
+   * Create an empty {@code Key} object
+   *
+   * @return an empty {@code Key} object
+   */
+  public static Key of() {
+    return new Key();
+  }
+
+  /**
    * Create a {@code Key} object with two columns
    *
    * @param n1 a column name of the 1st column


### PR DESCRIPTION
This PR introduces a `ScanAll` operation that scans all the data of a database. This PR doesn't contain the actual implementation of `ScanAll` but it contains only  the `ScanAll` operation class.

I added the `ScanAll` as a subclass of `Scan` because I think that minimizes the total change cost.

I assume the `ScanAll` operation is used with the existing `scan()` API as follows:
```java
Scanner scanner =
    storage.scan(
        new ScanAll().withProjection("col1").withLimit(10).forNamespace("ns").forTable("tbl"));
```
Currently `ScanAll` only supports specifying projections and limit.

Please take a look!