### PR TITLE
Remove non useful operation in ScannerImpl from the Cosmos DB adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/ScannerImpl.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ScannerImpl.java
@@ -43,11 +43,9 @@ public final class ScannerImpl implements Scanner {
       // Return the next record of the current page if there is one
       if (currentPageRecords.hasNext()) {
         Record currentRecord = currentPageRecords.next();
-        Optional<Result> ret = Optional.of(resultInterpreter.interpret(currentRecord));
-        currentPageRecords.remove();
-        return ret;
-        // Otherwise, advance to the next page
+        return Optional.of(resultInterpreter.interpret(currentRecord));
       } else {
+        // Otherwise, advance to the next page
         currentPageRecords = recordsPages.next().getResults().iterator();
       }
     }


### PR DESCRIPTION
This updates the ScannerImpl of the Cosmos DB adapter according to this PR comments that could not be applied before the merge on master. 
https://github.com/scalar-labs/scalardb/pull/619#discussion_r910671596
https://github.com/scalar-labs/scalardb/pull/619#discussion_r910672615