### PR TITLE
Handle projections in query for Cosmos DB

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -197,7 +197,10 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Act
     Get get = prepareGet(pKey, cKey);
-    get.withProjection(COL_NAME1).withProjection(COL_NAME2).withProjection(COL_NAME3);
+    get.withProjection(COL_NAME1)
+        .withProjection(COL_NAME2)
+        .withProjection(COL_NAME3)
+        .withProjection(COL_NAME6);
     Optional<Result> actual = storage.get(get);
 
     // Assert
@@ -210,6 +213,8 @@ public abstract class DistributedStorageIntegrationTestBase {
         .isEqualTo(Optional.of(new IntValue(COL_NAME3, pKey + cKey)));
     assertThat(actual.get().getValue(COL_NAME4).isPresent()).isTrue(); // since it's clustering key
     assertThat(actual.get().getValue(COL_NAME5).isPresent()).isFalse();
+    assertThat(actual.get().contains(COL_NAME6)).isTrue();
+    assertThat(actual.get().isNull(COL_NAME6)).isTrue();
   }
 
   @Test
@@ -224,7 +229,8 @@ public abstract class DistributedStorageIntegrationTestBase {
         new Scan(new Key(COL_NAME1, pKey))
             .withProjection(COL_NAME1)
             .withProjection(COL_NAME2)
-            .withProjection(COL_NAME3);
+            .withProjection(COL_NAME3)
+            .withProjection(COL_NAME6);
     List<Result> actual = scanAll(scan);
 
     // Assert
@@ -249,6 +255,8 @@ public abstract class DistributedStorageIntegrationTestBase {
           assertThat(a.getValue(COL_NAME3).isPresent()).isTrue();
           assertThat(a.getValue(COL_NAME4).isPresent()).isTrue(); // since it's clustering key
           assertThat(a.getValue(COL_NAME5).isPresent()).isFalse();
+          assertThat(a.contains(COL_NAME6)).isTrue();
+          assertThat(a.isNull(COL_NAME6)).isTrue();
         });
   }
 
@@ -1505,7 +1513,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
     // Act
     ScanAll scanAll =
-        new ScanAll().withProjection(COL_NAME1).withProjection(COL_NAME2).withProjection(COL_NAME3);
+        new ScanAll().withProjection(COL_NAME1).withProjection(COL_NAME2).withProjection(COL_NAME3).withProjection(COL_NAME6);
     List<Result> actualResults = scanAll(scanAll);
 
     // Assert
@@ -1523,13 +1531,13 @@ public abstract class DistributedStorageIntegrationTestBase {
                               ImmutableList.of(
                                   TextColumn.of(COL_NAME2, Integer.toString(i + j)),
                                   IntColumn.of(COL_NAME3, i + j)));
