### PR TITLE
Upgrade grpc_health_probe

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.32 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.2
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 ENV DOCKERIZE_VERSION v0.6.1
 
 # Install grpc_health_probe for kubernetes.


### PR DESCRIPTION
This PR upgrades `grpc_health_probe` to address CVE-2020-14040 and CVE-2021-38561.