### PR TITLE
Invalidate metadata cache when schema change happens in SQL API

### DIFF
--- a/core/src/main/java/com/scalar/db/sql/DdlStatementExecutor.java
+++ b/core/src/main/java/com/scalar/db/sql/DdlStatementExecutor.java
@@ -58,16 +58,16 @@ public class DdlStatementExecutor implements DdlStatementVisitor<Void, Void> {
           tableMetadata,
           statement.ifNotExists,
           statement.options);
-
+      return null;
+    } catch (ExecutionException e) {
+      throw new SqlException("Failed to create a table", e);
+    } finally {
       // Invalidate the metadata cache
       metadata
           .getNamespace(statement.namespaceName)
           .filter(n -> n instanceof CachedNamespaceMetadata)
           .map(n -> (CachedNamespaceMetadata) n)
           .ifPresent(CachedNamespaceMetadata::invalidateTableNamesCache);
-      return null;
-    } catch (ExecutionException e) {
-      throw new SqlException("Failed to create a table", e);
     }
   }
 
@@ -127,14 +127,14 @@ public class DdlStatementExecutor implements DdlStatementVisitor<Void, Void> {
         }
       }
       admin.dropNamespace(statement.namespaceName, statement.ifExists);
-
+      return null;
+    } catch (ExecutionException e) {
+      throw new SqlException("Failed to drop a namespace", e);
+    } finally {
       // Invalidate the metadata cache
       if (metadata instanceof CachedMetadata) {
         ((CachedMetadata) metadata).invalidateCache(statement.namespaceName);
       }
-      return null;
-    } catch (ExecutionException e) {
-      throw new SqlException("Failed to drop a namespace", e);
     }
   }
 
@@ -142,7 +142,10 @@ public class DdlStatementExecutor implements DdlStatementVisitor<Void, Void> {
   public Void visit(DropTableStatement statement, Void context) {
     try {
       admin.dropTable(statement.namespaceName, statement.tableName, statement.ifExists);
-
+      return null;
+    } catch (ExecutionException e) {
+      throw new SqlException("Failed to drop a table", e);
+    } finally {
       // Invalidate the metadata cache
       metadata
           .getNamespace(statement.namespaceName)
@@ -153,9 +156,6 @@ public class DdlStatementExecutor implements DdlStatementVisitor<Void, Void> {
                 n.invalidateTableNamesCache();
                 n.invalidateTableMetadataCache(statement.tableName);
               });
-      return null;
-    } catch (ExecutionException e) {
-      throw new SqlException("Failed to drop a table", e);
     }
   }
 
@@ -208,16 +208,16 @@ public class DdlStatementExecutor implements DdlStatementVisitor<Void, Void> {
           statement.columnName,
           statement.ifNotExists,
           statement.options);
-
+      return null;
+    } catch (ExecutionException e) {
+      throw new SqlException("Failed to create a index table", e);
+    } finally {
       // Invalidate the metadata cache
       metadata
           .getNamespace(statement.namespaceName)
           .filter(n -> n instanceof CachedNamespaceMetadata)
           .map(n -> (CachedNamespaceMetadata) n)
           .ifPresent(n -> n.invalidateTableMetadataCache(statement.tableName));
-      return null;
-    } catch (ExecutionException e) {
-      throw new SqlException("Failed to create a index table", e);
     }
   }
 
