### PR TITLE
Add repair table command to the Schema Loader Tool

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/util/AdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/AdminTestUtils.java
@@ -21,7 +21,7 @@ public abstract class AdminTestUtils {
       case "jdbc":
         return new JdbcAdminTestUtils(properties);
       default:
-        return null;
+        return new CassandraAdminTestUtils();
     }
   }
 

--- a/core/src/integration-test/java/com/scalar/db/util/CassandraAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/CassandraAdminTestUtils.java
@@ -1,0 +1,18 @@
+package com.scalar.db.util;
+
+public class CassandraAdminTestUtils extends AdminTestUtils {
+
+  public CassandraAdminTestUtils() {
+    super();
+  }
+
+  @Override
+  public void dropMetadataTable() {
+    // Do nothing
+  }
+
+  @Override
+  public void truncateMetadataTable() {
+    // Do nothing
+  }
+}

--- a/schema-loader/README.md
+++ b/schema-loader/README.md
@@ -85,9 +85,8 @@ Create/Delete Cosmos DB schemas
   -p, --password=<key>   Cosmos DB key
   -r, --ru=<ru>          Base resource unit
       --repair-all       Repair tables : it repairs the table metadata of
-                               existing tables. When using Cosmos DB, it
-                               additionally repairs stored procedure attached
-                               to each table
+                           existing tables and repairs stored procedure
+                           attached to each table
 ```
 
 For DynamoDB (Deprecated. Please use the command using a config file instead):
@@ -109,9 +108,7 @@ Create/Delete DynamoDB schemas
   -r, --ru=<ru>              Base resource unit
       --region=<awsRegion>   AWS region
       --repair-all           Repair tables : it repairs the table metadata of
-                               existing tables. When using Cosmos DB, it
-                               additionally repairs stored procedure attached
-                               to each table
+                               existing tables
   -u, --user=<awsKeyId>      AWS access key ID
 ```
 
@@ -137,9 +134,7 @@ Create/Delete Cassandra schemas
   -R, --replication-factor=<replicationFactor>
                         Cassandra replication factor
       --repair-all     Repair tables : it repairs the table metadata of
-                               existing tables. When using Cosmos DB, it
-                               additionally repairs stored procedure attached
-                               to each table
+                         existing tables
   -u, --user=<user>     Cassandra user
 ```
 
@@ -155,9 +150,7 @@ Create/Delete JDBC schemas
   -p, --password=<password>
                          JDBC password
       --repair-all       Repair tables : it repairs the table metadata of
-                               existing tables. When using Cosmos DB, it
-                               additionally repairs stored procedure attached
-                               to each table
+                           existing tables
   -u, --user=<user>      JDBC user
 ```
 

--- a/schema-loader/README.md
+++ b/schema-loader/README.md
@@ -1,13 +1,13 @@
 # Scalar DB Schema Loader
 
-Scalar DB Schema Loader creates and deletes Scalar DB schemas (namespaces and tables) on the basis of a provided schema file.
+Scalar DB Schema Loader creates, deletes and repairs Scalar DB schemas (namespaces and tables) on the basis of a provided schema file.
 Also, it automatically adds the Scalar DB transaction metadata (used in the Consensus Commit protocol) to the tables when you set the `transaction` parameter to `true` in the schema file.
 
 There are two ways to specify general CLI options in Schema Loader:
   - Pass a Scalar DB configuration file and database/storage-specific options additionally.
   - Pass the options without a Scalar DB configuration (Deprecated).
 
-Note that this tool supports only basic options to create/delete a table.
+Note that this tool supports only basic options to create/delete/repair a table.
 If you want to use advanced features of the database, please alter your tables after creating them with this tool.
 
 # Usage
@@ -60,6 +60,10 @@ Create/Delete schemas in the storage defined in the config file
                       Path to the schema json file
       --no-backup     Disable continuous backup (supported in DynamoDB)
       --no-scaling    Disable auto-scaling (supported in DynamoDB, Cosmos DB)
+      --repair-all    Repair tables : it repairs the table metadata of
+                               existing tables. When using Cosmos DB, it
+                               additionally repairs stored procedure attached
+                               to each table
       --replication-factor=<replicaFactor>
                       The replication factor (supported in Cassandra)
       --replication-strategy=<replicationStrategy>
