### PR TITLE
Trigger CI for "push" event on the master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [ pull_request, workflow_dispatch ]
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  pull_request:
 
 env:
   TERM: dumb


### PR DESCRIPTION
To be able to display a CI badge on the repository main page, we need to trigger the CI on push event on the master branch.