### PR TITLE
Update dependencies to fix CVE-2022-25647

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext {
         guiceVersion = '5.0.1'
-        guavaVersion = '30.1-jre'
+        guavaVersion = '31.1-jre'
         slf4jVersion = '1.7.30'
         cassandraDriverVersion = '3.6.0'
         azureCosmosVersion = '4.28.1'
@@ -32,9 +32,9 @@ subprojects {
         postgresqlDriverVersion = '42.3.3'
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'
-        grpcVersion = '1.38.0'
-        protocVersion = '3.17.2'
-        protobufVersion = '3.17.2'
+        grpcVersion = '1.46.0'
+        protocVersion = '3.20.1'
+        protobufVersion = '3.20.1'
         picocliVersion = '4.1.4'
         scalarAdminVersion = '1.2.0'
         dropwizardMetricsVersion = '4.2.2'
@@ -47,7 +47,7 @@ subprojects {
         spotbugsVersion = '4.3.0'
         errorproneVersion = '2.10.0'
         errorproneJavacVersion = '9+181-r4173-1'
-        gsonVersion = '2.8.7'
+        gsonVersion = '2.9.0'
         log4jVersion = '2.17.1'
     }
 

--- a/core/src/main/java/com/scalar/db/api/Operation.java
+++ b/core/src/main/java/com/scalar/db/api/Operation.java
@@ -3,8 +3,8 @@ package com.scalar.db.api;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Ordering;
 import com.scalar.db.io.Key;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -166,15 +166,15 @@ public abstract class Operation {
             .compare(
                 clusteringKey.orElse(null),
                 other.clusteringKey.orElse(null),
-                Ordering.natural().nullsFirst())
+                Comparator.nullsFirst(Comparator.naturalOrder()))
             .compare(
                 namespace.orElse(null),
                 other.namespace.orElse(null),
-                Ordering.natural().nullsFirst())
+                Comparator.nullsFirst(Comparator.naturalOrder()))
             .compare(
                 tableName.orElse(null),
                 other.tableName.orElse(null),
-                Ordering.natural().nullsFirst())
+                Comparator.nullsFirst(Comparator.naturalOrder()))
             .compare(consistency, other.consistency)
             .result()
         == 0;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -740,6 +740,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
    * @param columnName a column name
    * @return a vendor DB data type
    */
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   private String getVendorDbColumnType(TableMetadata metadata, String columnName) {
     HashSet<String> keysAndIndexes =
         Sets.newHashSet(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -2,7 +2,6 @@ package com.scalar.db.transaction.consensuscommit;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Ordering;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -20,6 +19,7 @@ import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecut
 import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -485,7 +485,7 @@ public class Snapshot {
           .compare(
               this.clusteringKey.orElse(null),
               o.clusteringKey.orElse(null),
-              Ordering.natural().nullsFirst())
+              Comparator.nullsFirst(Comparator.naturalOrder()))
           .result();
     }
   }

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageAdminGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageAdminGrpc.java
@@ -5,8 +5,9 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.38.0)",
+    value = "by gRPC proto compiler (version 1.46.0)",
     comments = "Source: scalardb.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class DistributedStorageAdminGrpc {
 
   private DistributedStorageAdminGrpc() {}

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageGrpc.java
@@ -5,8 +5,9 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.38.0)",
+    value = "by gRPC proto compiler (version 1.46.0)",
     comments = "Source: scalardb.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class DistributedStorageGrpc {
 
   private DistributedStorageGrpc() {}

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionAdminGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionAdminGrpc.java
@@ -5,8 +5,9 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.38.0)",
+    value = "by gRPC proto compiler (version 1.46.0)",
     comments = "Source: scalardb.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class DistributedTransactionAdminGrpc {
 
   private DistributedTransactionAdminGrpc() {}

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionGrpc.java
@@ -5,8 +5,9 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.38.0)",
+    value = "by gRPC proto compiler (version 1.46.0)",
     comments = "Source: scalardb.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class DistributedTransactionGrpc {
 
   private DistributedTransactionGrpc() {}