@@ -80,6 +84,10 @@ Create/Delete Cosmos DB schemas
       --no-scaling       Disable auto-scaling for Cosmos DB
   -p, --password=<key>   Cosmos DB key
   -r, --ru=<ru>          Base resource unit
+      --repair-all       Repair tables : it repairs the table metadata of
+                               existing tables. When using Cosmos DB, it
+                               additionally repairs stored procedure attached
+                               to each table
 ```
 
 For DynamoDB (Deprecated. Please use the command using a config file instead):
@@ -100,6 +108,10 @@ Create/Delete DynamoDB schemas
   -p, --password=<awsSecKey> AWS access secret key
   -r, --ru=<ru>              Base resource unit
       --region=<awsRegion>   AWS region
+      --repair-all           Repair tables : it repairs the table metadata of
+                               existing tables. When using Cosmos DB, it
+                               additionally repairs stored procedure attached
+                               to each table
   -u, --user=<awsKeyId>      AWS access key ID
 ```
 
@@ -124,6 +136,10 @@ Create/Delete Cassandra schemas
   -P, --port=<port>     Cassandra Port
   -R, --replication-factor=<replicationFactor>
                         Cassandra replication factor
+      --repair-all     Repair tables : it repairs the table metadata of
+                               existing tables. When using Cosmos DB, it
+                               additionally repairs stored procedure attached
+                               to each table
   -u, --user=<user>     Cassandra user
 ```
 
@@ -138,6 +154,10 @@ Create/Delete JDBC schemas
   -j, --jdbc-url=<url>   JDBC URL
   -p, --password=<password>
                          JDBC password
+      --repair-all       Repair tables : it repairs the table metadata of
+                               existing tables. When using Cosmos DB, it
+                               additionally repairs stored procedure attached
+                               to each table
   -u, --user=<user>      JDBC user
 ```
 
@@ -207,6 +227,36 @@ $ java -jar scalardb-schema-loader-<version>.jar --cassandra -h <CASSANDRA_IP> [
 $ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> -p <PASSWORD> -f schema.json -D
 ```
 
+### Repair tables
+
+This command will repair the table metadata of existing tables. When using Cosmos DB, it additionally repairs stored procedure attached to each table.
+
+For using config file (Sample config file can be found [here](../conf/database.properties)):
+```console
+$ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> -f schema.json [--coordinator] --repair-all 
+```
+- if `--coordinator` is specified, the coordinator tables will be repaired as well.
+
+For using CLI arguments fully for configuration (Deprecated. Please use the command using a config file instead):
+```console
+# For Cosmos DB
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json --repair-all
+```
+
+```console
+# For DynamoDB
+$ java -jar scalardb-schema-loader-<version>.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> [--no-backup] -f schema.json --repair-all
+```
+
+```console
+# For Cassandra
+$ java -jar scalardb-schema-loader-<version>.jar --cassandra -h <CASSANDRA_IP> [-P <CASSANDRA_PORT>] [-u <CASSNDRA_USER>] [-p <CASSANDRA_PASSWORD>] -f schema.json --repair-all
+```
+
+```console
+# For a JDBC database
+$ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> -p <PASSWORD> -f schema.json --repair-all
+```
 ### Sample schema file
 ```json
 {
@@ -341,8 +391,8 @@ dependencies {
 }
 ```
 
-### Create and delete tables
-You can create and delete tables that are defined in the schema using SchemaLoader by simply passing Scalar DB configuration file, schema, and additional options if needed as shown below.
+### Create, delete and repair tables
+You can create, delete or repair tables that are defined in the schema using SchemaLoader by simply passing Scalar DB configuration file, schema, and additional options if needed as shown below.
 
 ```java
 public class SchemaLoaderSample {
@@ -368,19 +418,25 @@ public class SchemaLoaderSample {
 
     // Delete tables
     SchemaLoader.unload(configFilePath, schemaFilePath, deleteCoordinatorTables);
+    
+    // Repair tables
+    SchemaLoader.repairTables(configFilePath, schemaFilePath, options, deleteCoordinatorTables);
 
     return 0;
   }
 }
 ```
 
-You can also create and delete a schema by passing a serialized schema JSON string (the raw text of a schema file).
+You can also create, delete or repair a schema by passing a serialized schema JSON string (the raw text of a schema file).
 ```java
 // Create tables
 SchemaLoader.load(configFilePath, serializedSchemaJson, options, createCoordinatorTables);
 
 // Delete tables
 SchemaLoader.unload(configFilePath, serializedSchemaJson, deleteCoordinatorTables);
+
+// Repair tables
+SchemaLoader.repairTables(configFilePath, serializedSchemaJson, options, deleteCoordinatorTables);
 ```
 
 For Scalar DB configuration, a `Properties` object can be used as well.
@@ -390,4 +446,7 @@ SchemaLoader.load(properties, serializedSchemaJson, options, createCoordinatorTa
 
 // Delete tables
 SchemaLoader.unload(properties, serializedSchemaJson, deleteCoordinatorTables);
+
+// Repair tables
+SchemaLoader.repairTables(properties, serializedSchemaJson, options, deleteCoordinatorTables);
 ```

--- a/schema-loader/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
@@ -33,7 +33,20 @@ public class CassandraSchemaLoaderWithStorageSpecificArgsIntegrationTest
         config.getPassword().get());
   }
 