@@ -226,16 +226,16 @@ public class DdlStatementExecutor implements DdlStatementVisitor<Void, Void> {
     try {
       admin.dropIndex(
           statement.namespaceName, statement.tableName, statement.columnName, statement.ifExists);
-
+      return null;
+    } catch (ExecutionException e) {
+      throw new SqlException("Failed to drop a index table", e);
+    } finally {
       // Invalidate the metadata cache
       metadata
           .getNamespace(statement.namespaceName)
           .filter(n -> n instanceof CachedNamespaceMetadata)
           .map(n -> (CachedNamespaceMetadata) n)
           .ifPresent(n -> n.invalidateTableMetadataCache(statement.tableName));
-      return null;
-    } catch (ExecutionException e) {
-      throw new SqlException("Failed to drop a index table", e);
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/sql/SqlStatementSessionFactory.java
+++ b/core/src/main/java/com/scalar/db/sql/SqlStatementSessionFactory.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.TransactionFactory;
+import com.scalar.db.sql.metadata.CachedMetadata;
 import com.scalar.db.sql.metadata.Metadata;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,7 +32,7 @@ public final class SqlStatementSessionFactory implements AutoCloseable {
     transactionAdmin = transactionFactory.getTransactionAdmin();
     transactionManager = transactionFactory.getTransactionManager();
     twoPhaseCommitTransactionManager = transactionFactory.getTwoPhaseCommitTransactionManager();
-    metadata = Metadata.create(transactionAdmin, config.getMetadataCacheExpirationTimeSecs());
+    metadata = CachedMetadata.create(transactionAdmin, config.getMetadataCacheExpirationTimeSecs());
   }
 
   public SqlStatementSession getTransactionSession() {

--- a/core/src/main/java/com/scalar/db/sql/TransactionSession.java
+++ b/core/src/main/java/com/scalar/db/sql/TransactionSession.java
@@ -36,7 +36,7 @@ public class TransactionSession implements SqlStatementSession {
     this.metadata = Objects.requireNonNull(metadata);
     statementValidator = new StatementValidator(metadata);
     dmlStatementExecutor = new DmlStatementExecutor(metadata);
-    ddlStatementExecutor = new DdlStatementExecutor(admin);
+    ddlStatementExecutor = new DdlStatementExecutor(admin, metadata);
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/sql/TwoPhaseCommitTransactionSession.java
+++ b/core/src/main/java/com/scalar/db/sql/TwoPhaseCommitTransactionSession.java
@@ -42,7 +42,7 @@ public class TwoPhaseCommitTransactionSession implements SqlStatementSession {
     this.metadata = Objects.requireNonNull(metadata);
     statementValidator = new StatementValidator(metadata);
     dmlStatementExecutor = new DmlStatementExecutor(metadata);
-    ddlStatementExecutor = new DdlStatementExecutor(admin);
+    ddlStatementExecutor = new DdlStatementExecutor(admin, metadata);
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/sql/metadata/CachedMetadata.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/CachedMetadata.java
@@ -1,0 +1,58 @@
+package com.scalar.db.sql.metadata;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.sql.exception.SqlException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class CachedMetadata implements Metadata {
+
+  private final LoadingCache<String, Optional<NamespaceMetadata>> cache;
+
+  private CachedMetadata(DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    if (cacheExpirationTimeSecs > 0) {
+      builder.expireAfterWrite(cacheExpirationTimeSecs, TimeUnit.SECONDS);
+    }
+    cache =
+        builder.build(
+            new CacheLoader<String, Optional<NamespaceMetadata>>() {
+              @Override
+              public Optional<NamespaceMetadata> load(@Nonnull String namespaceName) {
+                try {
+                  if (admin.namespaceExists(namespaceName)) {
+                    return Optional.of(
+                        new CachedNamespaceMetadata(namespaceName, admin, cacheExpirationTimeSecs));
+                  }
+                } catch (ExecutionException e) {
+                  throw new SqlException("Failed to check the namespace existence", e);
+                }
+                return Optional.empty();
+              }
+            });
+  }
+
+  @Override
+  public Optional<NamespaceMetadata> getNamespace(String namespaceName) {
+    try {
+      return cache.get(namespaceName);
+    } catch (java.util.concurrent.ExecutionException e) {
+      throw (RuntimeException) e.getCause();
+    }
+  }
+
+  public void invalidateCache(String namespaceName) {
+    cache.invalidate(namespaceName);
+  }
+
+  public static Metadata create(DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
+    return new CachedMetadata(admin, cacheExpirationTimeSecs);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/metadata/CachedNamespaceMetadata.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/CachedNamespaceMetadata.java
@@ -1,0 +1,142 @@
+package com.scalar.db.sql.metadata;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.sql.exception.SqlException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class CachedNamespaceMetadata implements NamespaceMetadata {
+
+  private final String name;
+
+  private final LoadingCache<String, ImmutableList<String>> tableNamesCache;
+  private final LoadingCache<String, Optional<TableMetadata>> tableMetadataCache;
+
+  CachedNamespaceMetadata(
+      String name, DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
+    this.name = Objects.requireNonNull(name);
+
+    tableNamesCache = createTableNamesCache(admin, cacheExpirationTimeSecs);
+    tableMetadataCache = createTableMetadataCache(admin, cacheExpirationTimeSecs);
+  }
+
+  private LoadingCache<String, ImmutableList<String>> createTableNamesCache(
+      DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    if (cacheExpirationTimeSecs > 0) {
+      builder.expireAfterWrite(cacheExpirationTimeSecs, TimeUnit.SECONDS);
+    }
+    return builder.build(
+        new CacheLoader<String, ImmutableList<String>>() {
+          @Override
+          public ImmutableList<String> load(@Nonnull String namespaceName) {
+            try {
+              return ImmutableList.copyOf(
+                  new ArrayList<>(admin.getNamespaceTableNames(namespaceName)));
+            } catch (ExecutionException e) {
+              throw new SqlException("Failed to check the namespace existence", e);
+            }
+          }
+        });
+  }
+
+  private LoadingCache<String, Optional<TableMetadata>> createTableMetadataCache(
+      DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    if (cacheExpirationTimeSecs > 0) {
+      builder.expireAfterWrite(cacheExpirationTimeSecs, TimeUnit.SECONDS);
+    }
+    return builder.build(
+        new CacheLoader<String, Optional<TableMetadata>>() {
+          @Override
+          public Optional<TableMetadata> load(@Nonnull String tableName) {
+            try {
+              com.scalar.db.api.TableMetadata tableMetadata =
+                  admin.getTableMetadata(name, tableName);
+              if (tableMetadata == null) {
+                return Optional.empty();
+              }
+              return Optional.of(new TableMetadataImpl(name, tableName, tableMetadata));
+            } catch (ExecutionException e) {
+              throw new SqlException("Failed to get a table metadata", e);
+            }
+          }
+        });
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Map<String, TableMetadata> getTables() {
+    try {
+      return tableNamesCache.get(name).stream()
+          .map(
+              t -> {
+                try {
+                  return tableMetadataCache.get(t);
+                } catch (java.util.concurrent.ExecutionException e) {
+                  throw (RuntimeException) e.getCause();
+                }
+              })
+          .filter(Optional::isPresent)
+          .collect(Collectors.toMap(t -> t.get().getName(), Optional::get));
+    } catch (java.util.concurrent.ExecutionException e) {
+      throw (RuntimeException) e.getCause();
+    }
+  }
+
+  @Override
+  public Optional<TableMetadata> getTable(String tableName) {
+    try {
+      return tableMetadataCache.get(tableName);
+    } catch (java.util.concurrent.ExecutionException e) {
+      throw (RuntimeException) e.getCause();
+    }
+  }
+
+  public void invalidateTableNamesCache() {
+    tableNamesCache.invalidate(name);
+  }
+
+  public void invalidateTableMetadataCache(String tableName) {
+    tableMetadataCache.invalidate(tableName);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("name", name).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CachedNamespaceMetadata)) {
+      return false;
+    }
+    CachedNamespaceMetadata that = (CachedNamespaceMetadata) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/metadata/ColumnMetadata.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/ColumnMetadata.java
@@ -1,68 +1,14 @@
 package com.scalar.db.sql.metadata;
 
-import com.google.common.base.MoreObjects;
 import com.scalar.db.sql.DataType;
-import java.util.Objects;
-import javax.annotation.concurrent.Immutable;
 
-@Immutable
-public class ColumnMetadata {
+public interface ColumnMetadata {
 
-  private final String namespaceName;
-  private final String tableName;
-  private final String name;
-  private final DataType dataType;
+  String getNamespaceName();
 
-  ColumnMetadata(String namespaceName, String tableName, String name, DataType dataType) {
-    this.namespaceName = Objects.requireNonNull(namespaceName);
-    this.tableName = Objects.requireNonNull(tableName);
-    this.name = Objects.requireNonNull(name);
-    this.dataType = Objects.requireNonNull(dataType);
-  }
+  String getTableName();
 
-  public String getNamespaceName() {
-    return namespaceName;
-  }
+  String getName();
 
-  public String getTableName() {
-    return tableName;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public DataType getDataType() {
-    return dataType;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("namespaceName", namespaceName)
-        .add("tableName", tableName)
-        .add("name", name)
-        .add("dataType", dataType)
-        .toString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof ColumnMetadata)) {
-      return false;
-    }
-    ColumnMetadata that = (ColumnMetadata) o;
-    return Objects.equals(namespaceName, that.namespaceName)
-        && Objects.equals(tableName, that.tableName)
-        && Objects.equals(name, that.name)
-        && dataType == that.dataType;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(namespaceName, tableName, name, dataType);
-  }
+  DataType getDataType();
 }

--- a/core/src/main/java/com/scalar/db/sql/metadata/ColumnMetadataImpl.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/ColumnMetadataImpl.java
@@ -1,0 +1,72 @@
+package com.scalar.db.sql.metadata;
+
+import com.google.common.base.MoreObjects;
+import com.scalar.db.sql.DataType;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class ColumnMetadataImpl implements ColumnMetadata {
+
+  private final String namespaceName;
+  private final String tableName;
+  private final String name;
+  private final DataType dataType;
+
+  ColumnMetadataImpl(String namespaceName, String tableName, String name, DataType dataType) {
+    this.namespaceName = Objects.requireNonNull(namespaceName);
+    this.tableName = Objects.requireNonNull(tableName);
+    this.name = Objects.requireNonNull(name);
+    this.dataType = Objects.requireNonNull(dataType);
+  }
+
+  @Override
+  public String getNamespaceName() {
+    return namespaceName;
+  }
+
+  @Override
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public DataType getDataType() {
+    return dataType;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespaceName", namespaceName)
+        .add("tableName", tableName)
+        .add("name", name)
+        .add("dataType", dataType)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ColumnMetadataImpl)) {
+      return false;
+    }
+    ColumnMetadataImpl that = (ColumnMetadataImpl) o;
+    return Objects.equals(namespaceName, that.namespaceName)
+        && Objects.equals(tableName, that.tableName)
+        && Objects.equals(name, that.name)
+        && dataType == that.dataType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespaceName, tableName, name, dataType);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/metadata/IndexMetadata.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/IndexMetadata.java
@@ -1,59 +1,10 @@
 package com.scalar.db.sql.metadata;
 
-import com.google.common.base.MoreObjects;
-import java.util.Objects;
-import javax.annotation.concurrent.Immutable;
+public interface IndexMetadata {
 
-@Immutable
-public class IndexMetadata {
+  String getNamespaceName();
 
-  private final String namespaceName;
-  private final String tableName;
-  private final String columnName;
+  String getTableName();
 
-  IndexMetadata(String namespaceName, String tableName, String columnName) {
-    this.namespaceName = Objects.requireNonNull(namespaceName);
-    this.tableName = Objects.requireNonNull(tableName);
-    this.columnName = Objects.requireNonNull(columnName);
-  }
-
-  public String getNamespaceName() {
-    return namespaceName;
-  }
-
-  public String getTableName() {
-    return tableName;
-  }
-
-  public String getColumnName() {
-    return columnName;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("namespaceName", namespaceName)
-        .add("tableName", tableName)
-        .add("columnName", columnName)
-        .toString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof IndexMetadata)) {
-      return false;
-    }
-    IndexMetadata that = (IndexMetadata) o;
-    return Objects.equals(namespaceName, that.namespaceName)
-        && Objects.equals(tableName, that.tableName)
-        && Objects.equals(columnName, that.columnName);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(namespaceName, tableName, columnName);
-  }
+  String getColumnName();
 }

--- a/core/src/main/java/com/scalar/db/sql/metadata/IndexMetadataImpl.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/IndexMetadataImpl.java
@@ -1,0 +1,62 @@
+package com.scalar.db.sql.metadata;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class IndexMetadataImpl implements IndexMetadata {
+
+  private final String namespaceName;
+  private final String tableName;
+  private final String columnName;
+
+  IndexMetadataImpl(String namespaceName, String tableName, String columnName) {
+    this.namespaceName = Objects.requireNonNull(namespaceName);
+    this.tableName = Objects.requireNonNull(tableName);
+    this.columnName = Objects.requireNonNull(columnName);
+  }
+
+  @Override
+  public String getNamespaceName() {
+    return namespaceName;
+  }
+
+  @Override
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public String getColumnName() {
+    return columnName;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespaceName", namespaceName)
+        .add("tableName", tableName)
+        .add("columnName", columnName)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IndexMetadataImpl)) {
+      return false;
+    }
+    IndexMetadataImpl that = (IndexMetadataImpl) o;
+    return Objects.equals(namespaceName, that.namespaceName)
+        && Objects.equals(tableName, that.tableName)
+        && Objects.equals(columnName, that.columnName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespaceName, tableName, columnName);
+  }
+}

--- a/core/src/main/java/com/scalar/db/sql/metadata/Metadata.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/Metadata.java
@@ -1,53 +1,8 @@
 package com.scalar.db.sql.metadata;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.scalar.db.api.DistributedTransactionAdmin;
-import com.scalar.db.exception.storage.ExecutionException;
-import com.scalar.db.sql.exception.SqlException;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.ThreadSafe;
 
-@ThreadSafe
-public class Metadata {
+public interface Metadata {
 
-  private final LoadingCache<String, Optional<NamespaceMetadata>> cache;
-
-  private Metadata(DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
-    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
-    if (cacheExpirationTimeSecs > 0) {
-      builder.expireAfterWrite(cacheExpirationTimeSecs, TimeUnit.SECONDS);
-    }
-    cache =
-        builder.build(
-            new CacheLoader<String, Optional<NamespaceMetadata>>() {
-              @Override
-              public Optional<NamespaceMetadata> load(@Nonnull String namespaceName) {
-                try {
-                  if (admin.namespaceExists(namespaceName)) {
-                    return Optional.of(
-                        new NamespaceMetadata(namespaceName, admin, cacheExpirationTimeSecs));
-                  }
-                } catch (ExecutionException e) {
-                  throw new SqlException("Failed to check the namespace existence", e);
-                }
-                return Optional.empty();
-              }
-            });
-  }
-
-  public Optional<NamespaceMetadata> getNamespace(String namespaceName) {
-    try {
-      return cache.get(namespaceName);
-    } catch (java.util.concurrent.ExecutionException e) {
-      throw (RuntimeException) e.getCause();
-    }
-  }
-
-  public static Metadata create(DistributedTransactionAdmin admin, long cacheExpirationTimeSecs) {
-    return new Metadata(admin, cacheExpirationTimeSecs);
-  }
+  Optional<NamespaceMetadata> getNamespace(String namespaceName);
 }

--- a/core/src/main/java/com/scalar/db/sql/metadata/TableMetadata.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/TableMetadata.java
@@ -1,208 +1,33 @@
 package com.scalar.db.sql.metadata;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.scalar.db.api.Scan;
 import com.scalar.db.sql.ClusteringOrder;
-import com.scalar.db.sql.DataType;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import javax.annotation.concurrent.Immutable;
 
-@Immutable
-public class TableMetadata {
+public interface TableMetadata {
 
-  private final String namespaceName;
-  private final String name;
-  private final ImmutableList<ColumnMetadata> primaryKey;
-  private final ImmutableList<ColumnMetadata> partitionKey;
-  private final ImmutableSet<String> partitionKeyColumnNames;
-  private final ImmutableMap<ColumnMetadata, ClusteringOrder> clusteringKey;
-  private final ImmutableSet<String> clusteringKeyColumnNames;
-  private final ImmutableMap<String, ColumnMetadata> columns;
-  private final ImmutableMap<String, IndexMetadata> indexes;
+  String getNamespaceName();
 
-  TableMetadata(String namespaceName, String name, com.scalar.db.api.TableMetadata tableMetadata) {
-    this.namespaceName = Objects.requireNonNull(namespaceName);
-    this.name = Objects.requireNonNull(name);
+  String getName();
 
-    partitionKey =
-        tableMetadata.getPartitionKeyNames().stream()
-            .map(
-                c ->
-                    new ColumnMetadata(
-                        namespaceName,
-                        name,
-                        c,
-                        convertDataType(tableMetadata.getColumnDataType(c))))
-            .collect(ImmutableList.toImmutableList());
+  List<ColumnMetadata> getPrimaryKey();
 
-    partitionKeyColumnNames =
-        partitionKey.stream().map(ColumnMetadata::getName).collect(ImmutableSet.toImmutableSet());
+  boolean isPrimaryKeyColumn(String columnName);
 
-    clusteringKey =
-        tableMetadata.getClusteringKeyNames().stream()
-            .map(
-                c ->
-                    new ColumnMetadata(
-                        namespaceName,
-                        name,
-                        c,
-                        convertDataType(tableMetadata.getColumnDataType(c))))
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    Function.identity(),
-                    c -> convertClusteringOrder(tableMetadata.getClusteringOrder(c.getName()))));
+  List<ColumnMetadata> getPartitionKey();
 
-    clusteringKeyColumnNames =
-        clusteringKey.keySet().stream()
-            .map(ColumnMetadata::getName)
-            .collect(ImmutableSet.toImmutableSet());
+  boolean isPartitionKeyColumn(String columnName);
 
-    primaryKey =
-        ImmutableList.<ColumnMetadata>builder()
-            .addAll(partitionKey)
-            .addAll(clusteringKey.keySet())
-            .build();
+  Map<ColumnMetadata, ClusteringOrder> getClusteringKey();
 
-    columns =
-        tableMetadata.getColumnNames().stream()
-            .map(
-                c ->
-                    new ColumnMetadata(
-                        namespaceName,
-                        name,
-                        c,
-                        convertDataType(tableMetadata.getColumnDataType(c))))
-            .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
+  boolean isClusteringKeyColumn(String columnName);
 
-    indexes =
-        tableMetadata.getSecondaryIndexNames().stream()
-            .collect(
-                ImmutableMap.toImmutableMap(
-                    Function.identity(), c -> new IndexMetadata(namespaceName, name, c)));
-  }
+  Map<String, ColumnMetadata> getColumns();
 
-  private DataType convertDataType(com.scalar.db.io.DataType dataType) {
-    switch (dataType) {
-      case BOOLEAN:
-        return DataType.BOOLEAN;
-      case INT:
-        return DataType.INT;
-      case BIGINT:
-        return DataType.BIGINT;
-      case FLOAT:
-        return DataType.FLOAT;
-      case DOUBLE:
-        return DataType.DOUBLE;
-      case TEXT:
-        return DataType.TEXT;
-      case BLOB:
-        return DataType.BLOB;
-      default:
-        throw new AssertionError();
-    }
-  }
+  Optional<ColumnMetadata> getColumn(String columnName);
 
-  private ClusteringOrder convertClusteringOrder(Scan.Ordering.Order order) {
-    switch (order) {
-      case ASC:
-        return ClusteringOrder.ASC;
-      case DESC:
-        return ClusteringOrder.DESC;
-      default:
-        throw new AssertionError();
-    }
-  }
+  Map<String, IndexMetadata> getIndexes();
 
-  public String getNamespaceName() {
-    return namespaceName;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public List<ColumnMetadata> getPrimaryKey() {
-    return primaryKey;
-  }
-
-  public boolean isPrimaryKeyColumn(String columnName) {
-    return partitionKeyColumnNames.contains(columnName)
-        || clusteringKeyColumnNames.contains(columnName);
-  }
-
-  public List<ColumnMetadata> getPartitionKey() {
-    return partitionKey;
-  }
-
-  public boolean isPartitionKeyColumn(String columnName) {
-    return partitionKeyColumnNames.contains(columnName);
-  }
-
-  public Map<ColumnMetadata, ClusteringOrder> getClusteringKey() {
-    return clusteringKey;
-  }
-
-  public boolean isClusteringKeyColumn(String columnName) {
-    return clusteringKeyColumnNames.contains(columnName);
-  }
-
-  public Map<String, ColumnMetadata> getColumns() {
-    return columns;
-  }
-
-  public Optional<ColumnMetadata> getColumn(String columnName) {
-    return Optional.ofNullable(columns.get(columnName));
-  }
-
-  public Map<String, IndexMetadata> getIndexes() {
-    return indexes;
-  }
-
-  public Optional<IndexMetadata> getIndex(String columnName) {
-    return Optional.ofNullable(indexes.get(columnName));
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("namespaceName", namespaceName)
-        .add("name", name)
-        .add("primaryKey", primaryKey)
-        .add("partitionKey", partitionKey)
-        .add("clusteringKey", clusteringKey)
-        .add("columns", columns)
-        .add("indexes", indexes)
-        .toString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof TableMetadata)) {
-      return false;
-    }
-    TableMetadata that = (TableMetadata) o;
-    return Objects.equals(namespaceName, that.namespaceName)
-        && Objects.equals(name, that.name)
-        && Objects.equals(primaryKey, that.primaryKey)
-        && Objects.equals(partitionKey, that.partitionKey)
-        && Objects.equals(clusteringKey, that.clusteringKey)
-        && Objects.equals(columns, that.columns)
-        && Objects.equals(indexes, that.indexes);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        namespaceName, name, primaryKey, partitionKey, clusteringKey, columns, indexes);
-  }
+  Optional<IndexMetadata> getIndex(String columnName);
 }

--- a/core/src/main/java/com/scalar/db/sql/metadata/TableMetadataImpl.java
+++ b/core/src/main/java/com/scalar/db/sql/metadata/TableMetadataImpl.java
@@ -1,0 +1,221 @@
+package com.scalar.db.sql.metadata;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.scalar.db.api.Scan;
+import com.scalar.db.sql.ClusteringOrder;
+import com.scalar.db.sql.DataType;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class TableMetadataImpl implements TableMetadata {
+
+  private final String namespaceName;
+  private final String name;
+  private final ImmutableList<ColumnMetadata> primaryKey;
+  private final ImmutableList<ColumnMetadata> partitionKey;
+  private final ImmutableSet<String> partitionKeyColumnNames;
+  private final ImmutableMap<ColumnMetadata, ClusteringOrder> clusteringKey;
+  private final ImmutableSet<String> clusteringKeyColumnNames;
+  private final ImmutableMap<String, ColumnMetadata> columns;
+  private final ImmutableMap<String, IndexMetadata> indexes;
+
+  TableMetadataImpl(
+      String namespaceName, String name, com.scalar.db.api.TableMetadata tableMetadata) {
+    this.namespaceName = Objects.requireNonNull(namespaceName);
+    this.name = Objects.requireNonNull(name);
+
+    partitionKey =
+        tableMetadata.getPartitionKeyNames().stream()
+            .map(
+                c ->
+                    new ColumnMetadataImpl(
+                        namespaceName,
+                        name,
+                        c,
+                        convertDataType(tableMetadata.getColumnDataType(c))))
+            .collect(ImmutableList.toImmutableList());
+
+    partitionKeyColumnNames =
+        partitionKey.stream().map(ColumnMetadata::getName).collect(ImmutableSet.toImmutableSet());
+
+    clusteringKey =
+        tableMetadata.getClusteringKeyNames().stream()
+            .map(
+                c ->
+                    new ColumnMetadataImpl(
+                        namespaceName,
+                        name,
+                        c,
+                        convertDataType(tableMetadata.getColumnDataType(c))))
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Function.identity(),
+                    c -> convertClusteringOrder(tableMetadata.getClusteringOrder(c.getName()))));
+
+    clusteringKeyColumnNames =
+        clusteringKey.keySet().stream()
+            .map(ColumnMetadata::getName)
+            .collect(ImmutableSet.toImmutableSet());
+
+    primaryKey =
+        ImmutableList.<ColumnMetadata>builder()
+            .addAll(partitionKey)
+            .addAll(clusteringKey.keySet())
+            .build();
+
+    columns =
+        tableMetadata.getColumnNames().stream()
+            .map(
+                c ->
+                    new ColumnMetadataImpl(
+                        namespaceName,
+                        name,
+                        c,
+                        convertDataType(tableMetadata.getColumnDataType(c))))
+            .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
+
+    indexes =
+        tableMetadata.getSecondaryIndexNames().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Function.identity(), c -> new IndexMetadataImpl(namespaceName, name, c)));
+  }
+
+  private DataType convertDataType(com.scalar.db.io.DataType dataType) {
+    switch (dataType) {
+      case BOOLEAN:
+        return DataType.BOOLEAN;
+      case INT:
+        return DataType.INT;
+      case BIGINT:
+        return DataType.BIGINT;
+      case FLOAT:
+        return DataType.FLOAT;
+      case DOUBLE:
+        return DataType.DOUBLE;
+      case TEXT:
+        return DataType.TEXT;
+      case BLOB:
+        return DataType.BLOB;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  private ClusteringOrder convertClusteringOrder(Scan.Ordering.Order order) {
+    switch (order) {
+      case ASC:
+        return ClusteringOrder.ASC;
+      case DESC:
+        return ClusteringOrder.DESC;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @Override
+  public String getNamespaceName() {
+    return namespaceName;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public List<ColumnMetadata> getPrimaryKey() {
+    return primaryKey;
+  }
+
+  @Override
+  public boolean isPrimaryKeyColumn(String columnName) {
+    return partitionKeyColumnNames.contains(columnName)
+        || clusteringKeyColumnNames.contains(columnName);
+  }
+
+  @Override
+  public List<ColumnMetadata> getPartitionKey() {
+    return partitionKey;
+  }
+
+  @Override
+  public boolean isPartitionKeyColumn(String columnName) {
+    return partitionKeyColumnNames.contains(columnName);
+  }
+
+  @Override
+  public Map<ColumnMetadata, ClusteringOrder> getClusteringKey() {
+    return clusteringKey;
+  }
+
+  @Override
+  public boolean isClusteringKeyColumn(String columnName) {
+    return clusteringKeyColumnNames.contains(columnName);
+  }
+
+  @Override
+  public Map<String, ColumnMetadata> getColumns() {
+    return columns;
+  }
+
+  @Override
+  public Optional<ColumnMetadata> getColumn(String columnName) {
+    return Optional.ofNullable(columns.get(columnName));
+  }
+
+  @Override
+  public Map<String, IndexMetadata> getIndexes() {
+    return indexes;
+  }
+
+  @Override
+  public Optional<IndexMetadata> getIndex(String columnName) {
+    return Optional.ofNullable(indexes.get(columnName));
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespaceName", namespaceName)
+        .add("name", name)
+        .add("primaryKey", primaryKey)
+        .add("partitionKey", partitionKey)
+        .add("clusteringKey", clusteringKey)
+        .add("columns", columns)
+        .add("indexes", indexes)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TableMetadataImpl)) {
+      return false;
+    }
+    TableMetadataImpl that = (TableMetadataImpl) o;
+    return Objects.equals(namespaceName, that.namespaceName)
+        && Objects.equals(name, that.name)
+        && Objects.equals(primaryKey, that.primaryKey)
+        && Objects.equals(partitionKey, that.partitionKey)
+        && Objects.equals(clusteringKey, that.clusteringKey)
+        && Objects.equals(columns, that.columns)
+        && Objects.equals(indexes, that.indexes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        namespaceName, name, primaryKey, partitionKey, clusteringKey, columns, indexes);
+  }
+}

--- a/core/src/test/java/com/scalar/db/sql/DmlStatementExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/DmlStatementExecutorTest.java
@@ -18,7 +18,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.io.Key;
-import com.scalar.db.sql.metadata.Metadata;
+import com.scalar.db.sql.metadata.CachedMetadata;
 import com.scalar.db.sql.statement.DeleteStatement;
 import com.scalar.db.sql.statement.InsertStatement;
 import com.scalar.db.sql.statement.SelectStatement;
@@ -62,7 +62,7 @@ public class DmlStatementExecutorTest {
     when(admin.namespaceExists(NAMESPACE_NAME)).thenReturn(true);
     when(admin.getTableMetadata(NAMESPACE_NAME, TABLE_NAME)).thenReturn(TABLE_METADATA);
 
-    dmlStatementExecutor = new DmlStatementExecutor(Metadata.create(admin, -1));
+    dmlStatementExecutor = new DmlStatementExecutor(CachedMetadata.create(admin, -1));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
+++ b/core/src/test/java/com/scalar/db/sql/StatementValidatorTest.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableList;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
-import com.scalar.db.sql.metadata.Metadata;
+import com.scalar.db.sql.metadata.CachedMetadata;
 import com.scalar.db.sql.statement.DeleteStatement;
 import com.scalar.db.sql.statement.InsertStatement;
 import com.scalar.db.sql.statement.SelectStatement;
@@ -49,7 +49,7 @@ public class StatementValidatorTest {
     when(admin.namespaceExists(NAMESPACE_NAME)).thenReturn(true);
     when(admin.getTableMetadata(NAMESPACE_NAME, TABLE_NAME)).thenReturn(TABLE_METADATA);
 
-    statementValidator = new StatementValidator(Metadata.create(admin, -1));
+    statementValidator = new StatementValidator(CachedMetadata.create(admin, -1));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/sql/metadata/CachedMetadataTest.java
+++ b/core/src/test/java/com/scalar/db/sql/metadata/CachedMetadataTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class MetadataTest {
+public class CachedMetadataTest {
 
   @Mock private DistributedTransactionAdmin admin;
   private Metadata metadata;
@@ -28,7 +28,7 @@ public class MetadataTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    metadata = Metadata.create(admin, -1);
+    metadata = CachedMetadata.create(admin, -1);
   }
 
   @Test


### PR DESCRIPTION
This PR adds a logic to invalidate metadata cache when schema change happens in SQL API. I will inline comments to make it more readable. Please take a look!