### PR TITLE
Change default value of is-transaction-table in Schema Loader

### DIFF
--- a/schema-loader/README.md
+++ b/schema-loader/README.md
@@ -1,7 +1,7 @@
 # Scalar DB Schema Loader
 
 Scalar DB Schema Loader creates, deletes and repairs Scalar DB schemas (namespaces and tables) on the basis of a provided schema file.
-Also, it automatically adds the Scalar DB transaction metadata (used in the Consensus Commit protocol) to the tables when you set the `transaction` parameter to `true` in the schema file.
+Also, when you use the Consensus Commit transaction manager, it automatically adds the Scalar DB transaction metadata to the tables.
 
 There are two ways to specify general CLI options in Schema Loader:
   - Pass a Scalar DB configuration file and database/storage-specific options additionally.
@@ -168,7 +168,7 @@ For using CLI arguments fully for configuration (Deprecated. Please use the comm
 $ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json [-r BASE_RESOURCE_UNIT]
 ```
   - `<COSMOS_DB_KEY>` you can use a primary key or a secondary key.
-  - `-r BASE_RESOURCE_UNIT` is an option. You can specify the RU of each database. The maximum RU in tables in the database will be set. If you don't specify RU of tables, the database RU will be set with this option. When you use transaction function, the RU of the coordinator tables of Scalar DB is specified by this option. By default, it's 400.
+  - `-r BASE_RESOURCE_UNIT` is an option. You can specify the RU of each database. The maximum RU in tables in the database will be set. If you don't specify RU of tables, the database RU will be set with this option. By default, it's 400.
 
 ```console
 # For DynamoDB
@@ -250,7 +250,11 @@ $ java -jar scalardb-schema-loader-<version>.jar --cassandra -h <CASSANDRA_IP> [
 # For a JDBC database
 $ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> -p <PASSWORD> -f schema.json --repair-all
 ```
+
 ### Sample schema file
+
+The sample schema is as follows (Sample schema file can be found [here](sample/schema_sample.json)):
+
 ```json
 {
   "sample_db.sample_table": {
@@ -312,6 +316,14 @@ $ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> 
   }
 }
 ```
+
+The schema has table definitions that include `columns`, `partition-key`, `clustering-key`, `secondary-index`,  and `transaction` fields.
+The `columns` field defines columns of the table and their data types.
+The `partition-key` field defines which columns the partition key is composed of, and `clustering-key` defines which columns the partition key is composed of.
+The `secondary-index` field defines which columns are indexed.
+The `transaction` field indicates whether the table is for transactions or not.
+If you set the `transaction` field to `true` or don't specify the `transaction` field, this tool creates a table with transaction metadata if needed.
+If not, it creates a table without any transaction metadata (that is, for a table with [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.md)).
 
 You can also specify database/storage-specific options in the table definition as follows:
 ```json

--- a/schema-loader/README.md
+++ b/schema-loader/README.md
@@ -319,7 +319,7 @@ The sample schema is as follows (Sample schema file can be found [here](sample/s
 
 The schema has table definitions that include `columns`, `partition-key`, `clustering-key`, `secondary-index`,  and `transaction` fields.
 The `columns` field defines columns of the table and their data types.
-The `partition-key` field defines which columns the partition key is composed of, and `clustering-key` defines which columns the partition key is composed of.
+The `partition-key` field defines which columns the partition key is composed of, and `clustering-key` defines which columns the clustering key is composed of.
 The `secondary-index` field defines which columns are indexed.
 The `transaction` field indicates whether the table is for transactions or not.
 If you set the `transaction` field to `true` or don't specify the `transaction` field, this tool creates a table with transaction metadata if needed.

--- a/schema-loader/src/integration-test/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/schema-loader/src/integration-test/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -149,6 +149,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
                 .build(),
         namespace2 + "." + TABLE_2,
             ImmutableMap.<String, Object>builder()
+                .put("transaction", false)
                 .put("partition-key", Collections.singletonList("pk1"))
                 .put("clustering-key", Collections.singletonList("ck1"))
                 .put(

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
@@ -42,7 +42,7 @@ public class TableSchema {
   private String tableName;
   private TableMetadata tableMetadata;
   private ImmutableMap<String, String> options;
-  private boolean isTransactionTable = false;
+  private boolean isTransactionTable = true;
   private Set<String> traveledKeys;
 
   @VisibleForTesting
@@ -107,14 +107,9 @@ public class TableSchema {
       }
     }
 
-    boolean transaction = false;
     if (tableDefinition.keySet().contains(TRANSACTION)) {
-      transaction = tableDefinition.get(TRANSACTION).getAsBoolean();
+      isTransactionTable = tableDefinition.get(TRANSACTION).getAsBoolean();
       traveledKeys.add(TRANSACTION);
-    }
-
-    if (transaction) {
-      isTransactionTable = true;
     }
 
     // Add columns

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/TableSchemaTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/TableSchemaTest.java
@@ -192,4 +192,44 @@ public class TableSchemaTest {
             () -> new TableSchema(tableFullName, tableDefinition, Collections.emptyMap()))
         .isInstanceOf(SchemaLoaderException.class);
   }
+
+  @Test
+  public void constructor_TableDefinitionWithoutTransactionGiven_ShouldConstructProperTableSchema()
+      throws SchemaLoaderException {
+    String tableDefinitionJson =
+        "{\"partition-key\": [\"c1\"],"
+            + "\"clustering-key\": [\"c3\",\"c4 ASC\",\"c6 DESC\"],"
+            + "\"columns\": {"
+            + "  \"c1\": \"INT\","
+            + "  \"c2\": \"TEXT\","
+            + "  \"c3\": \"BLOB\","
+            + "  \"c4\": \"INT\","
+            + "  \"c5\": \"BOOLEAN\","
+            + "  \"c6\": \"INT\""
+            + "},"
+            + "\"secondary-index\": [\"c2\",\"c4\"]}";
+    JsonObject tableDefinition = JsonParser.parseString(tableDefinitionJson).getAsJsonObject();
+
+    TableMetadata.Builder tableBuilder = TableMetadata.newBuilder();
+    tableBuilder.addPartitionKey("c1");
+    tableBuilder.addClusteringKey("c3");
+    tableBuilder.addClusteringKey("c4");
+    tableBuilder.addClusteringKey("c6", Order.DESC);
+    tableBuilder.addSecondaryIndex("c2");
+    tableBuilder.addSecondaryIndex("c4");
+    tableBuilder.addColumn("c1", DataType.INT);
+    tableBuilder.addColumn("c2", DataType.TEXT);
+    tableBuilder.addColumn("c3", DataType.BLOB);
+    tableBuilder.addColumn("c4", DataType.INT);
+    tableBuilder.addColumn("c5", DataType.BOOLEAN);
+    tableBuilder.addColumn("c6", DataType.INT);
+    TableMetadata expectedTableMetadata = tableBuilder.build();
+
+    // Act
+    TableSchema tableSchema = new TableSchema("ns.tb", tableDefinition, Collections.emptyMap());
+
+    // Assert
+    Assertions.assertThat(tableSchema.getTableMetadata()).isEqualTo(expectedTableMetadata);
+    Assertions.assertThat(tableSchema.isTransactionTable()).isTrue();
+  }
 }


### PR DESCRIPTION
Currently, if we don't specify the `transaction` field in a table definition in a schema file, the table is considered a non-transaction table. But I think the default should be a transaction table in Scalar DB because Scalar DB users usually use Transaction API and Storage API is an advanced feature for experts. This PR changes the default. Please take a look!