--- a/rpc/src/main/grpc/com/scalar/db/rpc/TwoPhaseCommitTransactionGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/TwoPhaseCommitTransactionGrpc.java
@@ -5,8 +5,9 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.38.0)",
+    value = "by gRPC proto compiler (version 1.46.0)",
     comments = "Source: scalardb.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class TwoPhaseCommitTransactionGrpc {
 
   private TwoPhaseCommitTransactionGrpc() {}

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortRequest.java
@@ -66,6 +66,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -139,7 +141,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getTransactionIdBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
     }
     unknownFields.writeTo(output);
@@ -151,7 +153,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getTransactionIdBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
     }
     size += unknownFields.getSerializedSize();

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortResponse.java
@@ -66,6 +66,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpression.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpression.java
@@ -86,6 +86,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -366,7 +368,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (value_ != null) {
@@ -384,7 +386,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (value_ != null) {

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistRequest.java
@@ -59,6 +59,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponse.java
@@ -64,6 +64,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequest.java
@@ -78,6 +78,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -144,7 +146,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     return internalGetOptions().getMap().containsKey(key);
   }
   /**
@@ -171,7 +173,7 @@ private static final long serialVersionUID = 0L;
   public java.lang.String getOptionsOrDefault(
       java.lang.String key,
       java.lang.String defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -183,7 +185,7 @@ private static final long serialVersionUID = 0L;
 
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     if (!map.containsKey(key)) {
@@ -590,7 +592,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetOptions().getMap().containsKey(key);
     }
     /**
@@ -617,7 +619,7 @@ private static final long serialVersionUID = 0L;
     public java.lang.String getOptionsOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -629,7 +631,7 @@ private static final long serialVersionUID = 0L;
 
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       if (!map.containsKey(key)) {
@@ -649,7 +651,7 @@ private static final long serialVersionUID = 0L;
 
     public Builder removeOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       internalGetMutableOptions().getMutableMap()
           .remove(key);
       return this;
@@ -668,8 +670,11 @@ private static final long serialVersionUID = 0L;
     public Builder putOptions(
         java.lang.String key,
         java.lang.String value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      if (value == null) {
+  throw new NullPointerException("map value");
+}
+
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequestOrBuilder.java
@@ -31,9 +31,11 @@ public interface CreateCoordinatorTablesRequestOrBuilder extends
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
 
-  java.lang.String getOptionsOrDefault(
+  /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue);
+      /* nullable */
+java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequest.java
@@ -99,6 +99,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -279,7 +281,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     return internalGetOptions().getMap().containsKey(key);
   }
   /**
@@ -306,7 +308,7 @@ private static final long serialVersionUID = 0L;
   public java.lang.String getOptionsOrDefault(
       java.lang.String key,
       java.lang.String defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -318,7 +320,7 @@ private static final long serialVersionUID = 0L;
 
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     if (!map.containsKey(key)) {
@@ -352,13 +354,13 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
-    if (!getColumnNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(columnName_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 3, columnName_);
     }
     com.google.protobuf.GeneratedMessageV3
@@ -379,13 +381,13 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
-    if (!getColumnNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(columnName_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, columnName_);
     }
     for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
@@ -1004,7 +1006,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetOptions().getMap().containsKey(key);
     }
     /**
@@ -1031,7 +1033,7 @@ private static final long serialVersionUID = 0L;
     public java.lang.String getOptionsOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -1043,7 +1045,7 @@ private static final long serialVersionUID = 0L;
 
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       if (!map.containsKey(key)) {
@@ -1063,7 +1065,7 @@ private static final long serialVersionUID = 0L;
 
     public Builder removeOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       internalGetMutableOptions().getMutableMap()
           .remove(key);
       return this;
@@ -1082,8 +1084,11 @@ private static final long serialVersionUID = 0L;
     public Builder putOptions(
         java.lang.String key,
         java.lang.String value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      if (value == null) {
+  throw new NullPointerException("map value");
+}
+
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequestOrBuilder.java
@@ -67,9 +67,11 @@ public interface CreateIndexRequestOrBuilder extends
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
 
-  java.lang.String getOptionsOrDefault(
+  /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue);
+      /* nullable */
+java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequest.java
@@ -85,6 +85,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -189,7 +191,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     return internalGetOptions().getMap().containsKey(key);
   }
   /**
@@ -216,7 +218,7 @@ private static final long serialVersionUID = 0L;
   public java.lang.String getOptionsOrDefault(
       java.lang.String key,
       java.lang.String defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -228,7 +230,7 @@ private static final long serialVersionUID = 0L;
 
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     if (!map.containsKey(key)) {
@@ -262,7 +264,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
     com.google.protobuf.GeneratedMessageV3
@@ -283,7 +285,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
     for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
@@ -728,7 +730,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetOptions().getMap().containsKey(key);
     }
     /**
@@ -755,7 +757,7 @@ private static final long serialVersionUID = 0L;
     public java.lang.String getOptionsOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -767,7 +769,7 @@ private static final long serialVersionUID = 0L;
 
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       if (!map.containsKey(key)) {
@@ -787,7 +789,7 @@ private static final long serialVersionUID = 0L;
 
     public Builder removeOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       internalGetMutableOptions().getMutableMap()
           .remove(key);
       return this;
@@ -806,8 +808,11 @@ private static final long serialVersionUID = 0L;
     public Builder putOptions(
         java.lang.String key,
         java.lang.String value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      if (value == null) {
+  throw new NullPointerException("map value");
+}
+
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequestOrBuilder.java
@@ -43,9 +43,11 @@ public interface CreateNamespaceRequestOrBuilder extends
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
 
-  java.lang.String getOptionsOrDefault(
+  /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue);
+      /* nullable */
+java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 2;</code>
    */

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequest.java
@@ -105,6 +105,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -273,7 +275,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     return internalGetOptions().getMap().containsKey(key);
   }
   /**
@@ -300,7 +302,7 @@ private static final long serialVersionUID = 0L;
   public java.lang.String getOptionsOrDefault(
       java.lang.String key,
       java.lang.String defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -312,7 +314,7 @@ private static final long serialVersionUID = 0L;
 
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
     if (!map.containsKey(key)) {
@@ -346,10 +348,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     if (tableMetadata_ != null) {
@@ -373,10 +375,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     if (tableMetadata_ != null) {
@@ -1054,7 +1056,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetOptions().getMap().containsKey(key);
     }
     /**
@@ -1081,7 +1083,7 @@ private static final long serialVersionUID = 0L;
     public java.lang.String getOptionsOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -1093,7 +1095,7 @@ private static final long serialVersionUID = 0L;
 
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
       if (!map.containsKey(key)) {
@@ -1113,7 +1115,7 @@ private static final long serialVersionUID = 0L;
 
     public Builder removeOptions(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       internalGetMutableOptions().getMutableMap()
           .remove(key);
       return this;
@@ -1132,8 +1134,11 @@ private static final long serialVersionUID = 0L;
     public Builder putOptions(
         java.lang.String key,
         java.lang.String value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      if (value == null) {
+  throw new NullPointerException("map value");
+}
+
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequestOrBuilder.java
@@ -70,9 +70,11 @@ public interface CreateTableRequestOrBuilder extends
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
 
-  java.lang.String getOptionsOrDefault(
+  /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue);
+      /* nullable */
+java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */

