### PR TITLE
Rename getCreateOptions() to getCreationOptions() in integration tests

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -102,7 +102,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     for (String namespace : Arrays.asList(namespace1, namespace2)) {
       admin.createNamespace(namespace, true, options);
       for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
@@ -111,7 +111,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     }
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 
@@ -276,7 +276,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
 
       // Act
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
@@ -310,7 +310,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   public void dropTable_ForExistingTable_ShouldDropTableProperly() throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
 
       // Act
@@ -403,7 +403,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   public void createIndex_ShouldCreateIndexCorrectly() throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
 
       // Act
@@ -422,7 +422,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   public void dropIndex_ShouldDropIndexCorrectly() throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
 
       // Act

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
@@ -78,12 +78,12 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
   }
 
   private void createTable() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(getNamespace(), options);
     admin.createTable(getNamespace(), getTable(), TABLE_METADATA, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 
@@ -119,7 +119,7 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
     adminTestUtils.dropMetadataTable();
 
     // Act
-    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
 
     // Assert
     assertThat(admin.tableExists(getNamespace(), getTable())).isTrue();
@@ -132,7 +132,7 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
     adminTestUtils.truncateMetadataTable();
 
     // Act
-    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
 
     // Assert
     assertThat(admin.tableExists(getNamespace(), getTable())).isTrue();

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -74,7 +74,7 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
   }
 
   private void createTable() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     admin.createTable(
         namespace,
@@ -94,7 +94,7 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
         options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -111,12 +111,12 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
   }
 
   private void createTable() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     admin.createTable(namespace, TABLE, TABLE_METADATA, true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -75,7 +75,7 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   private void createTable() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     admin.createTable(
         namespace,
@@ -95,7 +95,7 @@ public abstract class DistributedStorageIntegrationTestBase {
         options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -113,7 +113,7 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
   private void createTables() throws java.util.concurrent.ExecutionException, InterruptedException {
     List<Callable<Void>> testCallables = new ArrayList<>();
 
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     for (DataType firstClusteringKeyType : clusteringKeyTypes.keySet()) {
       Callable<Void> testCallable =
           () -> {
@@ -143,7 +143,7 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
     executeInParallel(testCallables.subList(1, testCallables.size()));
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
@@ -95,7 +95,7 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
   private void createTables() throws java.util.concurrent.ExecutionException, InterruptedException {
     List<Callable<Void>> testCallables = new ArrayList<>();
 
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     for (DataType firstPartitionKeyType : partitionKeyTypes.keySet()) {
       Callable<Void> testCallable =
           () -> {
@@ -115,7 +115,7 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
     executeInParallel(testCallables.subList(1, testCallables.size()));
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
@@ -69,14 +69,14 @@ public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     for (DataType secondaryIndexType : secondaryIndexTypes) {
       createTable(secondaryIndexType, options);
     }
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -81,7 +81,7 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     for (DataType clusteringKeyType : clusteringKeyTypes) {
       for (Order clusteringOrder : Order.values()) {
@@ -90,7 +90,7 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
     }
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
@@ -70,14 +70,14 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     for (DataType partitionKeyType : partitionKeyTypes) {
       createTable(partitionKeyType, options);
     }
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageWithReservedKeywordIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageWithReservedKeywordIntegrationTestBase.java
@@ -77,7 +77,7 @@ public abstract class DistributedStorageWithReservedKeywordIntegrationTestBase {
   protected abstract String getColumnName5();
 
   private void createTable() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     admin.createTable(
         namespace,
@@ -96,7 +96,7 @@ public abstract class DistributedStorageWithReservedKeywordIntegrationTestBase {
         options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -104,7 +104,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     for (String namespace : Arrays.asList(namespace1, namespace2)) {
       admin.createNamespace(namespace, true, options);
       for (String table : Arrays.asList(TABLE1, TABLE2, TABLE3)) {
@@ -114,7 +114,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     admin.createCoordinatorTables(true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 
@@ -280,7 +280,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
 
       // Act
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
@@ -314,7 +314,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   public void dropTable_ForExistingTable_ShouldDropTableProperly() throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
 
       // Act
@@ -411,7 +411,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   public void createIndex_ShouldCreateIndexCorrectly() throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
 
       // Act
@@ -430,7 +430,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   public void dropIndex_ShouldDropIndexCorrectly() throws ExecutionException {
     try {
       // Arrange
-      Map<String, String> options = getCreateOptions();
+      Map<String, String> options = getCreationOptions();
       admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
 
       // Act

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
@@ -81,13 +81,13 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
   }
 
   private void createTable() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(getNamespace(), options);
     admin.createTable(getNamespace(), getTable(), TABLE_METADATA, options);
     admin.createCoordinatorTables(true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 
@@ -126,8 +126,8 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
     adminTestUtils.dropMetadataTable();
 
     // Act
-    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
-    admin.repairCoordinatorTables(getCreateOptions());
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
+    admin.repairCoordinatorTables(getCreationOptions());
 
     // Assert
     assertThat(admin.tableExists(getNamespace(), TABLE)).isTrue();
@@ -145,8 +145,8 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
     adminTestUtils.truncateMetadataTable();
 
     // Act
-    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
-    admin.repairCoordinatorTables(getCreateOptions());
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
+    admin.repairCoordinatorTables(getCreationOptions());
 
     // Assert
     assertThat(admin.tableExists(getNamespace(), TABLE)).isTrue();

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -75,7 +75,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     admin.createTable(
         namespace,
@@ -94,7 +94,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     admin.createCoordinatorTables(true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -75,7 +75,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     admin.createNamespace(namespace, true, options);
     admin.createTable(
         namespace,
@@ -94,7 +94,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     admin.createCoordinatorTables(true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminRepairTableIntegrationTest.java
@@ -31,7 +31,8 @@ public class CassandraAdminRepairTableIntegrationTest
   public void repairTable_ShouldDoNothing() throws ExecutionException {
     // Act
     assertThatCode(
-            () -> admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions()))
+            () ->
+                admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions()))
         .doesNotThrowAnyException();
 
     // Assert

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminRepairTableIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminRepairTableIntegrationTestWithCassandra.java
@@ -32,8 +32,8 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCassandra
     // Act
     assertThatCode(
             () -> {
-              admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
-              admin.repairCoordinatorTables(getCreateOptions());
+              admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
+              admin.repairCoordinatorTables(getCreationOptions());
             })
         .doesNotThrowAnyException();
 

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -34,7 +34,7 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminRepairTableIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminRepairTableIntegrationTestWithCosmos.java
@@ -29,8 +29,8 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCosmos
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 
   @Test
@@ -41,7 +41,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCosmos
     cosmosAdminTestUtils.getTableStoredProcedure(getNamespace(), getTable()).delete();
 
     // Act
-    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
 
     // Assert
     assertThatCode(

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitIntegrationTestWithCosmos.java
@@ -20,7 +20,7 @@ public class ConsensusCommitIntegrationTestWithCosmos extends ConsensusCommitInt
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitSpecificIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitSpecificIntegrationTestWithCosmos.java
@@ -29,7 +29,7 @@ public class ConsensusCommitSpecificIntegrationTestWithCosmos
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -33,7 +33,7 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminRepairTableIntegrationTest.java
@@ -29,8 +29,8 @@ public class CosmosAdminRepairTableIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 
   @Test
@@ -41,7 +41,7 @@ public class CosmosAdminRepairTableIntegrationTest
     cosmosAdminTestUtils.getTableStoredProcedure(getNamespace(), getTable()).delete();
 
     // Act
-    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreateOptions());
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
 
     // Assert
     assertThatCode(

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosColumnValueIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosColumnValueIntegrationTest.java
@@ -20,7 +20,7 @@ public class CosmosColumnValueIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosConditionalMutationIntegrationTest.java
@@ -29,8 +29,8 @@ public class CosmosConditionalMutationIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
@@ -42,7 +42,7 @@ public final class CosmosEnv {
     return Optional.ofNullable(System.getProperty(PROP_COSMOS_DATABASE_PREFIX));
   }
 
-  public static Map<String, String> getCreateOptions() {
+  public static Map<String, String> getCreationOptions() {
     String createOptionsString = System.getProperty(PROP_COSMOS_CREATE_OPTIONS);
     if (createOptionsString == null) {
       return DEFAULT_COSMOS_CREATE_OPTIONS;

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -20,7 +20,7 @@ public class CosmosIntegrationTest extends DistributedStorageIntegrationTestBase
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
@@ -47,7 +47,7 @@ public class CosmosMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
@@ -25,7 +25,7 @@ public class CosmosMultiplePartitionKeyIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSecondaryIndexIntegrationTest.java
@@ -20,7 +20,7 @@ public class CosmosSecondaryIndexIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSingleClusteringKeyScanIntegrationTest.java
@@ -36,7 +36,7 @@ public class CosmosSingleClusteringKeyScanIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSinglePartitionKeyIntegrationTest.java
@@ -20,7 +20,7 @@ public class CosmosSinglePartitionKeyIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosWithReservedKeywordIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosWithReservedKeywordIntegrationTest.java
@@ -57,7 +57,7 @@ public class CosmosWithReservedKeywordIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitIntegrationTestWithCosmos.java
@@ -21,7 +21,7 @@ public class TwoPhaseConsensusCommitIntegrationTestWithCosmos
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos.java
@@ -21,7 +21,7 @@ public class TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return CosmosEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -15,8 +15,8 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminRepairTableIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminRepairTableIntegrationTestWithDynamo.java
@@ -13,7 +13,7 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithDynamo
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitIntegrationTestWithDynamo.java
@@ -12,7 +12,7 @@ public class ConsensusCommitIntegrationTestWithDynamo extends ConsensusCommitInt
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitSpecificIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitSpecificIntegrationTestWithDynamo.java
@@ -13,7 +13,7 @@ public class ConsensusCommitSpecificIntegrationTestWithDynamo
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -14,8 +14,8 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminRepairTableIntegrationTest.java
@@ -12,7 +12,7 @@ public class DynamoAdminRepairTableIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoColumnValueIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoColumnValueIntegrationTest.java
@@ -15,8 +15,8 @@ public class DynamoColumnValueIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoConditionalMutationIntegrationTest.java
@@ -19,8 +19,8 @@ public class DynamoConditionalMutationIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoEnv.java
@@ -42,7 +42,7 @@ public final class DynamoEnv {
     return props;
   }
 
-  public static Map<String, String> getCreateOptions() {
+  public static Map<String, String> getCreationOptions() {
     String createOptionsString = System.getProperty(PROP_DYNAMO_CREATE_OPTIONS);
     if (createOptionsString == null) {
       return DEFAULT_DYNAMO_CREATE_OPTIONS;

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoIntegrationTest.java
@@ -13,8 +13,8 @@ public class DynamoIntegrationTest extends DistributedStorageIntegrationTestBase
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   // DynamoDB doesn't support putting a null value for a secondary index column

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMultipleClusteringKeyScanIntegrationTest.java
@@ -36,8 +36,8 @@ public class DynamoMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMultiplePartitionKeyIntegrationTest.java
@@ -17,8 +17,8 @@ public class DynamoMultiplePartitionKeyIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSecondaryIndexIntegrationTest.java
@@ -31,8 +31,8 @@ public class DynamoSecondaryIndexIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSingleClusteringKeyScanIntegrationTest.java
@@ -31,8 +31,8 @@ public class DynamoSingleClusteringKeyScanIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSinglePartitionKeyIntegrationTest.java
@@ -15,8 +15,8 @@ public class DynamoSinglePartitionKeyIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoWithReservedKeywordIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoWithReservedKeywordIntegrationTest.java
@@ -55,7 +55,7 @@ public class DynamoWithReservedKeywordIntegrationTest
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseConsensusCommitIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseConsensusCommitIntegrationTestWithDynamo.java
@@ -13,7 +13,7 @@ public class TwoPhaseConsensusCommitIntegrationTestWithDynamo
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseConsensusCommitSpecificIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/TwoPhaseConsensusCommitSpecificIntegrationTestWithDynamo.java
@@ -13,7 +13,7 @@ public class TwoPhaseConsensusCommitSpecificIntegrationTestWithDynamo
   }
 
   @Override
-  protected Map<String, String> getCreateOptions() {
-    return DynamoEnv.getCreateOptions();
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -112,7 +112,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(ACCOUNT_ID, DataType.INT)
@@ -128,7 +128,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     consensusCommitAdmin.createCoordinatorTables(true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -91,7 +91,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
-    Map<String, String> options = getCreateOptions();
+    Map<String, String> options = getCreationOptions();
     TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn(ACCOUNT_ID, DataType.INT)
@@ -106,7 +106,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     consensusCommitAdmin.createCoordinatorTables(true, options);
   }
 
-  protected Map<String, String> getCreateOptions() {
+  protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
 

--- a/docs/getting-started/src/main/java/sample/ElectronicMoneyMain.java
+++ b/docs/getting-started/src/main/java/sample/ElectronicMoneyMain.java
@@ -58,7 +58,7 @@ public class ElectronicMoneyMain {
 
   private static void printUsageAndExit() {
     System.err.println(
-        "ElectronicMoneyMain -action charge/pay [-amount number (needed for charge and pay)] [-to id (needed for charge and pay)] [-from id (needed for pay)] [-id id (needed for getBalance)]");
+        "ElectronicMoneyMain -action charge/pay/getBalance [-amount number (needed for charge and pay)] [-to id (needed for charge and pay)] [-from id (needed for pay)] [-id id (needed for getBalance)]");
     System.exit(1);
   }
 }


### PR DESCRIPTION
This PR just renames `getCreateOptions()` to `getCreationOptions()` in the integration tests. Please take a look!