### PR TITLE
Upgrade PostgreSQL driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         awssdkVersion = '2.17.69'
         commonsDbcp2Version = '2.8.0'
         mysqlDriverVersion = '8.0.22'
-        postgresqlDriverVersion = '42.3.2'
+        postgresqlDriverVersion = '42.3.3'
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'
         grpcVersion = '1.38.0'


### PR DESCRIPTION
This PR upgrades the PostgreSQL driver to address GHSA-673j-qm5f-xpv8 and GMS-2022-75. Please take a look!