+                                  BlobColumn.ofNull(COL_NAME6);
                           expectedResults.add(erBuilder.build());
                         }));
     assertResultsContainsExactlyInAnyOrder(actualResults, expectedResults);
     actualResults.forEach(
         actualResult -> {
           assertThat(actualResult.contains(COL_NAME5)).isFalse();
-          assertThat(actualResult.contains(COL_NAME6)).isFalse();
         });
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ResultInterpreter.java
@@ -38,7 +38,6 @@ public class ResultInterpreter {
     if (projections.isEmpty()) {
       metadata.getColumnNames().forEach(name -> add(ret, name, recordValues.get(name), metadata));
     } else {
-      // This isn't actual projection...
       projections.forEach(name -> add(ret, name, recordValues.get(name), metadata));
     }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
@@ -165,7 +165,7 @@ public class SelectStatementHandler extends StatementHandler {
                 c ->
                     !tableMetadata.getPartitionKeyNames().contains(c)
                         && !tableMetadata.getClusteringKeyNames().contains(c))
-            .map(c -> "\"" + c + "\":r.values." + c)
+            .map(c -> "\"" + c + "\":r.values" + CosmosUtils.quoteKeyword(c))
             .collect(Collectors.toList());
     // Since Jooq parser consumes curly brace character as there are placeholder, each curly brace
     // need to be doubled "{{" to have a

--- a/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
@@ -13,19 +13,23 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.util.ScalarDbUtils;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.jooq.Field;
 import org.jooq.SQLDialect;
 import org.jooq.SelectConditionStep;
+import org.jooq.SelectJoinStep;
 import org.jooq.SelectWhereStep;
 import org.jooq.conf.ParamType;
 import org.jooq.impl.DSL;
@@ -44,12 +48,14 @@ public class SelectStatementHandler extends StatementHandler {
   @Override
   @Nonnull
   protected List<Record> execute(Operation operation) throws CosmosException, ExecutionException {
+    assert operation instanceof Selection;
+    Selection selection = (Selection) operation;
     TableMetadata tableMetadata = metadataManager.getTableMetadata(operation);
     try {
-      if (operation instanceof Get) {
-        return executeRead(operation, tableMetadata);
+      if (selection instanceof Get) {
+        return executeRead((Get) selection, tableMetadata);
       } else {
-        return executeQuery(operation, tableMetadata);
+        return executeQuery((Scan) selection, tableMetadata);
       }
     } catch (CosmosException e) {
       if (e.getStatusCode() == CosmosErrorCode.NOT_FOUND.get()) {
@@ -59,44 +65,51 @@ public class SelectStatementHandler extends StatementHandler {
     }
   }
 
-  private List<Record> executeRead(Operation operation, TableMetadata tableMetadata)
-      throws CosmosException {
-    CosmosOperation cosmosOperation = new CosmosOperation(operation, tableMetadata);
+  private List<Record> executeRead(Get get, TableMetadata tableMetadata) throws CosmosException {
+    CosmosOperation cosmosOperation = new CosmosOperation(get, tableMetadata);
     cosmosOperation.checkArgument(Get.class);
 
-    if (ScalarDbUtils.isSecondaryIndexSpecified(operation, tableMetadata)) {
-      return executeReadWithIndex(operation, tableMetadata);
+    if (ScalarDbUtils.isSecondaryIndexSpecified(get, tableMetadata)) {
+      return executeReadWithIndex(get, tableMetadata);
     }
 
-    String id = cosmosOperation.getId();
-    PartitionKey partitionKey = cosmosOperation.getCosmosPartitionKey();
+    if (get.getProjections().isEmpty()) {
+      String id = cosmosOperation.getId();
+      PartitionKey partitionKey = cosmosOperation.getCosmosPartitionKey();
+      return Collections.singletonList(
+          getContainer(get).readItem(id, partitionKey, Record.class).getItem());
+    }
 
-    Record record = getContainer(operation).readItem(id, partitionKey, Record.class).getItem();
+    String query =
+        makeQueryWithProjections(get, tableMetadata)
+            .where(
+                DSL.field("r.concatenatedPartitionKey")
+                    .eq(cosmosOperation.getConcatenatedPartitionKey()),
+                DSL.field("r.id").eq(cosmosOperation.getId()))
+            .getSQL(ParamType.INLINED);
 
-    return Collections.singletonList(record);
+    return getContainer(get).queryItems(query, new CosmosQueryRequestOptions(), Record.class)
+        .stream()
+        .collect(Collectors.toList());
   }
 
-  private List<Record> executeReadWithIndex(Operation operation, TableMetadata tableMetadata)
+  private List<Record> executeReadWithIndex(Selection selection, TableMetadata tableMetadata)
       throws CosmosException {
-    String query = makeQueryWithIndex(operation, tableMetadata);
+    String query = makeQueryWithIndex(selection, tableMetadata);
     CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
     CosmosPagedIterable<Record> iterable =
-        getContainer(operation).queryItems(query, options, Record.class);
+        getContainer(selection).queryItems(query, options, Record.class);
 
     return Lists.newArrayList(iterable);
   }
 
-  private List<Record> executeQuery(Operation operation, TableMetadata tableMetadata)
-      throws CosmosException {
-    CosmosOperation cosmosOperation = new CosmosOperation(operation, tableMetadata);
-    cosmosOperation.checkArgument(Scan.class);
-    Scan scan = (Scan) operation;
-
+  private List<Record> executeQuery(Scan scan, TableMetadata tableMetadata) throws CosmosException {
+    CosmosOperation cosmosOperation = new CosmosOperation(scan, tableMetadata);
     String query;
     CosmosQueryRequestOptions options;
 
     if (scan instanceof ScanAll) {
-      query = "select * from Record r";
+      query = makeQueryWithProjections(scan, tableMetadata).getSQL(ParamType.INLINED);
       options = new CosmosQueryRequestOptions();
     } else if (ScalarDbUtils.isSecondaryIndexSpecified(scan, tableMetadata)) {
       query = makeQueryWithIndex(scan, tableMetadata);
@@ -123,8 +136,7 @@ public class SelectStatementHandler extends StatementHandler {
       TableMetadata tableMetadata, CosmosOperation cosmosOperation, Scan scan) {
     String concatenatedPartitionKey = cosmosOperation.getConcatenatedPartitionKey();
     SelectConditionStep<org.jooq.Record> select =
-        DSL.using(SQLDialect.DEFAULT)
-            .selectFrom("Record r")
+        makeQueryWithProjections(scan, tableMetadata)
             .where(DSL.field("r.concatenatedPartitionKey").eq(concatenatedPartitionKey));
 
     setStart(select, scan);
@@ -133,6 +145,38 @@ public class SelectStatementHandler extends StatementHandler {
     setOrderings(select, scan.getOrderings(), tableMetadata);
 
     return select.getSQL(ParamType.INLINED);
+  }
+
+  private SelectJoinStep<org.jooq.Record> makeQueryWithProjections(
+      Selection selection, TableMetadata tableMetadata) {
+    if (selection.getProjections().isEmpty()) {
+      return DSL.using(SQLDialect.DEFAULT).select().from("Record r");
+    }
+
+    List<String> projectedFields = new ArrayList<>();
+    projectedFields.add("r.id");
+    projectedFields.add("r.concatenatedPartitionKey");
+    projectedFields.add("r.partitionKey");
+    projectedFields.add("r.clusteringKey");
+
+    List<String> projectedValues =
+        selection.getProjections().stream()
+            .filter(
+                c ->
+                    !tableMetadata.getPartitionKeyNames().contains(c)
+                        && !tableMetadata.getClusteringKeyNames().contains(c))
+            .map(c -> "\"" + c + "\":r.values." + c)
+            .collect(Collectors.toList());
+    // Since Jooq parser consumes curly brace character as there are placeholder, each curly brace
+    // need to be doubled "{{" to have a
+    // single curly brace "{" present in the generated sql query
+    if (!projectedValues.isEmpty()) {
+      projectedFields.add("{{" + String.join(",", projectedValues) + "}} as values");
+    }
+
+    return DSL.using(SQLDialect.DEFAULT)
+        .select(projectedFields.stream().map(DSL::field).collect(Collectors.toList()))
+        .from("Record r");
   }
 
   private void setStart(SelectConditionStep<org.jooq.Record> select, Scan scan) {
@@ -217,9 +261,9 @@ public class SelectStatementHandler extends StatementHandler {
     }
   }
 
-  private String makeQueryWithIndex(Operation operation, TableMetadata tableMetadata) {
-    SelectWhereStep<org.jooq.Record> select = DSL.using(SQLDialect.DEFAULT).selectFrom("Record r");
-    Column<?> column = operation.getPartitionKey().getColumns().get(0);
+  private String makeQueryWithIndex(Selection selection, TableMetadata tableMetadata) {
+    SelectWhereStep<org.jooq.Record> select = makeQueryWithProjections(selection, tableMetadata);
+    Column<?> column = selection.getPartitionKey().getColumns().get(0);
     String fieldName;
     if (tableMetadata.getClusteringKeyNames().contains(column.getName())) {
       fieldName = "r.clusteringKey";

--- a/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/SelectStatementHandler.java
@@ -154,6 +154,10 @@ public class SelectStatementHandler extends StatementHandler {
     }
 
     List<String> projectedFields = new ArrayList<>();
+
+    // To project the required columns, we build a JSON object with the same structure as the
+    // `Record.class`so that each field can be deserialized properly into a `Record.class` object.
+    // For example, the projected field "r.id" will be mapped to the `Record.id` attribute
     projectedFields.add("r.id");
     projectedFields.add("r.concatenatedPartitionKey");
     projectedFields.add("r.partitionKey");
@@ -167,10 +171,14 @@ public class SelectStatementHandler extends StatementHandler {
                         && !tableMetadata.getClusteringKeyNames().contains(c))
             .map(c -> "\"" + c + "\":r.values" + CosmosUtils.quoteKeyword(c))
             .collect(Collectors.toList());
-    // Since Jooq parser consumes curly brace character as there are placeholder, each curly brace
-    // need to be doubled "{{" to have a
-    // single curly brace "{" present in the generated sql query
+
     if (!projectedValues.isEmpty()) {
+      // The following will be mapped to the "Record.values" map attribute
+      // For example, to project the columns c1 and c2, the values field will be
+      // `{"c1": r["c1"], "c2":r["c2"]} as values`
+      // Besides, since the Jooq parser consumes curly brace character as they are treated as
+      // placeholder, each curly brace need to be doubled "{{" to have a single curly brace "{"
+      // present in the generated sql query
       projectedFields.add("{{" + String.join(",", projectedValues) + "}} as values");
     }
 

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -548,7 +548,7 @@ public class SelectStatementHandlerTest {
             + "r.concatenatedPartitionKey, "
             + "r.partitionKey, "
             + "r.clusteringKey, "
-            + "{\"name3\":r.values.name3,\"name4\":r.values.name4} as values "
+            + "{\"name3\":r.values[\"name3\"],\"name4\":r.values[\"name4\"]} as values "
             + "from Record r "
             + "where (r.concatenatedPartitionKey = '"
             + ANY_TEXT_1
@@ -610,7 +610,7 @@ public class SelectStatementHandlerTest {
             + "r.concatenatedPartitionKey, "
             + "r.partitionKey, "
             + "r.clusteringKey, "
-            + "{\"name3\":r.values.name3,\"name4\":r.values.name4} as values "
+            + "{\"name3\":r.values[\"name3\"],\"name4\":r.values[\"name4\"]} as values "
             + "from Record r where r.values[\""
             + ANY_NAME_3
             + "\"]"
@@ -644,7 +644,7 @@ public class SelectStatementHandlerTest {
             + "r.concatenatedPartitionKey, "
             + "r.partitionKey, "
             + "r.clusteringKey, "
-            + "{\"name3\":r.values.name3,\"name4\":r.values.name4} as values "
+            + "{\"name3\":r.values[\"name3\"],\"name4\":r.values[\"name4\"]} as values "
             + "from Record r";
     verify(container)
         .queryItems(eq(expectedQuery), any(CosmosQueryRequestOptions.class), eq(Record.class));
@@ -693,7 +693,7 @@ public class SelectStatementHandlerTest {
             + "r.concatenatedPartitionKey, "
             + "r.partitionKey, "
             + "r.clusteringKey, "
-            + "{\"name3\":r.values.name3,\"name4\":r.values.name4} as values "
+            + "{\"name3\":r.values[\"name3\"],\"name4\":r.values[\"name4\"]} as values "
             + "from Record r where r.values[\""
             + ANY_NAME_3
             + "\"]"
@@ -729,7 +729,7 @@ public class SelectStatementHandlerTest {
             + "r.concatenatedPartitionKey, "
             + "r.partitionKey, "
             + "r.clusteringKey, "
-            + "{\"name3\":r.values.name3,\"name4\":r.values.name4} as values "
+            + "{\"name3\":r.values[\"name3\"],\"name4\":r.values[\"name4\"]} as values "
             + "from Record r where (r.concatenatedPartitionKey = '"
             + ANY_TEXT_1
             + "' and r.clusteringKey[\""


### PR DESCRIPTION
Currently, columns are not projected when doing a Selection operation for Cosmos DB, the projected columns are filtered on the client side after the query is executed.
With this PR, the projected columns are now parametrized in the query directly. 

Please have a look.