--- a/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequest.java
@@ -64,6 +64,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequest.java
@@ -85,6 +85,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -245,13 +247,13 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
-    if (!getColumnNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(columnName_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 3, columnName_);
     }
     if (ifExists_ != false) {
@@ -266,13 +268,13 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
-    if (!getColumnNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(columnName_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, columnName_);
     }
     if (ifExists_ != false) {

--- a/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequest.java
@@ -71,6 +71,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -155,7 +157,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
     if (ifExists_ != false) {
@@ -170,7 +172,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
     if (ifExists_ != false) {

--- a/rpc/src/main/java/com/scalar/db/rpc/DropTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropTableRequest.java
@@ -78,6 +78,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -200,10 +202,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     if (ifExists_ != false) {
@@ -218,10 +220,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     if (ifExists_ != false) {

--- a/rpc/src/main/java/com/scalar/db/rpc/Get.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Get.java
@@ -117,6 +117,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -337,10 +339,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     if (partitionKey_ != null) {
@@ -364,10 +366,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     if (partitionKey_ != null) {

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequest.java
@@ -66,6 +66,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -139,7 +141,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
     unknownFields.writeTo(output);
@@ -151,7 +153,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
     size += unknownFields.getSerializedSize();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponse.java
@@ -70,6 +70,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/GetRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetRequest.java
@@ -72,6 +72,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/GetResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetResponse.java
@@ -72,6 +72,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequest.java
@@ -73,6 +73,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -184,10 +186,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     unknownFields.writeTo(output);
@@ -199,10 +201,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     size += unknownFields.getSerializedSize();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponse.java
@@ -72,6 +72,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequest.java
@@ -66,6 +66,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -139,7 +141,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getTransactionIdBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
     }
     unknownFields.writeTo(output);
@@ -151,7 +153,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getTransactionIdBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
     }
     size += unknownFields.getSerializedSize();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponse.java
@@ -66,6 +66,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/Key.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Key.java
@@ -70,6 +70,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateCondition.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateCondition.java
@@ -77,6 +77,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateRequest.java
@@ -70,6 +70,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/Mutation.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Mutation.java
@@ -137,6 +137,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -535,10 +537,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     if (partitionKey_ != null) {
@@ -568,10 +570,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     if (partitionKey_ != null) {

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequest.java
@@ -66,6 +66,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -139,7 +141,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
     unknownFields.writeTo(output);
@@ -151,7 +153,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
     size += unknownFields.getSerializedSize();

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponse.java
@@ -64,6 +64,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/Ordering.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Ordering.java
@@ -73,6 +73,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -165,7 +167,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (order_ != com.scalar.db.rpc.Order.ORDER_ASC.getNumber()) {
@@ -180,7 +182,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (order_ != com.scalar.db.rpc.Order.ORDER_ASC.getNumber()) {

--- a/rpc/src/main/java/com/scalar/db/rpc/Result.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Result.java
@@ -70,6 +70,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/Scan.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Scan.java
@@ -155,6 +155,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -477,10 +479,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     if (partitionKey_ != null) {
@@ -519,10 +521,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     if (partitionKey_ != null) {

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanRequest.java
@@ -78,6 +78,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanResponse.java
@@ -75,6 +75,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/TableMetadata.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TableMetadata.java
@@ -116,6 +116,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -206,7 +208,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean containsColumn(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     return internalGetColumn().getMap().containsKey(key);
   }
   /**
@@ -232,10 +234,12 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
 
-  public com.scalar.db.rpc.DataType getColumnOrDefault(
+  public /* nullable */
+com.scalar.db.rpc.DataType getColumnOrDefault(
       java.lang.String key,
-      com.scalar.db.rpc.DataType defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+      /* nullable */
+com.scalar.db.rpc.DataType defaultValue) {
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetColumn().getMap();
     return map.containsKey(key)
@@ -249,7 +253,7 @@ private static final long serialVersionUID = 0L;
 
   public com.scalar.db.rpc.DataType getColumnOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetColumn().getMap();
     if (!map.containsKey(key)) {
@@ -283,7 +287,7 @@ private static final long serialVersionUID = 0L;
   public int getColumnValueOrDefault(
       java.lang.String key,
       int defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetColumn().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -295,7 +299,7 @@ private static final long serialVersionUID = 0L;
 
   public int getColumnValueOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetColumn().getMap();
     if (!map.containsKey(key)) {
@@ -420,7 +424,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean containsClusteringOrder(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     return internalGetClusteringOrder().getMap().containsKey(key);
   }
   /**
@@ -446,10 +450,12 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
 
-  public com.scalar.db.rpc.Order getClusteringOrderOrDefault(
+  public /* nullable */
+com.scalar.db.rpc.Order getClusteringOrderOrDefault(
       java.lang.String key,
-      com.scalar.db.rpc.Order defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+      /* nullable */
+com.scalar.db.rpc.Order defaultValue) {
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetClusteringOrder().getMap();
     return map.containsKey(key)
@@ -463,7 +469,7 @@ private static final long serialVersionUID = 0L;
 
   public com.scalar.db.rpc.Order getClusteringOrderOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetClusteringOrder().getMap();
     if (!map.containsKey(key)) {
@@ -497,7 +503,7 @@ private static final long serialVersionUID = 0L;
   public int getClusteringOrderValueOrDefault(
       java.lang.String key,
       int defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetClusteringOrder().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -509,7 +515,7 @@ private static final long serialVersionUID = 0L;
 
   public int getClusteringOrderValueOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.Integer> map =
         internalGetClusteringOrder().getMap();
     if (!map.containsKey(key)) {
@@ -1055,7 +1061,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean containsColumn(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetColumn().getMap().containsKey(key);
     }
     /**
@@ -1081,10 +1087,12 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
 
-    public com.scalar.db.rpc.DataType getColumnOrDefault(
+    public /* nullable */
+com.scalar.db.rpc.DataType getColumnOrDefault(
         java.lang.String key,
-        com.scalar.db.rpc.DataType defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+        /* nullable */
+com.scalar.db.rpc.DataType defaultValue) {
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetColumn().getMap();
       return map.containsKey(key)
@@ -1098,7 +1106,7 @@ private static final long serialVersionUID = 0L;
 
     public com.scalar.db.rpc.DataType getColumnOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetColumn().getMap();
       if (!map.containsKey(key)) {
@@ -1132,7 +1140,7 @@ private static final long serialVersionUID = 0L;
     public int getColumnValueOrDefault(
         java.lang.String key,
         int defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetColumn().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -1144,7 +1152,7 @@ private static final long serialVersionUID = 0L;
 
     public int getColumnValueOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetColumn().getMap();
       if (!map.containsKey(key)) {
@@ -1164,7 +1172,7 @@ private static final long serialVersionUID = 0L;
 
     public Builder removeColumn(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       internalGetMutableColumn().getMutableMap()
           .remove(key);
       return this;
@@ -1184,8 +1192,8 @@ private static final long serialVersionUID = 0L;
     public Builder putColumn(
         java.lang.String key,
         com.scalar.db.rpc.DataType value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      
       internalGetMutableColumn().getMutableMap()
           .put(key, columnValueConverter.doBackward(value));
       return this;
@@ -1214,7 +1222,8 @@ private static final long serialVersionUID = 0L;
     public Builder putColumnValue(
         java.lang.String key,
         int value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      
       internalGetMutableColumn().getMutableMap()
           .put(key, value);
       return this;
@@ -1482,7 +1491,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean containsClusteringOrder(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetClusteringOrder().getMap().containsKey(key);
     }
     /**
@@ -1508,10 +1517,12 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
 
-    public com.scalar.db.rpc.Order getClusteringOrderOrDefault(
+    public /* nullable */
+com.scalar.db.rpc.Order getClusteringOrderOrDefault(
         java.lang.String key,
-        com.scalar.db.rpc.Order defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+        /* nullable */
+com.scalar.db.rpc.Order defaultValue) {
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetClusteringOrder().getMap();
       return map.containsKey(key)
@@ -1525,7 +1536,7 @@ private static final long serialVersionUID = 0L;
 
     public com.scalar.db.rpc.Order getClusteringOrderOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetClusteringOrder().getMap();
       if (!map.containsKey(key)) {
@@ -1559,7 +1570,7 @@ private static final long serialVersionUID = 0L;
     public int getClusteringOrderValueOrDefault(
         java.lang.String key,
         int defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetClusteringOrder().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -1571,7 +1582,7 @@ private static final long serialVersionUID = 0L;
 
     public int getClusteringOrderValueOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.Integer> map =
           internalGetClusteringOrder().getMap();
       if (!map.containsKey(key)) {
@@ -1591,7 +1602,7 @@ private static final long serialVersionUID = 0L;
 
     public Builder removeClusteringOrder(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       internalGetMutableClusteringOrder().getMutableMap()
           .remove(key);
       return this;
@@ -1611,8 +1622,8 @@ private static final long serialVersionUID = 0L;
     public Builder putClusteringOrder(
         java.lang.String key,
         com.scalar.db.rpc.Order value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      
       internalGetMutableClusteringOrder().getMutableMap()
           .put(key, clusteringOrderValueConverter.doBackward(value));
       return this;
@@ -1641,7 +1652,8 @@ private static final long serialVersionUID = 0L;
     public Builder putClusteringOrderValue(
         java.lang.String key,
         int value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
+      
       internalGetMutableClusteringOrder().getMutableMap()
           .put(key, value);
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/TableMetadataOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TableMetadataOrBuilder.java
@@ -30,9 +30,11 @@ public interface TableMetadataOrBuilder extends
   /**
    * <code>map&lt;string, .rpc.DataType&gt; column = 1;</code>
    */
-  com.scalar.db.rpc.DataType getColumnOrDefault(
+  /* nullable */
+com.scalar.db.rpc.DataType getColumnOrDefault(
       java.lang.String key,
-      com.scalar.db.rpc.DataType defaultValue);
+      /* nullable */
+com.scalar.db.rpc.DataType         defaultValue);
   /**
    * <code>map&lt;string, .rpc.DataType&gt; column = 1;</code>
    */
@@ -136,9 +138,11 @@ public interface TableMetadataOrBuilder extends
   /**
    * <code>map&lt;string, .rpc.Order&gt; clustering_order = 4;</code>
    */
-  com.scalar.db.rpc.Order getClusteringOrderOrDefault(
+  /* nullable */
+com.scalar.db.rpc.Order getClusteringOrderOrDefault(
       java.lang.String key,
-      com.scalar.db.rpc.Order defaultValue);
+      /* nullable */
+com.scalar.db.rpc.Order         defaultValue);
   /**
    * <code>map&lt;string, .rpc.Order&gt; clustering_order = 4;</code>
    */

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionRequest.java
@@ -143,6 +143,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -249,6 +251,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -855,6 +859,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -1476,6 +1482,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2104,6 +2112,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2862,6 +2872,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -3280,6 +3292,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -4420,8 +4434,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 1) {
           startRequestBuilder_.mergeFrom(value);
+        } else {
+          startRequestBuilder_.setMessage(value);
         }
-        startRequestBuilder_.setMessage(value);
       }
       requestCase_ = 1;
       return this;
@@ -4561,8 +4576,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 2) {
           getRequestBuilder_.mergeFrom(value);
+        } else {
+          getRequestBuilder_.setMessage(value);
         }
-        getRequestBuilder_.setMessage(value);
       }
       requestCase_ = 2;
       return this;
@@ -4702,8 +4718,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 3) {
           scanRequestBuilder_.mergeFrom(value);
+        } else {
+          scanRequestBuilder_.setMessage(value);
         }
-        scanRequestBuilder_.setMessage(value);
       }
       requestCase_ = 3;
       return this;
@@ -4843,8 +4860,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 4) {
           mutateRequestBuilder_.mergeFrom(value);
+        } else {
+          mutateRequestBuilder_.setMessage(value);
         }
-        mutateRequestBuilder_.setMessage(value);
       }
       requestCase_ = 4;
       return this;
@@ -4984,8 +5002,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 5) {
           commitRequestBuilder_.mergeFrom(value);
+        } else {
+          commitRequestBuilder_.setMessage(value);
         }
-        commitRequestBuilder_.setMessage(value);
       }
       requestCase_ = 5;
       return this;
@@ -5125,8 +5144,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 6) {
           abortRequestBuilder_.mergeFrom(value);
+        } else {
+          abortRequestBuilder_.setMessage(value);
         }
-        abortRequestBuilder_.setMessage(value);
       }
       requestCase_ = 6;
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionResponse.java
@@ -115,6 +115,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -215,6 +217,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -288,7 +292,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getTransactionIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
       }
       unknownFields.writeTo(output);
@@ -300,7 +304,7 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (!getTransactionIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
       }
       size += unknownFields.getSerializedSize();
@@ -792,6 +796,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -1420,6 +1426,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2215,6 +2223,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2436,7 +2446,7 @@ private static final long serialVersionUID = 0L;
       if (errorCode_ != com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.INVALID_ARGUMENT.getNumber()) {
         output.writeEnum(1, errorCode_);
       }
-      if (!getMessageBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, message_);
       }
       unknownFields.writeTo(output);
@@ -2452,7 +2462,7 @@ private static final long serialVersionUID = 0L;
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(1, errorCode_);
       }
-      if (!getMessageBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, message_);
       }
       size += unknownFields.getSerializedSize();
@@ -3583,8 +3593,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 1) {
           startResponseBuilder_.mergeFrom(value);
+        } else {
+          startResponseBuilder_.setMessage(value);
         }
-        startResponseBuilder_.setMessage(value);
       }
       responseCase_ = 1;
       return this;
@@ -3724,8 +3735,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 2) {
           getResponseBuilder_.mergeFrom(value);
+        } else {
+          getResponseBuilder_.setMessage(value);
         }
-        getResponseBuilder_.setMessage(value);
       }
       responseCase_ = 2;
       return this;
@@ -3865,8 +3877,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 3) {
           scanResponseBuilder_.mergeFrom(value);
+        } else {
+          scanResponseBuilder_.setMessage(value);
         }
-        scanResponseBuilder_.setMessage(value);
       }
       responseCase_ = 3;
       return this;
@@ -4006,8 +4019,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 4) {
           errorBuilder_.mergeFrom(value);
+        } else {
+          errorBuilder_.setMessage(value);
         }
-        errorBuilder_.setMessage(value);
       }
       responseCase_ = 4;
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateCoordinatorTablesRequest.java
@@ -59,6 +59,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequest.java
@@ -73,6 +73,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -184,10 +186,10 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 2, table_);
     }
     unknownFields.writeTo(output);
@@ -199,10 +201,10 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNamespaceBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, namespace_);
     }
-    if (!getTableBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(table_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, table_);
     }
     size += unknownFields.getSerializedSize();

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
@@ -185,6 +185,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -291,6 +293,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -888,6 +892,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -961,7 +967,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getTransactionIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
       }
       unknownFields.writeTo(output);
@@ -973,7 +979,7 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (!getTransactionIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
       }
       size += unknownFields.getSerializedSize();
@@ -1465,6 +1471,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2086,6 +2094,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2714,6 +2724,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -3472,6 +3484,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -3890,6 +3904,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -4308,6 +4324,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -4726,6 +4744,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -6043,8 +6063,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 1) {
           startRequestBuilder_.mergeFrom(value);
+        } else {
+          startRequestBuilder_.setMessage(value);
         }
-        startRequestBuilder_.setMessage(value);
       }
       requestCase_ = 1;
       return this;
@@ -6184,8 +6205,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 2) {
           joinRequestBuilder_.mergeFrom(value);
+        } else {
+          joinRequestBuilder_.setMessage(value);
         }
-        joinRequestBuilder_.setMessage(value);
       }
       requestCase_ = 2;
       return this;
@@ -6325,8 +6347,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 3) {
           getRequestBuilder_.mergeFrom(value);
+        } else {
+          getRequestBuilder_.setMessage(value);
         }
