### PR TITLE
Rename `transactional` to `transaction`

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
@@ -164,7 +164,7 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
             .orElse(Coordinator.NAMESPACE);
     String coordinatorTable = Coordinator.TABLE;
     // Use the DistributedStorageAdmin instead of the DistributedTransactionAdmin because the latter
-    // expects the table to hold transactional table metadata columns which is not the case for the
+    // expects the table to hold transaction table metadata columns which is not the case for the
     // coordinator table
     DistributedStorageAdmin storageAdmin =
         StorageFactory.create(TestUtils.addSuffix(getStorageProperties(), TEST_NAME))

--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -137,8 +137,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     truncateTables();
     storage = spy(originalStorage);
     coordinator = spy(new Coordinator(storage, consensusCommitConfig));
-    TransactionalTableMetadataManager tableMetadataManager =
-        new TransactionalTableMetadataManager(admin, -1);
+    TransactionTableMetadataManager tableMetadataManager =
+        new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
     commit = spy(new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor));
     manager =

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * An interface for transaction CRUD operations. Note that the LINEARIZABLE consistency level is
+ * An interface for transactional CRUD operations. Note that the LINEARIZABLE consistency level is
  * always used in transactional CRUD operations, so {@link Consistency} specified for CRUD
  * operations is ignored.
  */

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -24,13 +24,13 @@ public class CommitHandler {
   private static final Logger logger = LoggerFactory.getLogger(CommitHandler.class);
   private final DistributedStorage storage;
   private final Coordinator coordinator;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
   private final ParallelExecutor parallelExecutor;
 
   public CommitHandler(
       DistributedStorage storage,
       Coordinator coordinator,
-      TransactionalTableMetadataManager tableMetadataManager,
+      TransactionTableMetadataManager tableMetadataManager,
       ParallelExecutor parallelExecutor) {
     this.storage = checkNotNull(storage);
     this.coordinator = checkNotNull(coordinator);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -1,7 +1,7 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.buildTransactionalTableMetadata;
-import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.removeTransactionalMetaColumns;
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.buildTransactionTableMetadata;
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.removeTransactionMetaColumns;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
@@ -65,7 +65,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   public void createTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
-    admin.createTable(namespace, table, buildTransactionalTableMetadata(metadata), options);
+    admin.createTable(namespace, table, buildTransactionTableMetadata(metadata), options);
   }
 
   @Override
@@ -99,7 +99,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   @Override
   public TableMetadata getTableMetadata(String namespace, String table) throws ExecutionException {
     TableMetadata metadata = admin.getTableMetadata(namespace, table);
-    return metadata == null ? null : removeTransactionalMetaColumns(metadata);
+    return metadata == null ? null : removeTransactionMetaColumns(metadata);
   }
 
   @Override
@@ -116,7 +116,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   public void repairTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
-    admin.repairTable(namespace, table, buildTransactionalTableMetadata(metadata), options);
+    admin.repairTable(namespace, table, buildTransactionTableMetadata(metadata), options);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -25,7 +25,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;
   private final ConsensusCommitConfig config;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
   private final Coordinator coordinator;
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
@@ -40,7 +40,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     this.coordinator = new Coordinator(storage, config);
     this.parallelExecutor = new ParallelExecutor(config);
     tableMetadataManager =
-        new TransactionalTableMetadataManager(
+        new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
@@ -60,7 +60,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     this.admin = admin;
     this.config = config;
     tableMetadataManager =
-        new TransactionalTableMetadataManager(
+        new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     this.coordinator = coordinator;
     this.parallelExecutor = parallelExecutor;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -37,15 +37,15 @@ public final class ConsensusCommitUtils {
   private ConsensusCommitUtils() {}
 
   /**
-   * Builds a transactional table metadata based on the specified table metadata.
+   * Builds a transaction table metadata based on the specified table metadata.
    *
-   * @param tableMetadata the base table metadata to build a transactional table metadata
-   * @return a transactional table metadata based on the table metadata
+   * @param tableMetadata the base table metadata to build a transaction table metadata
+   * @return a transaction table metadata based on the table metadata
    */
-  public static TableMetadata buildTransactionalTableMetadata(TableMetadata tableMetadata) {
+  public static TableMetadata buildTransactionTableMetadata(TableMetadata tableMetadata) {
     List<String> nonPrimaryKeyColumns = getNonPrimaryKeyColumns(tableMetadata);
 
-    // Check if the table metadata already has the transactional columns
+    // Check if the table metadata already has the transaction columns
     TRANSACTION_META_COLUMNS
         .keySet()
         .forEach(
@@ -68,7 +68,7 @@ public final class ConsensusCommitUtils {
           }
         });
 
-    // Build a transactional table metadata
+    // Build a transaction table metadata
     TableMetadata.Builder builder = TableMetadata.newBuilder(tableMetadata);
     TRANSACTION_META_COLUMNS.forEach(builder::addColumn);
     nonPrimaryKeyColumns.forEach(
@@ -79,14 +79,14 @@ public final class ConsensusCommitUtils {
   /**
    * Returns whether the specified table metadata is transactional.
    *
-   * <p>This method checks all the transactional meta columns including the before prefix column,
-   * and if any of them is missing, it returns false.
+   * <p>This method checks all the transaction meta columns including the before prefix column, and
+   * if any of them is missing, it returns false.
    *
    * @param tableMetadata a table metadata
    * @return whether the table metadata is transactional
    */
-  public static boolean isTransactionalTableMetadata(TableMetadata tableMetadata) {
-    // if the table metadata doesn't have the transactional meta columns, it's not transactional
+  public static boolean isTransactionTableMetadata(TableMetadata tableMetadata) {
+    // if the table metadata doesn't have the transaction meta columns, it's not transactional
     for (String column : TRANSACTION_META_COLUMNS.keySet()) {
       if (!tableMetadata.getColumnNames().contains(column)) {
         return false;
@@ -121,12 +121,12 @@ public final class ConsensusCommitUtils {
   }
 
   /**
-   * Removes transactional meta columns from the specified table metadata.
+   * Removes transaction meta columns from the specified table metadata.
    *
-   * @param tableMetadata a transactional table metadata
-   * @return a table metadata without transactional meta columns
+   * @param tableMetadata a transaction table metadata
+   * @return a table metadata without transaction meta columns
    */
-  public static TableMetadata removeTransactionalMetaColumns(TableMetadata tableMetadata) {
+  public static TableMetadata removeTransactionMetaColumns(TableMetadata tableMetadata) {
     Set<String> transactionMetaColumns = new HashSet<>(TRANSACTION_META_COLUMNS.keySet());
     transactionMetaColumns.addAll(
         tableMetadata.getColumnNames().stream()
@@ -151,23 +151,23 @@ public final class ConsensusCommitUtils {
   }
 
   /**
-   * Returns whether the specified column is a transactional meta column or not.
+   * Returns whether the specified column is a transaction meta column or not.
    *
    * @param columnName a column name
-   * @param tableMetadata a transactional table metadata
-   * @return whether the specified column is a transactional meta column or not
+   * @param tableMetadata a transaction table metadata
+   * @return whether the specified column is a transaction meta column or not
    */
-  public static boolean isTransactionalMetaColumn(String columnName, TableMetadata tableMetadata) {
+  public static boolean isTransactionMetaColumn(String columnName, TableMetadata tableMetadata) {
     return AFTER_IMAGE_META_COLUMNS.containsKey(columnName)
         || isBeforeImageColumn(columnName, tableMetadata);
   }
 
   /**
-   * Returns whether the specified column is a before image column or not.
+   * Returns whether the specified column is a part of the before image columns or not.
    *
    * @param columnName a column name
-   * @param tableMetadata a transactional table metadata
-   * @return whether the specified column is transactional or not
+   * @param tableMetadata a transaction table metadata
+   * @return whether the specified column is a part of the before image columns or not
    */
   public static boolean isBeforeImageColumn(String columnName, TableMetadata tableMetadata) {
     if (!tableMetadata.getColumnNames().contains(columnName)
@@ -180,7 +180,8 @@ public final class ConsensusCommitUtils {
       return true;
     }
     if (columnName.startsWith(Attribute.BEFORE_PREFIX)) {
-      // if the column name without the "before_" prefix exists, it's a transactional meta column
+      // if the column name without the "before_" prefix exists, it's a part of the before image
+      // columns
       return tableMetadata
           .getColumnNames()
           .contains(columnName.substring(Attribute.BEFORE_PREFIX.length()));
@@ -189,11 +190,11 @@ public final class ConsensusCommitUtils {
   }
 
   /**
-   * Returns whether the specified column is an after image column or not.
+   * Returns whether the specified column is a part of the after image columns or not.
    *
    * @param columnName a column name
-   * @param tableMetadata a transactional table metadata
-   * @return whether the specified column is transactional or not
+   * @param tableMetadata a transaction table metadata
+   * @return whether the specified column is a part of the after image columns or not
    */
   public static boolean isAfterImageColumn(String columnName, TableMetadata tableMetadata) {
     if (!tableMetadata.getColumnNames().contains(columnName)) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -29,12 +29,12 @@ public class CrudHandler {
   private static final Logger logger = LoggerFactory.getLogger(CrudHandler.class);
   private final DistributedStorage storage;
   private final Snapshot snapshot;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
 
   public CrudHandler(
       DistributedStorage storage,
       Snapshot snapshot,
-      TransactionalTableMetadataManager tableMetadataManager) {
+      TransactionTableMetadataManager tableMetadataManager) {
     this.storage = checkNotNull(storage);
     this.snapshot = checkNotNull(snapshot);
     this.tableMetadataManager = tableMetadataManager;
@@ -131,7 +131,7 @@ public class CrudHandler {
       // get only after image columns
       get.clearProjections();
       LinkedHashSet<String> afterImageColumnNames =
-          tableMetadataManager.getTransactionalTableMetadata(get).getAfterImageColumnNames();
+          tableMetadataManager.getTransactionTableMetadata(get).getAfterImageColumnNames();
       get.withProjections(afterImageColumnNames);
 
       get.withConsistency(Consistency.LINEARIZABLE);
@@ -146,7 +146,7 @@ public class CrudHandler {
       // get only after image columns
       scan.clearProjections();
       LinkedHashSet<String> afterImageColumnNames =
-          tableMetadataManager.getTransactionalTableMetadata(scan).getAfterImageColumnNames();
+          tableMetadataManager.getTransactionTableMetadata(scan).getAfterImageColumnNames();
       scan.withProjections(afterImageColumnNames);
 
       scan.withConsistency(Consistency.LINEARIZABLE);
@@ -158,8 +158,8 @@ public class CrudHandler {
 
   private TableMetadata getTableMetadata(String namespace, String table) throws CrudException {
     try {
-      TransactionalTableMetadata metadata =
-          tableMetadataManager.getTransactionalTableMetadata(namespace, table);
+      TransactionTableMetadata metadata =
+          tableMetadataManager.getTransactionTableMetadata(namespace, table);
       if (metadata == null) {
         throw new IllegalArgumentException(
             "The specified table is not found: "

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An implementation of {@code Result} to filter out unprojected columns and transactional columns.
+ * An implementation of {@code Result} to filter out unprojected columns and transaction columns.
  */
 @Immutable
 public class FilteredResult extends AbstractResult {
@@ -37,7 +37,7 @@ public class FilteredResult extends AbstractResult {
     ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     original.getContainedColumnNames().stream()
         .filter(c -> projections.isEmpty() || projections.contains(c))
-        .filter(c -> !ConsensusCommitUtils.isTransactionalMetaColumn(c, metadata))
+        .filter(c -> !ConsensusCommitUtils.isTransactionMetaColumn(c, metadata))
         .forEach(builder::add);
     containedColumnNames = builder.build();
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryHandler.java
@@ -25,12 +25,12 @@ public class RecoveryHandler {
   private static final Logger logger = LoggerFactory.getLogger(RecoveryHandler.class);
   private final DistributedStorage storage;
   private final Coordinator coordinator;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
 
   public RecoveryHandler(
       DistributedStorage storage,
       Coordinator coordinator,
-      TransactionalTableMetadataManager tableMetadataManager) {
+      TransactionTableMetadataManager tableMetadataManager) {
     this.storage = checkNotNull(storage);
     this.coordinator = checkNotNull(coordinator);
     this.tableMetadataManager = checkNotNull(tableMetadataManager);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
@@ -34,12 +34,10 @@ import org.slf4j.LoggerFactory;
 public class RollbackMutationComposer extends AbstractMutationComposer {
   private static final Logger logger = LoggerFactory.getLogger(RollbackMutationComposer.class);
   private final DistributedStorage storage;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
 
   public RollbackMutationComposer(
-      String id,
-      DistributedStorage storage,
-      TransactionalTableMetadataManager tableMetadataManager) {
+      String id, DistributedStorage storage, TransactionTableMetadataManager tableMetadataManager) {
     super(id);
     this.storage = storage;
     this.tableMetadataManager = tableMetadataManager;
@@ -49,7 +47,7 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
   RollbackMutationComposer(
       String id,
       DistributedStorage storage,
-      TransactionalTableMetadataManager tableMetadataManager,
+      TransactionTableMetadataManager tableMetadataManager,
       List<Mutation> mutations) {
     super(id, mutations, System.currentTimeMillis());
     this.storage = storage;
@@ -89,7 +87,7 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
     assert result.getState().equals(TransactionState.PREPARED)
         || result.getState().equals(TransactionState.DELETED);
 
-    TransactionalTableMetadata metadata = tableMetadataManager.getTransactionalTableMetadata(base);
+    TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
     LinkedHashSet<String> beforeImageColumnNames = metadata.getBeforeImageColumnNames();
 
     Map<String, Value<?>> map = new HashMap<>();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -41,7 +41,7 @@ public class Snapshot {
   private final String id;
   private final Isolation isolation;
   private final SerializableStrategy strategy;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
   private final ParallelExecutor parallelExecutor;
   private final Map<Key, Optional<TransactionResult>> readSet;
   private final Map<Scan, List<Key>> scanSet;
@@ -52,7 +52,7 @@ public class Snapshot {
       String id,
       Isolation isolation,
       SerializableStrategy strategy,
-      TransactionalTableMetadataManager tableMetadataManager,
+      TransactionTableMetadataManager tableMetadataManager,
       ParallelExecutor parallelExecutor) {
     this.id = id;
     this.isolation = isolation;
@@ -70,7 +70,7 @@ public class Snapshot {
       String id,
       Isolation isolation,
       SerializableStrategy strategy,
-      TransactionalTableMetadataManager tableMetadataManager,
+      TransactionTableMetadataManager tableMetadataManager,
       ParallelExecutor parallelExecutor,
       Map<Key, Optional<TransactionResult>> readSet,
       Map<Scan, List<Key>> scanSet,
@@ -147,8 +147,8 @@ public class Snapshot {
 
   private TableMetadata getTableMetadata(Key key) throws CrudException {
     try {
-      TransactionalTableMetadata metadata =
-          tableMetadataManager.getTransactionalTableMetadata(key.getNamespace(), key.getTable());
+      TransactionTableMetadata metadata =
+          tableMetadataManager.getTransactionTableMetadata(key.getNamespace(), key.getTable());
       if (metadata == null) {
         throw new IllegalArgumentException(
             "The specified table is not found: "
@@ -162,8 +162,8 @@ public class Snapshot {
 
   private TableMetadata getTableMetadata(Scan scan) throws ExecutionException {
     try {
-      TransactionalTableMetadata metadata =
-          tableMetadataManager.getTransactionalTableMetadata(
+      TransactionTableMetadata metadata =
+          tableMetadataManager.getTransactionTableMetadata(
               scan.forNamespace().get(), scan.forTable().get());
       if (metadata == null) {
         throw new IllegalArgumentException(

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadata.java
@@ -12,19 +12,19 @@ import java.util.stream.Collectors;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
-public class TransactionalTableMetadata {
+public class TransactionTableMetadata {
 
   private final TableMetadata tableMetadata;
-  private final ImmutableLinkedHashSet<String> transactionalMetaColumnNames;
+  private final ImmutableLinkedHashSet<String> transactionMetaColumnNames;
   private final ImmutableLinkedHashSet<String> beforeImageColumnNames;
   private final ImmutableLinkedHashSet<String> afterImageColumnNames;
 
-  public TransactionalTableMetadata(TableMetadata tableMetadata) {
+  public TransactionTableMetadata(TableMetadata tableMetadata) {
     this.tableMetadata = tableMetadata;
-    transactionalMetaColumnNames =
+    transactionMetaColumnNames =
         new ImmutableLinkedHashSet<>(
             tableMetadata.getColumnNames().stream()
-                .filter(c -> ConsensusCommitUtils.isTransactionalMetaColumn(c, tableMetadata))
+                .filter(c -> ConsensusCommitUtils.isTransactionMetaColumn(c, tableMetadata))
                 .collect(Collectors.toList()));
     beforeImageColumnNames =
         new ImmutableLinkedHashSet<>(
@@ -70,8 +70,8 @@ public class TransactionalTableMetadata {
     return tableMetadata.getSecondaryIndexNames();
   }
 
-  public LinkedHashSet<String> getTransactionalMetaColumnNames() {
-    return transactionalMetaColumnNames;
+  public LinkedHashSet<String> getTransactionMetaColumnNames() {
+    return transactionMetaColumnNames;
   }
 
   public LinkedHashSet<String> getBeforeImageColumnNames() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManager.java
@@ -14,11 +14,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-public class TransactionalTableMetadataManager {
+public class TransactionTableMetadataManager {
 
-  private final LoadingCache<TableKey, Optional<TransactionalTableMetadata>> tableMetadataCache;
+  private final LoadingCache<TableKey, Optional<TransactionTableMetadata>> tableMetadataCache;
 
-  public TransactionalTableMetadataManager(
+  public TransactionTableMetadataManager(
       DistributedStorageAdmin admin, long cacheExpirationTimeSecs) {
 
     CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
@@ -27,44 +27,43 @@ public class TransactionalTableMetadataManager {
     }
     tableMetadataCache =
         builder.build(
-            new CacheLoader<TableKey, Optional<TransactionalTableMetadata>>() {
+            new CacheLoader<TableKey, Optional<TransactionTableMetadata>>() {
               @Override
-              public Optional<TransactionalTableMetadata> load(@Nonnull TableKey key)
+              public Optional<TransactionTableMetadata> load(@Nonnull TableKey key)
                   throws ExecutionException {
                 TableMetadata tableMetadata = admin.getTableMetadata(key.namespace, key.table);
                 if (tableMetadata == null) {
                   return Optional.empty();
                 }
-                return Optional.of(new TransactionalTableMetadata(tableMetadata));
+                return Optional.of(new TransactionTableMetadata(tableMetadata));
               }
             });
   }
 
   /**
-   * Returns a transactional table metadata corresponding to the specified operation.
+   * Returns a transaction table metadata corresponding to the specified operation.
    *
    * @param operation an operation
    * @return a table metadata. null if the table is not found.
    * @throws ExecutionException if the operation failed
    */
-  public TransactionalTableMetadata getTransactionalTableMetadata(Operation operation)
+  public TransactionTableMetadata getTransactionTableMetadata(Operation operation)
       throws ExecutionException {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
       throw new IllegalArgumentException("operation has no target namespace and table name");
     }
-    return getTransactionalTableMetadata(
-        operation.forNamespace().get(), operation.forTable().get());
+    return getTransactionTableMetadata(operation.forNamespace().get(), operation.forTable().get());
   }
 
   /**
-   * Returns a transactional table metadata corresponding to the specified namespace and table.
+   * Returns a transaction table metadata corresponding to the specified namespace and table.
    *
    * @param namespace a namespace
    * @param table a table
    * @return a table metadata. null if the table is not found.
    * @throws ExecutionException if the operation failed
    */
-  public TransactionalTableMetadata getTransactionalTableMetadata(String namespace, String table)
+  public TransactionTableMetadata getTransactionTableMetadata(String namespace, String table)
       throws ExecutionException {
     try {
       TableKey key = new TableKey(namespace, table);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -33,7 +33,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;
   private final ConsensusCommitConfig config;
-  private final TransactionalTableMetadataManager tableMetadataManager;
+  private final TransactionTableMetadataManager tableMetadataManager;
   private final Coordinator coordinator;
   private final ParallelExecutor parallelExecutor;
   private final RecoveryHandler recovery;
@@ -48,7 +48,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     this.admin = admin;
     config = new ConsensusCommitConfig(databaseConfig);
     tableMetadataManager =
-        new TransactionalTableMetadataManager(
+        new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     coordinator = new Coordinator(storage, config);
     parallelExecutor = new ParallelExecutor(config);
@@ -83,7 +83,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     this.admin = admin;
     this.config = config;
     tableMetadataManager =
-        new TransactionalTableMetadataManager(
+        new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
     this.coordinator = coordinator;
     this.parallelExecutor = parallelExecutor;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -44,7 +44,7 @@ public class CommitHandlerTest {
 
   @Mock private DistributedStorage storage;
   @Mock private Coordinator coordinator;
-  @Mock private TransactionalTableMetadataManager tableMetadataManager;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
   @Mock private ConsensusCommitConfig config;
 
   private CommitHandler handler;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTest.java
@@ -198,7 +198,7 @@ public class ConsensusCommitAdminTest {
   }
 
   @Test
-  public void createTable_tableMetadataGiven_shouldCreateTransactionalTableProperly()
+  public void createTable_tableMetadataGiven_shouldCreateTransactionTableProperly()
       throws ExecutionException {
     // Arrange
     final String ACCOUNT_ID = "account_id";

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
@@ -11,7 +11,7 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
-      buildTransactionalTableMetadata_tableMetadataGiven_shouldCreateTransactionalTableProperly() {
+      buildTransactionTableMetadata_tableMetadataGiven_shouldCreateTransactionTableProperly() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -47,7 +47,7 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act
-    TableMetadata actual = ConsensusCommitUtils.buildTransactionalTableMetadata(tableMetadata);
+    TableMetadata actual = ConsensusCommitUtils.buildTransactionTableMetadata(tableMetadata);
 
     // Assert
     assertThat(actual).isEqualTo(expected);
@@ -55,13 +55,13 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
-      buildTransactionalTableMetadata_tableMetadataThatHasTransactionMetaColumnGiven_shouldThrowIllegalArgumentException() {
+      buildTransactionTableMetadata_tableMetadataThatHasTransactionMetaColumnGiven_shouldThrowIllegalArgumentException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(
             () ->
-                ConsensusCommitUtils.buildTransactionalTableMetadata(
+                ConsensusCommitUtils.buildTransactionTableMetadata(
                     TableMetadata.newBuilder()
                         .addColumn("col1", DataType.INT)
                         .addColumn("col2", DataType.INT)
@@ -73,13 +73,13 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
-      buildTransactionalTableMetadata_tableMetadataThatHasNonPrimaryKeyColumnWithBeforePrefixGiven_shouldThrowIllegalArgumentException() {
+      buildTransactionTableMetadata_tableMetadataThatHasNonPrimaryKeyColumnWithBeforePrefixGiven_shouldThrowIllegalArgumentException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(
             () ->
-                ConsensusCommitUtils.buildTransactionalTableMetadata(
+                ConsensusCommitUtils.buildTransactionTableMetadata(
                     TableMetadata.newBuilder()
                         .addColumn("col1", DataType.INT)
                         .addColumn("col2", DataType.INT)
@@ -92,8 +92,7 @@ public class ConsensusCommitUtilsTest {
   }
 
   @Test
-  public void
-      isTransactionalTableMetadata_properTransactionalTableMetadataGiven_shouldReturnTrue() {
+  public void isTransactionTableMetadata_properTransactionTableMetadataGiven_shouldReturnTrue() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -120,7 +119,7 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act
-    boolean actual = ConsensusCommitUtils.isTransactionalTableMetadata(metadata);
+    boolean actual = ConsensusCommitUtils.isTransactionTableMetadata(metadata);
 
     // Assert
     assertThat(actual).isTrue();
@@ -128,7 +127,7 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
-      isTransactionalTableMetadata_transactionalTableMetadataWithoutMetaColumnGiven_shouldReturnFalse() {
+      isTransactionTableMetadata_TransactionTableMetadataWithoutMetaColumnGiven_shouldReturnFalse() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -154,7 +153,7 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act
-    boolean actual = ConsensusCommitUtils.isTransactionalTableMetadata(metadata);
+    boolean actual = ConsensusCommitUtils.isTransactionTableMetadata(metadata);
 
     // Assert
     assertThat(actual).isFalse();
@@ -162,7 +161,7 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
-      isTransactionalTableMetadata_transactionalTableMetadataWithoutProperBeforeColumnGiven_shouldReturnFalse() {
+      isTransactionTableMetadata_TransactionTableMetadataWithoutProperBeforeColumnGiven_shouldReturnFalse() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -188,7 +187,7 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act
-    boolean actual = ConsensusCommitUtils.isTransactionalTableMetadata(metadata);
+    boolean actual = ConsensusCommitUtils.isTransactionTableMetadata(metadata);
 
     // Assert
     assertThat(actual).isFalse();
@@ -196,7 +195,7 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
-      removeTransactionalMetaColumns_transactionalTableMetadataWithoutProperBeforeColumnGiven_shouldReturnFalse() {
+      removeTransactionMetaColumns_TransactionTableMetadataWithoutProperBeforeColumnGiven_shouldReturnFalse() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -223,7 +222,7 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act
-    TableMetadata actual = ConsensusCommitUtils.removeTransactionalMetaColumns(metadata);
+    TableMetadata actual = ConsensusCommitUtils.removeTransactionMetaColumns(metadata);
 
     // Assert
     assertThat(actual)
@@ -238,7 +237,7 @@ public class ConsensusCommitUtilsTest {
   }
 
   @Test
-  public void isTransactionalMetaColumn_TableMetadataGiven_shouldReturnProperResult() {
+  public void isTransactionMetaColumn_TableMetadataGiven_shouldReturnProperResult() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -265,38 +264,36 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act Assert
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_ID, metadata)).isFalse();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_TYPE, metadata)).isFalse();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(BALANCE, metadata)).isFalse();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.ID, metadata)).isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.STATE, metadata)).isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.VERSION, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(ACCOUNT_ID, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(ACCOUNT_TYPE, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(BALANCE, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.ID, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.STATE, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.VERSION, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.PREPARED_AT, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.PREPARED_AT, metadata))
-        .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.COMMITTED_AT, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.COMMITTED_AT, metadata))
         .isTrue();
     assertThat(
-            ConsensusCommitUtils.isTransactionalMetaColumn(
+            ConsensusCommitUtils.isTransactionMetaColumn(
                 Attribute.BEFORE_PREFIX + BALANCE, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_ID, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_ID, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_STATE, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_STATE, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_VERSION, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_VERSION, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_PREPARED_AT, metadata))
         .isTrue();
     assertThat(
-            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_PREPARED_AT, metadata))
+            ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_COMMITTED_AT, metadata))
         .isTrue();
-    assertThat(
-            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_COMMITTED_AT, metadata))
-        .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn("aaa", metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn("aaa", metadata)).isFalse();
   }
 
   @Test
-  public void isTransactionalMetaColumn_ResultGiven_shouldReturnProperResult() {
+  public void isTransactionMetaColumn_ResultGiven_shouldReturnProperResult() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
@@ -323,34 +320,32 @@ public class ConsensusCommitUtilsTest {
             .build();
 
     // Act Assert
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_ID, metadata)).isFalse();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(ACCOUNT_TYPE, metadata)).isFalse();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(BALANCE, metadata)).isFalse();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.ID, metadata)).isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.STATE, metadata)).isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.VERSION, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(ACCOUNT_ID, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(ACCOUNT_TYPE, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(BALANCE, metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.ID, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.STATE, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.VERSION, metadata)).isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.PREPARED_AT, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.PREPARED_AT, metadata))
-        .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.COMMITTED_AT, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.COMMITTED_AT, metadata))
         .isTrue();
     assertThat(
-            ConsensusCommitUtils.isTransactionalMetaColumn(
+            ConsensusCommitUtils.isTransactionMetaColumn(
                 Attribute.BEFORE_PREFIX + BALANCE, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_ID, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_ID, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_STATE, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_STATE, metadata))
         .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_VERSION, metadata))
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_VERSION, metadata))
+        .isTrue();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_PREPARED_AT, metadata))
         .isTrue();
     assertThat(
-            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_PREPARED_AT, metadata))
+            ConsensusCommitUtils.isTransactionMetaColumn(Attribute.BEFORE_COMMITTED_AT, metadata))
         .isTrue();
-    assertThat(
-            ConsensusCommitUtils.isTransactionalMetaColumn(Attribute.BEFORE_COMMITTED_AT, metadata))
-        .isTrue();
-    assertThat(ConsensusCommitUtils.isTransactionalMetaColumn("aaa", metadata)).isFalse();
+    assertThat(ConsensusCommitUtils.isTransactionMetaColumn("aaa", metadata)).isFalse();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -52,7 +52,7 @@ public class CrudHandlerTest {
   private static final String ANY_TX_ID = "tx_id";
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)
@@ -63,7 +63,7 @@ public class CrudHandlerTest {
   @InjectMocks private CrudHandler handler;
   @Mock private DistributedStorage storage;
   @Mock private Snapshot snapshot;
-  @Mock private TransactionalTableMetadataManager tableMetadataManager;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
   @Mock private ParallelExecutor parallelExecutor;
   @Mock private Scanner scanner;
   @Mock private Result result;
@@ -73,10 +73,10 @@ public class CrudHandlerTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    when(tableMetadataManager.getTransactionalTableMetadata(any()))
-        .thenReturn(new TransactionalTableMetadata(TABLE_METADATA));
-    when(tableMetadataManager.getTransactionalTableMetadata(any(), any()))
-        .thenReturn(new TransactionalTableMetadata(TABLE_METADATA));
+    when(tableMetadataManager.getTransactionTableMetadata(any()))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
+    when(tableMetadataManager.getTransactionTableMetadata(any(), any()))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
   }
 
   private Get prepareGet() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/FilteredResultTest.java
@@ -27,7 +27,7 @@ public class FilteredResultTest {
   private static final String BALANCE = "balance";
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ACCOUNT_ID, DataType.INT)
               .addColumn(ACCOUNT_TYPE, DataType.INT)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/MergedResultTest.java
@@ -48,7 +48,7 @@ public class MergedResultTest {
   private static final int ANY_VERSION_2 = 2;
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -50,7 +50,7 @@ public class PrepareMutationComposerTest {
   private static final int ANY_INT_3 = 300;
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryHandlerTest.java
@@ -32,7 +32,7 @@ public class RecoveryHandlerTest {
   private static final long ANY_TIME_1 = 100;
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addPartitionKey(ANY_NAME_1)
@@ -40,7 +40,7 @@ public class RecoveryHandlerTest {
 
   @Mock private DistributedStorage storage;
   @Mock private Coordinator coordinator;
-  @Mock private TransactionalTableMetadataManager tableMetadataManager;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
   @Mock private Selection selection;
 
   private RecoveryHandler handler;

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -58,7 +58,7 @@ public class RollbackMutationComposerTest {
   private static final int ANY_INT_3 = 300;
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)
@@ -70,7 +70,7 @@ public class RollbackMutationComposerTest {
   private RollbackMutationComposer composer;
   private List<Mutation> mutations;
   @Mock private DistributedStorage storage;
-  @Mock private TransactionalTableMetadataManager tableMetadataManager;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -78,8 +78,8 @@ public class RollbackMutationComposerTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    when(tableMetadataManager.getTransactionalTableMetadata(any()))
-        .thenReturn(new TransactionalTableMetadata(TABLE_METADATA));
+    when(tableMetadataManager.getTransactionTableMetadata(any()))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
   }
 
   private Get prepareGet() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -68,7 +68,7 @@ public class SnapshotTest {
   private static final String ANY_TEXT_6 = "text6";
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)
@@ -88,17 +88,17 @@ public class SnapshotTest {
   @Mock private PrepareMutationComposer prepareComposer;
   @Mock private CommitMutationComposer commitComposer;
   @Mock private RollbackMutationComposer rollbackComposer;
-  @Mock private TransactionalTableMetadataManager tableMetadataManager;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
 
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    when(tableMetadataManager.getTransactionalTableMetadata(any()))
-        .thenReturn(new TransactionalTableMetadata(TABLE_METADATA));
-    when(tableMetadataManager.getTransactionalTableMetadata(any(), any()))
-        .thenReturn(new TransactionalTableMetadata(TABLE_METADATA));
+    when(tableMetadataManager.getTransactionTableMetadata(any()))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
+    when(tableMetadataManager.getTransactionTableMetadata(any(), any()))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
   }
 
   private Snapshot prepareSnapshot(Isolation isolation) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionResultTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionResultTest.java
@@ -42,7 +42,7 @@ public class TransactionResultTest {
   private static final int ANY_VERSION_2 = 2;
 
   private static final TableMetadata TABLE_METADATA =
-      ConsensusCommitUtils.buildTransactionalTableMetadata(
+      ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)

--- a/schema-loader/src/integration-test/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -368,7 +368,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
             .orElse(Coordinator.NAMESPACE);
     String coordinatorTable = Coordinator.TABLE;
     // Use the DistributedStorageAdmin instead of the DistributedTransactionAdmin because the latter
-    // expects the table to hold transactional table metadata columns which is not the case for the
+    // expects the table to hold transaction table metadata columns which is not the case for the
     // coordinator table
     DistributedStorageAdmin storageAdmin =
         StorageFactory.create(coordinatorStorageProperties).getStorageAdmin();

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -55,7 +55,7 @@ public class SchemaOperator {
       String namespace = tableSchema.getNamespace();
       String tableName = tableSchema.getTable();
       try {
-        if (tableSchema.isTransactionalTable()) {
+        if (tableSchema.isTransactionTable()) {
           transactionAdmin.repairTable(
               namespace, tableName, tableSchema.getTableMetadata(), tableSchema.getOptions());
         } else {
@@ -83,7 +83,7 @@ public class SchemaOperator {
     String namespace = tableSchema.getNamespace();
     String tableName = tableSchema.getTable();
     try {
-      if (tableSchema.isTransactionalTable()) {
+      if (tableSchema.isTransactionTable()) {
         transactionAdmin.createTable(
             namespace, tableName, tableSchema.getTableMetadata(), tableSchema.getOptions());
       } else {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
@@ -42,7 +42,7 @@ public class TableSchema {
   private String tableName;
   private TableMetadata tableMetadata;
   private ImmutableMap<String, String> options;
-  private boolean isTransactionalTable = false;
+  private boolean isTransactionTable = false;
   private Set<String> traveledKeys;
 
   @VisibleForTesting
@@ -114,7 +114,7 @@ public class TableSchema {
     }
 
     if (transaction) {
-      isTransactionalTable = true;
+      isTransactionTable = true;
     }
 
     // Add columns
@@ -180,7 +180,7 @@ public class TableSchema {
     return options;
   }
 
-  public boolean isTransactionalTable() {
-    return isTransactionalTable;
+  public boolean isTransactionTable() {
+    return isTransactionTable;
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/StorageSpecificCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/StorageSpecificCommand.java
@@ -50,22 +50,22 @@ public abstract class StorageSpecificCommand {
     // Create or delete tables
     SchemaOperator operator = getSchemaOperator(props);
     try {
-      boolean hasTransactionalTable =
-          tableSchemaList.stream().anyMatch(TableSchema::isTransactionalTable);
+      boolean hasTransactionTable =
+          tableSchemaList.stream().anyMatch(TableSchema::isTransactionTable);
 
       if (getDeleteOrRepairTables() == null) {
         operator.createTables(tableSchemaList);
-        if (hasTransactionalTable) {
+        if (hasTransactionTable) {
           operator.createCoordinatorTables(options);
         }
       } else if (getDeleteOrRepairTables().deleteTables) {
         operator.deleteTables(tableSchemaList);
-        if (hasTransactionalTable) {
+        if (hasTransactionTable) {
           operator.dropCoordinatorTables();
         }
       } else {
         operator.repairTables(tableSchemaList);
-        if (hasTransactionalTable) {
+        if (hasTransactionTable) {
           operator.repairCoordinatorTables(options);
         }
       }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -35,12 +35,12 @@ public class SchemaOperatorTest {
   }
 
   @Test
-  public void createTables_WithTransactionalTables_ShouldCallProperMethods() throws Exception {
+  public void createTables_WithTransactionTables_ShouldCallProperMethods() throws Exception {
     // Arrange
     List<TableSchema> tableSchemaList = Arrays.asList(tableSchema, tableSchema, tableSchema);
     when(tableSchema.getNamespace()).thenReturn("ns");
     when(tableSchema.getOptions()).thenReturn(options);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(tableSchema.getTable()).thenReturn("tb");
     TableMetadata tableMetadata = mock(TableMetadata.class);
     when(tableSchema.getTableMetadata()).thenReturn(tableMetadata);
@@ -55,12 +55,12 @@ public class SchemaOperatorTest {
   }
 
   @Test
-  public void createTables_WithNonTransactionalTables_ShouldCallProperMethods() throws Exception {
+  public void createTables_WithNonTransactionTables_ShouldCallProperMethods() throws Exception {
     // Arrange
     List<TableSchema> tableSchemaList = Arrays.asList(tableSchema, tableSchema, tableSchema);
     when(tableSchema.getNamespace()).thenReturn("ns");
     when(tableSchema.getOptions()).thenReturn(options);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(tableSchema.getTable()).thenReturn("tb");
     TableMetadata tableMetadata = mock(TableMetadata.class);
     when(tableSchema.getTableMetadata()).thenReturn(tableMetadata);
@@ -110,7 +110,7 @@ public class SchemaOperatorTest {
     List<TableSchema> tableSchemaList = Arrays.asList(tableSchema, tableSchema, tableSchema);
     when(tableSchema.getNamespace()).thenReturn("ns");
     when(tableSchema.getOptions()).thenReturn(options);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(tableSchema.getTable()).thenReturn("tb");
     TableMetadata tableMetadata = mock(TableMetadata.class);
     when(tableSchema.getTableMetadata()).thenReturn(tableMetadata);
@@ -154,12 +154,12 @@ public class SchemaOperatorTest {
   }
 
   @Test
-  public void repairTables_WithTransactionalTables_ShouldCallProperMethods() throws Exception {
+  public void repairTables_WithTransactionTables_ShouldCallProperMethods() throws Exception {
     // Arrange
     List<TableSchema> tableSchemaList = Arrays.asList(tableSchema, tableSchema, tableSchema);
     when(tableSchema.getNamespace()).thenReturn("ns");
     when(tableSchema.getOptions()).thenReturn(options);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(tableSchema.getTable()).thenReturn("tb");
     TableMetadata tableMetadata = mock(TableMetadata.class);
     when(tableSchema.getTableMetadata()).thenReturn(tableMetadata);
@@ -173,12 +173,12 @@ public class SchemaOperatorTest {
   }
 
   @Test
-  public void repairTables_WithoutTransactionalTables_ShouldCallProperMethods() throws Exception {
+  public void repairTables_WithoutTransactionTables_ShouldCallProperMethods() throws Exception {
     // Arrange
     List<TableSchema> tableSchemaList = Arrays.asList(tableSchema, tableSchema, tableSchema);
     when(tableSchema.getNamespace()).thenReturn("ns");
     when(tableSchema.getOptions()).thenReturn(options);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(tableSchema.getTable()).thenReturn("tb");
     TableMetadata tableMetadata = mock(TableMetadata.class);
     when(tableSchema.getTableMetadata()).thenReturn(tableMetadata);

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaParserTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaParserTest.java
@@ -93,7 +93,7 @@ public class SchemaParserTest {
 
     assertThat(actual.get(0).getNamespace()).isEqualTo("sample_db");
     assertThat(actual.get(0).getTable()).isEqualTo("sample_table");
-    assertThat(actual.get(0).isTransactionalTable()).isFalse();
+    assertThat(actual.get(0).isTransactionTable()).isFalse();
     assertThat(actual.get(0).getOptions())
         .isEqualTo(ImmutableMap.of("ru", "5000", "compaction-strategy", "LCS"));
     TableMetadata tableMetadata = actual.get(0).getTableMetadata();
@@ -117,7 +117,7 @@ public class SchemaParserTest {
 
     assertThat(actual.get(1).getNamespace()).isEqualTo("sample_db");
     assertThat(actual.get(1).getTable()).isEqualTo("sample_table1");
-    assertThat(actual.get(1).isTransactionalTable()).isTrue();
+    assertThat(actual.get(1).isTransactionTable()).isTrue();
     assertThat(actual.get(1).getOptions()).isEmpty();
     tableMetadata = actual.get(1).getTableMetadata();
     assertThat(tableMetadata.getPartitionKeyNames())
@@ -136,7 +136,7 @@ public class SchemaParserTest {
 
     assertThat(actual.get(2).getNamespace()).isEqualTo("sample_db2");
     assertThat(actual.get(2).getTable()).isEqualTo("sample_table2");
-    assertThat(actual.get(2).isTransactionalTable()).isFalse();
+    assertThat(actual.get(2).isTransactionTable()).isFalse();
     assertThat(actual.get(2).getOptions()).isEmpty();
     tableMetadata = actual.get(2).getTableMetadata();
     assertThat(tableMetadata.getPartitionKeyNames())

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CassandraCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CassandraCommandTest.java
@@ -36,7 +36,7 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_ProperArgumentsForCreatingTablesGivenWithTransactionalTableSchema_ShouldCallCreateTablesProperly()
+      call_ProperArgumentsForCreatingTablesGivenWithTransactionTableSchema_ShouldCallCreateTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options =
@@ -47,7 +47,7 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
             .build();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -86,7 +86,7 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_ProperArgumentsForCreatingTablesGivenWithNonTransactionalTableSchema_ShouldCallCreateTablesProperly()
+      call_ProperArgumentsForCreatingTablesGivenWithNonTransactionTableSchema_ShouldCallCreateTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options =
@@ -97,7 +97,7 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
             .build();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -136,11 +136,11 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -163,11 +163,11 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithNonTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithNonTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -190,14 +190,14 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(false);
   }
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(true);
   }
@@ -209,9 +209,9 @@ public class CassandraCommandTest extends StorageSpecificCommandTestBase {
 
     TableSchema tableSchema = mock(TableSchema.class);
     if (hasTransactionTables) {
-      when(tableSchema.isTransactionalTable()).thenReturn(true);
+      when(tableSchema.isTransactionTable()).thenReturn(true);
     } else {
-      when(tableSchema.isTransactionalTable()).thenReturn(false);
+      when(tableSchema.isTransactionTable()).thenReturn(false);
     }
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CosmosCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/CosmosCommandTest.java
@@ -33,7 +33,7 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForCreatingTablesWithTransactionalTableSchema_ShouldCallCreateTablesProperly()
+      call_WithProperArgumentsForCreatingTablesWithTransactionTableSchema_ShouldCallCreateTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options =
@@ -43,7 +43,7 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
             .build();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -64,7 +64,7 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForCreatingTablesWithNonTransactionalTableSchema_ShouldCallCreateTablesProperly()
+      call_WithProperArgumentsForCreatingTablesWithNonTransactionTableSchema_ShouldCallCreateTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options =
@@ -74,7 +74,7 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
             .build();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -95,11 +95,11 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -120,11 +120,11 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithNonTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithNonTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -145,14 +145,14 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(false);
   }
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(true);
   }
@@ -164,9 +164,9 @@ public class CosmosCommandTest extends StorageSpecificCommandTestBase {
 
     TableSchema tableSchema = mock(TableSchema.class);
     if (hasTransactionTables) {
-      when(tableSchema.isTransactionalTable()).thenReturn(true);
+      when(tableSchema.isTransactionTable()).thenReturn(true);
     } else {
-      when(tableSchema.isTransactionalTable()).thenReturn(false);
+      when(tableSchema.isTransactionTable()).thenReturn(false);
     }
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/DynamoCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/DynamoCommandTest.java
@@ -40,7 +40,7 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForCreatingTablesWithTransactionalTableSchema_ShouldCallCreateTablesProperly()
+      call_WithProperArgumentsForCreatingTablesWithTransactionTableSchema_ShouldCallCreateTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options =
@@ -51,7 +51,7 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
             .build();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -88,7 +88,7 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForCreatingTablesWithNonTransactionalTableSchema_ShouldCallCreateTablesProperly()
+      call_WithProperArgumentsForCreatingTablesWithNonTransactionTableSchema_ShouldCallCreateTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options =
@@ -99,7 +99,7 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
             .build();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -136,11 +136,11 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -174,11 +174,11 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithNonTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithNonTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -212,28 +212,28 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionalTableSchemaAndNoBackupOption_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionTableSchemaAndNoBackupOption_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(false, true);
   }
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(false, false);
   }
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(true, false);
   }
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithTransactionalTableSchemaAndNoBackupOption_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithTransactionTableSchemaAndNoBackupOption_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(true, true);
   }
@@ -248,9 +248,9 @@ public class DynamoCommandTest extends StorageSpecificCommandTestBase {
 
     TableSchema tableSchema = mock(TableSchema.class);
     if (hasTransactionTables) {
-      when(tableSchema.isTransactionalTable()).thenReturn(true);
+      when(tableSchema.isTransactionTable()).thenReturn(true);
     } else {
-      when(tableSchema.isTransactionalTable()).thenReturn(false);
+      when(tableSchema.isTransactionTable()).thenReturn(false);
     }
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/JdbcCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/JdbcCommandTest.java
@@ -31,13 +31,13 @@ public class JdbcCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForCreatingTablesWithTransactionalTableSchema_ShouldCallCreateTableProperly()
+      call_WithProperArgumentsForCreatingTablesWithTransactionTableSchema_ShouldCallCreateTableProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options = Collections.emptyMap();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -59,13 +59,13 @@ public class JdbcCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForCreatingTablesWithNonTransactionalTableSchema_ShouldCallCreateTableProperly()
+      call_WithProperArgumentsForCreatingTablesWithNonTransactionTableSchema_ShouldCallCreateTableProperly()
           throws SchemaLoaderException {
     // Arrange
     Map<String, String> options = Collections.emptyMap();
 
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -87,11 +87,11 @@ public class JdbcCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(true);
+    when(tableSchema.isTransactionTable()).thenReturn(true);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -113,11 +113,11 @@ public class JdbcCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_WithProperArgumentsForDeletingTablesWithNonTransactionalTableSchema_ShouldCallDeleteTablesProperly()
+      call_WithProperArgumentsForDeletingTablesWithNonTransactionTableSchema_ShouldCallDeleteTablesProperly()
           throws SchemaLoaderException {
     // Arrange
     TableSchema tableSchema = mock(TableSchema.class);
-    when(tableSchema.isTransactionalTable()).thenReturn(false);
+    when(tableSchema.isTransactionTable()).thenReturn(false);
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 
     Properties properties = new Properties();
@@ -139,14 +139,14 @@ public class JdbcCommandTest extends StorageSpecificCommandTestBase {
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithNonTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(false);
   }
 
   @Test
   public void
-      call_ProperArgumentsForRepairingTablesGivenWithTransactionalTableSchema_ShouldCallRepairTablesProperly()
+      call_ProperArgumentsForRepairingTablesGivenWithTransactionTableSchema_ShouldCallRepairTablesProperly()
           throws SchemaLoaderException {
     callProperArgumentsForRepairingTables(true);
   }
@@ -158,9 +158,9 @@ public class JdbcCommandTest extends StorageSpecificCommandTestBase {
 
     TableSchema tableSchema = mock(TableSchema.class);
     if (hasTransactionTables) {
-      when(tableSchema.isTransactionalTable()).thenReturn(true);
+      when(tableSchema.isTransactionTable()).thenReturn(true);
     } else {
-      when(tableSchema.isTransactionalTable()).thenReturn(false);
+      when(tableSchema.isTransactionTable()).thenReturn(false);
     }
     when(parser.parse()).thenReturn(Collections.singletonList(tableSchema));
 


### PR DESCRIPTION
Currently, we have used the two terms `transactional` and `transaction` mixed together. Though I don't think we need to fix it in the documentation, we should fix it in the code. This PR does that. Please take a look!