### PR TITLE
Add CI triggers for "push" events on support and release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
   workflow_dispatch:
   pull_request:
 


### PR DESCRIPTION
When we push commits to the support and release branches (like `3`, `3.4`, `3.5`), we always need to run CI for them. So this PR adds triggers for CI for them. Please take a look!