-        getRequestBuilder_.setMessage(value);
       }
       requestCase_ = 3;
       return this;
@@ -6466,8 +6489,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 4) {
           scanRequestBuilder_.mergeFrom(value);
+        } else {
+          scanRequestBuilder_.setMessage(value);
         }
-        scanRequestBuilder_.setMessage(value);
       }
       requestCase_ = 4;
       return this;
@@ -6607,8 +6631,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 5) {
           mutateRequestBuilder_.mergeFrom(value);
+        } else {
+          mutateRequestBuilder_.setMessage(value);
         }
-        mutateRequestBuilder_.setMessage(value);
       }
       requestCase_ = 5;
       return this;
@@ -6748,8 +6773,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 6) {
           prepareRequestBuilder_.mergeFrom(value);
+        } else {
+          prepareRequestBuilder_.setMessage(value);
         }
-        prepareRequestBuilder_.setMessage(value);
       }
       requestCase_ = 6;
       return this;
@@ -6889,8 +6915,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 7) {
           validateRequestBuilder_.mergeFrom(value);
+        } else {
+          validateRequestBuilder_.setMessage(value);
         }
-        validateRequestBuilder_.setMessage(value);
       }
       requestCase_ = 7;
       return this;
@@ -7030,8 +7057,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 8) {
           commitRequestBuilder_.mergeFrom(value);
+        } else {
+          commitRequestBuilder_.setMessage(value);
         }
