### PR TITLE
Introduce GetWithIndex and ScanWithIndex operations

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1299,15 +1299,26 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Arrange
     storage.put(preparePuts().get(0)); // (0,0)
     int c3 = 0;
-    Get get = new Get(new Key(COL_NAME3, c3));
+    Get getBuiltByConstructor = new Get(new Key(COL_NAME3, c3));
+    Get getBuiltByBuilder =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .indexKey(Key.ofInt(COL_NAME3, c3))
+            .build();
 
     // Act
-    Optional<Result> actual = storage.get(get);
+    Optional<Result> actual1 = storage.get(getBuiltByConstructor);
+    Optional<Result> actual2 = storage.get(getBuiltByBuilder);
 
     // Assert
-    assertThat(actual.isPresent()).isTrue();
-    assertThat(actual.get().getValue(COL_NAME1)).isEqualTo(Optional.of(new IntValue(COL_NAME1, 0)));
-    assertThat(actual.get().getValue(COL_NAME4)).isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+    assertThat(actual1.isPresent()).isTrue();
+    assertThat(actual1.get().getValue(COL_NAME1))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME1, 0)));
+    assertThat(actual1.get().getValue(COL_NAME4))
+        .isEqualTo(Optional.of(new IntValue(COL_NAME4, 0)));
+
+    assertThat(actual2).isEqualTo(actual1);
   }
 
   @Test
@@ -1327,17 +1338,24 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Arrange
     populateRecords();
     int c3 = 3;
-    Scan scan = new Scan(new Key(COL_NAME3, c3));
+    Scan scanBuiltByConstructor = new Scan(new Key(COL_NAME3, c3));
+    Scan scanBuiltByBuilder =
+        Scan.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .indexKey(Key.ofInt(COL_NAME3, c3))
+            .build();
 
     // Act
-    List<Result> actual = scanAll(scan);
+    List<Result> actual1 = scanAll(scanBuiltByConstructor);
+    List<Result> actual2 = scanAll(scanBuiltByBuilder);
 
     // Assert
-    assertThat(actual.size()).isEqualTo(3); // (1,2), (2,1), (3,0)
+    assertThat(actual1.size()).isEqualTo(3); // (1,2), (2,1), (3,0)
     List<List<Integer>> expectedValues =
         new ArrayList<>(
             Arrays.asList(Arrays.asList(1, 2), Arrays.asList(2, 1), Arrays.asList(3, 0)));
