### PR TITLE
Use dockerize command by default in the Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -39,9 +39,8 @@ ENV SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY ''
 
 WORKDIR /scalardb/server
 
-COPY log4j2.properties .
-# Support use cases where environment variables are used to configure the database
 COPY database.properties.tmpl .
+COPY log4j2.properties.tmpl .
 COPY docker-entrypoint.sh .
 
 RUN groupadd -r --gid 201 scalardb && \
@@ -51,11 +50,12 @@ RUN chown -R scalardb:scalardb /scalardb/server
 USER 201
 
 ENV JAVA_OPT_MAX_RAM_PERCENTAGE '70.0'
-ENV SCALARDB_SERVER_OPTS -Dlog4j.configurationFile=file:log4j2.properties
+ENV JAVA_OPTS '-Dlog4j.configurationFile=file:log4j2.properties'
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 CMD ["dockerize", "-template", "database.properties.tmpl:database.properties", \
-    "./bin/scalardb-server", "--config", "database.properties"]
+    "-template", "log4j2.properties.tmpl:log4j2.properties", \
+    "./bin/scalardb-server", "--config=database.properties"]
 
 EXPOSE 60051 8080

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -55,6 +55,7 @@ ENV SCALARDB_SERVER_OPTS -Dlog4j.configurationFile=file:log4j2.properties
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-CMD ["./bin/scalardb-server", "--config", "database.properties"]
+CMD ["dockerize", "-template", "database.properties.tmpl:database.properties", \
+    "./bin/scalardb-server", "--config", "database.properties"]
 
 EXPOSE 60051 8080

--- a/server/README.md
+++ b/server/README.md
@@ -39,7 +39,7 @@ $ docker run -v <your local configuration file path>:/scalardb/server/database.p
 $ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -e JAVA_OPTS=-Dlog4j.logLevel=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # For custom log configuration
-$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties.tmpl -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # Use environment variables
 docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PORT=9042 --env SCALAR_DB_USERNAME=cassandra --env SCALAR_DB_PASSWORD=cassandra --env SCALAR_DB_STORAGE=cassandra -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>

--- a/server/README.md
+++ b/server/README.md
@@ -33,17 +33,17 @@ $ ./gradlew docker
 This runs the Scalar DB Server (you need to specify your local configuration file path with `-v` flag):
 
 ```
-$ docker run -v <your local configuration file path>:/scalardb/server/database.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # For DEBUG logging
-$ docker run -v <your local configuration file path>:/scalardb/server/database.properties -e JAVA_OPTS=-Dlog4j.logLevel=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -e JAVA_OPTS=-Dlog4j.logLevel=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # For custom log configuration
-$ docker run -v <your local configuration file path>:/scalardb/server/database.properties -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # Use environment variables
-docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PORT=9042 --env SCALAR_DB_USERNAME=cassandra --env SCALAR_DB_PASSWORD=cassandra --env SCALAR_DB_STORAGE=cassandra -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version> dockerize -template database.properties.tmpl:database.properties /scalardb/server/bin/scalardb-server --config=database.properties
+docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PORT=9042 --env SCALAR_DB_USERNAME=cassandra --env SCALAR_DB_PASSWORD=cassandra --env SCALAR_DB_STORAGE=cassandra -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # For JMX
-$ docker run -v <your local configuration file path>:/scalardb/server/database.properties -e JAVA_OPTS="-Djava.rmi.server.hostname=<your container hostname or IP address> -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9990 -Dcom.sun.management.jmxremote.rmi.port=9990 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" -d -p 60051:60051 -p 8080:8080 -p 9990:9990 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -e JAVA_OPTS="-Djava.rmi.server.hostname=<your container hostname or IP address> -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9990 -Dcom.sun.management.jmxremote.rmi.port=9990 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" -d -p 60051:60051 -p 8080:8080 -p 9990:9990 ghcr.io/scalar-labs/scalardb-server:<version>
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -14,7 +14,7 @@ This runs Scalar DB Server:
 
 ```
 $ cd server/build/install/server