+  @Override
+  protected List<String> getCommandArgsForTableReparationWithCoordinator(
+      String configFile, String schemaFile) throws Exception {
+    return ImmutableList.<String>builder()
+        .addAll(getCommandArgsForCreationWithCoordinator(configFile, schemaFile))
+        .add("--repair-all")
+        .build();
+  }
+
   @Disabled
   @Override
   public void createTablesThenDeleteTables_ShouldExecuteProperly() {}
+
+  @Disabled
+  @Override
+  public void createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly() {}
 }

--- a/schema-loader/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
@@ -57,7 +57,20 @@ public class CosmosSchemaLoaderWithStorageSpecificArgsIntegrationTest
     return builder.build();
   }
 
+  @Override
+  protected List<String> getCommandArgsForTableReparationWithCoordinator(
+      String configFile, String schemaFile) throws Exception {
+    return ImmutableList.<String>builder()
+        .addAll(getCommandArgsForCreationWithCoordinator(configFile, schemaFile))
+        .add("--repair-all")
+        .build();
+  }
+
   @Disabled
   @Override
   public void createTablesThenDeleteTables_ShouldExecuteProperly() {}
+
+  @Disabled
+  @Override
+  public void createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly() {}
 }

--- a/schema-loader/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
@@ -21,4 +21,12 @@ public class DynamoSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTe
         .add("--no-backup")
         .build();
   }
+
+  @Override
+  protected List<String> getCommandArgsForTableReparation(String configFile, String schemaFile) {
+    return ImmutableList.<String>builder()
+        .addAll(super.getCommandArgsForTableReparation(configFile, schemaFile))
+        .add("--no-backup")
+        .build();
+  }
 }

--- a/schema-loader/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
@@ -37,7 +37,20 @@ public class DynamoSchemaLoaderWithStorageSpecificArgsIntegrationTest
         "--no-backup");
   }
 
+  @Override
+  protected List<String> getCommandArgsForTableReparationWithCoordinator(
+      String configFile, String schemaFile) throws Exception {
+    return ImmutableList.<String>builder()
+        .addAll(getCommandArgsForCreationWithCoordinator(configFile, schemaFile))
+        .add("--repair-all")
+        .build();
+  }
+
   @Disabled
   @Override
   public void createTablesThenDeleteTables_ShouldExecuteProperly() {}
+
+  @Disabled
+  @Override
+  public void createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly() {}
 }

--- a/schema-loader/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderWithStorageSpecificArgsIntegrationTest.java
@@ -33,7 +33,20 @@ public class JdbcSchemaLoaderWithStorageSpecificArgsIntegrationTest
         config.getPassword().get());
   }
 
+  @Override
+  protected List<String> getCommandArgsForTableReparationWithCoordinator(
+      String configFile, String schemaFile) throws Exception {
+    return ImmutableList.<String>builder()
+        .addAll(getCommandArgsForCreationWithCoordinator(configFile, schemaFile))
+        .add("--repair-all")
+        .build();
+  }
+
   @Disabled
   @Override
   public void createTablesThenDeleteTables_ShouldExecuteProperly() {}