-    for (Result result : actual) {
+    for (Result result : actual1) {
       assertThat(result.getValue(COL_NAME1).isPresent()).isTrue();
       assertThat(result.getValue(COL_NAME4).isPresent()).isTrue();
 
@@ -1347,8 +1365,9 @@ public abstract class DistributedStorageIntegrationTestBase {
       assertThat(expectedValues).contains(col1AndCol4);
       expectedValues.remove(col1AndCol4);
     }
-
     assertThat(expectedValues).isEmpty();
+
+    assertThat(actual2).isEqualTo(actual1);
   }
 
   @Test

--- a/core/src/integration-test/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -325,33 +325,92 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnEmpty() throws TransactionException {
+  public void get_GetGivenForIndexColumn_ShouldReturnRecords() throws TransactionException {
     // Arrange
-    populateRecords();
     TwoPhaseCommitTransaction transaction = manager.start();
-    Scan scan =
-        new Scan(Key.ofInt(SOME_COLUMN, 2))
+    transaction.put(
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .intValue(SOME_COLUMN, 2)
+            .build());
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    transaction = manager.start();
+    Get getBuiltByConstructor =
+        new Get(Key.ofInt(SOME_COLUMN, 2))
             .forNamespace(namespace)
             .forTable(TABLE)
             .withConsistency(Consistency.LINEARIZABLE);
 
+    Get getBuiltByBuilder =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .indexKey(Key.ofInt(SOME_COLUMN, 2))
+            .build();
+
     // Act
-    List<Result> results = transaction.scan(scan);
+    Optional<Result> result1 = transaction.get(getBuiltByConstructor);
+    Optional<Result> result2 = transaction.get(getBuiltByBuilder);
+    transaction.get(getBuiltByBuilder);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
 
     // Assert
-    assertThat(results.size()).isEqualTo(2);
-    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(1);
-    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(2);
-    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
-    assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(2);
+    assertThat(result1).isPresent();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(result1.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result1.get().getInt(SOME_COLUMN)).isEqualTo(2);
 
-    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(2);
-    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
-    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
-    assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(2);
+    assertThat(result2).isEqualTo(result1);
+  }
+
+  @Test
+  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() throws TransactionException {
+    // Arrange
+    populateRecords();
+    TwoPhaseCommitTransaction transaction = manager.start();
+    Scan scanBuiltByConstructor =
+        new Scan(Key.ofInt(SOME_COLUMN, 2))
+            .forNamespace(namespace)
+            .forTable(TABLE)
+            .withConsistency(Consistency.LINEARIZABLE);
+
+    Scan scanBuiltByBuilder =
+        Scan.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .indexKey(Key.ofInt(SOME_COLUMN, 2))
+            .build();
+
+    // Act
+    List<Result> results1 = transaction.scan(scanBuiltByConstructor);
+    List<Result> results2 = transaction.scan(scanBuiltByBuilder);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    assertThat(results1.size()).isEqualTo(2);
+    assertThat(results1.get(0).getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(results1.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results1.get(0))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results1.get(0).getInt(SOME_COLUMN)).isEqualTo(2);
+
+    assertThat(results1.get(1).getInt(ACCOUNT_ID)).isEqualTo(2);
+    assertThat(results1.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results1.get(1))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results1.get(1).getInt(SOME_COLUMN)).isEqualTo(2);
+
+    assertThat(results2).isEqualTo(results1);
   }
 
   @Test

--- a/core/src/main/java/com/scalar/db/api/DeleteBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/DeleteBuilder.java
@@ -2,6 +2,8 @@ package com.scalar.db.api;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
+import com.scalar.db.api.OperationBuilder.ClearCondition;
 import com.scalar.db.api.OperationBuilder.ClusteringKey;
 import com.scalar.db.api.OperationBuilder.Condition;
 import com.scalar.db.api.OperationBuilder.Consistency;
@@ -13,6 +15,9 @@ import javax.annotation.Nullable;
 public class DeleteBuilder {
 
   public static class Namespace implements OperationBuilder.Namespace<Table> {
+
+    Namespace() {}
+
     @Override
     public Table namespace(String namespaceName) {
       checkNotNull(namespaceName);
@@ -22,7 +27,7 @@ public class DeleteBuilder {
 
   public static class Table extends TableBuilder<PartitionKey> {
 
-    public Table(String namespaceName) {
+    private Table(String namespaceName) {
       super(namespaceName);
     }
 
@@ -34,7 +39,8 @@ public class DeleteBuilder {
   }
 
   public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
-    public PartitionKey(String namespace, String table) {
+
+    private PartitionKey(String namespace, String table) {
       super(namespace, table);
     }
 
@@ -51,7 +57,7 @@ public class DeleteBuilder {
     @Nullable com.scalar.db.api.Consistency consistency;
     @Nullable MutationCondition condition;
 
-    public Buildable(String namespace, String table, Key partitionKey) {
+    private Buildable(String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
     }
 
@@ -95,10 +101,10 @@ public class DeleteBuilder {
       implements OperationBuilder.Namespace<BuildableFromExisting>,
           OperationBuilder.Table<BuildableFromExisting>,
           OperationBuilder.PartitionKey<BuildableFromExisting>,
-          OperationBuilder.ClearCondition<BuildableFromExisting>,
-          OperationBuilder.ClearClusteringKey<BuildableFromExisting> {
+          ClearCondition<BuildableFromExisting>,
+          ClearClusteringKey<BuildableFromExisting> {
 
-    public BuildableFromExisting(Delete delete) {
+    BuildableFromExisting(Delete delete) {
       super(
           delete.forNamespace().orElse(null),
           delete.forTable().orElse(null),

--- a/core/src/main/java/com/scalar/db/api/Get.java
+++ b/core/src/main/java/com/scalar/db/api/Get.java
@@ -3,7 +3,7 @@ package com.scalar.db.api;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.scalar.db.api.GetBuilder.BuildableFromExisting;
+import com.scalar.db.api.GetBuilder.BuildableGetOrIndexGetFromExisting;
 import com.scalar.db.api.GetBuilder.Namespace;
 import com.scalar.db.io.Key;
 import java.util.Collection;
@@ -73,9 +73,9 @@ public class Get extends Selection {
    * @param get an existing {@code Get} operation
    * @return a {@code Get} operation builder
    */
-  public static BuildableFromExisting newBuilder(Get get) {
+  public static BuildableGetOrIndexGetFromExisting newBuilder(Get get) {
     checkNotNull(get);
-    return new BuildableFromExisting(get);
+    return new BuildableGetOrIndexGetFromExisting(get);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/api/Get.java
+++ b/core/src/main/java/com/scalar/db/api/Get.java
@@ -3,7 +3,7 @@ package com.scalar.db.api;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.scalar.db.api.GetBuilder.BuildableGetOrIndexGetFromExisting;
+import com.scalar.db.api.GetBuilder.BuildableGetOrGetWithIndexFromExisting;
 import com.scalar.db.api.GetBuilder.Namespace;
 import com.scalar.db.io.Key;
 import java.util.Collection;
@@ -73,9 +73,9 @@ public class Get extends Selection {
    * @param get an existing {@code Get} operation
    * @return a {@code Get} operation builder
    */
-  public static BuildableGetOrIndexGetFromExisting newBuilder(Get get) {
+  public static BuildableGetOrGetWithIndexFromExisting newBuilder(Get get) {
     checkNotNull(get);
-    return new BuildableGetOrIndexGetFromExisting(get);
+    return new BuildableGetOrGetWithIndexFromExisting(get);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/api/GetBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/GetBuilder.java
@@ -281,7 +281,7 @@ public class GetBuilder {
     private void checkNotIndexGet() {
       if (isIndexGet) {
         throw new UnsupportedOperationException(
-            "This operation is not supported when getting records of a database with using a secondary index.");
+            "This operation is not supported when getting records of a database using a secondary index.");
       }
     }
 

--- a/core/src/main/java/com/scalar/db/api/GetBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/GetBuilder.java
@@ -46,7 +46,7 @@ public class GetBuilder {
   }
 
   public static class PartitionKeyOrIndexKey extends PartitionKeyBuilder<BuildableGet>
-      implements IndexKey<BuildableIndexGet> {
+      implements IndexKey<BuildableGetWithIndex> {
 
     private PartitionKeyOrIndexKey(String namespace, String table) {
       super(namespace, table);
@@ -59,8 +59,8 @@ public class GetBuilder {
     }
 
     @Override
-    public BuildableIndexGet indexKey(Key indexKey) {
-      return new BuildableIndexGet(namespaceName, tableName, indexKey);
+    public BuildableGetWithIndex indexKey(Key indexKey) {
+      return new BuildableGetWithIndex(namespaceName, tableName, indexKey);
     }
   }
 
@@ -121,105 +121,105 @@ public class GetBuilder {
     }
   }
 
-  public static class BuildableIndexGet
-      implements Consistency<BuildableIndexGet>, Projection<BuildableIndexGet> {
+  public static class BuildableGetWithIndex
+      implements Consistency<BuildableGetWithIndex>, Projection<BuildableGetWithIndex> {
     private final String namespaceName;
     private final String tableName;
     private final Key indexKey;
     private final List<String> projections = new ArrayList<>();
     @Nullable private com.scalar.db.api.Consistency consistency;
 
-    private BuildableIndexGet(String namespace, String table, Key indexKey) {
+    private BuildableGetWithIndex(String namespace, String table, Key indexKey) {
       namespaceName = namespace;
       tableName = table;
       this.indexKey = indexKey;
     }
 
     @Override
-    public BuildableIndexGet projection(String projection) {
+    public BuildableGetWithIndex projection(String projection) {
       checkNotNull(projection);
       projections.add(projection);
       return this;
     }
 
     @Override
-    public BuildableIndexGet projections(Collection<String> projections) {
+    public BuildableGetWithIndex projections(Collection<String> projections) {
       checkNotNull(projections);
       this.projections.addAll(projections);
       return this;
     }
 
     @Override
-    public BuildableIndexGet projections(String... projections) {
+    public BuildableGetWithIndex projections(String... projections) {
       return projections(Arrays.asList(projections));
     }
 
     @Override
-    public BuildableIndexGet consistency(com.scalar.db.api.Consistency consistency) {
+    public BuildableGetWithIndex consistency(com.scalar.db.api.Consistency consistency) {
       checkNotNull(consistency);
       this.consistency = consistency;
       return this;
     }
 
     public Get build() {
-      IndexGet indexGet = new IndexGet(indexKey);
-      indexGet.forNamespace(namespaceName).forTable(tableName);
+      GetWithIndex getWithIndex = new GetWithIndex(indexKey);
+      getWithIndex.forNamespace(namespaceName).forTable(tableName);
       if (!projections.isEmpty()) {
-        indexGet.withProjections(projections);
+        getWithIndex.withProjections(projections);
       }
       if (consistency != null) {
-        indexGet.withConsistency(consistency);
+        getWithIndex.withConsistency(consistency);
       }
-      return indexGet;
+      return getWithIndex;
     }
   }
 
-  public static class BuildableGetOrIndexGetFromExisting extends BuildableGet
-      implements OperationBuilder.Namespace<BuildableGetOrIndexGetFromExisting>,
-          OperationBuilder.Table<BuildableGetOrIndexGetFromExisting>,
-          PartitionKey<BuildableGetOrIndexGetFromExisting>,
-          IndexKey<BuildableGetOrIndexGetFromExisting>,
-          ClearProjections<BuildableGetOrIndexGetFromExisting>,
-          ClearClusteringKey<BuildableGetOrIndexGetFromExisting> {
+  public static class BuildableGetOrGetWithIndexFromExisting extends BuildableGet
+      implements OperationBuilder.Namespace<BuildableGetOrGetWithIndexFromExisting>,
+          OperationBuilder.Table<BuildableGetOrGetWithIndexFromExisting>,
+          PartitionKey<BuildableGetOrGetWithIndexFromExisting>,
+          IndexKey<BuildableGetOrGetWithIndexFromExisting>,
+          ClearProjections<BuildableGetOrGetWithIndexFromExisting>,
+          ClearClusteringKey<BuildableGetOrGetWithIndexFromExisting> {
 
     private Key indexKey;
-    private final boolean isIndexGet;
+    private final boolean isGetWithIndex;
 
-    BuildableGetOrIndexGetFromExisting(Get get) {
+    BuildableGetOrGetWithIndexFromExisting(Get get) {
       super(get.forNamespace().orElse(null), get.forTable().orElse(null), get.getPartitionKey());
       clusteringKey = get.getClusteringKey().orElse(null);
       projections.addAll(get.getProjections());
       consistency = get.getConsistency();
-      isIndexGet = get instanceof IndexGet;
-      if (isIndexGet) {
+      isGetWithIndex = get instanceof GetWithIndex;
+      if (isGetWithIndex) {
         indexKey = get.getPartitionKey();
       }
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting namespace(String namespaceName) {
+    public BuildableGetOrGetWithIndexFromExisting namespace(String namespaceName) {
       checkNotNull(namespaceName);
       this.namespaceName = namespaceName;
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting table(String tableName) {
+    public BuildableGetOrGetWithIndexFromExisting table(String tableName) {
       checkNotNull(tableName);
       this.tableName = tableName;
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting partitionKey(Key partitionKey) {
-      checkNotIndexGet();
+    public BuildableGetOrGetWithIndexFromExisting partitionKey(Key partitionKey) {
+      checkNotGetWithIndex();
       checkNotNull(partitionKey);
       this.partitionKey = partitionKey;
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting indexKey(Key indexKey) {
+    public BuildableGetOrGetWithIndexFromExisting indexKey(Key indexKey) {
       checkNotGet();
       checkNotNull(indexKey);
       this.indexKey = indexKey;
@@ -227,59 +227,59 @@ public class GetBuilder {
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting clusteringKey(Key clusteringKey) {
-      checkNotIndexGet();
+    public BuildableGetOrGetWithIndexFromExisting clusteringKey(Key clusteringKey) {
+      checkNotGetWithIndex();
       super.clusteringKey(clusteringKey);
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting consistency(
+    public BuildableGetOrGetWithIndexFromExisting consistency(
         com.scalar.db.api.Consistency consistency) {
       super.consistency(consistency);
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting projection(String projection) {
+    public BuildableGetOrGetWithIndexFromExisting projection(String projection) {
       super.projection(projection);
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting projections(Collection<String> projections) {
+    public BuildableGetOrGetWithIndexFromExisting projections(Collection<String> projections) {
       super.projections(projections);
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting projections(String... projections) {
+    public BuildableGetOrGetWithIndexFromExisting projections(String... projections) {
       super.projections(projections);
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting clearProjections() {
+    public BuildableGetOrGetWithIndexFromExisting clearProjections() {
       this.projections.clear();
       return this;
     }
 
     @Override
-    public BuildableGetOrIndexGetFromExisting clearClusteringKey() {
-      checkNotIndexGet();
+    public BuildableGetOrGetWithIndexFromExisting clearClusteringKey() {
+      checkNotGetWithIndex();
       this.clusteringKey = null;
       return this;
     }
 
     private void checkNotGet() {
-      if (!isIndexGet) {
+      if (!isGetWithIndex) {
         throw new UnsupportedOperationException(
             "This operation is not supported when getting records of a database without using a secondary index.");
       }
     }
 
-    private void checkNotIndexGet() {
-      if (isIndexGet) {
+    private void checkNotGetWithIndex() {
+      if (isGetWithIndex) {
         throw new UnsupportedOperationException(
             "This operation is not supported when getting records of a database using a secondary index.");
       }
@@ -289,8 +289,8 @@ public class GetBuilder {
     public Get build() {
       Get get;
 
-      if (isIndexGet) {
-        get = new IndexGet(indexKey);
+      if (isGetWithIndex) {
+        get = new GetWithIndex(indexKey);
       } else {
         get = new Get(partitionKey, clusteringKey);
       }

--- a/core/src/main/java/com/scalar/db/api/GetWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/GetWithIndex.java
@@ -5,10 +5,10 @@ import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
 
-public class IndexGet extends Get {
+public class GetWithIndex extends Get {
 
   /**
-   * Constructs an {@code IndexGet} with the specified index {@code Key}.
+   * Constructs an {@code GetWithIndex} with the specified index {@code Key}.
    *
    * @param indexKey an index key
    * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Get#newBuilder()}
@@ -16,20 +16,20 @@ public class IndexGet extends Get {
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public IndexGet(Key indexKey) {
+  public GetWithIndex(Key indexKey) {
     super(indexKey);
   }
 
   /**
-   * Copy a IndexGet.
+   * Copy a GetWithIndex.
    *
-   * @param indexGet an IndexGet
+   * @param getWithIndex a GetWithIndex
    * @deprecated Use {@link Get#newBuilder(Get)} instead
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public IndexGet(IndexGet indexGet) {
-    super(indexGet);
+  public GetWithIndex(GetWithIndex getWithIndex) {
+    super(getWithIndex);
   }
 
   /**
@@ -38,8 +38,8 @@ public class IndexGet extends Get {
    */
   @Deprecated
   @Override
-  public IndexGet forNamespace(String namespace) {
-    return (IndexGet) super.forNamespace(namespace);
+  public GetWithIndex forNamespace(String namespace) {
+    return (GetWithIndex) super.forNamespace(namespace);
   }
 
   /**
@@ -48,8 +48,8 @@ public class IndexGet extends Get {
    */
   @Deprecated
   @Override
-  public IndexGet forTable(String tableName) {
-    return (IndexGet) super.forTable(tableName);
+  public GetWithIndex forTable(String tableName) {
+    return (GetWithIndex) super.forTable(tableName);
   }
 
   /**
@@ -58,8 +58,8 @@ public class IndexGet extends Get {
    */
   @Deprecated
   @Override
-  public IndexGet withConsistency(Consistency consistency) {
-    return (IndexGet) super.withConsistency(consistency);
+  public GetWithIndex withConsistency(Consistency consistency) {
+    return (GetWithIndex) super.withConsistency(consistency);
   }
 
   /**
@@ -68,8 +68,8 @@ public class IndexGet extends Get {
    */
   @Deprecated
   @Override
-  public IndexGet withProjection(String projection) {
-    return (IndexGet) super.withProjection(projection);
+  public GetWithIndex withProjection(String projection) {
+    return (GetWithIndex) super.withProjection(projection);
   }
 
   /**
@@ -78,8 +78,8 @@ public class IndexGet extends Get {
    */
   @Deprecated
   @Override
-  public IndexGet withProjections(Collection<String> projections) {
-    return (IndexGet) super.withProjections(projections);
+  public GetWithIndex withProjections(Collection<String> projections) {
+    return (GetWithIndex) super.withProjections(projections);
   }
 
   @Override
@@ -90,7 +90,7 @@ public class IndexGet extends Get {
     if (o == this) {
       return true;
     }
-    return o instanceof IndexGet;
+    return o instanceof GetWithIndex;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/api/IndexGet.java
+++ b/core/src/main/java/com/scalar/db/api/IndexGet.java
@@ -1,0 +1,105 @@
+package com.scalar.db.api;
+
+import com.google.common.base.MoreObjects;
+import com.scalar.db.io.Key;
+import java.util.Collection;
+import java.util.Objects;
+
+public class IndexGet extends Get {
+
+  /**
+   * Constructs an {@code IndexGet} with the specified index {@code Key}.
+   *
+   * @param indexKey an index key
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link Get#newBuilder()}
+   *     instead
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public IndexGet(Key indexKey) {
+    super(indexKey);
+  }
+
+  /**
+   * Copy a IndexGet.
+   *
+   * @param indexGet an IndexGet
+   * @deprecated Use {@link Get#newBuilder(Get)} instead
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public IndexGet(IndexGet indexGet) {
+    super(indexGet);
+  }
+
+  /**
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
+   */
+  @Deprecated
+  @Override
+  public IndexGet forNamespace(String namespace) {
+    return (IndexGet) super.forNamespace(namespace);
+  }
+
+  /**
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
+   */
+  @Deprecated
+  @Override
+  public IndexGet forTable(String tableName) {
+    return (IndexGet) super.forTable(tableName);
+  }
+
+  /**
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
+   */
+  @Deprecated
+  @Override
+  public IndexGet withConsistency(Consistency consistency) {
+    return (IndexGet) super.withConsistency(consistency);
+  }
+
+  /**
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
+   */
+  @Deprecated
+  @Override
+  public IndexGet withProjection(String projection) {
+    return (IndexGet) super.withProjection(projection);
+  }
+
+  /**
+   * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use the setter method of the
+   *     Get builder instead; to create a Get builder, use {@link Get#newBuilder()}
+   */
+  @Deprecated
+  @Override
+  public IndexGet withProjections(Collection<String> projections) {
+    return (IndexGet) super.withProjections(projections);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    return o instanceof IndexGet;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + MoreObjects.toStringHelper(this);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/IndexScan.java
+++ b/core/src/main/java/com/scalar/db/api/IndexScan.java
@@ -4,39 +4,31 @@ import com.google.common.base.MoreObjects;
 import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
-import javax.annotation.concurrent.NotThreadSafe;
 
-/**
- * A command to retrieve all the entries of the database. The scan range of clustering key and
- * {@link Ordering} cannot be specified for this command. The number of {@link Result} can be
- * limited.
- */
-@NotThreadSafe
-public class ScanAll extends Scan {
-
-  private static final Key DUMMY_PARTITION_KEY = Key.of();
+public class IndexScan extends Scan {
 
   /**
+   * @param indexKey an index key
    * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
    *     Scan#newBuilder()} instead
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public ScanAll() {
-    super(DUMMY_PARTITION_KEY);
+  public IndexScan(Key indexKey) {
+    super(indexKey);
   }
 
   /**
-   * Copy a ScanAll.
+   * Copy a IndexScan.
    *
-   * @param scanAll a ScanAll
+   * @param indexScan a IndexScan
    * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
    *     Scan#newBuilder(Scan)} instead
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public ScanAll(ScanAll scanAll) {
-    super(scanAll);
+  public IndexScan(IndexScan indexScan) {
+    super(indexScan);
   }
 
   /**
@@ -47,7 +39,7 @@ public class ScanAll extends Scan {
    */
   @Deprecated
   @Override
-  public ScanAll withStart(Key clusteringKey) {
+  public IndexScan withStart(Key clusteringKey) {
     throw new UnsupportedOperationException();
   }
 
@@ -59,7 +51,7 @@ public class ScanAll extends Scan {
    */
   @Deprecated
   @Override
-  public ScanAll withStart(Key clusteringKey, boolean inclusive) {
+  public IndexScan withStart(Key clusteringKey, boolean inclusive) {
     throw new UnsupportedOperationException();
   }
 
@@ -71,7 +63,7 @@ public class ScanAll extends Scan {
    */
   @Deprecated
   @Override
-  public ScanAll withEnd(Key clusteringKey) {
+  public IndexScan withEnd(Key clusteringKey) {
     throw new UnsupportedOperationException();
   }
 
@@ -83,7 +75,7 @@ public class ScanAll extends Scan {
    */
   @Deprecated
   @Override
-  public ScanAll withEnd(Key clusteringKey, boolean inclusive) {
+  public IndexScan withEnd(Key clusteringKey, boolean inclusive) {
     throw new UnsupportedOperationException();
   }
 
@@ -95,7 +87,7 @@ public class ScanAll extends Scan {
    */
   @Deprecated
   @Override
-  public ScanAll withOrdering(Ordering ordering) {
+  public IndexScan withOrdering(Ordering ordering) {
     throw new UnsupportedOperationException();
   }
 
@@ -105,8 +97,8 @@ public class ScanAll extends Scan {
    */
   @Override
   @Deprecated
-  public ScanAll withLimit(int limit) {
-    return (ScanAll) super.withLimit(limit);
+  public IndexScan withLimit(int limit) {
+    return (IndexScan) super.withLimit(limit);
   }
 
   /**
@@ -115,8 +107,8 @@ public class ScanAll extends Scan {
    */
   @Override
   @Deprecated
-  public ScanAll forNamespace(String namespace) {
-    return (ScanAll) super.forNamespace(namespace);
+  public IndexScan forNamespace(String namespace) {
+    return (IndexScan) super.forNamespace(namespace);
   }
 
   /**
@@ -125,8 +117,8 @@ public class ScanAll extends Scan {
    */
   @Override
   @Deprecated
-  public ScanAll forTable(String tableName) {
-    return (ScanAll) super.forTable(tableName);
+  public IndexScan forTable(String tableName) {
+    return (IndexScan) super.forTable(tableName);
   }
 
   /**
@@ -135,8 +127,8 @@ public class ScanAll extends Scan {
    */
   @Override
   @Deprecated
-  public ScanAll withConsistency(Consistency consistency) {
-    return (ScanAll) super.withConsistency(consistency);
+  public IndexScan withConsistency(Consistency consistency) {
+    return (IndexScan) super.withConsistency(consistency);
   }
 
   /**
@@ -145,8 +137,8 @@ public class ScanAll extends Scan {
    */
   @Override
   @Deprecated
-  public ScanAll withProjection(String projection) {
-    return (ScanAll) super.withProjection(projection);
+  public IndexScan withProjection(String projection) {
+    return (IndexScan) super.withProjection(projection);
   }
 
   /**
@@ -155,8 +147,8 @@ public class ScanAll extends Scan {
    */
   @Override
   @Deprecated
-  public ScanAll withProjections(Collection<String> projections) {
-    return (ScanAll) super.withProjections(projections);
+  public IndexScan withProjections(Collection<String> projections) {
+    return (IndexScan) super.withProjections(projections);
   }
 
   @Override
@@ -167,7 +159,7 @@ public class ScanAll extends Scan {
     if (o == this) {
       return true;
     }
-    return o instanceof ScanAll;
+    return o instanceof IndexScan;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/api/OperationBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/OperationBuilder.java
@@ -383,6 +383,16 @@ class OperationBuilder {
     T all();
   }
 
+  interface IndexKey<T> {
+    /**
+     * Constructs the operation with the specified index {@link Key}.
+     *
+     * @param indexKey an index {@code Key}
+     * @return the operation builder
+     */
+    T indexKey(Key indexKey);
+  }
+
   abstract static class TableBuilder<T> implements Table<T> {
     final String namespace;
 

--- a/core/src/main/java/com/scalar/db/api/PutBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/PutBuilder.java
@@ -28,6 +28,9 @@ import javax.annotation.Nullable;
 public class PutBuilder {
 
   public static class Namespace implements OperationBuilder.Namespace<Table> {
+
+    Namespace() {}
+
     @Override
     public Table namespace(String namespaceName) {
       checkNotNull(namespaceName);
@@ -37,7 +40,7 @@ public class PutBuilder {
 
   public static class Table extends TableBuilder<PartitionKey> {
 
-    public Table(String namespaceName) {
+    private Table(String namespaceName) {
       super(namespaceName);
     }
 
@@ -49,7 +52,8 @@ public class PutBuilder {
   }
 
   public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
-    public PartitionKey(String namespaceName, String tableName) {
+
+    private PartitionKey(String namespaceName, String tableName) {
       super(namespaceName, tableName);
     }
 
@@ -70,7 +74,7 @@ public class PutBuilder {
     @Nullable com.scalar.db.api.Consistency consistency;
     @Nullable MutationCondition condition;
 
-    public Buildable(String namespace, String table, Key partitionKey) {
+    private Buildable(String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
     }
 
@@ -218,7 +222,7 @@ public class PutBuilder {
           ClearValues<BuildableFromExisting>,
           ClearCondition<BuildableFromExisting> {
 
-    public BuildableFromExisting(Put put) {
+    BuildableFromExisting(Put put) {
       super(put.forNamespace().orElse(null), put.forTable().orElse(null), put.getPartitionKey());
       this.clusteringKey = put.getClusteringKey().orElse(null);
       this.columns.putAll(put.getColumns());

--- a/core/src/main/java/com/scalar/db/api/ScanBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ScanBuilder.java
@@ -491,14 +491,14 @@ public class ScanBuilder {
       if (isIndexScan || isScanAll) {
         throw new UnsupportedOperationException(
             "This operation is not supported when scanning all the records of a database "
-                + "or scanning records of a database with using secondary index.");
+                + "or scanning records of a database using a secondary index.");
       }
     }
 
     private void checkNotScanOrScanAll() {
       if (!isIndexScan) {
         throw new UnsupportedOperationException(
-            "This operation is supported only when scanning records of a database with using secondary index.");
+            "This operation is supported only when scanning records of a database using a secondary index.");
       }
     }
 

--- a/core/src/main/java/com/scalar/db/api/ScanBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ScanBuilder.java
@@ -50,7 +50,7 @@ public class ScanBuilder {
   }
 
   public static class PartitionKeyOrIndexKeyOrAll extends PartitionKeyBuilder<BuildableScan>
-      implements IndexKey<BuildableIndexScan>, All<BuildableScanAll> {
+      implements IndexKey<BuildableScanWithIndex>, All<BuildableScanAll> {
 
     private PartitionKeyOrIndexKeyOrAll(String namespace, String table) {
       super(namespace, table);
@@ -63,9 +63,9 @@ public class ScanBuilder {
     }
 
     @Override
-    public BuildableIndexScan indexKey(Key indexKey) {
+    public BuildableScanWithIndex indexKey(Key indexKey) {
       checkNotNull(indexKey);
-      return new BuildableIndexScan(namespaceName, tableName, indexKey);
+      return new BuildableScanWithIndex(namespaceName, tableName, indexKey);
     }
 
     @Override
@@ -184,10 +184,10 @@ public class ScanBuilder {
     }
   }
 
-  public static class BuildableIndexScan
-      implements Consistency<BuildableIndexScan>,
-          Projection<BuildableIndexScan>,
-          Limit<BuildableIndexScan> {
+  public static class BuildableScanWithIndex
+      implements Consistency<BuildableScanWithIndex>,
+          Projection<BuildableScanWithIndex>,
+          Limit<BuildableScanWithIndex> {
     private final String namespaceName;
     private final String tableName;
     private final Key indexKey;
@@ -195,46 +195,46 @@ public class ScanBuilder {
     private int limit = 0;
     @Nullable private com.scalar.db.api.Consistency consistency;
 
-    private BuildableIndexScan(String namespaceName, String tableName, Key indexKey) {
+    private BuildableScanWithIndex(String namespaceName, String tableName, Key indexKey) {
       this.namespaceName = namespaceName;
       this.tableName = tableName;
       this.indexKey = indexKey;
     }
 
     @Override
-    public BuildableIndexScan projection(String projection) {
+    public BuildableScanWithIndex projection(String projection) {
       checkNotNull(projection);
       projections.add(projection);
       return this;
     }
 
     @Override
-    public BuildableIndexScan projections(Collection<String> projections) {
+    public BuildableScanWithIndex projections(Collection<String> projections) {
       checkNotNull(projections);
       this.projections.addAll(projections);
       return this;
     }
 
     @Override
-    public BuildableIndexScan projections(String... projections) {
+    public BuildableScanWithIndex projections(String... projections) {
       return projections(Arrays.asList(projections));
     }
 
     @Override
-    public BuildableIndexScan limit(int limit) {
+    public BuildableScanWithIndex limit(int limit) {
       this.limit = limit;
       return this;
     }
 
     @Override
-    public BuildableIndexScan consistency(com.scalar.db.api.Consistency consistency) {
+    public BuildableScanWithIndex consistency(com.scalar.db.api.Consistency consistency) {
       checkNotNull(consistency);
       this.consistency = consistency;
       return this;
     }
 
     public Scan build() {
-      Scan scan = new IndexScan(indexKey);
+      Scan scan = new ScanWithIndex(indexKey);
       scan.forNamespace(namespaceName).forTable(tableName).withLimit(limit);
 
       if (!projections.isEmpty()) {
@@ -321,14 +321,14 @@ public class ScanBuilder {
           ClearOrderings<BuildableScanOrScanAllFromExisting>,
           ClearBoundaries<BuildableScanOrScanAllFromExisting> {
 
-    private final boolean isIndexScan;
+    private final boolean isScanWithIndex;
     private final boolean isScanAll;
     private Key indexKey;
 
     BuildableScanOrScanAllFromExisting(Scan scan) {
       super(scan.forNamespace().orElse(null), scan.forTable().orElse(null), scan.getPartitionKey());
-      isIndexScan = scan instanceof IndexScan;
-      if (isIndexScan) {
+      isScanWithIndex = scan instanceof ScanWithIndex;
+      if (isScanWithIndex) {
         indexKey = scan.getPartitionKey();
       }
       isScanAll = scan instanceof ScanAll;
@@ -366,7 +366,7 @@ public class ScanBuilder {
 
     @Override
     public BuildableScanOrScanAllFromExisting partitionKey(Key partitionKey) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       checkNotNull(partitionKey);
       this.partitionKey = partitionKey;
       return this;
@@ -419,76 +419,76 @@ public class ScanBuilder {
 
     @Override
     public BuildableScanOrScanAllFromExisting ordering(Scan.Ordering ordering) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.ordering(ordering);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting orderings(Collection<Scan.Ordering> orderings) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.orderings(orderings);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting orderings(Scan.Ordering... orderings) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.orderings(orderings);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting start(Key clusteringKey, boolean inclusive) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.start(clusteringKey, inclusive);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting end(Key clusteringKey, boolean inclusive) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.end(clusteringKey, inclusive);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting start(Key clusteringKey) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.start(clusteringKey);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting end(Key clusteringKey) {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       super.end(clusteringKey);
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting clearStart() {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       this.startClusteringKey = null;
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting clearEnd() {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       this.endClusteringKey = null;
       return this;
     }
 
     @Override
     public BuildableScanOrScanAllFromExisting clearOrderings() {
-      checkNotIndexScanOrScanAll();
+      checkNotScanWithIndexOrScanAll();
       this.orderings.clear();
       return this;
     }
 
-    private void checkNotIndexScanOrScanAll() {
-      if (isIndexScan || isScanAll) {
+    private void checkNotScanWithIndexOrScanAll() {
+      if (isScanWithIndex || isScanAll) {
         throw new UnsupportedOperationException(
             "This operation is not supported when scanning all the records of a database "
                 + "or scanning records of a database using a secondary index.");
@@ -496,7 +496,7 @@ public class ScanBuilder {
     }
 
     private void checkNotScanOrScanAll() {
-      if (!isIndexScan) {
+      if (!isScanWithIndex) {
         throw new UnsupportedOperationException(
             "This operation is supported only when scanning records of a database using a secondary index.");
       }
@@ -506,8 +506,8 @@ public class ScanBuilder {
     public Scan build() {
       Scan scan;
 
-      if (isIndexScan) {
-        scan = new IndexScan(indexKey);
+      if (isScanWithIndex) {
+        scan = new ScanWithIndex(indexKey);
       } else if (isScanAll) {
         scan = new ScanAll();
       } else {

--- a/core/src/main/java/com/scalar/db/api/ScanBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ScanBuilder.java
@@ -3,10 +3,16 @@ package com.scalar.db.api;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.OperationBuilder.All;
+import com.scalar.db.api.OperationBuilder.Buildable;
+import com.scalar.db.api.OperationBuilder.ClearBoundaries;
+import com.scalar.db.api.OperationBuilder.ClearOrderings;
+import com.scalar.db.api.OperationBuilder.ClearProjections;
 import com.scalar.db.api.OperationBuilder.ClusteringKeyFiltering;
 import com.scalar.db.api.OperationBuilder.Consistency;
+import com.scalar.db.api.OperationBuilder.IndexKey;
 import com.scalar.db.api.OperationBuilder.Limit;
 import com.scalar.db.api.OperationBuilder.Ordering;
+import com.scalar.db.api.OperationBuilder.PartitionKey;
 import com.scalar.db.api.OperationBuilder.PartitionKeyBuilder;
 import com.scalar.db.api.OperationBuilder.Projection;
 import com.scalar.db.api.OperationBuilder.TableBuilder;
@@ -20,6 +26,9 @@ import javax.annotation.Nullable;
 public class ScanBuilder {
 
   public static class Namespace implements OperationBuilder.Namespace<Table> {
+
+    Namespace() {}
+
     @Override
     public Table namespace(String namespaceName) {
       checkNotNull(namespaceName);
@@ -27,22 +36,23 @@ public class ScanBuilder {
     }
   }
 
-  public static class Table extends TableBuilder<PartitionKeyOrAll> {
+  public static class Table extends TableBuilder<PartitionKeyOrIndexKeyOrAll> {
 
-    public Table(String namespaceName) {
+    private Table(String namespaceName) {
       super(namespaceName);
     }
 
     @Override
-    public PartitionKeyOrAll table(String tableName) {
+    public PartitionKeyOrIndexKeyOrAll table(String tableName) {
       checkNotNull(tableName);
-      return new PartitionKeyOrAll(namespace, tableName);
+      return new PartitionKeyOrIndexKeyOrAll(namespace, tableName);
     }
   }
 
-  public static class PartitionKeyOrAll extends PartitionKeyBuilder<BuildableScan>
-      implements All<BuildableScanAll> {
-    public PartitionKeyOrAll(String namespace, String table) {
+  public static class PartitionKeyOrIndexKeyOrAll extends PartitionKeyBuilder<BuildableScan>
+      implements IndexKey<BuildableIndexScan>, All<BuildableScanAll> {
+
+    private PartitionKeyOrIndexKeyOrAll(String namespace, String table) {
       super(namespace, table);
     }
 
@@ -53,12 +63,18 @@ public class ScanBuilder {
     }
 
     @Override
+    public BuildableIndexScan indexKey(Key indexKey) {
+      checkNotNull(indexKey);
+      return new BuildableIndexScan(namespaceName, tableName, indexKey);
+    }
+
+    @Override
     public BuildableScanAll all() {
       return new BuildableScanAll(namespaceName, tableName);
     }
   }
 
-  public static class BuildableScan extends OperationBuilder.Buildable<Scan>
+  public static class BuildableScan extends Buildable<Scan>
       implements ClusteringKeyFiltering<BuildableScan>,
           Ordering<BuildableScan>,
           Consistency<BuildableScan>,
@@ -73,7 +89,7 @@ public class ScanBuilder {
     int limit = 0;
     @Nullable com.scalar.db.api.Consistency consistency;
 
-    public BuildableScan(String namespace, String table, Key partitionKey) {
+    private BuildableScan(String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
     }
 
@@ -168,195 +184,65 @@ public class ScanBuilder {
     }
   }
 
-  public static class BuildableScanOrScanAllFromExisting extends BuildableScan
-      implements OperationBuilder.Namespace<BuildableScanOrScanAllFromExisting>,
-          OperationBuilder.Table<BuildableScanOrScanAllFromExisting>,
-          OperationBuilder.PartitionKey<BuildableScanOrScanAllFromExisting>,
-          OperationBuilder.ClearProjections<BuildableScanOrScanAllFromExisting>,
-          OperationBuilder.ClearOrderings<BuildableScanOrScanAllFromExisting>,
-          OperationBuilder.ClearBoundaries<BuildableScanOrScanAllFromExisting> {
-    private final boolean isScanAll;
+  public static class BuildableIndexScan
+      implements Consistency<BuildableIndexScan>,
+          Projection<BuildableIndexScan>,
+          Limit<BuildableIndexScan> {
+    private final String namespaceName;
+    private final String tableName;
+    private final Key indexKey;
+    private final List<String> projections = new ArrayList<>();
+    private int limit = 0;
+    @Nullable private com.scalar.db.api.Consistency consistency;
 
-    public BuildableScanOrScanAllFromExisting(Scan scan) {
-      super(scan.forNamespace().orElse(null), scan.forTable().orElse(null), scan.getPartitionKey());
-      isScanAll = scan instanceof ScanAll;
-      scan.getStartClusteringKey()
-          .ifPresent(
-              key -> {
-                this.startClusteringKey = key;
-                this.startInclusive = scan.getStartInclusive();
-              });
-      scan.getEndClusteringKey()
-          .ifPresent(
-              key -> {
-                this.endClusteringKey = key;
-                this.endInclusive = scan.getEndInclusive();
-              });
-      this.limit = scan.getLimit();
-      this.orderings.addAll(scan.getOrderings());
-      this.projections.addAll(scan.getProjections());
-      this.consistency = scan.getConsistency();
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting namespace(String namespaceName) {
-      checkNotNull(namespaceName);
+    private BuildableIndexScan(String namespaceName, String tableName, Key indexKey) {
       this.namespaceName = namespaceName;
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting table(String tableName) {
-      checkNotNull(tableName);
       this.tableName = tableName;
+      this.indexKey = indexKey;
+    }
+
+    @Override
+    public BuildableIndexScan projection(String projection) {
+      checkNotNull(projection);
+      projections.add(projection);
       return this;
     }
 
     @Override
-    public BuildableScanOrScanAllFromExisting partitionKey(Key partitionKey) {
-      checkNotScanAll();
-      checkNotNull(partitionKey);
-      this.partitionKey = partitionKey;
+    public BuildableIndexScan projections(Collection<String> projections) {
+      checkNotNull(projections);
+      this.projections.addAll(projections);
       return this;
     }
 
     @Override
-    public BuildableScanOrScanAllFromExisting consistency(
-        com.scalar.db.api.Consistency consistency) {
-      super.consistency(consistency);
+    public BuildableIndexScan projections(String... projections) {
+      return projections(Arrays.asList(projections));
+    }
+
+    @Override
+    public BuildableIndexScan limit(int limit) {
+      this.limit = limit;
       return this;
     }
 
     @Override
-    public BuildableScanOrScanAllFromExisting projection(String projection) {
-      super.projection(projection);
+    public BuildableIndexScan consistency(com.scalar.db.api.Consistency consistency) {
+      checkNotNull(consistency);
+      this.consistency = consistency;
       return this;
     }
 
-    @Override
-    public BuildableScanOrScanAllFromExisting projections(Collection<String> projections) {
-      super.projections(projections);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting projections(String... projections) {
-      super.projections(projections);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting clearProjections() {
-      this.projections.clear();
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting limit(int limit) {
-      super.limit(limit);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting ordering(Scan.Ordering ordering) {
-      checkNotScanAll();
-      super.ordering(ordering);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting orderings(Collection<Scan.Ordering> orderings) {
-      checkNotScanAll();
-      super.orderings(orderings);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting orderings(Scan.Ordering... orderings) {
-      checkNotScanAll();
-      super.orderings(orderings);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting start(Key clusteringKey, boolean inclusive) {
-      checkNotScanAll();
-      super.start(clusteringKey, inclusive);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting end(Key clusteringKey, boolean inclusive) {
-      checkNotScanAll();
-      super.end(clusteringKey, inclusive);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting start(Key clusteringKey) {
-      checkNotScanAll();
-      super.start(clusteringKey);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting end(Key clusteringKey) {
-      checkNotScanAll();
-      super.end(clusteringKey);
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting clearStart() {
-      checkNotScanAll();
-      this.startClusteringKey = null;
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting clearEnd() {
-      checkNotScanAll();
-      this.endClusteringKey = null;
-      return this;
-    }
-
-    @Override
-    public BuildableScanOrScanAllFromExisting clearOrderings() {
-      checkNotScanAll();
-      this.orderings.clear();
-      return this;
-    }
-
-    private void checkNotScanAll() {
-      if (isScanAll) {
-        throw new UnsupportedOperationException(
-            "This operation is not supported when scanning all the records of a database.");
-      }
-    }
-
-    @Override
     public Scan build() {
-      Scan scan;
+      Scan scan = new IndexScan(indexKey);
+      scan.forNamespace(namespaceName).forTable(tableName).withLimit(limit);
 
-      if (isScanAll) {
-        scan = new ScanAll();
-      } else {
-        scan = new Scan(partitionKey);
-        orderings.forEach(scan::withOrdering);
-        if (startClusteringKey != null) {
-          scan.withStart(startClusteringKey, startInclusive);
-        }
-        if (endClusteringKey != null) {
-          scan.withEnd(endClusteringKey, endInclusive);
-        }
-      }
-
-      scan.forNamespace(namespaceName)
-          .forTable(tableName)
-          .withLimit(limit)
-          .withConsistency(consistency);
       if (!projections.isEmpty()) {
         scan.withProjections(projections);
+      }
+
+      if (consistency != null) {
+        scan.withConsistency(consistency);
       }
 
       return scan;
@@ -373,7 +259,7 @@ public class ScanBuilder {
     private int limit = 0;
     @Nullable private com.scalar.db.api.Consistency consistency;
 
-    public BuildableScanAll(String namespaceName, String tableName) {
+    private BuildableScanAll(String namespaceName, String tableName) {
       this.namespaceName = namespaceName;
       this.tableName = tableName;
     }
@@ -420,6 +306,227 @@ public class ScanBuilder {
 
       if (consistency != null) {
         scan.withConsistency(consistency);
+      }
+
+      return scan;
+    }
+  }
+
+  public static class BuildableScanOrScanAllFromExisting extends BuildableScan
+      implements OperationBuilder.Namespace<BuildableScanOrScanAllFromExisting>,
+          OperationBuilder.Table<BuildableScanOrScanAllFromExisting>,
+          PartitionKey<BuildableScanOrScanAllFromExisting>,
+          IndexKey<BuildableScanOrScanAllFromExisting>,
+          ClearProjections<BuildableScanOrScanAllFromExisting>,
+          ClearOrderings<BuildableScanOrScanAllFromExisting>,
+          ClearBoundaries<BuildableScanOrScanAllFromExisting> {
+
+    private final boolean isIndexScan;
+    private final boolean isScanAll;
+    private Key indexKey;
+
+    BuildableScanOrScanAllFromExisting(Scan scan) {
+      super(scan.forNamespace().orElse(null), scan.forTable().orElse(null), scan.getPartitionKey());
+      isIndexScan = scan instanceof IndexScan;
+      if (isIndexScan) {
+        indexKey = scan.getPartitionKey();
+      }
+      isScanAll = scan instanceof ScanAll;
+      scan.getStartClusteringKey()
+          .ifPresent(
+              key -> {
+                startClusteringKey = key;
+                startInclusive = scan.getStartInclusive();
+              });
+      scan.getEndClusteringKey()
+          .ifPresent(
+              key -> {
+                endClusteringKey = key;
+                endInclusive = scan.getEndInclusive();
+              });
+      limit = scan.getLimit();
+      orderings.addAll(scan.getOrderings());
+      projections.addAll(scan.getProjections());
+      consistency = scan.getConsistency();
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      this.namespaceName = namespaceName;
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting table(String tableName) {
+      checkNotNull(tableName);
+      this.tableName = tableName;
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting partitionKey(Key partitionKey) {
+      checkNotIndexScanOrScanAll();
+      checkNotNull(partitionKey);
+      this.partitionKey = partitionKey;
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting indexKey(Key indexKey) {
+      checkNotScanOrScanAll();
+      checkNotNull(indexKey);
+      this.indexKey = indexKey;
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting consistency(
+        com.scalar.db.api.Consistency consistency) {
+      super.consistency(consistency);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting projection(String projection) {
+      super.projection(projection);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting projections(Collection<String> projections) {
+      super.projections(projections);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting projections(String... projections) {
+      super.projections(projections);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting clearProjections() {
+      this.projections.clear();
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting limit(int limit) {
+      super.limit(limit);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting ordering(Scan.Ordering ordering) {
+      checkNotIndexScanOrScanAll();
+      super.ordering(ordering);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting orderings(Collection<Scan.Ordering> orderings) {
+      checkNotIndexScanOrScanAll();
+      super.orderings(orderings);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting orderings(Scan.Ordering... orderings) {
+      checkNotIndexScanOrScanAll();
+      super.orderings(orderings);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting start(Key clusteringKey, boolean inclusive) {
+      checkNotIndexScanOrScanAll();
+      super.start(clusteringKey, inclusive);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting end(Key clusteringKey, boolean inclusive) {
+      checkNotIndexScanOrScanAll();
+      super.end(clusteringKey, inclusive);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting start(Key clusteringKey) {
+      checkNotIndexScanOrScanAll();
+      super.start(clusteringKey);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting end(Key clusteringKey) {
+      checkNotIndexScanOrScanAll();
+      super.end(clusteringKey);
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting clearStart() {
+      checkNotIndexScanOrScanAll();
+      this.startClusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting clearEnd() {
+      checkNotIndexScanOrScanAll();
+      this.endClusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableScanOrScanAllFromExisting clearOrderings() {
+      checkNotIndexScanOrScanAll();
+      this.orderings.clear();
+      return this;
+    }
+
+    private void checkNotIndexScanOrScanAll() {
+      if (isIndexScan || isScanAll) {
+        throw new UnsupportedOperationException(
+            "This operation is not supported when scanning all the records of a database "
+                + "or scanning records of a database with using secondary index.");
+      }
+    }
+
+    private void checkNotScanOrScanAll() {
+      if (!isIndexScan) {
+        throw new UnsupportedOperationException(
+            "This operation is supported only when scanning records of a database with using secondary index.");
+      }
+    }
+
+    @Override
+    public Scan build() {
+      Scan scan;
+
+      if (isIndexScan) {
+        scan = new IndexScan(indexKey);
+      } else if (isScanAll) {
+        scan = new ScanAll();
+      } else {
+        scan = new Scan(partitionKey);
+        orderings.forEach(scan::withOrdering);
+        if (startClusteringKey != null) {
+          scan.withStart(startClusteringKey, startInclusive);
+        }
+        if (endClusteringKey != null) {
+          scan.withEnd(endClusteringKey, endInclusive);
+        }
+      }
+
+      scan.forNamespace(namespaceName)
+          .forTable(tableName)
+          .withLimit(limit)
+          .withConsistency(consistency);
+      if (!projections.isEmpty()) {
+        scan.withProjections(projections);
       }
 
       return scan;

--- a/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
@@ -5,7 +5,7 @@ import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
 
-public class IndexScan extends Scan {
+public class ScanWithIndex extends Scan {
 
   /**
    * @param indexKey an index key
@@ -14,21 +14,21 @@ public class IndexScan extends Scan {
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public IndexScan(Key indexKey) {
+  public ScanWithIndex(Key indexKey) {
     super(indexKey);
   }
 
   /**
-   * Copy a IndexScan.
+   * Copy a ScanWithIndex.
    *
-   * @param indexScan a IndexScan
+   * @param scanWithIndex a ScanWithIndex
    * @deprecated As of release 3.6.0. Will be removed in release 5.0.0. Use {@link
    *     Scan#newBuilder(Scan)} instead
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public IndexScan(IndexScan indexScan) {
-    super(indexScan);
+  public ScanWithIndex(ScanWithIndex scanWithIndex) {
+    super(scanWithIndex);
   }
 
   /**
@@ -39,7 +39,7 @@ public class IndexScan extends Scan {
    */
   @Deprecated
   @Override
-  public IndexScan withStart(Key clusteringKey) {
+  public ScanWithIndex withStart(Key clusteringKey) {
     throw new UnsupportedOperationException();
   }
 
@@ -51,7 +51,7 @@ public class IndexScan extends Scan {
    */
   @Deprecated
   @Override
-  public IndexScan withStart(Key clusteringKey, boolean inclusive) {
+  public ScanWithIndex withStart(Key clusteringKey, boolean inclusive) {
     throw new UnsupportedOperationException();
   }
 
@@ -63,7 +63,7 @@ public class IndexScan extends Scan {
    */
   @Deprecated
   @Override
-  public IndexScan withEnd(Key clusteringKey) {
+  public ScanWithIndex withEnd(Key clusteringKey) {
     throw new UnsupportedOperationException();
   }
 
@@ -75,7 +75,7 @@ public class IndexScan extends Scan {
    */
   @Deprecated
   @Override
-  public IndexScan withEnd(Key clusteringKey, boolean inclusive) {
+  public ScanWithIndex withEnd(Key clusteringKey, boolean inclusive) {
     throw new UnsupportedOperationException();
   }
 
@@ -87,7 +87,7 @@ public class IndexScan extends Scan {
    */
   @Deprecated
   @Override
-  public IndexScan withOrdering(Ordering ordering) {
+  public ScanWithIndex withOrdering(Ordering ordering) {
     throw new UnsupportedOperationException();
   }
 
@@ -97,8 +97,8 @@ public class IndexScan extends Scan {
    */
   @Override
   @Deprecated
-  public IndexScan withLimit(int limit) {
-    return (IndexScan) super.withLimit(limit);
+  public ScanWithIndex withLimit(int limit) {
+    return (ScanWithIndex) super.withLimit(limit);
   }
 
   /**
@@ -107,8 +107,8 @@ public class IndexScan extends Scan {
    */
   @Override
   @Deprecated
-  public IndexScan forNamespace(String namespace) {
-    return (IndexScan) super.forNamespace(namespace);
+  public ScanWithIndex forNamespace(String namespace) {
+    return (ScanWithIndex) super.forNamespace(namespace);
   }
 
   /**
@@ -117,8 +117,8 @@ public class IndexScan extends Scan {
    */
   @Override
   @Deprecated
-  public IndexScan forTable(String tableName) {
-    return (IndexScan) super.forTable(tableName);
+  public ScanWithIndex forTable(String tableName) {
+    return (ScanWithIndex) super.forTable(tableName);
   }
 
   /**
@@ -127,8 +127,8 @@ public class IndexScan extends Scan {
    */
   @Override
   @Deprecated
-  public IndexScan withConsistency(Consistency consistency) {
-    return (IndexScan) super.withConsistency(consistency);
+  public ScanWithIndex withConsistency(Consistency consistency) {
+    return (ScanWithIndex) super.withConsistency(consistency);
   }
 
   /**
@@ -137,8 +137,8 @@ public class IndexScan extends Scan {
    */
   @Override
   @Deprecated
-  public IndexScan withProjection(String projection) {
-    return (IndexScan) super.withProjection(projection);
+  public ScanWithIndex withProjection(String projection) {
+    return (ScanWithIndex) super.withProjection(projection);
   }
 
   /**
@@ -147,8 +147,8 @@ public class IndexScan extends Scan {
    */
   @Override
   @Deprecated
-  public IndexScan withProjections(Collection<String> projections) {
-    return (IndexScan) super.withProjections(projections);
+  public ScanWithIndex withProjections(Collection<String> projections) {
+    return (ScanWithIndex) super.withProjections(projections);
   }
 
   @Override
@@ -159,7 +159,7 @@ public class IndexScan extends Scan {
     if (o == this) {
       return true;
     }
-    return o instanceof IndexScan;
+    return o instanceof ScanWithIndex;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -13,7 +13,6 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -88,11 +87,7 @@ public class Cassandra extends AbstractDistributedStorage {
   @Nonnull
   public Scanner scan(Scan scan) throws ExecutionException {
     scan = copyAndSetTargetToIfNot(scan);
-    if (scan instanceof ScanAll) {
-      operationChecker.check((ScanAll) scan);
-    } else {
-      operationChecker.check(scan);
-    }
+    operationChecker.check(scan);
 
     ResultSet results = handlers.select().handle(scan);
 

--- a/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/common/checker/OperationChecker.java
@@ -53,7 +53,7 @@ public class OperationChecker {
             "The partition key is not properly specified. Operation: " + get);
       }
 
-      // The following check is not needed when we use IndexGet. But we need to keep it for
+      // The following check is not needed when we use GetWithIndex. But we need to keep it for
       // backward compatibility. We will remove it in release 5.0.0.
       if (get.getClusteringKey().isPresent()) {
         throw new IllegalArgumentException(
@@ -93,7 +93,7 @@ public class OperationChecker {
             "The partition key is not properly specified. Operation: " + scan);
       }
 
-      // The following checks are not needed when we use IndexScan. But we need to keep them for
+      // The following checks are not needed when we use ScanWithIndex. But we need to keep them for
       // backward compatibility. We will remove them in release 5.0.0.
       if (scan.getStartClusteringKey().isPresent() || scan.getEndClusteringKey().isPresent()) {
         throw new IllegalArgumentException(

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -13,7 +13,6 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
@@ -92,11 +91,7 @@ public class Cosmos extends AbstractDistributedStorage {
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
     scan = copyAndSetTargetToIfNot(scan);
-    if (scan instanceof ScanAll) {
-      operationChecker.check((ScanAll) scan);
-    } else {
-      operationChecker.check(scan);
-    }
+    operationChecker.check(scan);
 
     List<Record> records = selectStatementHandler.handle(scan);
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -10,7 +10,6 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
@@ -103,11 +102,7 @@ public class Dynamo extends AbstractDistributedStorage {
   @Override
   public Scanner scan(Scan scan) throws ExecutionException {
     scan = copyAndSetTargetToIfNot(scan);
-    if (scan instanceof ScanAll) {
-      operationChecker.check((ScanAll) scan);
-    } else {
-      operationChecker.check(scan);
-    }
+    operationChecker.check(scan);
 
     return selectStatementHandler.handle(scan);
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -83,11 +83,7 @@ public class JdbcService {
   @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
   public Scanner getScanner(Scan scan, Connection connection)
       throws SQLException, ExecutionException {
-    if (scan instanceof ScanAll) {
-      operationChecker.check((ScanAll) scan);
-    } else {
-      operationChecker.check(scan);
-    }
+    operationChecker.check(scan);
 
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
 
@@ -107,11 +103,8 @@ public class JdbcService {
 
   public List<Result> scan(Scan scan, Connection connection)
       throws SQLException, ExecutionException {
-    if (scan instanceof ScanAll) {
-      operationChecker.check((ScanAll) scan);
-    } else {
-      operationChecker.check(scan);
-    }
+    operationChecker.check(scan);
+
     TableMetadata tableMetadata = tableMetadataManager.getTableMetadata(scan);
 
     SelectQuery selectQuery =

--- a/core/src/main/java/com/scalar/db/util/ProtoUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ProtoUtils.java
@@ -8,8 +8,7 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.IndexGet;
-import com.scalar.db.api.IndexScan;
+import com.scalar.db.api.GetWithIndex;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
@@ -19,6 +18,7 @@ import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.ScanWithIndex;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
@@ -46,7 +46,7 @@ public final class ProtoUtils {
 
     Key partitionKey = toKey(get.getPartitionKey(), metadata);
     if (isIndexKey(partitionKey, metadata)) {
-      ret = new IndexGet(partitionKey);
+      ret = new GetWithIndex(partitionKey);
     } else {
       Key clusteringKey = null;
       if (get.hasClusteringKey()) {
@@ -278,7 +278,7 @@ public final class ProtoUtils {
     if (scan.hasPartitionKey()) {
       Key partitionKey = toKey(scan.getPartitionKey(), metadata);
       if (isIndexKey(partitionKey, metadata)) {
-        ret = new IndexScan(partitionKey);
+        ret = new ScanWithIndex(partitionKey);
       } else {
         ret = new Scan(partitionKey);
         if (scan.hasStartClusteringKey()) {

--- a/core/src/main/java/com/scalar/db/util/ProtoUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ProtoUtils.java
@@ -8,6 +8,8 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.IndexGet;
+import com.scalar.db.api.IndexScan;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
@@ -32,6 +34,7 @@ import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.rpc.MutateCondition;
 import com.scalar.db.rpc.Order;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -39,15 +42,19 @@ public final class ProtoUtils {
   private ProtoUtils() {}
 
   public static Get toGet(com.scalar.db.rpc.Get get, TableMetadata metadata) {
+    Get ret;
+
     Key partitionKey = toKey(get.getPartitionKey(), metadata);
-    Key clusteringKey;
-    if (get.hasClusteringKey()) {
-      clusteringKey = toKey(get.getClusteringKey(), metadata);
+    if (isIndexKey(partitionKey, metadata)) {
+      ret = new IndexGet(partitionKey);
     } else {
-      clusteringKey = null;
+      Key clusteringKey = null;
+      if (get.hasClusteringKey()) {
+        clusteringKey = toKey(get.getClusteringKey(), metadata);
+      }
+      ret = new Get(partitionKey, clusteringKey);
     }
 
-    Get ret = new Get(partitionKey, clusteringKey);
     if (!get.getNamespace().isEmpty()) {
       ret.forNamespace(get.getNamespace());
     }
@@ -269,14 +276,19 @@ public final class ProtoUtils {
   public static Scan toScan(com.scalar.db.rpc.Scan scan, TableMetadata metadata) {
     Scan ret;
     if (scan.hasPartitionKey()) {
-      ret = new Scan(toKey(scan.getPartitionKey(), metadata));
-      if (scan.hasStartClusteringKey()) {
-        ret.withStart(toKey(scan.getStartClusteringKey(), metadata), scan.getStartInclusive());
+      Key partitionKey = toKey(scan.getPartitionKey(), metadata);
+      if (isIndexKey(partitionKey, metadata)) {
+        ret = new IndexScan(partitionKey);
+      } else {
+        ret = new Scan(partitionKey);
+        if (scan.hasStartClusteringKey()) {
+          ret.withStart(toKey(scan.getStartClusteringKey(), metadata), scan.getStartInclusive());
+        }
+        if (scan.hasEndClusteringKey()) {
+          ret.withEnd(toKey(scan.getEndClusteringKey(), metadata), scan.getEndInclusive());
+        }
+        scan.getOrderingList().forEach(o -> ret.withOrdering(toOrdering(o)));
       }
-      if (scan.hasEndClusteringKey()) {
-        ret.withEnd(toKey(scan.getEndClusteringKey(), metadata), scan.getEndInclusive());
-      }
-      scan.getOrderingList().forEach(o -> ret.withOrdering(toOrdering(o)));
     } else {
       ret = new ScanAll();
     }
@@ -291,6 +303,15 @@ public final class ProtoUtils {
     ret.withConsistency(toConsistency(scan.getConsistency()));
     ret.withProjections(scan.getProjectionList());
     return ret;
+  }
+
+  private static boolean isIndexKey(Key key, TableMetadata metadata) {
+    List<Column<?>> columns = key.getColumns();
+    if (columns.size() == 1) {
+      String name = columns.get(0).getName();
+      return metadata.getSecondaryIndexNames().contains(name);
+    }
+    return false;
   }
 
   public static com.scalar.db.rpc.Scan toScan(Scan scan) {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -3,6 +3,8 @@ package com.scalar.db.util;
 import com.google.common.collect.Streams;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.IndexGet;
+import com.scalar.db.api.IndexScan;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
@@ -106,8 +108,13 @@ public final class ScalarDbUtils {
     }
   }
 
-  public static boolean isSecondaryIndexSpecified(Operation operation, TableMetadata metadata) {
-    List<Value<?>> keyValues = operation.getPartitionKey().get();
+  public static boolean isSecondaryIndexSpecified(Selection selection, TableMetadata metadata) {
+    if (selection instanceof IndexGet || selection instanceof IndexScan) {
+      return true;
+    }
+
+    // We need to keep this for backward compatibility. We will remove it in release 5.0.0.
+    List<Value<?>> keyValues = selection.getPartitionKey().get();
     if (keyValues.size() == 1) {
       String name = keyValues.get(0).getName();
       return metadata.getSecondaryIndexNames().contains(name);

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -3,13 +3,13 @@ package com.scalar.db.util;
 import com.google.common.collect.Streams;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.IndexGet;
-import com.scalar.db.api.IndexScan;
+import com.scalar.db.api.GetWithIndex;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.ScanWithIndex;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.BigIntColumn;
@@ -109,7 +109,7 @@ public final class ScalarDbUtils {
   }
 
   public static boolean isSecondaryIndexSpecified(Selection selection, TableMetadata metadata) {
-    if (selection instanceof IndexGet || selection instanceof IndexScan) {
+    if (selection instanceof GetWithIndex || selection instanceof ScanWithIndex) {
       return true;
     }
 

--- a/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
@@ -160,17 +160,17 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void buildIndexGet_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
+  public void buildGetWithIndex_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
     // Arrange Act
     Get actual = Get.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).indexKey(indexKey1).build();
 
     // Assert
     assertThat(actual)
-        .isEqualTo(new IndexGet(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
   }
 
   @Test
-  public void buildIndexGet_WithAllParameters_ShouldBuildGetWithAllParameters() {
+  public void buildGetWithIndex_WithAllParameters_ShouldBuildGetWithAllParameters() {
     // Arrange Act
     Get get =
         Get.newBuilder()
@@ -187,7 +187,7 @@ public class GetBuilderTest {
     // Assert
     assertThat(get)
         .isEqualTo(
-            new IndexGet(indexKey1)
+            new GetWithIndex(indexKey1)
                 .forNamespace(NAMESPACE_1)
                 .forTable(TABLE_1)
                 .withProjections(Arrays.asList("c1", "c2", "c3", "c4", "c5", "c6"))
@@ -195,10 +195,10 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void buildIndexGet_FromExistingWithoutChange_ShouldCopy() {
+  public void buildGetWithIndex_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
-    IndexGet existingGet =
-        new IndexGet(indexKey1)
+    GetWithIndex existingGet =
+        new GetWithIndex(indexKey1)
             .forNamespace(NAMESPACE_1)
             .forTable(TABLE_1)
             .withProjections(Arrays.asList("c1", "c2"))
@@ -213,10 +213,10 @@ public class GetBuilderTest {
 
   @Test
   public void
-      buildIndexGet_FromExistingAndUpdateAllParameters_ShouldBuildGetWithUpdatedParameters() {
+      buildGetWithIndex_FromExistingAndUpdateAllParameters_ShouldBuildGetWithUpdatedParameters() {
     // Arrange
-    IndexGet existingGet =
-        new IndexGet(indexKey1)
+    GetWithIndex existingGet =
+        new GetWithIndex(indexKey1)
             .forNamespace(NAMESPACE_1)
             .forTable(TABLE_1)
             .withProjections(Arrays.asList("c1", "c2"))
@@ -238,7 +238,7 @@ public class GetBuilderTest {
     // Assert
     assertThat(newGet)
         .isEqualTo(
-            new IndexGet(indexKey2)
+            new GetWithIndex(indexKey2)
                 .forNamespace(NAMESPACE_2)
                 .forTable(TABLE_2)
                 .withConsistency(Consistency.EVENTUAL)
@@ -247,9 +247,10 @@ public class GetBuilderTest {
 
   @Test
   public void
-      buildIndexGet_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+      buildGetWithIndex_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    IndexGet existingGet = new IndexGet(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    GetWithIndex existingGet =
+        new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
 
     // Act Assert
     assertThatThrownBy(() -> Get.newBuilder(existingGet).partitionKey(partitionKey1))

--- a/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.scalar.db.io.Key;
 import java.util.Arrays;
@@ -19,6 +20,8 @@ public class GetBuilderTest {
   @Mock private Key partitionKey2;
   @Mock private Key clusteringKey1;
   @Mock private Key clusteringKey2;
+  @Mock private Key indexKey1;
+  @Mock private Key indexKey2;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -26,7 +29,7 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void build_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
+  public void buildGet_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
     // Arrange Act
     Get actual =
         Get.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).partitionKey(partitionKey1).build();
@@ -37,7 +40,7 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void build_WithClusteringKey_ShouldBuildGetWithClusteringKey() {
+  public void buildGet_WithClusteringKey_ShouldBuildGetWithClusteringKey() {
     // Arrange Act
     Get get =
         Get.newBuilder()
@@ -54,7 +57,7 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void build_WithAllParameters_ShouldBuildGetWithAllParameters() {
+  public void buildGet_WithAllParameters_ShouldBuildGetWithAllParameters() {
     // Arrange Act
     Get get =
         Get.newBuilder()
@@ -80,7 +83,7 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void build_FromExistingWithoutChange_ShouldCopy() {
+  public void buildGet_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Get existingGet =
         new Get(partitionKey1, clusteringKey1)
@@ -97,7 +100,7 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void build_FromExistingAndUpdateAllParameters_ShouldBuildGetWithUpdatedParameters() {
+  public void buildGet_FromExistingAndUpdateAllParameters_ShouldBuildGetWithUpdatedParameters() {
     // Arrange
     Get existingGet =
         new Get(partitionKey1, clusteringKey1)
@@ -131,7 +134,7 @@ public class GetBuilderTest {
   }
 
   @Test
-  public void build_FromExistingAndClearClusteringKey_ShouldBuildGetWithoutClusteringKey() {
+  public void buildGet_FromExistingAndClearClusteringKey_ShouldBuildGetWithoutClusteringKey() {
     // Arrange
     Get existingGet =
         new Get(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
@@ -142,5 +145,118 @@ public class GetBuilderTest {
     // Assert
     assertThat(newGet)
         .isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void
+      buildGet_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    Get existingGet =
+        new Get(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act Assert
+    assertThatThrownBy(() -> Get.newBuilder(existingGet).indexKey(indexKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void buildIndexGet_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
+    // Arrange Act
+    Get actual = Get.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).indexKey(indexKey1).build();
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(new IndexGet(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void buildIndexGet_WithAllParameters_ShouldBuildGetWithAllParameters() {
+    // Arrange Act
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .indexKey(indexKey1)
+            .consistency(Consistency.EVENTUAL)
+            .projection("c1")
+            .projection("c2")
+            .projections(Arrays.asList("c3", "c4"))
+            .projections("c5", "c6")
+            .build();
+
+    // Assert
+    assertThat(get)
+        .isEqualTo(
+            new IndexGet(indexKey1)
+                .forNamespace(NAMESPACE_1)
+                .forTable(TABLE_1)
+                .withProjections(Arrays.asList("c1", "c2", "c3", "c4", "c5", "c6"))
+                .withConsistency(Consistency.EVENTUAL));
+  }
+
+  @Test
+  public void buildIndexGet_FromExistingWithoutChange_ShouldCopy() {
+    // Arrange
+    IndexGet existingGet =
+        new IndexGet(indexKey1)
+            .forNamespace(NAMESPACE_1)
+            .forTable(TABLE_1)
+            .withProjections(Arrays.asList("c1", "c2"))
+            .withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    Get newGet = Get.newBuilder(existingGet).build();
+
+    // Assert
+    assertThat(newGet).isEqualTo(existingGet);
+  }
+
+  @Test
+  public void
+      buildIndexGet_FromExistingAndUpdateAllParameters_ShouldBuildGetWithUpdatedParameters() {
+    // Arrange
+    IndexGet existingGet =
+        new IndexGet(indexKey1)
+            .forNamespace(NAMESPACE_1)
+            .forTable(TABLE_1)
+            .withProjections(Arrays.asList("c1", "c2"))
+            .withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    Get newGet =
+        Get.newBuilder(existingGet)
+            .indexKey(indexKey2)
+            .namespace(NAMESPACE_2)
+            .table(TABLE_2)
+            .consistency(Consistency.EVENTUAL)
+            .clearProjections()
+            .projections(Arrays.asList("c3", "c4"))
+            .projection("c5")
+            .projections("c6", "c7")
+            .build();
+
+    // Assert
+    assertThat(newGet)
+        .isEqualTo(
+            new IndexGet(indexKey2)
+                .forNamespace(NAMESPACE_2)
+                .forTable(TABLE_2)
+                .withConsistency(Consistency.EVENTUAL)
+                .withProjections(Arrays.asList("c3", "c4", "c5", "c6", "c7")));
+  }
+
+  @Test
+  public void
+      buildIndexGet_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    IndexGet existingGet = new IndexGet(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act Assert
+    assertThatThrownBy(() -> Get.newBuilder(existingGet).partitionKey(partitionKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Get.newBuilder(existingGet).clusteringKey(clusteringKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Get.newBuilder(existingGet).clearClusteringKey())
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
@@ -27,6 +27,8 @@ public class ScanBuilderTest {
   @Mock private Scan.Ordering ordering3;
   @Mock private Scan.Ordering ordering4;
   @Mock private Scan.Ordering ordering5;
+  @Mock private Key indexKey1;
+  @Mock private Key indexKey2;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -232,6 +234,17 @@ public class ScanBuilderTest {
   }
 
   @Test
+  public void
+      buildScan_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    Scan existingScan = new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act Assert
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).indexKey(indexKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
   public void buildScanAll_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
     // Arrange Act
     Scan actual = Scan.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).all().build();
@@ -325,28 +338,152 @@ public class ScanBuilderTest {
 
   @Test
   public void
-      buildScanAll_FromExistingScanAllWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+      buildScanAll_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    Scan existingScanAll = new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    Scan existingScan = new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1);
 
     // Act Assert
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).partitionKey(partitionKey1))
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).partitionKey(partitionKey1))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).clearOrderings())
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).indexKey(indexKey1))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).start(startClusteringKey1))
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearOrderings())
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).start(startClusteringKey1, false))
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).start(startClusteringKey1))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).end(endClusteringKey1, false))
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).start(startClusteringKey1, false))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).end(endClusteringKey1))
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).end(endClusteringKey1, false))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).ordering(ordering1))
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).end(endClusteringKey1))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).clearStart())
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).ordering(ordering1))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> Scan.newBuilder(existingScanAll).clearEnd())
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearStart())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearEnd())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void buildIndexScan_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
+    // Arrange Act
+    Scan actual =
+        Scan.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).indexKey(indexKey1).build();
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(new IndexScan(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void buildIndexScan_ScanWithAllParameters_ShouldBuildScanCorrectly() {
+    // Arrange Act
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .indexKey(indexKey1)
+            .limit(10)
+            .projections(Arrays.asList("pk1", "ck1"))
+            .projection("ck2")
+            .projections("ck3", "ck4")
+            .consistency(Consistency.EVENTUAL)
+            .build();
+
+    // Assert
+    assertThat(scan)
+        .isEqualTo(
+            new IndexScan(indexKey1)
+                .forNamespace(NAMESPACE_1)
+                .forTable(TABLE_1)
+                .withConsistency(Consistency.EVENTUAL)
+                .withLimit(10)
+                .withProjections(Arrays.asList("pk1", "ck1", "ck2", "ck3", "ck4"))
+                .withConsistency(Consistency.EVENTUAL));
+  }
+
+  @Test
+  public void buildIndexScan_FromExistingWithoutChange_ShouldCopy() {
+    // Arrange
+    Scan existingScan =
+        new IndexScan(indexKey1)
+            .forNamespace(NAMESPACE_1)
+            .forTable(TABLE_1)
+            .withConsistency(Consistency.EVENTUAL)
+            .withLimit(10)
+            .withProjections(Arrays.asList("pk1", "ck1"))
+            .withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    Scan newScan = Scan.newBuilder(existingScan).build();
+
+    // Assert
+    assertThat(newScan).isEqualTo(existingScan);
+  }
+
+  @Test
+  public void
+      buildIndexScan_FromExistingAndUpdateAllParameters_ShouldBuildScanWithUpdatedParameters() {
+    // Arrange
+    Scan existingScan =
+        new IndexScan(indexKey1)
+            .forNamespace(NAMESPACE_1)
+            .forTable(TABLE_1)
+            .withConsistency(Consistency.EVENTUAL)
+            .withLimit(10)
+            .withProjections(Arrays.asList("pk1", "ck1"))
+            .withConsistency(Consistency.EVENTUAL);
+
+    // Act
+    Scan newScan =
+        Scan.newBuilder(existingScan)
+            .namespace(NAMESPACE_2)
+            .table(TABLE_2)
+            .indexKey(indexKey2)
+            .limit(5)
+            .clearProjections()
+            .projections(Arrays.asList("pk2", "ck2"))
+            .projection("ck3")
+            .projections("ck4", "ck5")
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+
+    // Assert
+    assertThat(newScan)
+        .isEqualTo(
+            new IndexScan(indexKey2)
+                .forNamespace(NAMESPACE_2)
+                .forTable(TABLE_2)
+                .withLimit(5)
+                .withProjections(Arrays.asList("pk2", "ck2", "ck3", "ck4", "ck5"))
+                .withConsistency(Consistency.LINEARIZABLE));
+  }
+
+  @Test
+  public void
+      buildIndexScan_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    Scan existingScan = new IndexScan(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act Assert
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).partitionKey(partitionKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearOrderings())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).start(startClusteringKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).start(startClusteringKey1, false))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).end(endClusteringKey1, false))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).end(endClusteringKey1))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).ordering(ordering1))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearStart())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearEnd())
         .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
@@ -366,18 +366,18 @@ public class ScanBuilderTest {
   }
 
   @Test
-  public void buildIndexScan_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
+  public void buildScanWithIndex_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
     // Arrange Act
     Scan actual =
         Scan.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).indexKey(indexKey1).build();
 
     // Assert
     assertThat(actual)
-        .isEqualTo(new IndexScan(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+        .isEqualTo(new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
   }
 
   @Test
-  public void buildIndexScan_ScanWithAllParameters_ShouldBuildScanCorrectly() {
+  public void buildScanWithIndex_ScanWithAllParameters_ShouldBuildScanCorrectly() {
     // Arrange Act
     Scan scan =
         Scan.newBuilder()
@@ -394,7 +394,7 @@ public class ScanBuilderTest {
     // Assert
     assertThat(scan)
         .isEqualTo(
-            new IndexScan(indexKey1)
+            new ScanWithIndex(indexKey1)
                 .forNamespace(NAMESPACE_1)
                 .forTable(TABLE_1)
                 .withConsistency(Consistency.EVENTUAL)
@@ -404,10 +404,10 @@ public class ScanBuilderTest {
   }
 
   @Test
-  public void buildIndexScan_FromExistingWithoutChange_ShouldCopy() {
+  public void buildScanWithIndex_FromExistingWithoutChange_ShouldCopy() {
     // Arrange
     Scan existingScan =
-        new IndexScan(indexKey1)
+        new ScanWithIndex(indexKey1)
             .forNamespace(NAMESPACE_1)
             .forTable(TABLE_1)
             .withConsistency(Consistency.EVENTUAL)
@@ -424,10 +424,10 @@ public class ScanBuilderTest {
 
   @Test
   public void
-      buildIndexScan_FromExistingAndUpdateAllParameters_ShouldBuildScanWithUpdatedParameters() {
+      buildScanWithIndex_FromExistingAndUpdateAllParameters_ShouldBuildScanWithUpdatedParameters() {
     // Arrange
     Scan existingScan =
-        new IndexScan(indexKey1)
+        new ScanWithIndex(indexKey1)
             .forNamespace(NAMESPACE_1)
             .forTable(TABLE_1)
             .withConsistency(Consistency.EVENTUAL)
@@ -452,7 +452,7 @@ public class ScanBuilderTest {
     // Assert
     assertThat(newScan)
         .isEqualTo(
-            new IndexScan(indexKey2)
+            new ScanWithIndex(indexKey2)
                 .forNamespace(NAMESPACE_2)
                 .forTable(TABLE_2)
                 .withLimit(5)
@@ -462,9 +462,9 @@ public class ScanBuilderTest {
 
   @Test
   public void
-      buildIndexScan_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
+      buildScanWithIndex_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
-    Scan existingScan = new IndexScan(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+    Scan existingScan = new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
 
     // Act Assert
     assertThatThrownBy(() -> Scan.newBuilder(existingScan).partitionKey(partitionKey1))

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -1409,6 +1409,72 @@ public class OperationCheckerTest {
   }
 
   @Test
+  public void whenCheckingIndexGetOperationWithProperArguments_shouldNotThrowAnyException() {
+    // Arrange
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.ofInt(COL1, 1))
+            .projections(COL1, COL2, COL3)
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(get)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      whenCheckingIndexGetOperationWithMultipleIndexedColumns_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.of(COL1, 1, COL2, 1.23))
+            .projections(COL1, COL2, COL3)
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(get))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingIndexGetOperationWithNonIndexedColumn_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.ofDouble(COL2, 1.23))
+            .projections(COL1, COL2, COL3)
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(get))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingIndexGetOperationWithIndexedColumnButWrongType_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Get get =
+        Get.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.ofDouble(COL1, 1.0))
+            .projections(COL1, COL2, COL3)
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(get))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void
       whenCheckingScanOperationWithIndexedColumnAsPartitionKey_shouldNotThrowAnyException() {
     // Arrange
@@ -1517,6 +1583,76 @@ public class OperationCheckerTest {
             .withOrdering(new Scan.Ordering(CKEY1, Scan.Ordering.Order.ASC))
             .forNamespace(NAMESPACE)
             .forTable(TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(scan))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void whenCheckingIndexScanOperationWithProperArguments_shouldNotThrowAnyException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.ofInt(COL1, 1))
+            .projections(COL1, COL2, COL3)
+            .limit(10)
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(scan)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      whenCheckingIndexScanOperationWithMultipleIndexedColumns_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.of(COL1, 1, COL2, 1.23))
+            .projections(COL1, COL2, COL3)
+            .limit(10)
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(scan))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingIndexScanOperationWithNonIndexedColumn_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.ofDouble(COL2, 1.23))
+            .projections(COL1, COL2, COL3)
+            .limit(10)
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(scan))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingIndexScanOperationWithIndexedColumnButWrongType_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .indexKey(Key.ofDouble(COL1, 1.0))
+            .projections(COL1, COL2, COL3)
+            .limit(10)
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(scan))

--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -1409,7 +1409,7 @@ public class OperationCheckerTest {
   }
 
   @Test
-  public void whenCheckingIndexGetOperationWithProperArguments_shouldNotThrowAnyException() {
+  public void whenCheckingGetWithIndexOperationWithProperArguments_shouldNotThrowAnyException() {
     // Arrange
     Get get =
         Get.newBuilder()
@@ -1425,7 +1425,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingIndexGetOperationWithMultipleIndexedColumns_shouldThrowIllegalArgumentException() {
+      whenCheckingGetWithIndexOperationWithMultipleIndexedColumns_shouldThrowIllegalArgumentException() {
     // Arrange
     Get get =
         Get.newBuilder()
@@ -1442,7 +1442,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingIndexGetOperationWithNonIndexedColumn_shouldThrowIllegalArgumentException() {
+      whenCheckingGetWithIndexOperationWithNonIndexedColumn_shouldThrowIllegalArgumentException() {
     // Arrange
     Get get =
         Get.newBuilder()
@@ -1459,7 +1459,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingIndexGetOperationWithIndexedColumnButWrongType_shouldThrowIllegalArgumentException() {
+      whenCheckingGetWithIndexOperationWithIndexedColumnButWrongType_shouldThrowIllegalArgumentException() {
     // Arrange
     Get get =
         Get.newBuilder()
@@ -1590,7 +1590,7 @@ public class OperationCheckerTest {
   }
 
   @Test
-  public void whenCheckingIndexScanOperationWithProperArguments_shouldNotThrowAnyException() {
+  public void whenCheckingScanWithIndexOperationWithProperArguments_shouldNotThrowAnyException() {
     // Arrange
     Scan scan =
         Scan.newBuilder()
@@ -1607,7 +1607,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingIndexScanOperationWithMultipleIndexedColumns_shouldThrowIllegalArgumentException() {
+      whenCheckingScanWithIndexOperationWithMultipleIndexedColumns_shouldThrowIllegalArgumentException() {
     // Arrange
     Scan scan =
         Scan.newBuilder()
@@ -1625,7 +1625,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingIndexScanOperationWithNonIndexedColumn_shouldThrowIllegalArgumentException() {
+      whenCheckingScanWithIndexOperationWithNonIndexedColumn_shouldThrowIllegalArgumentException() {
     // Arrange
     Scan scan =
         Scan.newBuilder()
@@ -1643,7 +1643,7 @@ public class OperationCheckerTest {
 
   @Test
   public void
-      whenCheckingIndexScanOperationWithIndexedColumnButWrongType_shouldThrowIllegalArgumentException() {
+      whenCheckingScanWithIndexOperationWithIndexedColumnButWrongType_shouldThrowIllegalArgumentException() {
     // Arrange
     Scan scan =
         Scan.newBuilder()

--- a/core/src/test/java/com/scalar/db/util/ProtoUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ProtoUtilsTest.java
@@ -8,14 +8,14 @@ import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.IndexGet;
-import com.scalar.db.api.IndexScan;
+import com.scalar.db.api.GetWithIndex;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.ScanWithIndex;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.io.BigIntColumn;
@@ -157,17 +157,17 @@ public class ProtoUtilsTest {
   }
 
   @Test
-  public void toGet_IndexGetGiven_ShouldConvertProperly() {
+  public void toGet_GetWithIndexGiven_ShouldConvertProperly() {
     // Arrange
-    IndexGet indexGet =
-        new IndexGet(Key.ofInt("col2", 1))
+    GetWithIndex getWithIndex =
+        new GetWithIndex(Key.ofInt("col2", 1))
             .withProjections(Arrays.asList("col1", "col2", "col3"))
             .withConsistency(Consistency.SEQUENTIAL)
             .forNamespace("ns")
             .forTable("tbl");
 
     // Act
-    com.scalar.db.rpc.Get actual = ProtoUtils.toGet(indexGet);
+    com.scalar.db.rpc.Get actual = ProtoUtils.toGet(getWithIndex);
 
     // Assert
     assertThat(actual)
@@ -188,7 +188,7 @@ public class ProtoUtilsTest {
   }
 
   @Test
-  public void tGet_ProtoScanForIndexGetGiven_ShouldConvertProperly() {
+  public void tGet_ProtoScanForGetWithIndexGiven_ShouldConvertProperly() {
     // Arrange
     com.scalar.db.rpc.Get get =
         com.scalar.db.rpc.Get.newBuilder()
@@ -211,7 +211,7 @@ public class ProtoUtilsTest {
     // Assert
     assertThat(actual)
         .isEqualTo(
-            new IndexGet(Key.ofInt("col2", 1))
+            new GetWithIndex(Key.ofInt("col2", 1))
                 .withProjections(Arrays.asList("col1", "col2", "col3"))
                 .withConsistency(Consistency.SEQUENTIAL)
                 .forNamespace("ns")
@@ -486,10 +486,10 @@ public class ProtoUtilsTest {
   }
 
   @Test
-  public void toScan_IndexScanGiven_ShouldConvertProperly() {
+  public void toScan_ScanWithIndexGiven_ShouldConvertProperly() {
     // Arrange
-    IndexScan indexScan =
-        new IndexScan(Key.ofInt("col2", 1))
+    ScanWithIndex scanWithIndex =
+        new ScanWithIndex(Key.ofInt("col2", 1))
             .withLimit(10)
             .withProjections(Arrays.asList("col1", "col2", "col3"))
             .withConsistency(Consistency.SEQUENTIAL)
@@ -497,7 +497,7 @@ public class ProtoUtilsTest {
             .forTable("tbl");
 
     // Act
-    com.scalar.db.rpc.Scan actual = ProtoUtils.toScan(indexScan);
+    com.scalar.db.rpc.Scan actual = ProtoUtils.toScan(scanWithIndex);
 
     // Assert
     assertThat(actual)
@@ -519,7 +519,7 @@ public class ProtoUtilsTest {
   }
 
   @Test
-  public void toScan_ProtoScanForIndexScanGiven_ShouldConvertProperly() {
+  public void toScan_ProtoScanForScanWithIndexGiven_ShouldConvertProperly() {
     // Arrange
     com.scalar.db.rpc.Scan scan =
         com.scalar.db.rpc.Scan.newBuilder()
@@ -543,7 +543,7 @@ public class ProtoUtilsTest {
     // Assert
     assertThat(actual)
         .isEqualTo(
-            new IndexScan(Key.ofInt("col2", 1))
+            new ScanWithIndex(Key.ofInt("col2", 1))
                 .withLimit(10)
                 .withProjections(Arrays.asList("col1", "col2", "col3"))
                 .withConsistency(Consistency.SEQUENTIAL)

--- a/core/src/test/java/com/scalar/db/util/ProtoUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ProtoUtilsTest.java
@@ -8,6 +8,8 @@ import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.IndexGet;
+import com.scalar.db.api.IndexScan;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
@@ -150,6 +152,68 @@ public class ProtoUtilsTest {
             new Get(Key.of("p1", 10, "p2", "text1"), Key.of("c1", "text2", "c2", 20))
                 .withProjections(Arrays.asList("col1", "col2", "col3"))
                 .withConsistency(Consistency.LINEARIZABLE)
+                .forNamespace("ns")
+                .forTable("tbl"));
+  }
+
+  @Test
+  public void toGet_IndexGetGiven_ShouldConvertProperly() {
+    // Arrange
+    IndexGet indexGet =
+        new IndexGet(Key.ofInt("col2", 1))
+            .withProjections(Arrays.asList("col1", "col2", "col3"))
+            .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace("ns")
+            .forTable("tbl");
+
+    // Act
+    com.scalar.db.rpc.Get actual = ProtoUtils.toGet(indexGet);
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            com.scalar.db.rpc.Get.newBuilder()
+                .setPartitionKey(
+                    com.scalar.db.rpc.Key.newBuilder()
+                        .addColumn(
+                            com.scalar.db.rpc.Column.newBuilder()
+                                .setName("col2")
+                                .setIntValue(1)
+                                .build()))
+                .addAllProjection(Arrays.asList("col1", "col2", "col3"))
+                .setConsistency(com.scalar.db.rpc.Consistency.CONSISTENCY_SEQUENTIAL)
+                .setNamespace("ns")
+                .setTable("tbl")
+                .build());
+  }
+
+  @Test
+  public void tGet_ProtoScanForIndexGetGiven_ShouldConvertProperly() {
+    // Arrange
+    com.scalar.db.rpc.Get get =
+        com.scalar.db.rpc.Get.newBuilder()
+            .setPartitionKey(
+                com.scalar.db.rpc.Key.newBuilder()
+                    .addColumn(
+                        com.scalar.db.rpc.Column.newBuilder()
+                            .setName("col2")
+                            .setIntValue(1)
+                            .build()))
+            .addAllProjection(Arrays.asList("col1", "col2", "col3"))
+            .setConsistency(com.scalar.db.rpc.Consistency.CONSISTENCY_SEQUENTIAL)
+            .setNamespace("ns")
+            .setTable("tbl")
+            .build();
+
+    // Act
+    Get actual = ProtoUtils.toGet(get, TABLE_METADATA);
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            new IndexGet(Key.ofInt("col2", 1))
+                .withProjections(Arrays.asList("col1", "col2", "col3"))
+                .withConsistency(Consistency.SEQUENTIAL)
                 .forNamespace("ns")
                 .forTable("tbl"));
   }
@@ -414,6 +478,72 @@ public class ProtoUtilsTest {
                 .withEnd(Key.of("c1", "text2", "c2", 100), false)
                 .withOrdering(Ordering.desc("c1"))
                 .withOrdering(Ordering.asc("c2"))
+                .withLimit(10)
+                .withProjections(Arrays.asList("col1", "col2", "col3"))
+                .withConsistency(Consistency.SEQUENTIAL)
+                .forNamespace("ns")
+                .forTable("tbl"));
+  }
+
+  @Test
+  public void toScan_IndexScanGiven_ShouldConvertProperly() {
+    // Arrange
+    IndexScan indexScan =
+        new IndexScan(Key.ofInt("col2", 1))
+            .withLimit(10)
+            .withProjections(Arrays.asList("col1", "col2", "col3"))
+            .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace("ns")
+            .forTable("tbl");
+
+    // Act
+    com.scalar.db.rpc.Scan actual = ProtoUtils.toScan(indexScan);
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            com.scalar.db.rpc.Scan.newBuilder()
+                .setPartitionKey(
+                    com.scalar.db.rpc.Key.newBuilder()
+                        .addColumn(
+                            com.scalar.db.rpc.Column.newBuilder()
+                                .setName("col2")
+                                .setIntValue(1)
+                                .build()))
+                .setLimit(10)
+                .addAllProjection(Arrays.asList("col1", "col2", "col3"))
+                .setConsistency(com.scalar.db.rpc.Consistency.CONSISTENCY_SEQUENTIAL)
+                .setNamespace("ns")
+                .setTable("tbl")
+                .build());
+  }
+
+  @Test
+  public void toScan_ProtoScanForIndexScanGiven_ShouldConvertProperly() {
+    // Arrange
+    com.scalar.db.rpc.Scan scan =
+        com.scalar.db.rpc.Scan.newBuilder()
+            .setPartitionKey(
+                com.scalar.db.rpc.Key.newBuilder()
+                    .addColumn(
+                        com.scalar.db.rpc.Column.newBuilder()
+                            .setName("col2")
+                            .setIntValue(1)
+                            .build()))
+            .setLimit(10)
+            .addAllProjection(Arrays.asList("col1", "col2", "col3"))
+            .setConsistency(com.scalar.db.rpc.Consistency.CONSISTENCY_SEQUENTIAL)
+            .setNamespace("ns")
+            .setTable("tbl")
+            .build();
+
+    // Act
+    Scan actual = ProtoUtils.toScan(scan, TABLE_METADATA);
+
+    // Assert
+    assertThat(actual)
+        .isEqualTo(
+            new IndexScan(Key.ofInt("col2", 1))
                 .withLimit(10)
                 .withProjections(Arrays.asList("col1", "col2", "col3"))
                 .withConsistency(Consistency.SEQUENTIAL)


### PR DESCRIPTION
This PR introduces `GetWithIndex` and `ScanWithIndex` operations that are read operations using secondary indexes.

We can build `GetWithIndex` and `ScanWithIndex` operations with the builder, and after this change, we can execute read operations using secondary indexes as follows:
```java
Get get =
    Get.newBuilder()
        .namespace("ns")
        .table("tbl")
        .indexKey(Key.ofInt("<index key column>", 0)) // specify the index key
        .build();
Optional<Result> result = transaction.get(get);

Scan scan =
    Scan.newBuilder()
        .namespace("ns")
        .table("tbl")
        .indexKey(Key.ofInt("<index key column>", 0)) // specify the index key
        .build();
List<Result> results = transaction.scan(scan);
```

We can already execute read operations using secondary indexes with the existing `Get` and `Scan` actually, but I think using the `GetWithIndex` and `ScanWithIndex` operations is easier to use and more readable.

Please take a look!