### PR TITLE
Add Scanner paging support for scan operations to the Cosmos adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/common/EmptyScanner.java
+++ b/core/src/main/java/com/scalar/db/storage/common/EmptyScanner.java
@@ -1,4 +1,4 @@
-package com.scalar.db.storage.dynamo;
+package com.scalar.db.storage.common;
 
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scanner;

--- a/core/src/main/java/com/scalar/db/storage/cosmos/DeleteStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/DeleteStatementHandler.java
@@ -6,12 +6,9 @@ import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Mutation;
-import com.scalar.db.api.Operation;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -27,16 +24,13 @@ public class DeleteStatementHandler extends MutateStatementHandler {
   }
 
   @Override
-  protected List<Record> execute(Operation operation) throws CosmosException, ExecutionException {
-    Mutation mutation = (Mutation) operation;
+  protected void execute(Mutation mutation) throws CosmosException, ExecutionException {
     TableMetadata tableMetadata = metadataManager.getTableMetadata(mutation);
     if (mutation.getCondition().isPresent()) {
       executeStoredProcedure(mutation, tableMetadata);
     } else {
       execute(mutation, tableMetadata);
     }
-
-    return Collections.emptyList();
   }
 
   private void execute(Mutation mutation, TableMetadata tableMetadata) throws CosmosException {

--- a/core/src/main/java/com/scalar/db/storage/cosmos/MutateStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/MutateStatementHandler.java
@@ -3,16 +3,13 @@ package com.scalar.db.storage.cosmos;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosException;
 import com.scalar.db.api.Mutation;
-import com.scalar.db.api.Operation;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,18 +23,23 @@ public abstract class MutateStatementHandler extends StatementHandler {
   public MutateStatementHandler(CosmosClient client, TableMetadataManager metadataManager) {
     super(client, metadataManager);
   }
-
-  @Override
-  @Nonnull
-  public List<Record> handle(Operation operation) throws ExecutionException {
+  /**
+   * Executes the specified {@code Mutation}
+   *
+   * @param mutation a {@code Mutation} to execute
+   * @throws ExecutionException if the execution failed
+   */
+  public void handle(Mutation mutation) throws ExecutionException {
     try {
-      return execute(operation);
+      execute(mutation);
     } catch (CosmosException e) {
       throwException(e);
+    } catch (RuntimeException e) {
+      throw new ExecutionException(e.getMessage(), e);
     }
-
-    return Collections.emptyList();
   }
+
+  abstract void execute(Mutation mutation) throws CosmosException, ExecutionException;
 
   protected void executeStoredProcedure(Mutation mutation, TableMetadata tableMetadata)
       throws CosmosException {

--- a/core/src/main/java/com/scalar/db/storage/cosmos/PutStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/PutStatementHandler.java
@@ -3,12 +3,9 @@ package com.scalar.db.storage.cosmos;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosException;
 import com.scalar.db.api.Mutation;
-import com.scalar.db.api.Operation;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -24,10 +21,8 @@ public class PutStatementHandler extends MutateStatementHandler {
   }
 
   @Override
-  protected List<Record> execute(Operation operation) throws CosmosException, ExecutionException {
-    Mutation mutation = (Mutation) operation;
+  protected void execute(Mutation mutation) throws CosmosException, ExecutionException {
     TableMetadata tableMetadata = metadataManager.getTableMetadata(mutation);
     executeStoredProcedure(mutation, tableMetadata);
-    return Collections.emptyList();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/SingleRecordScanner.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/SingleRecordScanner.java
@@ -1,0 +1,57 @@
+package com.scalar.db.storage.cosmos;
+
+import com.google.common.collect.ImmutableList;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scanner;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public final class SingleRecordScanner implements Scanner {
+
+  @Nullable private Record record;
+  private final ResultInterpreter resultInterpreter;
+
+  public SingleRecordScanner(@Nullable Record record, ResultInterpreter resultInterpreter) {
+    this.record = record;
+    this.resultInterpreter = resultInterpreter;
+  }
+
+  @Override
+  @Nonnull
+  public Optional<Result> one() {
+    if (record != null) {
+      Optional<Result> ret = Optional.of(resultInterpreter.interpret(record));
+      record = null;
+      return ret;
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  @Nonnull
+  public List<Result> all() {
+    if (record != null) {
+      List<Result> ret = ImmutableList.of(resultInterpreter.interpret(record));
+      record = null;
+      return ret;
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  @Nonnull
+  public Iterator<Result> iterator() {
+    return all().iterator();
+  }
+
+  @Override
+  public void close() {}
+}

--- a/core/src/main/java/com/scalar/db/storage/cosmos/StatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/StatementHandler.java
@@ -4,20 +4,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosException;
 import com.scalar.db.api.Operation;
 import com.scalar.db.common.TableMetadataManager;
-import com.scalar.db.exception.storage.ExecutionException;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** A handler class for statements */
 @ThreadSafe
 public abstract class StatementHandler {
-  private static final Logger logger = LoggerFactory.getLogger(StatementHandler.class);
   protected final CosmosClient client;
   protected final TableMetadataManager metadataManager;
 
@@ -31,26 +25,6 @@ public abstract class StatementHandler {
     this.client = checkNotNull(client);
     this.metadataManager = checkNotNull(metadataManager);
   }
-
-  /**
-   * Executes the specified {@code Operation}
-   *
-   * @param operation an {@code Operation} to execute
-   * @return a {@code ResultSet}
-   * @throws ExecutionException if the execution failed
-   */
-  @Nonnull
-  public List<Record> handle(Operation operation) throws ExecutionException {
-    try {
-      return execute(operation);
-    } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
-      throw new ExecutionException(e.getMessage(), e);
-    }
-  }
-
-  protected abstract List<Record> execute(Operation operation)
-      throws CosmosException, ExecutionException;
 
   @Nonnull
   protected CosmosContainer getContainer(Operation operation) {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -16,6 +16,7 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
+import com.scalar.db.storage.common.EmptyScanner;
 import com.scalar.db.storage.dynamo.bytes.BytesUtils;
 import com.scalar.db.storage.dynamo.bytes.KeyBytesEncoder;
 import com.scalar.db.util.ScalarDbUtils;

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ScannerImplTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ScannerImplTest.java
@@ -1,0 +1,158 @@
+package com.scalar.db.storage.cosmos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.azure.cosmos.models.FeedResponse;
+import com.scalar.db.api.Result;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ScannerImplTest {
+
+  @Mock ResultInterpreter resultInterpreter;
+  @Mock Record record1;
+  @Mock Record record2;
+  @Mock Record record3;
+  @Mock Record record4;
+  @Mock Result result1;
+  @Mock Result result2;
+  @Mock Result result3;
+  @Mock Result result4;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    when(resultInterpreter.interpret(record1)).thenReturn(result1);
+    when(resultInterpreter.interpret(record2)).thenReturn(result2);
+    when(resultInterpreter.interpret(record3)).thenReturn(result3);
+    when(resultInterpreter.interpret(record4)).thenReturn(result4);
+  }
+
+  @Test
+  public void one_WithSingleRecord_ShouldContainOnlyOneResult() {
+    // Arrange
+    ScannerImpl scanner = buildScanner(Lists.newArrayList(record1));
+
+    // Act
+    Optional<Result> actualResult1 = scanner.one();
+    Optional<Result> emptyResult = scanner.one();
+
+    // Assert
+    assertThat(actualResult1).contains(result1);
+    assertThat(emptyResult).isEmpty();
+  }
+
+  @Test
+  public void all_WithSingleRecord_ShouldContainOnlyOneResult() {
+    // Arrange
+    ScannerImpl scanner = buildScanner(Lists.newArrayList(record1));
+
+    // Act
+    List<Result> actualResults = scanner.all();
+    List<Result> emptyResults = scanner.all();
+
+    // Assert
+    assertThat(actualResults).containsExactly(result1);
+    assertThat(emptyResults).isEmpty();
+  }
+
+  @Test
+  public void all_WithTwoPages_ShouldReturnAllResults() {
+    // Arrange
+    ScannerImpl scanner =
+        buildScanner(Lists.newArrayList(record1, record2), Lists.newArrayList(record3, record4));
+
+    // Act
+    List<Result> actualResults = scanner.all();
+
+    // Assert
+    assertThat(actualResults).containsExactly(result1, result2, result3, result4);
+  }
+
+  @Test
+  public void one_WithTwoPages_ShouldReturnAllResults() {
+    // Arrange
+    ScannerImpl scanner =
+        buildScanner(Lists.newArrayList(record1, record2), Lists.newArrayList(record3, record4));
+
+    // Act
+    Optional<Result> actualResult1 = scanner.one();
+    Optional<Result> actualResult2 = scanner.one();
+    Optional<Result> actualResult3 = scanner.one();
+    Optional<Result> actualResult4 = scanner.one();
+    Optional<Result> actualResult5 = scanner.one();
+
+    // Assert
+    assertThat(actualResult1).contains(result1);
+    assertThat(actualResult2).contains(result2);
+    assertThat(actualResult3).contains(result3);
+    assertThat(actualResult4).contains(result4);
+    assertThat(actualResult5).isEmpty();
+  }
+
+  @Test
+  public void oneAndAll_WithTwoPages_ShouldReturnAllResults() {
+    // Arrange
+    ScannerImpl scanner =
+        buildScanner(Lists.newArrayList(record1, record2), Lists.newArrayList(record3, record4));
+
+    // Act
+    Optional<Result> oneResult = scanner.one();
+    List<Result> remainingResults = scanner.all();
+    Optional<Result> emptyResultForOne = scanner.one();
+    List<Result> emptyResultForAll = scanner.all();
+
+    // Assert
+    assertThat(oneResult).contains(result1);
+    assertThat(remainingResults).containsExactly(result2, result3, result4);
+    assertThat(emptyResultForOne).isEmpty();
+    assertThat(emptyResultForAll).isEmpty();
+  }
+
+  @Test
+  public void one_WithNoRecord_ShouldReturnEmpty() {
+    // Arrange
+    ScannerImpl scanner = buildScanner();
+
+    // Act
+    Optional<Result> oneResult = scanner.one();
+
+    // Assert
+    assertThat(oneResult).isEmpty();
+  }
+
+  @Test
+  public void all_WithNoRecord_ShouldReturnEmpty() {
+    // Arrange
+    ScannerImpl scanner = buildScanner();
+
+    // Act
+    List<Result> allResults = scanner.all();
+
+    // Assert
+    assertThat(allResults).isEmpty();
+  }
+
+  @SafeVarargs
+  private final ScannerImpl buildScanner(List<Record>... pages) {
+    List<FeedResponse<Record>> pagesFeed = new ArrayList<>();
+    for (List<Record> page : pages) {
+      FeedResponse<Record> pageFeed = (FeedResponse<Record>) mock(FeedResponse.class);
+      when(pageFeed.getResults()).thenReturn(page);
+      pagesFeed.add(pageFeed);
+    }
+
+    return new ScannerImpl(pagesFeed.iterator(), resultInterpreter);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SelectStatementHandlerTest.java
@@ -24,6 +24,7 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -31,7 +32,6 @@ import com.scalar.db.io.Key;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -134,7 +134,7 @@ public class SelectStatementHandlerTest {
   }
 
   @Test
-  public void handle_CosmosExceptionWithNotFound_ShouldReturnEmptyList() throws Exception {
+  public void handle_CosmosExceptionWithNotFound_ShouldReturnEmptyScanner() throws Exception {
     // Arrange
     CosmosException toThrow = mock(CosmosException.class);
     doThrow(toThrow)
@@ -145,10 +145,10 @@ public class SelectStatementHandlerTest {
     Get get = prepareGet();
 
     // Act Assert
-    List<Record> actual = handler.handle(get);
+    Scanner scanner = handler.handle(get);
 
     // Assert
-    assertThat(actual).isEmpty();
+    assertThat(scanner.all()).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/SingleRecordScannerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/SingleRecordScannerTest.java
@@ -1,0 +1,64 @@
+package com.scalar.db.storage.cosmos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Result;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SingleRecordScannerTest {
+  @Mock ResultInterpreter resultInterpreter;
+  @Mock Record record1;
+
+  @Mock Result result1;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    when(resultInterpreter.interpret(record1)).thenReturn(result1);
+  }
+
+  @Test
+  public void one_ShouldContainOnlyOneResult() {
+    // Arrange
+    SingleRecordScanner scanner = buildScanner(record1);
+
+    // Act
+    Optional<Result> actualResult = scanner.one();
+    Optional<Result> emptyResultForOne = scanner.one();
+    List<Result> emptyResultForAll = scanner.all();
+
+    // Assert
+    assertThat(actualResult).contains(result1);
+    assertThat(emptyResultForOne).isEmpty();
+    assertThat(emptyResultForAll).isEmpty();
+  }
+
+  @Test
+  public void all_ShouldContainOnlyOneResult() {
+    // Arrange
+    SingleRecordScanner scanner = buildScanner(record1);
+
+    // Act
+    List<Result> actualResult = scanner.all();
+    Optional<Result> emptyResultForOne = scanner.one();
+    List<Result> emptyResultForAll = scanner.all();
+
+    // Assert
+    assertThat(actualResult).containsExactly(result1);
+    assertThat(emptyResultForOne).isEmpty();
+    assertThat(emptyResultForAll).isEmpty();
+  }
+
+  private SingleRecordScanner buildScanner(Record record) {
+    return new SingleRecordScanner(record, resultInterpreter);
+  }
+}


### PR DESCRIPTION
This updates the Cosmos Adapter for Scan operation. Up until now, the `Scanner` object, returned by performing a Scan,  downloaded all at once the records eagerly. Now, the Scanner retrieves the records on demand page by page.