### PR TITLE
Use `max_pause_wait_time` in AdminService

### DIFF
--- a/server/src/main/java/com/scalar/db/server/AdminService.java
+++ b/server/src/main/java/com/scalar/db/server/AdminService.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 public class AdminService extends AdminGrpc.AdminImplBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminService.class);
 
-  private static final long DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS = 10000; // 10 seconds
+  private static final long DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS = 30000; // 30 seconds
 
   private final GateKeeper gateKeeper;
 

--- a/server/src/main/java/com/scalar/db/server/AdminService.java
+++ b/server/src/main/java/com/scalar/db/server/AdminService.java
@@ -29,14 +29,14 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   @Override
   public void pause(PauseRequest request, StreamObserver<Empty> responseObserver) {
     gateKeeper.close();
-    long maxPauseWaitTime =
-        request.getMaxPauseWaitTime() != 0
-            ? request.getMaxPauseWaitTime()
-            : DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS;
 
     if (request.getWaitOutstanding()) {
       LOGGER.warn("Pausing... waiting until outstanding requests are all finished");
       boolean drained = false;
+      long maxPauseWaitTime =
+          request.getMaxPauseWaitTime() != 0
+              ? request.getMaxPauseWaitTime()
+              : DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS;
 
       try {
         drained = gateKeeper.awaitDrained(maxPauseWaitTime, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This PR uses the gRPC optional argument max_pause_wait_time to drain the service.

The optional argument `max_pause_wait_time` was added in scalar-admin 1.1.0, but, for a release issue, it wasn't applied on the server side yet.

This PR does the makeup.