### PR TITLE
Add suspend method to TwoPhaseCommitTransactionManager

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -580,20 +580,38 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     Delete delete = prepareDelete(1, 0);
 
     TwoPhaseCommitTransaction transaction1 = manager.start();
-    TwoPhaseCommitTransaction transaction2 = manager.join(transaction1.getId());
+    TwoPhaseCommitTransaction transaction2;
 
     // Act
     transaction1.get(get1);
     transaction1.put(put);
 
+    transaction2 = manager.join(transaction1.getId());
     transaction2.get(get2);
-    transaction2.delete(delete);
+    manager.suspend(transaction2);
 
+    transaction2 = manager.resume(transaction1.getId());
+    transaction2.delete(delete);
+    manager.suspend(transaction2);
+
+    // Prepare
     transaction1.prepare();
+
+    transaction2 = manager.resume(transaction1.getId());
     transaction2.prepare();
+    manager.suspend(transaction2);
+
+    // Validate
     transaction1.validate();
+
+    transaction2 = manager.resume(transaction1.getId());
     transaction2.validate();
+    manager.suspend(transaction2);
+
+    // Commit
     transaction1.commit();
+
+    transaction2 = manager.resume(transaction1.getId());
     transaction2.commit();
 
     // Assert
@@ -620,20 +638,38 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     Delete delete = prepareDelete(1, 0);
 
     TwoPhaseCommitTransaction transaction1 = manager.start();
-    TwoPhaseCommitTransaction transaction2 = manager.join(transaction1.getId());
+    TwoPhaseCommitTransaction transaction2;
 
     // Act
     transaction1.get(get1);
     transaction1.put(put);
 
+    transaction2 = manager.join(transaction1.getId());
     transaction2.get(get2);
-    transaction2.delete(delete);
+    manager.suspend(transaction2);
 
+    transaction2 = manager.resume(transaction1.getId());
+    transaction2.delete(delete);
+    manager.suspend(transaction2);
+
+    // Prepare
     transaction1.prepare();
+
+    transaction2 = manager.resume(transaction1.getId());
     transaction2.prepare();
+    manager.suspend(transaction2);
+
+    // Validate
     transaction1.validate();
+
+    transaction2 = manager.resume(transaction1.getId());
     transaction2.validate();
+    manager.suspend(transaction2);
+
+    // Rollback
     transaction1.rollback();