-$ export SCALARDB_SERVER_OPTS="<your JVM options>"
+$ export JAVA_OPTS="<your JVM options>"
 $ bin/scalardb-server --config <your configuration file path>
 ```
 

--- a/server/README.md
+++ b/server/README.md
@@ -36,7 +36,7 @@ This runs the Scalar DB Server (you need to specify your local configuration fil
 $ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # For DEBUG logging
-$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -e JAVA_OPTS=-Dlog4j.logLevel=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -e SCALAR_DB_LOG_LEVEL=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 
 # For custom log configuration
 $ docker run -v <your local configuration file path>:/scalardb/server/database.properties.tmpl -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties.tmpl -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -72,7 +72,7 @@ application {
 
 docker {
     name "ghcr.io/scalar-labs/scalardb-server:${project.version}"
-    files tasks.distTar.outputs, 'conf/log4j2.properties', 'conf/database.properties.tmpl', 'docker-entrypoint.sh'
+    files tasks.distTar.outputs, 'conf/log4j2.properties.tmpl', 'conf/database.properties.tmpl', 'docker-entrypoint.sh'
 }
 
 task dockerfileLint(type: Exec) {

--- a/server/conf/database.properties.tmpl
+++ b/server/conf/database.properties.tmpl
@@ -9,10 +9,10 @@ scalar.db.username={{ default .Env.SCALAR_DB_USERNAME "" }}
 scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
 
 # Storage implementation. "cassandra" or "cosmos" or "dynamo" or "jdbc" or "grpc" can be set. Default storage is "cassandra".
-scalar.db.storage={{ default .Env.SCALAR_DB_STORAGE "cassandra" }}
+scalar.db.storage={{ default .Env.SCALAR_DB_STORAGE "" }}
 
 # The type of the transaction manager. "consensus-commit" or "jdbc" or "grpc" can be set. The default is "consensus-commit"
-scalar.db.transaction_manager={{ default .Env.SCALAR_DB_TRANSACTION_MANAGER "consensus-commit" }}
+scalar.db.transaction_manager={{ default .Env.SCALAR_DB_TRANSACTION_MANAGER "" }}
 
 # Default isolation level for ConsensusCommit. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
 scalar.db.consensus_commit.isolation_level={{ default .Env.SCALAR_DB_CONSENSUSCOMMIT_ISOLATION_LEVEL "" }}

--- a/server/conf/log4j2.properties.tmpl
+++ b/server/conf/log4j2.properties.tmpl
@@ -1,4 +1,4 @@
-rootLogger.level=${sys:log4j.logLevel:-INFO}
+rootLogger.level={{ default .Env.SCALAR_DB_LOG_LEVEL "INFO" }}
 rootLogger.appenderRef.stdout.ref=STDOUT
 appender.console.type=Console
 appender.console.name=STDOUT

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-export SCALARDB_SERVER_OPTS="${SCALARDB_SERVER_OPTS} -XX:MaxRAMPercentage=${JAVA_OPT_MAX_RAM_PERCENTAGE}"
+export JAVA_OPTS="${JAVA_OPTS} -XX:MaxRAMPercentage=${JAVA_OPT_MAX_RAM_PERCENTAGE}"
 
 exec "$@"


### PR DESCRIPTION
This PR updates Dockerfile of Scalar DB Server to use `dockerize` for templating of database.properteis file.

In the Helm Charts of Scalar DB, I want to pass the username and password as a secret resource.
And, I want to set them as environment variables in the database.properties file as follows.

```
scalar.db.contact_points=localhost
scalar.db.contact_port=9042
scalar.db.storage=cassandra
scalar.db.username={{ default .Env.SCALAR_DB_USERNAME "" }}
scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
```

To achieve the above purpose, first, I need to update the Dockerfile of Scalar DB to use `dockerize` command by default.
Please take a look!
