### PR TITLE
Add ScanAll for Cosmos DB storage

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -4,7 +4,6 @@ import com.scalar.db.api.DistributedStorageIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.Disabled;
 
 public class CosmosIntegrationTest extends DistributedStorageIntegrationTestBase {
 
@@ -24,20 +23,4 @@ public class CosmosIntegrationTest extends DistributedStorageIntegrationTestBase
   protected Map<String, String> getCreateOptions() {
     return CosmosEnv.getCreateOptions();
   }
-
-  @Override
-  @Disabled("ScanAll is not yet implemented for Cosmos DB")
-  public void scan_ScanAllWithNoLimitGiven_ShouldRetrieveAllRecords() {}
-
-  @Override
-  @Disabled("ScanAll is not yet implemented for Cosmos DB")
-  public void scan_ScanAllWithLimitGiven_ShouldRetrieveExpectedRecords() {}
-
-  @Override
-  @Disabled("ScanAll is not yet implemented for Cosmos DB")
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues() {}
-
-  @Override
-  @Disabled("ScanAll is not yet implemented for Cosmos DB")
-  public void scan_ScanAllWithLargeData_ShouldRetrieveExpectedValues() {}
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -88,12 +88,12 @@ public class Cosmos extends AbstractDistributedStorage {
 
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
-    if (scan instanceof ScanAll) {
-      throw new UnsupportedOperationException();
-    }
-
     scan = copyAndSetTargetToIfNot(scan);
-    operationChecker.check(scan);
+    if (scan instanceof ScanAll) {
+      operationChecker.check((ScanAll) scan);
+    } else {
+      operationChecker.check(scan);
+    }
 
     List<Record> records = selectStatementHandler.handle(scan);
 


### PR DESCRIPTION
This adds the ScanAll operation for the Cosmos DB storage. 
Please have a look. 