-        commitRequestBuilder_.setMessage(value);
       }
       requestCase_ = 8;
       return this;
@@ -7171,8 +7199,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (requestCase_ == 9) {
           rollbackRequestBuilder_.mergeFrom(value);
+        } else {
+          rollbackRequestBuilder_.setMessage(value);
         }
-        rollbackRequestBuilder_.setMessage(value);
       }
       requestCase_ = 9;
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
@@ -115,6 +115,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -215,6 +217,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -288,7 +292,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getTransactionIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
       }
       unknownFields.writeTo(output);
@@ -300,7 +304,7 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (!getTransactionIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
       }
       size += unknownFields.getSerializedSize();
@@ -792,6 +796,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -1420,6 +1426,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2215,6 +2223,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2436,7 +2446,7 @@ private static final long serialVersionUID = 0L;
       if (errorCode_ != com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.INVALID_ARGUMENT.getNumber()) {
         output.writeEnum(1, errorCode_);
       }
-      if (!getMessageBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, message_);
       }
       unknownFields.writeTo(output);
@@ -2452,7 +2462,7 @@ private static final long serialVersionUID = 0L;
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(1, errorCode_);
       }
-      if (!getMessageBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(message_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, message_);
       }
       size += unknownFields.getSerializedSize();
@@ -3583,8 +3593,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 1) {
           startResponseBuilder_.mergeFrom(value);
+        } else {
+          startResponseBuilder_.setMessage(value);
         }