+
+  @Disabled
+  @Override
+  public void createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly() {}
 }

--- a/schema-loader/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
@@ -3,10 +3,10 @@ package com.scalar.db.storage.multistorage;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 
 public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTestBase {
-
   @Override
   protected Properties getProperties() {
     Properties props = new Properties();
@@ -68,5 +68,21 @@ public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegra
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "storage1");
 
     return props;
+  }
+
+  @Override
+  protected void dropMetadataTable() throws Exception {
+    AdminTestUtils storage1AdminUtils =
+        AdminTestUtils.create(MultiStorageEnv.getPropertiesForStorage1());
+    storage1AdminUtils.dropMetadataTable();
+    AdminTestUtils storage2AdminUtils =
+        AdminTestUtils.create(MultiStorageEnv.getPropertiesForStorage2());
+    storage2AdminUtils.dropMetadataTable();
+  }
+
+  @Override
+  protected void assertTableMetadataForCoordinatorTableArePresent() throws Exception {
+    assertTableMetadataForCoordinatorTableArePresentForStorage(
+        MultiStorageEnv.getPropertiesForStorage1());
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -274,6 +274,109 @@ public class SchemaLoader {
       operator.close();
     }
   }
+  /**
+   * Repair tables defined in the schema.
+   *
+   * @param configProperties Scalar DB config properties
+   * @param serializedSchemaJson serialized json string schema.
+   * @param options specific options for creating tables.
+   * @param repairCoordinatorTable repair coordinator tables or not.
+   * @throws SchemaLoaderException thrown when creating tables failed.
+   */
+  public static void repairTables(
+      Properties configProperties,
+      String serializedSchemaJson,
+      Map<String, String> options,
+      boolean repairCoordinatorTable)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Right<>(configProperties);
+    Either<Path, String> schema = new Right<>(serializedSchemaJson);
+    repairTables(config, schema, options, repairCoordinatorTable);
+  }
+  /**
+   * Repair tables defined in the schema file.
+   *
+   * @param configProperties Scalar DB properties.
+   * @param schemaPath path to the schema file.
+   * @param options specific options for creating tables.
+   * @param repairCoordinatorTable repair coordinator tables or not.
+   * @throws SchemaLoaderException thrown when creating tables failed.
+   */
+  public static void repairTables(
+      Properties configProperties,
+      Path schemaPath,
+      Map<String, String> options,
+      boolean repairCoordinatorTable)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Right<>(configProperties);
+    Either<Path, String> schema = new Left<>(schemaPath);
+    repairTables(config, schema, options, repairCoordinatorTable);
+  }
+
+  /**
+   * Repair tables defined in the schema.
+   *
+   * @param configPath path to the Scalar DB config.
+   * @param serializedSchemaJson serialized json string schema.
+   * @param options specific options for creating tables.
+   * @param repairCoordinatorTable repair coordinator tables or not.
+   * @throws SchemaLoaderException thrown when creating tables failed.
+   */
+  public static void repairTables(
+      Path configPath,
+      String serializedSchemaJson,
+      Map<String, String> options,
+      boolean repairCoordinatorTable)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Left<>(configPath);
+    Either<Path, String> schema = new Right<>(serializedSchemaJson);
+    repairTables(config, schema, options, repairCoordinatorTable);
+  }
+  /**
+   * Repair tables defined in the schema file.
+   *
+   * @param configPath path to the Scalar DB config.
+   * @param schemaPath path to the schema file.
+   * @param options specific options for creating tables.
+   * @param repairCoordinatorTable repair coordinator tables or not.
+   * @throws SchemaLoaderException thrown when creating tables failed.
+   */
+  public static void repairTables(
+      Path configPath, Path schemaPath, Map<String, String> options, boolean repairCoordinatorTable)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Left<>(configPath);
+    Either<Path, String> schema = new Left<>(schemaPath);
+    repairTables(config, schema, options, repairCoordinatorTable);
+  }
+  /**
+   * Repair tables defined in the schema file.
+   *
+   * @param config Scalar DB config
+   * @param schema schema.
+   * @param options specific options for creating tables.
+   * @param repairCoordinatorTable repair coordinator tables or not.
+   * @throws SchemaLoaderException thrown when creating tables failed.
+   */
+  private static void repairTables(
+      Either<Path, Properties> config,
+      Either<Path, String> schema,
+      Map<String, String> options,
+      boolean repairCoordinatorTable)
+      throws SchemaLoaderException {
+    // Parse the schema
+    List<TableSchema> tableSchemaList = getTableSchemaList(schema, options);
+
+    // Repair tables
+    SchemaOperator operator = getSchemaOperator(config);
+    try {
+      operator.repairTables(tableSchemaList);
+      if (repairCoordinatorTable) {
+        operator.repairCoordinatorTables(options);
+      }
+    } finally {
+      operator.close();
+    }
+  }
 
   @VisibleForTesting
   static SchemaOperator getSchemaOperator(Either<Path, Properties> config)

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CassandraCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CassandraCommand.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -55,6 +56,9 @@ public class CassandraCommand extends StorageSpecificCommand implements Callable
       description = "Cassandra replication factor")
   private String replicationFactor;
 
