### PR TITLE
Fix equals method of Value for bytes type

### DIFF
--- a/core/src/main/java/com/scalar/db/sql/Value.java
+++ b/core/src/main/java/com/scalar/db/sql/Value.java
@@ -2,6 +2,7 @@ package com.scalar.db.sql;
 
 import com.google.common.base.MoreObjects;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -30,8 +31,14 @@ public class Value implements Term {
     if (!(o instanceof Value)) {
       return false;
     }
-    Value value1 = (Value) o;
-    return type == value1.type && Objects.equals(value, value1.value);
+    Value that = (Value) o;
+    if (type != that.type) {
+      return false;
+    }
+    if (type == Type.BLOB_BYTES) {
+      return Arrays.equals((byte[]) value, (byte[]) that.value);
+    }
+    return Objects.equals(value, that.value);
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/sql/ValueTest.java
+++ b/core/src/test/java/com/scalar/db/sql/ValueTest.java
@@ -115,4 +115,44 @@ public class ValueTest {
     assertThat(value.type).isEqualTo(Value.Type.NULL);
     assertThat(value.value).isNull();
   }
+
+  @Test
+  public void equals_ShouldBehaveCorrectly() {
+    // Arrange
+
+    // Act Assert
+    assertThat(Value.ofBoolean(true).equals(Value.ofBoolean(true))).isTrue();
+    assertThat(Value.ofInt(10).equals(Value.ofInt(10))).isTrue();
+    assertThat(Value.ofBigInt(100L).equals(Value.ofBigInt(100L))).isTrue();
+    assertThat(Value.ofFloat(1.23F).equals(Value.ofFloat(1.23F))).isTrue();
+    assertThat(Value.ofDouble(4.56).equals(Value.ofDouble(4.56))).isTrue();
+    assertThat(Value.ofText("text").equals(Value.ofText("text"))).isTrue();
+    assertThat(
+            Value.ofBlob(ByteBuffer.wrap("blob1".getBytes(StandardCharsets.UTF_8)))
+                .equals(Value.ofBlob(ByteBuffer.wrap("blob1".getBytes(StandardCharsets.UTF_8)))))
+        .isTrue();
+    assertThat(
+            Value.ofBlob("blob2".getBytes(StandardCharsets.UTF_8))
+                .equals(Value.ofBlob("blob2".getBytes(StandardCharsets.UTF_8))))
+        .isTrue();
+
+    assertThat(Value.ofBoolean(true).equals(Value.ofInt(10))).isFalse();
+    assertThat(Value.ofBigInt(100L).equals(Value.ofFloat(1.23F))).isFalse();
+    assertThat(Value.ofDouble(4.56).equals(Value.ofText("text"))).isFalse();
+
+    assertThat(Value.ofBoolean(true).equals(Value.ofBoolean(false))).isFalse();
+    assertThat(Value.ofInt(10).equals(Value.ofInt(11))).isFalse();
+    assertThat(Value.ofBigInt(100L).equals(Value.ofBigInt(101L))).isFalse();
+    assertThat(Value.ofFloat(1.23F).equals(Value.ofFloat(1.24F))).isFalse();
+    assertThat(Value.ofDouble(4.56).equals(Value.ofDouble(4.57))).isFalse();
+    assertThat(Value.ofText("text").equals(Value.ofText("text2"))).isFalse();
+    assertThat(
+            Value.ofBlob(ByteBuffer.wrap("blob1".getBytes(StandardCharsets.UTF_8)))
+                .equals(Value.ofBlob(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)))))
+        .isFalse();
+    assertThat(
+            Value.ofBlob("blob1".getBytes(StandardCharsets.UTF_8))
+                .equals(Value.ofBlob("blob2".getBytes(StandardCharsets.UTF_8))))
+        .isFalse();
+  }
 }


### PR DESCRIPTION
Currently, the `equals` of the `Value` class in SQL API doesn't work expected for bytes type. This PR fixes this issue. Please take a look!