### PR TITLE
Update the base image jre8 to 1.1.1

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.0
+FROM ghcr.io/scalar-labs/jre8:1.1.1
 
 ADD scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM ghcr.io/scalar-labs/jre8:1.1.0
+FROM ghcr.io/scalar-labs/jre8:1.1.1
 
 COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/


### PR DESCRIPTION
This PR updates the in-house JRE Docker base image to 1.1.1. Please take a look!