+  @ArgGroup(exclusive = true)
+  DeleteOrRepairTables deleteOrRepairTables;
+
   @Override
   public Integer call() throws SchemaLoaderException {
     Properties props = new Properties();
@@ -79,5 +83,10 @@ public class CassandraCommand extends StorageSpecificCommand implements Callable
 
     execute(props, options);
     return 0;
+  }
+
+  @Override
+  DeleteOrRepairTables getDeleteOrRepairTables() {
+    return deleteOrRepairTables;
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CassandraCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CassandraCommand.java
@@ -57,7 +57,7 @@ public class CassandraCommand extends StorageSpecificCommand implements Callable
   private String replicationFactor;
 
   @ArgGroup(exclusive = true)
-  DeleteOrRepairTables deleteOrRepairTables;
+  private DeleteOrRepairTables deleteOrRepairTables;
 
   @Override
   public Integer call() throws SchemaLoaderException {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CosmosCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CosmosCommand.java
@@ -62,7 +62,7 @@ public class CosmosCommand extends StorageSpecificCommand implements Callable<In
   private String coordinatorNamespacePrefix;
 
   @ArgGroup(exclusive = true)
-  DeleteOrRepairCosmosTables deleteOrRepairCosmosTables;
+  private DeleteOrRepairCosmosTables deleteOrRepairCosmosTables;
 
   /**
    * To be able to have a "--repair-all" option description that is different only for the
@@ -71,7 +71,7 @@ public class CosmosCommand extends StorageSpecificCommand implements Callable<In
    * StorageSpecificCommand.DeleteOrRepairTables} is the {@link
    * DeleteOrRepairCosmosTables#repairTables} description value
    */
-  static class DeleteOrRepairCosmosTables {
+  private static class DeleteOrRepairCosmosTables {
 
     @Option(
         names = {"-D", "--delete-all"},

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/DynamoCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/DynamoCommand.java
@@ -49,7 +49,7 @@ public class DynamoCommand extends StorageSpecificCommand implements Callable<In
   private String endpointOverride;
 
   @ArgGroup(exclusive = true)
-  DeleteOrRepairTables deleteOrRepairTables;
+  private DeleteOrRepairTables deleteOrRepairTables;
 
   @Override
   public Integer call() throws SchemaLoaderException {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/DynamoCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/DynamoCommand.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -47,6 +48,9 @@ public class DynamoCommand extends StorageSpecificCommand implements Callable<In
       description = "Endpoint with which the DynamoDB SDK should communicate")
   private String endpointOverride;
 
+  @ArgGroup(exclusive = true)
+  DeleteOrRepairTables deleteOrRepairTables;
+
   @Override
   public Integer call() throws SchemaLoaderException {
     Properties props = new Properties();
@@ -72,5 +76,10 @@ public class DynamoCommand extends StorageSpecificCommand implements Callable<In
 
     execute(props, options);
     return 0;
+  }
+
+  @Override
+  DeleteOrRepairTables getDeleteOrRepairTables() {
+    return deleteOrRepairTables;
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/JdbcCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/JdbcCommand.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -31,6 +32,9 @@ public class JdbcCommand extends StorageSpecificCommand implements Callable<Inte
       required = true)
   private String password;
 
+  @ArgGroup(exclusive = true)
+  DeleteOrRepairTables deleteOrRepairTables;
+
   @Override
   public Integer call() throws Exception {
     Properties props = new Properties();
@@ -43,5 +47,10 @@ public class JdbcCommand extends StorageSpecificCommand implements Callable<Inte
 
     execute(props, options);
     return 0;
+  }
+
+  @Override
+  DeleteOrRepairTables getDeleteOrRepairTables() {
+    return deleteOrRepairTables;
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/JdbcCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/JdbcCommand.java
@@ -33,7 +33,7 @@ public class JdbcCommand extends StorageSpecificCommand implements Callable<Inte
   private String password;
 
   @ArgGroup(exclusive = true)
-  DeleteOrRepairTables deleteOrRepairTables;
+  private DeleteOrRepairTables deleteOrRepairTables;
 
   @Override
   public Integer call() throws Exception {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -66,9 +66,9 @@ public class SchemaLoaderCommand implements Callable<Integer> {
   private Path schemaFile;
 
   @ArgGroup(exclusive = true)
-  DeleteOrRepairTables deleteOrRepairTables;
+  private DeleteOrRepairTables deleteOrRepairTables;
 
-  static class DeleteOrRepairTables {
+  private static class DeleteOrRepairTables {
     @Option(
         names = {"-D", "--delete-all"},
         description = "Delete tables",

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -66,9 +66,9 @@ public class SchemaLoaderCommand implements Callable<Integer> {
   private Path schemaFile;
 
   @ArgGroup(exclusive = true)
-  DeleteOrRepairTablesTables deleteOrRepairTables;
+  DeleteOrRepairTables deleteOrRepairTables;
 
-  static class DeleteOrRepairTablesTables {
+  static class DeleteOrRepairTables {
     @Option(
         names = {"-D", "--delete-all"},
         description = "Delete tables",

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/StorageSpecificCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/StorageSpecificCommand.java
@@ -6,12 +6,14 @@ import com.scalar.db.schemaloader.SchemaLoaderException;
 import com.scalar.db.schemaloader.SchemaOperator;
 import com.scalar.db.schemaloader.SchemaParser;
 import com.scalar.db.schemaloader.TableSchema;
+import com.scalar.db.schemaloader.command.SchemaLoaderCommand.DeleteOrRepairTablesTables;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Option;
 
 public abstract class StorageSpecificCommand {
@@ -23,11 +25,24 @@ public abstract class StorageSpecificCommand {
       required = true)
   private Path schemaFile;
 
-  @Option(
-      names = {"-D", "--delete-all"},
-      description = "Delete tables",
-      defaultValue = "false")
-  private boolean deleteTables;
+  @ArgGroup(exclusive = true)
+  DeleteOrRepairTablesTables deleteOrRepairTables;
+
+  static class DeleteOrRepair {
+
+    @Option(
+        names = {"-D", "--delete-all"},
+        description = "Delete tables",
+        defaultValue = "false")
+    boolean deleteTables;
+
+    @Option(
+        names = {"--repair-all"},
+        description =
+            "Repair tables : it repairs the table metadata of existing tables. When using Cosmos DB, it additionally repairs stored procedure attached to each table",
+        defaultValue = "false")
+    boolean repairTables;
+  }
 
   protected void execute(Properties props, Map<String, String> options)
       throws SchemaLoaderException {
@@ -43,15 +58,20 @@ public abstract class StorageSpecificCommand {
       boolean hasTransactionalTable =
           tableSchemaList.stream().anyMatch(TableSchema::isTransactionalTable);
 
-      if (!deleteTables) {
+      if (deleteOrRepairTables == null) {
         operator.createTables(tableSchemaList);
         if (hasTransactionalTable) {
           operator.createCoordinatorTables(options);
         }
-      } else {
+      } else if (deleteOrRepairTables.deleteTables) {
         operator.deleteTables(tableSchemaList);
         if (hasTransactionalTable) {
           operator.dropCoordinatorTables();
+        }
+      } else {
+        operator.repairTables(tableSchemaList);
+        if (hasTransactionalTable) {
+          operator.repairCoordinatorTables(options);
         }
       }
     } finally {

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
@@ -31,7 +31,7 @@ public class SchemaLoaderTest {
   @Mock private Path configFilePath;
   @Mock private Properties configProperties;
   @Mock private Path schemaFilePath;
-  @Mock private Path serializedSchemaJson;
+  private static final String SERIALIZED_SCHEMA_JSON = "some_schema";
   @Mock private Map<String, String> options;
 
   @BeforeEach
@@ -121,7 +121,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.load(configFilePath, serializedSchemaJson, options, true);
+    SchemaLoader.load(configFilePath, SERIALIZED_SCHEMA_JSON, options, true);
 
     // Assert
     verify(parser).parse();
@@ -136,7 +136,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.load(configFilePath, serializedSchemaJson, options, false);
+    SchemaLoader.load(configFilePath, SERIALIZED_SCHEMA_JSON, options, false);
 
     // Assert
     verify(parser).parse();
@@ -241,7 +241,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.load(configProperties, serializedSchemaJson, options, true);
+    SchemaLoader.load(configProperties, SERIALIZED_SCHEMA_JSON, options, true);
 
     // Assert
     verify(parser).parse();
@@ -256,7 +256,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.load(configProperties, serializedSchemaJson, options, false);
+    SchemaLoader.load(configProperties, SERIALIZED_SCHEMA_JSON, options, false);
 
     // Assert
     verify(parser).parse();
@@ -361,7 +361,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.unload(configFilePath, serializedSchemaJson, true);
+    SchemaLoader.unload(configFilePath, SERIALIZED_SCHEMA_JSON, true);
 
     // Assert
     verify(parser).parse();
@@ -376,7 +376,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.unload(configFilePath, serializedSchemaJson, false);
+    SchemaLoader.unload(configFilePath, SERIALIZED_SCHEMA_JSON, false);
 
     // Assert
     verify(parser).parse();
@@ -481,7 +481,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.unload(configProperties, serializedSchemaJson, true);
+    SchemaLoader.unload(configProperties, SERIALIZED_SCHEMA_JSON, true);
 
     // Assert
     verify(parser).parse();
@@ -496,7 +496,7 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.unload(configProperties, serializedSchemaJson, false);
+    SchemaLoader.unload(configProperties, SERIALIZED_SCHEMA_JSON, false);
 
     // Assert
     verify(parser).parse();
@@ -532,5 +532,125 @@ public class SchemaLoaderTest {
     verify(parser, never()).parse();
     verify(operator).deleteTables(anyList());
     verify(operator, never()).dropCoordinatorTables();
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigFilePathAndSerializedSchemaAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configFilePath, SERIALIZED_SCHEMA_JSON, options, true);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator).repairCoordinatorTables(options);
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigFilePathAndSerializedSchemaAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configFilePath, SERIALIZED_SCHEMA_JSON, options, false);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator, never()).repairCoordinatorTables(anyMap());
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigPropertiesAndSerializedSchemaAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configProperties, SERIALIZED_SCHEMA_JSON, options, true);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator).repairCoordinatorTables(options);
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigPropertiesAndSerializedSchemaAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configProperties, SERIALIZED_SCHEMA_JSON, options, false);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator, never()).repairCoordinatorTables(anyMap());
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigPropertiesAndSchemaFilePathAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configProperties, schemaFilePath, options, true);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator).repairCoordinatorTables(options);
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigPropertiesAndSchemaFilePathAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configProperties, schemaFilePath, options, false);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator, never()).repairCoordinatorTables(anyMap());
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigFilePathAndSchemaFilePathAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configFilePath, schemaFilePath, options, true);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator).repairCoordinatorTables(options);
+  }
+
+  @Test
+  public void
+      repairTable_WithConfigFilePathAndSchemaFilePathAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.repairTables(configFilePath, schemaFilePath, options, false);
+
+    // Assert
+    verify(parser).parse();
+    verify(operator).repairTables(anyList());
+    verify(operator, never()).repairCoordinatorTables(anyMap());
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CassandraCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CassandraCommandTest.java
@@ -189,6 +189,56 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
   }
 
   @Test
+  public void
+      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionalTableSchema_ShouldCallRepairTablesProperly()
+          throws SchemaLoaderException {
+    callProperArgumentsForRepairingTables(false);
+  }
+
+  @Test
+  public void
+      call_ProperArgumentsForRepairingTablesGivenWithTransactionalTableSchema_ShouldCallRepairTablesProperly()
+          throws SchemaLoaderException {
+    callProperArgumentsForRepairingTables(true);
+  }
+
+  private void callProperArgumentsForRepairingTables(boolean hasTransactionTables)
+      throws SchemaLoaderException {
+    // Arrange
+    Map<String, String> options = ImmutableMap.of();
+
+    TableSchema tableSchema = mock(TableSchema.class);
+    if (hasTransactionTables) {
+      when(tableSchema.isTransactionalTable()).thenReturn(true);
+    } else {
+      when(tableSchema.isTransactionalTable()).thenReturn(false);
+    }
+    when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
+
+    Properties properties = new Properties();
+    properties.setProperty(DatabaseConfig.CONTACT_POINTS, host);
+    properties.setProperty(DatabaseConfig.CONTACT_PORT, port);
+    properties.setProperty(DatabaseConfig.USERNAME, user);
+    properties.setProperty(DatabaseConfig.PASSWORD, password);
+    properties.setProperty(DatabaseConfig.STORAGE, "cassandra");
+
+    // Act
+    commandLine.execute(
+        "-h", host, "-P", port, "-u", user, "-p", password, "-f", schemaFile, "--repair-all");
+
+    // Assert
+    verify(command).getSchemaParser(options);
+    verify(parser).parse();
+    verify(command).getSchemaOperator(properties);
+    verify(operator).repairTables(anyList());
+    if (hasTransactionTables) {
+      verify(operator).repairCoordinatorTables(options);
+    } else {
+      verify(operator, never()).repairCoordinatorTables(options);
+    }
+  }
+
+  @Test
   public void call_WithInvalidReplicationStrategy_ShouldExitWithErrorCode() {
     // Arrange
     String replicationStrategy = "InvalidStrategy";

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
@@ -193,6 +193,56 @@ public class SchemaLoaderCommandTest {
 
   @Test
   public void
+      call_WithProperArgumentsForRepairingTablesWithoutCoordinatorArgument_ShouldCallRepairTableProperly() {
+    // Arrange
+    String schemaFile = "path_to_file";
+    String configFile = "path_to_config_file";
+    Map<String, String> options = ImmutableMap.of(DynamoAdmin.NO_BACKUP, noBackup.toString());
+
+    // Act
+    commandLine.execute("-f", schemaFile, "--repair-all", "--config", configFile, "--no-backup");
+
+    // Assert
+    schemaLoaderMockedStatic.verify(
+        () ->
+            SchemaLoader.repairTables(
+                Paths.get(configFile), Paths.get(schemaFile), options, false));
+  }
+
+  @Test
+  public void
+      call_WithProperArgumentsForRepairingTablesWithCoordinatorArgument_ShouldCallRepairTableProperly() {
+    // Arrange
+    String schemaFile = "path_to_file";
+    String configFile = "path_to_config_file";
+    Map<String, String> options = ImmutableMap.of(DynamoAdmin.NO_BACKUP, noBackup.toString());
+
+    // Act
+    commandLine.execute(
+        "-f", schemaFile, "--repair-all", "--config", configFile, "--coordinator", "--no-backup");
+
+    // Assert
+    schemaLoaderMockedStatic.verify(
+        () ->
+            SchemaLoader.repairTables(Paths.get(configFile), Paths.get(schemaFile), options, true));
+  }
+
+  @Test
+  public void call_forRepairingTablesWithoutSchemaFile_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    String configFile = "path_to_config_file";
+
+    // Act
+    int exitCode =
+        commandLine.execute("--repair-all", "--config", configFile, "--coordinator", "--no-backup");
+
+    // Assert
+    Assertions.assertThat(exitCode).isEqualTo(1);
+    schemaLoaderMockedStatic.verifyNoInteractions();
+  }
+
+  @Test
+  public void
       call_WithProperArgumentsForDeletingTablesWithoutSchemaFileArgument_ShouldCallUnloadProperly() {
     // Arrange
     String configFile = "path_to_config_file";


### PR DESCRIPTION
This adds a `--repair-all` command the Schema Loader Tool used to repair the tables present in the schema file.

For the detailed command usage, please refer to the "Repair table" section in the [readme](https://github.com/scalar-labs/scalardb/blob/d97fe328c9ee460af0db366e899f96bcef861935/schema-loader/README.md#repair-tables).