-        startResponseBuilder_.setMessage(value);
       }
       responseCase_ = 1;
       return this;
@@ -3724,8 +3735,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 2) {
           getResponseBuilder_.mergeFrom(value);
+        } else {
+          getResponseBuilder_.setMessage(value);
         }
-        getResponseBuilder_.setMessage(value);
       }
       responseCase_ = 2;
       return this;
@@ -3865,8 +3877,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 3) {
           scanResponseBuilder_.mergeFrom(value);
+        } else {
+          scanResponseBuilder_.setMessage(value);
         }
-        scanResponseBuilder_.setMessage(value);
       }
       responseCase_ = 3;
       return this;
@@ -4006,8 +4019,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (responseCase_ == 4) {
           errorBuilder_.mergeFrom(value);
+        } else {
+          errorBuilder_.setMessage(value);
         }
-        errorBuilder_.setMessage(value);
       }
       responseCase_ = 4;
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/Value.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Value.java
@@ -56,28 +56,28 @@ private static final long serialVersionUID = 0L;
             break;
           }
           case 16: {
-            valueCase_ = 2;
             value_ = input.readBool();
+            valueCase_ = 2;
             break;
           }
           case 24: {
-            valueCase_ = 3;
             value_ = input.readInt32();
+            valueCase_ = 3;
             break;
           }
           case 32: {
-            valueCase_ = 4;
             value_ = input.readInt64();
+            valueCase_ = 4;
             break;
           }
           case 45: {
-            valueCase_ = 5;
             value_ = input.readFloat();
+            valueCase_ = 5;
             break;
           }
           case 49: {
-            valueCase_ = 6;
             value_ = input.readDouble();
+            valueCase_ = 6;
             break;
           }
           case 58: {
@@ -119,6 +119,8 @@ private static final long serialVersionUID = 0L;
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
+    } catch (com.google.protobuf.UninitializedMessageException e) {
+      throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
@@ -225,6 +227,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -821,6 +825,8 @@ private static final long serialVersionUID = 0L;
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -1540,7 +1546,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (!getNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
     if (valueCase_ == 2) {
@@ -1578,7 +1584,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (!getNameBytes().isEmpty()) {
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (valueCase_ == 2) {
@@ -2393,8 +2399,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (valueCase_ == 7) {
           textValueBuilder_.mergeFrom(value);
+        } else {
+          textValueBuilder_.setMessage(value);
         }
-        textValueBuilder_.setMessage(value);
       }
       valueCase_ = 7;
       return this;
@@ -2534,8 +2541,9 @@ private static final long serialVersionUID = 0L;
       } else {
         if (valueCase_ == 8) {
           blobValueBuilder_.mergeFrom(value);
+        } else {
+          blobValueBuilder_.setMessage(value);
         }
-        blobValueBuilder_.setMessage(value);
       }
       valueCase_ = 8;
       return this;


### PR DESCRIPTION
This fixes [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57 ) targeting `com.google.code.gson:gson`. 
As a result, multiple dependencies needed to be updated such as grpc so the proto files needed to be regenerated.
 
Besides, this raised new spotbugs warning as a side effects. They are addressed in https://github.com/scalar-labs/scalardb/pull/589/commits/9150618116936154167ceb7551260e8d093c4985 .
