### PR TITLE
Update the docs

### DIFF
--- a/docs/getting-started-with-scalardb-on-cassandra.md
+++ b/docs/getting-started-with-scalardb-on-cassandra.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with Scalar DB on Cassand
 
 Scalar DB is written in Java and uses Cassandra as an underlying storage implementation, so the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (OpenJDK 8) or higher
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
 * [Casssandra](http://cassandra.apache.org/) 3.11.x (the current stable version as of writing)
     * Take a look at [this document](http://cassandra.apache.org/download/) for how to set up Cassandra.
     * Change `commitlog_sync` from `periodic` to `batch` in `cassandra.yaml` not to lose data when quorum of replica nodes go down

--- a/docs/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/getting-started-with-scalardb-on-cosmosdb.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with Scalar DB on Cosmos 
 
 Scalar DB is written in Java. So the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (OpenJDK 8) or higher
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
 * Other libraries used from the above are automatically installed through gradle
 
 ## Cosmos DB setup

--- a/docs/getting-started-with-scalardb-on-dynamodb.md
+++ b/docs/getting-started-with-scalardb-on-dynamodb.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with Scalar DB on DynamoD
 
 Scalar DB is written in Java. So the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (OpenJDK 8) or higher
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
 * Other libraries used from the above are automatically installed through gradle
         
 From here, we assume Oracle JDK 8 is properly installed in your local environment.

--- a/docs/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/getting-started-with-scalardb-on-jdbc.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with Scalar DB on JDBC da
 
 Scalar DB is written in Java and uses a JDBC database as an underlining storage implementation, so the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (OpenJDK 8) or higher
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
 * A JDBC database instance. Currently, MySQL, PostgreSQL, Oracle Database, SQL Server, and Amazon Aurora are officially supported
 * Other libraries used from the above are automatically installed through gradle
 


### PR DESCRIPTION
The getting started guides build scalardb from the source code so we need Java 8 to do it instead of higher versions.