### PR TITLE
Implement the checkPaused service according to scalar-admin 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ subprojects {
         protocVersion = '3.17.2'
         protobufVersion = '3.17.2'
         picocliVersion = '4.1.4'
-        scalarAdminVersion = '1.0.0'
+        scalarAdminVersion = '1.2.0'
         dropwizardMetricsVersion = '4.2.2'
         prometheusVersion = '0.12.0'
         jettyVersion = '9.4.43.v20210629'

--- a/server/src/main/java/com/scalar/db/server/AdminService.java
+++ b/server/src/main/java/com/scalar/db/server/AdminService.java
@@ -3,6 +3,7 @@ package com.scalar.db.server;
 import com.google.inject.Inject;
 import com.google.protobuf.Empty;
 import com.scalar.admin.rpc.AdminGrpc;
+import com.scalar.admin.rpc.CheckPausedResponse;
 import com.scalar.admin.rpc.PauseRequest;
 import com.scalar.admin.rpc.StatsResponse;
 import io.grpc.Status;
@@ -64,6 +65,13 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   public void stats(Empty request, StreamObserver<StatsResponse> responseObserver) {
     // returns empty for now
     responseObserver.onNext(StatsResponse.newBuilder().setStats("{}").build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void checkPaused(Empty request, StreamObserver<CheckPausedResponse> responseObserver) {
+    responseObserver.onNext(
+        CheckPausedResponse.newBuilder().setPaused(!gateKeeper.letIn()).build());
     responseObserver.onCompleted();
   }
 }

--- a/server/src/main/java/com/scalar/db/server/AdminService.java
+++ b/server/src/main/java/com/scalar/db/server/AdminService.java
@@ -71,7 +71,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   @Override
   public void checkPaused(Empty request, StreamObserver<CheckPausedResponse> responseObserver) {
     responseObserver.onNext(
-        CheckPausedResponse.newBuilder().setPaused(!gateKeeper.letIn()).build());
+        CheckPausedResponse.newBuilder().setPaused(!gateKeeper.isOpen()).build());
     responseObserver.onCompleted();
   }
 }

--- a/server/src/main/java/com/scalar/db/server/GateKeeper.java
+++ b/server/src/main/java/com/scalar/db/server/GateKeeper.java
@@ -17,6 +17,13 @@ public interface GateKeeper {
   void close();
 
   /**
+   * Returns if the gate is open or not.
+   *
+   * @return true if the gate is open
+   */
+  boolean isOpen();
+
+  /**
    * Waits for the server to finish outstanding requests, giving up if the timeout is reached.
    *
    * @param timeout the maximum time to wait

--- a/server/src/main/java/com/scalar/db/server/LockFreeGateKeeper.java
+++ b/server/src/main/java/com/scalar/db/server/LockFreeGateKeeper.java
@@ -27,6 +27,11 @@ public class LockFreeGateKeeper implements GateKeeper {
   }
 
   @Override
+  public boolean isOpen() {
+    return isOpen.get();
+  }
+
+  @Override
   public boolean awaitDrained(long timeout, TimeUnit unit) throws InterruptedException {
     long start = System.currentTimeMillis();
     while (outstandingRequestCount.longValue() > 0) {

--- a/server/src/main/java/com/scalar/db/server/SynchronizedGateKeeper.java
+++ b/server/src/main/java/com/scalar/db/server/SynchronizedGateKeeper.java
@@ -26,6 +26,11 @@ public class SynchronizedGateKeeper implements GateKeeper {
   }
 
   @Override
+  public synchronized boolean isOpen() {
+    return isOpen;
+  }
+
+  @Override
   public synchronized boolean awaitDrained(long timeout, TimeUnit unit)
       throws InterruptedException {
     long timeoutNanos = unit.toNanos(timeout);


### PR DESCRIPTION
This PR implements the new Admin gRPC service `checkPaused` by which the client can get the pause status.

I tested it with the scalar-admin 1.2.0's executables and it works as expected.

@Torch3333 
Vincent, for your reference.
Scalar server has implemented a gRPC server for these services of this [Protocol Buffers](https://github.com/scalar-labs/scalar-admin/blob/main/admin.proto) by which we can pause/unpause the Scalar server.

This PR implements the new service `checkPaused` which is used for getting the pause status of the Scalar server.