+
+    transaction2 = manager.resume(transaction1.getId());
     transaction2.rollback();
 
     // Assert

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
@@ -80,7 +80,7 @@ public interface TwoPhaseCommitTransactionManager {
   TwoPhaseCommitTransaction start(String txId) throws TransactionException;
 
   /**
-   * Join a transaction associated with the specified transaction ID. The transaction should be
+   * Joins a transaction associated with the specified transaction ID. The transaction should be
    * started by a coordinator process. This method is assumed to be called by a participant process.
    *
    * @param txId the transaction ID
@@ -90,8 +90,15 @@ public interface TwoPhaseCommitTransactionManager {
   TwoPhaseCommitTransaction join(String txId) throws TransactionException;
 
   /**
-   * Resumes a transaction associated with the specified transaction ID that it has already joined.
-   * This method is assumed to be called by a participant process.
+   * Suspends a transaction. You can resume this transaction with {@link #resume(String)}.
+   *
+   * @param transaction a transaction to suspend
+   * @throws TransactionException if suspending the transaction failed
+   */
+  void suspend(TwoPhaseCommitTransaction transaction) throws TransactionException;
+
+  /**
+   * Resumes a suspended transaction associated with the specified transaction ID.
    *
    * @param txId the transaction ID
    * @return {@link TwoPhaseCommitTransaction}

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -65,6 +65,11 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   }
 
   @Override
+  public void suspend(TwoPhaseCommitTransaction transaction) throws TransactionException {
+    manager.suspend(transaction);
+  }
+
+  @Override
   public TwoPhaseCommitTransaction resume(String txId) throws TransactionException {
     return manager.resume(txId);
   }

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
@@ -1,6 +1,5 @@
 package com.scalar.db.storage.rpc;
 
-import static com.scalar.db.config.ConfigUtils.getBoolean;
 import static com.scalar.db.config.ConfigUtils.getLong;
 
 import com.scalar.db.config.DatabaseConfig;
@@ -20,13 +19,6 @@ public class GrpcConfig {
 
   private final long deadlineDurationMillis;
 
-  // for two-phase commit transactions
-  public static final String TWO_PHASE_COMMIT_TRANSACTION_PREFIX = PREFIX + "2pc.";
-  public static final String ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED =
-      TWO_PHASE_COMMIT_TRANSACTION_PREFIX + "active_transactions_management.enabled";
-
-  private final boolean activeTransactionsManagementEnabled;
-
   public GrpcConfig(DatabaseConfig databaseConfig) {
     String storage = databaseConfig.getProperties().getProperty(DatabaseConfig.STORAGE);
     if (storage == null || !storage.equals("grpc")) {
@@ -43,8 +35,6 @@ public class GrpcConfig {
             databaseConfig.getProperties(),
             DEADLINE_DURATION_MILLIS,
             DEFAULT_DEADLINE_DURATION_MILLIS);
-    activeTransactionsManagementEnabled =
-        getBoolean(databaseConfig.getProperties(), ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, true);
   }
 
   public String getHost() {
@@ -57,9 +47,5 @@ public class GrpcConfig {
 
   public long getDeadlineDurationMillis() {
     return deadlineDurationMillis;
-  }
-
-  public boolean isActiveTransactionsManagementEnabled() {
-    return activeTransactionsManagementEnabled;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -43,13 +43,6 @@ public class ConsensusCommitConfig {
   private final boolean asyncCommitEnabled;
   private final boolean asyncRollbackEnabled;
 
-  // for two-phase consensus commit
-  public static final String TWO_PHASE_CONSENSUS_COMMIT_PREFIX = PREFIX + "2pcc.";
-  public static final String ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED =
-      TWO_PHASE_CONSENSUS_COMMIT_PREFIX + "active_transactions_management.enabled";
-
-  private final boolean activeTransactionsManagementEnabled;
-
   public ConsensusCommitConfig(DatabaseConfig databaseConfig) {
     if (databaseConfig.getProperties().containsValue("scalar.db.isolation_level")) {
       LOGGER.warn(
@@ -75,9 +68,6 @@ public class ConsensusCommitConfig {
                     SERIALIZABLE_STRATEGY,
                     SerializableStrategy.EXTRA_READ.toString())
                 .toUpperCase());
-
-    activeTransactionsManagementEnabled =
-        getBoolean(databaseConfig.getProperties(), ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, true);
 
     coordinatorNamespace = getString(databaseConfig.getProperties(), COORDINATOR_NAMESPACE, null);
 
@@ -111,10 +101,6 @@ public class ConsensusCommitConfig {
 
   public SerializableStrategy getSerializableStrategy() {
     return strategy;
-  }
-
-  public boolean isActiveTransactionsManagementEnabled() {
-    return activeTransactionsManagementEnabled;
   }
 
   public Optional<String> getCoordinatorNamespace() {

--- a/core/src/main/java/com/scalar/db/util/ActiveExpiringMap.java
+++ b/core/src/main/java/com/scalar/db/util/ActiveExpiringMap.java
@@ -81,8 +81,12 @@ public class ActiveExpiringMap<K, V> {
     return map.containsKey(key);
   }
 
-  public void remove(K key) {
-    map.remove(key);
+  public V remove(K key) {
+    ValueHolder<V> prev = map.remove(key);
+    if (prev == null) {
+      return null;
+    }
+    return prev.get();
   }
 
   public void updateExpirationTime(K key) {

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
@@ -28,7 +28,6 @@ public class GrpcConfigTest {
     assertThat(config.getPort()).isEqualTo(ANY_PORT);
     assertThat(config.getDeadlineDurationMillis())
         .isEqualTo(GrpcConfig.DEFAULT_DEADLINE_DURATION_MILLIS);
-    assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(true);
   }
 
   @Test
@@ -46,7 +45,6 @@ public class GrpcConfigTest {
     assertThat(config.getPort()).isEqualTo(GrpcConfig.DEFAULT_SCALAR_DB_SERVER_PORT);
     assertThat(config.getDeadlineDurationMillis())
         .isEqualTo(GrpcConfig.DEFAULT_DEADLINE_DURATION_MILLIS);
-    assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(true);
   }
 
   @Test
@@ -72,40 +70,9 @@ public class GrpcConfigTest {
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
     props.setProperty(DatabaseConfig.STORAGE, "grpc");
-    props.setProperty(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "aaa");
+    props.setProperty(GrpcConfig.DEADLINE_DURATION_MILLIS, "aaa");
 
     // Act
-    assertThatThrownBy(() -> new GrpcConfig(new DatabaseConfig(props)))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      constructor_PropertiesWithValidActiveTransactionsManagementEnabledGiven_ShouldLoadProperly() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.STORAGE, "grpc");
-    props.setProperty(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "false");
-
-    // Act
-    GrpcConfig config = new GrpcConfig(new DatabaseConfig(props));
-
-    // Assert
-    assertThat(config.getHost()).isEqualTo(ANY_HOST);
-    assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(false);
-  }
-
-  @Test
-  public void
-      constructor_PropertiesWithInvalidActiveTransactionsManagementEnabledGiven_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
-    props.setProperty(DatabaseConfig.STORAGE, "grpc");
-    props.setProperty(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "aaa");
-
-    // Act Assert
     assertThatThrownBy(() -> new GrpcConfig(new DatabaseConfig(props)))
         .isInstanceOf(IllegalArgumentException.class);
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -20,7 +20,6 @@ public class ConsensusCommitConfigTest {
     // Assert
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
     assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
-    assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(true);
     assertThat(config.getCoordinatorNamespace()).isNotPresent();
     assertThat(config.getParallelExecutorCount())
         .isEqualTo(ConsensusCommitConfig.DEFAULT_PARALLEL_EXECUTOR_COUNT);
@@ -89,32 +88,6 @@ public class ConsensusCommitConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, "NO_STRATEGY");
-
-    // Act Assert
-    assertThatThrownBy(() -> new ConsensusCommitConfig(new DatabaseConfig(props)))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void
-      constructor_PropertiesWithValidActiveTransactionsManagementEnabledGiven_ShouldLoadProperly() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(ConsensusCommitConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "false");
-
-    // Act
-    ConsensusCommitConfig config = new ConsensusCommitConfig(new DatabaseConfig(props));
-
-    // Assert
-    assertThat(config.isActiveTransactionsManagementEnabled()).isEqualTo(false);
-  }
-
-  @Test
-  public void
-      constructor_PropertiesWithInvalidActiveTransactionsManagementEnabledGiven_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(ConsensusCommitConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "aaa");
 
     // Act Assert
     assertThatThrownBy(() -> new ConsensusCommitConfig(new DatabaseConfig(props)))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -39,7 +39,6 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Arrange
     when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);
     when(config.getSerializableStrategy()).thenReturn(SerializableStrategy.EXTRA_READ);
-    when(config.isActiveTransactionsManagementEnabled()).thenReturn(true);
 
     manager =
         new TwoPhaseConsensusCommitManager(
@@ -100,8 +99,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
-  public void join_TxIdGiven_ReturnWithSpecifiedTxIdAndSnapshotIsolation()
-      throws TransactionException {
+  public void join_TxIdGiven_ReturnWithSpecifiedTxIdAndSnapshotIsolation() {
     // Arrange
 
     // Act
@@ -114,20 +112,12 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
-  public void join_CalledTwiceWithSameTxId_ThrowTransactionException() throws TransactionException {
-    // Arrange
-
-    // Act Assert
-    manager.join(ANY_TX_ID);
-    assertThatThrownBy(() -> manager.join(ANY_TX_ID)).isInstanceOf(TransactionException.class);
-  }
-
-  @Test
-  public void resume_CalledAfterJoin_ReturnSameTransactionObjects() throws TransactionException {
+  public void resume_CalledAfterSuspend_ReturnSameTransactionObjects() throws TransactionException {
     // Arrange
 
     // Act
     TwoPhaseConsensusCommit transaction1 = manager.join(ANY_TX_ID);
+    manager.suspend(transaction1);
     TwoPhaseConsensusCommit transaction2 = manager.resume(ANY_TX_ID);
 
     // Assert
@@ -135,32 +125,11 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
-  public void resume_CalledWithoutJoin_ThrowTransactionException() {
+  public void resume_CalledWithoutSuspend_ThrowTransactionException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(TransactionException.class);
-  }
-
-  @Test
-  public void
-      resume_WhenActiveTransactionsManagementEnabledIsFalse_ShouldThrowUnsupportedOperationException() {
-    // Arrange
-    when(config.isActiveTransactionsManagementEnabled()).thenReturn(false);
-    manager =
-        new TwoPhaseConsensusCommitManager(
-            storage,
-            admin,
-            config,
-            databaseConfig,
-            coordinator,
-            parallelExecutor,
-            recovery,
-            commit);
-
-    // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
-        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -47,7 +47,6 @@ public class TwoPhaseConsensusCommitTest {
   @Mock private CrudHandler crud;
   @Mock private CommitHandler commit;
   @Mock private RecoveryHandler recovery;
-  @Mock private TwoPhaseConsensusCommitManager manager;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -89,7 +88,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Get get = prepareGet();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     TransactionResult result = mock(TransactionResult.class);
     when(crud.get(get)).thenReturn(Optional.of(result));
     when(crud.getSnapshot()).thenReturn(snapshot);
@@ -108,7 +107,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Get get = prepareGet();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     TransactionResult result = mock(TransactionResult.class);
     UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
     when(crud.get(get)).thenThrow(toThrow);
@@ -127,7 +126,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Scan scan = prepareScan();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     TransactionResult result = mock(TransactionResult.class);
     List<Result> results = Collections.singletonList(result);
     when(crud.scan(scan)).thenReturn(results);
@@ -146,7 +145,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Put put = preparePut();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -161,7 +160,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Put put = preparePut();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -176,7 +175,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Delete delete = prepareDelete();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -191,7 +190,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Delete delete = prepareDelete();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -207,7 +206,7 @@ public class TwoPhaseConsensusCommitTest {
     Put put = preparePut();
     Delete delete = prepareDelete();
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -223,7 +222,7 @@ public class TwoPhaseConsensusCommitTest {
       throws PreparationException, CommitException, UnknownTransactionStatusException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -238,7 +237,7 @@ public class TwoPhaseConsensusCommitTest {
       throws ValidationException, CommitException, UnknownTransactionStatusException {
     // Arrange
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -255,7 +254,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = true;
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -273,7 +272,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = false; // means it's a participant process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
@@ -284,7 +283,6 @@ public class TwoPhaseConsensusCommitTest {
     // Assert
     verify(commit, never()).commitState(snapshot);
     verify(commit).commitRecords(snapshot);
-    verify(manager).removeTransaction(ANY_TX_ID);
   }
 
   @Test
@@ -293,7 +291,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = true; // means it's a coordinator process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.VALIDATED;
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
@@ -312,7 +310,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = true; // means it's a coordinator process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
@@ -328,7 +326,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = true; // means it's a coordinator process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -346,7 +344,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = true; // means it's a coordinator process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     when(crud.getSnapshot()).thenReturn(snapshot);
     doThrow(CommitException.class).when(commit).prepare(snapshot, false);
 
@@ -366,7 +364,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = true; // means it's a coordinator process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
     doThrow(CommitException.class).when(commit).commitState(snapshot);
@@ -385,7 +383,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = false; // means it's a participant process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     transaction.status = Status.PREPARED;
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
@@ -395,7 +393,6 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     verify(commit).rollbackRecords(snapshot);
-    verify(manager).removeTransaction(ANY_TX_ID);
   }
 
   @Test
@@ -404,7 +401,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     boolean isCoordinator = false; // means it's a participant process
     TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator, manager);
+        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
     doThrow(CommitException.class).when(commit).prepare(snapshot, false);
@@ -415,6 +412,5 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     verify(commit).rollbackRecords(snapshot);
-    verify(manager).removeTransaction(ANY_TX_ID);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.rpc.TransactionState;
 import com.scalar.db.rpc.TwoPhaseCommitTransactionGrpc;
 import com.scalar.db.storage.rpc.GrpcConfig;
 import io.grpc.Status;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -40,18 +39,6 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
     manager.with("namespace", "table");
     when(config.getDeadlineDurationMillis()).thenReturn(60000L);
     when(blockingStub.withDeadlineAfter(anyLong(), any())).thenReturn(blockingStub);
-  }
-
-  @Test
-  public void
-      resume_WhenActiveTransactionsManagementEnabledIsFalse_ShouldThrowUnsupportedOperationException() {
-    // Arrange
-    when(config.isActiveTransactionsManagementEnabled()).thenReturn(false);
-    manager = new GrpcTwoPhaseCommitTransactionManager(config, stub, blockingStub, metadataManager);
-
-    // Act Assert
-    AssertionsForClassTypes.assertThatThrownBy(() -> manager.resume(ANY_ID))
-        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/server/src/main/java/com/scalar/db/server/ServerModule.java
+++ b/server/src/main/java/com/scalar/db/server/ServerModule.java
@@ -12,11 +12,6 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
-import com.scalar.db.storage.rpc.GrpcConfig;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitManager;
-import com.scalar.db.transaction.rpc.GrpcTransactionManager;
-import java.util.Properties;
 
 public class ServerModule extends AbstractModule {
 
@@ -29,19 +24,7 @@ public class ServerModule extends AbstractModule {
     this.config = config;
     this.databaseConfig = new DatabaseConfig(config.getProperties());
     storageFactory = new StorageFactory(databaseConfig);
-
-    Properties transactionProperties = new Properties();
-    transactionProperties.putAll(databaseConfig.getProperties());
-
-    // For two-phase consensus commit transactions in Scalar DB server, disable the active
-    // transactions management because Scalar DB server takes care of active transactions management
-    if (databaseConfig.getTransactionManagerClass() == ConsensusCommitManager.class) {
-      transactionProperties.put(
-          ConsensusCommitConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "false");
-    } else if (databaseConfig.getTransactionManagerClass() == GrpcTransactionManager.class) {
-      transactionProperties.put(GrpcConfig.ACTIVE_TRANSACTIONS_MANAGEMENT_ENABLED, "false");
-    }
-    transactionFactory = new TransactionFactory(new DatabaseConfig(transactionProperties));
+    transactionFactory = new TransactionFactory(databaseConfig);
   }
 
   @Override


### PR DESCRIPTION
This is actually a backward incompatible change for Two-phase Commit Transactions. But I don't think the 2PC transaction feature is not widely used, so we can change it for now.

Currently, when we join a transaction (with `TwoPhaseCommitTransactionManager.join()`), the transaction object is automatically put in the object map (`activeTransactions`), and we can resume this transaction with `TwoPhaseCommitTransactionManager.resume()`. But after this change, we need to call `TwoPhaseCommitTransactionManager.suspend()` explicitly if you want to resume the transaction.

I also modified the document for this feature:
https://github.com/scalar-labs/scalardb/blob/add-suspend-to-2pc/docs/two-phase-commit-transactions.md#suspend-and-resume-the-transaction

Please take a look!