### PR TITLE
Fix SQL syntax error that happens when scanning a table without clustering key in JDBC adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
@@ -86,7 +86,9 @@ public class SimpleSelectQuery implements SelectQuery {
   }
 
   private String orderBySqlString() {
-    if (!isRangeQuery || indexedColumn.isPresent()) {
+    if (!isRangeQuery
+        || indexedColumn.isPresent()
+        || tableMetadata.getClusteringKeyNames().isEmpty()) {
       return "";
     }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -387,6 +387,52 @@ public class QueryBuilderTest {
   }
 
   @Test
+  public void selectQueryWithTableWithoutClusteringKeyTest() throws SQLException {
+    TableMetadata tableMetadataWithoutClusteringKey =
+        TableMetadata.newBuilder()
+            .addColumn("p1", DataType.TEXT)
+            .addColumn("p2", DataType.INT)
+            .addColumn("v1", DataType.TEXT)
+            .addColumn("v2", DataType.TEXT)
+            .addColumn("v3", DataType.TEXT)
+            .addPartitionKey("p1")
+            .addPartitionKey("p2")
+            .build();
+
+    SelectQuery query;
+    PreparedStatement preparedStatement;
+
+    preparedStatement = mock(PreparedStatement.class);
+    query =
+        queryBuilder
+            .select(Arrays.asList("c1", "c2"))
+            .from(NAMESPACE, TABLE, tableMetadataWithoutClusteringKey)
+            .where(Key.of("p1", "p1Value", "p2", "p2Value"), Optional.empty())
+            .build();
+    assertThat(query.sql()).isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE p1=? AND p2=?"));
+    query.bind(preparedStatement);
+    verify(preparedStatement).setString(1, "p1Value");
+    verify(preparedStatement).setString(2, "p2Value");
+
+    preparedStatement = mock(PreparedStatement.class);
+    query =
+        queryBuilder
+            .select(Arrays.asList("c1", "c2"))
+            .from(NAMESPACE, TABLE, tableMetadataWithoutClusteringKey)
+            .where(
+                Key.of("p1", "p1Value", "p2", "p2Value"),
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                false)
+            .build();
+    assertThat(query.sql()).isEqualTo(encloseSql("SELECT c1,c2 FROM n1.t1 WHERE p1=? AND p2=?"));
+    query.bind(preparedStatement);
+    verify(preparedStatement).setString(1, "p1Value");
+    verify(preparedStatement).setString(2, "p2Value");
+  }
+
+  @Test
   public void insertQueryTest() throws SQLException {
     InsertQuery query;
     PreparedStatement preparedStatement;


### PR DESCRIPTION
This PR is a fix for a bug where an SQL syntax error happens when scanning a table without clustering key in JDBC adapter. We basically don't need to scan a table without clustering key, but an error should not happen if we do that. Please take a look!