### PR TITLE
In the Admin create and drop index methods, alter column type if necessary

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -66,7 +66,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
           .addSecondaryIndex(COL_NAME5)
           .addSecondaryIndex(COL_NAME6)
           .build();
-
+  private StorageFactory storageFactory;
   private DistributedStorageAdmin admin;
   private DistributedStorage storage;
   private String namespace1;
@@ -76,13 +76,13 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   @BeforeAll
   public void beforeAll() throws Exception {
     initialize();
-    StorageFactory factory = StorageFactory.create(TestUtils.addSuffix(getProperties(), TEST_NAME));
-    admin = factory.getAdmin();
+    storageFactory = StorageFactory.create(TestUtils.addSuffix(getProperties(), TEST_NAME));
+    admin = storageFactory.getAdmin();
     namespace1 = getNamespace1();
     namespace2 = getNamespace2();
     namespace3 = getNamespace3();
     createTables();
-    storage = factory.getStorage();
+    storage = storageFactory.getStorage();
   }
 
   protected void initialize() throws Exception {}
@@ -119,6 +119,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   public void afterAll() throws ExecutionException {
     dropTables();
     admin.close();
+    storage.close();
   }
 
   private void dropTables() throws ExecutionException {
@@ -400,40 +401,155 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   }
 
   @Test
-  public void createIndex_ShouldCreateIndexCorrectly() throws ExecutionException {
+  public void createIndex_ForAllDataTypesWithExistingData_ShouldCreateIndexesCorrectly()
+      throws ExecutionException {
+    DistributedStorage storage = null;
     try {
       // Arrange
       Map<String, String> options = getCreationOptions();
-      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
-
+      TableMetadata metadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.BIGINT)
+              .addColumn(COL_NAME5, DataType.FLOAT)
+              .addColumn(COL_NAME6, DataType.DOUBLE)
+              .addColumn(COL_NAME7, DataType.BOOLEAN)
+              .addColumn(COL_NAME8, DataType.BLOB)
+              .addColumn(COL_NAME9, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addSecondaryIndex(COL_NAME9)
+              .build();
+      admin.createTable(namespace1, TABLE4, metadata, options);
+      storage = storageFactory.getStorage();
+      storage.put(
+          Put.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt(COL_NAME1, 1))
+              .intValue(COL_NAME2, 2)
+              .textValue(COL_NAME3, "3")
+              .bigIntValue(COL_NAME4, 4)
+              .floatValue(COL_NAME5, 5)
+              .doubleValue(COL_NAME6, 6)
+              .booleanValue(COL_NAME7, true)
+              .blobValue(COL_NAME8, "8".getBytes(StandardCharsets.UTF_8))
+              .textValue(COL_NAME9, "9")
+              .build());
       // Act
-      admin.createIndex(namespace1, TABLE4, COL_NAME7, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME2, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME3, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME4, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME5, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME6, options);
+      if (isIndexOnBooleanColumnSupported()) {
+        admin.createIndex(namespace1, TABLE4, COL_NAME7, options);
+      }
+      admin.createIndex(namespace1, TABLE4, COL_NAME8, options);
 
       // Assert
-      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isTrue();
-      assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
-          .contains(COL_NAME7);
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME2)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME3)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME4)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME5)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME6)).isTrue();
+      if (isIndexOnBooleanColumnSupported()) {
+        assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isTrue();
+      }
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME8)).isTrue();
+      if (isIndexOnBooleanColumnSupported()) {
+        assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
+            .containsOnly(
+                COL_NAME2, COL_NAME3, COL_NAME4, COL_NAME5, COL_NAME6, COL_NAME7, COL_NAME8,
+                COL_NAME9);
+      } else {
+        assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
+            .containsOnly(
+                COL_NAME2, COL_NAME3, COL_NAME4, COL_NAME5, COL_NAME6, COL_NAME8, COL_NAME9);
+      }
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
+      if (storage != null) {
+        storage.close();
+      }
     }
   }
 
   @Test
-  public void dropIndex_ShouldDropIndexCorrectly() throws ExecutionException {
+  public void dropIndex_ForAllDataTypesWithExistingData_ShouldDropIndexCorrectly()
+      throws ExecutionException {
+    DistributedStorage storage = null;
     try {
       // Arrange
       Map<String, String> options = getCreationOptions();
-      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+      TableMetadata metadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.BIGINT)
+              .addColumn(COL_NAME5, DataType.FLOAT)
+              .addColumn(COL_NAME6, DataType.DOUBLE)
+              .addColumn(COL_NAME7, DataType.BOOLEAN)
+              .addColumn(COL_NAME8, DataType.BLOB)
+              .addColumn(COL_NAME9, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addSecondaryIndex(COL_NAME2)
+              .addSecondaryIndex(COL_NAME3)
+              .addSecondaryIndex(COL_NAME4)
+              .addSecondaryIndex(COL_NAME5)
+              .addSecondaryIndex(COL_NAME6)
+              .addSecondaryIndex(COL_NAME8)
+              .addSecondaryIndex(COL_NAME9)
+              .addSecondaryIndex(COL_NAME9)
+              .build();
+      if (isIndexOnBooleanColumnSupported()) {
+        metadata = TableMetadata.newBuilder(metadata).addSecondaryIndex(COL_NAME7).build();
+      }
+      admin.createTable(namespace1, TABLE4, metadata, options);
+      storage = storageFactory.getStorage();
+      storage.put(
+          Put.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt(COL_NAME1, 1))
+              .intValue(COL_NAME2, 2)
+              .textValue(COL_NAME3, "3")
+              .bigIntValue(COL_NAME4, 4)
+              .floatValue(COL_NAME5, 5)
+              .doubleValue(COL_NAME6, 6)
+              .booleanValue(COL_NAME7, true)
+              .blobValue(COL_NAME8, "8".getBytes(StandardCharsets.UTF_8))
+              .textValue(COL_NAME9, "9")
+              .build());
 
       // Act
+      admin.dropIndex(namespace1, TABLE4, COL_NAME2);
+      admin.dropIndex(namespace1, TABLE4, COL_NAME3);
+      admin.dropIndex(namespace1, TABLE4, COL_NAME4);
+      admin.dropIndex(namespace1, TABLE4, COL_NAME5);
       admin.dropIndex(namespace1, TABLE4, COL_NAME6);
+      if (isIndexOnBooleanColumnSupported()) {
+        admin.dropIndex(namespace1, TABLE4, COL_NAME7);
+      }
+      admin.dropIndex(namespace1, TABLE4, COL_NAME8);
 
       // Assert
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME2)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME3)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME4)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME5)).isFalse();
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME6)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME8)).isFalse();
       assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
-          .doesNotContain(COL_NAME6);
+          .containsOnly(COL_NAME9);
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
+      if (storage != null) {
+        storage.close();
+      }
     }
   }
 
@@ -475,5 +591,9 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
     }
+  }
+
+  protected boolean isIndexOnBooleanColumnSupported() {
+    return true;
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -95,6 +95,10 @@ public abstract class DistributedStorageIntegrationTestBase {
         options);
   }
 
+  protected int getLargeDataSizeInBytes() {
+    return 5000;
+  }
+
   protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
@@ -1388,7 +1392,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     Key partitionKey = new Key(COL_NAME1, 1);
     for (int i = 0; i < 345; i++) {
       Key clusteringKey = new Key(COL_NAME4, i);
-      storage.put(new Put(partitionKey, clusteringKey).withBlobValue(COL_NAME6, new byte[5000]));
+      storage.put(
+          new Put(partitionKey, clusteringKey)
+              .withBlobValue(COL_NAME6, new byte[getLargeDataSizeInBytes()]));
     }
     Scan scan = new Scan(partitionKey);
 
@@ -1412,7 +1418,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     Key partitionKey = new Key(COL_NAME1, 1);
     for (int i = 0; i < 345; i++) {
       Key clusteringKey = new Key(COL_NAME4, i);
-      storage.put(new Put(partitionKey, clusteringKey).withBlobValue(COL_NAME6, new byte[5000]));
+      storage.put(
+          new Put(partitionKey, clusteringKey)
+              .withBlobValue(COL_NAME6, new byte[getLargeDataSizeInBytes()]));
     }
     Scan scan = new Scan(partitionKey).withOrdering(new Ordering(COL_NAME4, Order.ASC));
 
@@ -1574,7 +1582,9 @@ public abstract class DistributedStorageIntegrationTestBase {
     for (int i = 0; i < 345; i++) {
       Key partitionKey = new Key(COL_NAME1, i % 4);
       Key clusteringKey = new Key(COL_NAME4, i);
-      storage.put(new Put(partitionKey, clusteringKey).withBlobValue(COL_NAME6, new byte[5000]));
+      storage.put(
+          new Put(partitionKey, clusteringKey)
+              .withBlobValue(COL_NAME6, new byte[getLargeDataSizeInBytes()]));
     }
     Scan scan = new ScanAll();
 
@@ -1595,7 +1605,7 @@ public abstract class DistributedStorageIntegrationTestBase {
                       TextColumn.ofNull(COL_NAME2),
                       IntColumn.ofNull(COL_NAME3),
                       BooleanColumn.ofNull(COL_NAME5),
-                      BlobColumn.of(COL_NAME6, new byte[5000])))
+                      BlobColumn.of(COL_NAME6, new byte[getLargeDataSizeInBytes()])))
               .build());
     }
     assertResultsContainsExactlyInAnyOrder(results, expectedResults);

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -67,7 +67,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
           .addSecondaryIndex(COL_NAME5)
           .addSecondaryIndex(COL_NAME6)
           .build();
-
+  private TransactionFactory transactionFactory;
   private DistributedTransactionAdmin admin;
   private DistributedTransactionManager manager;
   private String namespace1;
@@ -77,14 +77,13 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   @BeforeAll
   public void beforeAll() throws Exception {
     initialize();
-    TransactionFactory factory =
-        TransactionFactory.create(TestUtils.addSuffix(gerProperties(), TEST_NAME));
-    admin = factory.getTransactionAdmin();
+    transactionFactory = TransactionFactory.create(TestUtils.addSuffix(gerProperties(), TEST_NAME));
+    admin = transactionFactory.getTransactionAdmin();
     namespace1 = getNamespace1();
     namespace2 = getNamespace2();
     namespace3 = getNamespace3();
     createTables();
-    manager = factory.getTransactionManager();
+    manager = transactionFactory.getTransactionManager();
   }
 
   protected void initialize() throws Exception {}
@@ -122,6 +121,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   public void afterAll() throws ExecutionException {
     dropTables();
     admin.close();
+    manager.close();
   }
 
   private void dropTables() throws ExecutionException {
@@ -408,46 +408,167 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   }
 
   @Test
-  public void createIndex_ShouldCreateIndexCorrectly() throws ExecutionException {
+  public void createIndex_ForAllDataTypesWithExistingData_ShouldCreateIndexesCorrectly()
+      throws Exception {
+    DistributedTransactionManager transactionManager = null;
     try {
       // Arrange
       Map<String, String> options = getCreationOptions();
-      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+      TableMetadata metadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.BIGINT)
+              .addColumn(COL_NAME5, DataType.FLOAT)
+              .addColumn(COL_NAME6, DataType.DOUBLE)
+              .addColumn(COL_NAME7, DataType.BOOLEAN)
+              .addColumn(COL_NAME8, DataType.BLOB)
+              .addColumn(COL_NAME9, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addSecondaryIndex(COL_NAME9)
+              .build();
+      admin.createTable(namespace1, TABLE4, metadata, options);
+      transactionManager = transactionFactory.getTransactionManager();
+      DistributedTransaction tx = transactionManager.start();
+      tx.put(
+          Put.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt(COL_NAME1, 1))
+              .intValue(COL_NAME2, 2)
+              .textValue(COL_NAME3, "3")
+              .bigIntValue(COL_NAME4, 4)
+              .floatValue(COL_NAME5, 5)
+              .doubleValue(COL_NAME6, 6)
+              .booleanValue(COL_NAME7, true)
+              .blobValue(COL_NAME8, "8".getBytes(StandardCharsets.UTF_8))
+              .textValue(COL_NAME9, "9")
+              .build());
+      tx.commit();
 
       // Act
-      admin.createIndex(namespace1, TABLE4, COL_NAME7, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME2, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME3, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME4, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME5, options);
+      admin.createIndex(namespace1, TABLE4, COL_NAME6, options);
+      if (isIndexOnBooleanColumnSupported()) {
+        admin.createIndex(namespace1, TABLE4, COL_NAME7, options);
+      }
+      admin.createIndex(namespace1, TABLE4, COL_NAME8, options);
 
       // Assert
-      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isTrue();
-      assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
-          .contains(COL_NAME7);
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME2)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME3)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME4)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME5)).isTrue();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME6)).isTrue();
+      if (isIndexOnBooleanColumnSupported()) {
+        assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isTrue();
+      }
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME8)).isTrue();
+      if (isIndexOnBooleanColumnSupported()) {
+        assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
+            .containsOnly(
+                COL_NAME2, COL_NAME3, COL_NAME4, COL_NAME5, COL_NAME6, COL_NAME7, COL_NAME8,
+                COL_NAME9);
+      } else {
+        assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
+            .containsOnly(
+                COL_NAME2, COL_NAME3, COL_NAME4, COL_NAME5, COL_NAME6, COL_NAME8, COL_NAME9);
+      }
+
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
+      if (transactionManager != null) {
+        transactionManager.close();
+      }
     }
   }
 
   @Test
-  public void dropIndex_ShouldDropIndexCorrectly() throws ExecutionException {
+  public void dropIndex_ForAllDataTypesWithExistingData_ShouldDropIndexCorrectly()
+      throws Exception {
+    DistributedTransactionManager transactionManager = null;
     try {
       // Arrange
       Map<String, String> options = getCreationOptions();
-      admin.createTable(namespace1, TABLE4, TABLE_METADATA, options);
+      TableMetadata metadata =
+          TableMetadata.newBuilder()
+              .addColumn(COL_NAME1, DataType.INT)
+              .addColumn(COL_NAME2, DataType.INT)
+              .addColumn(COL_NAME3, DataType.TEXT)
+              .addColumn(COL_NAME4, DataType.BIGINT)
+              .addColumn(COL_NAME5, DataType.FLOAT)
+              .addColumn(COL_NAME6, DataType.DOUBLE)
+              .addColumn(COL_NAME7, DataType.BOOLEAN)
+              .addColumn(COL_NAME8, DataType.BLOB)
+              .addColumn(COL_NAME9, DataType.TEXT)
+              .addPartitionKey(COL_NAME1)
+              .addSecondaryIndex(COL_NAME2)
+              .addSecondaryIndex(COL_NAME3)
+              .addSecondaryIndex(COL_NAME4)
+              .addSecondaryIndex(COL_NAME5)
+              .addSecondaryIndex(COL_NAME6)
+              .addSecondaryIndex(COL_NAME8)
+              .addSecondaryIndex(COL_NAME9)
+              .addSecondaryIndex(COL_NAME9)
+              .build();
+      if (isIndexOnBooleanColumnSupported()) {
+        metadata = TableMetadata.newBuilder(metadata).addSecondaryIndex(COL_NAME7).build();
+      }
+      admin.createTable(namespace1, TABLE4, metadata, options);
+      transactionManager = transactionFactory.getTransactionManager();
+      DistributedTransaction tx = transactionManager.start();
+      tx.put(
+          Put.newBuilder()
+              .namespace(namespace1)
+              .table(TABLE4)
+              .partitionKey(Key.ofInt(COL_NAME1, 1))
+              .intValue(COL_NAME2, 2)
+              .textValue(COL_NAME3, "3")
+              .bigIntValue(COL_NAME4, 4)
+              .floatValue(COL_NAME5, 5)
+              .doubleValue(COL_NAME6, 6)
+              .booleanValue(COL_NAME7, true)
+              .blobValue(COL_NAME8, "8".getBytes(StandardCharsets.UTF_8))
+              .textValue(COL_NAME9, "9")
+              .build());
+      tx.commit();
 
       // Act
+      admin.dropIndex(namespace1, TABLE4, COL_NAME2);
+      admin.dropIndex(namespace1, TABLE4, COL_NAME3);
+      admin.dropIndex(namespace1, TABLE4, COL_NAME4);
+      admin.dropIndex(namespace1, TABLE4, COL_NAME5);
       admin.dropIndex(namespace1, TABLE4, COL_NAME6);
+      if (isIndexOnBooleanColumnSupported()) {
+        admin.dropIndex(namespace1, TABLE4, COL_NAME7);
+      }
+      admin.dropIndex(namespace1, TABLE4, COL_NAME8);
 
       // Assert
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME2)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME3)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME4)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME5)).isFalse();
       assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME6)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME7)).isFalse();
+      assertThat(admin.indexExists(namespace1, TABLE4, COL_NAME8)).isFalse();
       assertThat(admin.getTableMetadata(namespace1, TABLE4).getSecondaryIndexNames())
-          .doesNotContain(COL_NAME6);
+          .containsOnly(COL_NAME9);
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
+      if (transactionManager != null) {
+        transactionManager.close();
+      }
     }
   }
 
   @Test
   public void addNewColumnToTable_AddColumnForEachExistingDataType_ShouldAddNewColumnsCorrectly()
-      throws ExecutionException, TransactionException {
+      throws ExecutionException {
     try {
       // Arrange
       Map<String, String> options = getCreationOptions();
@@ -483,5 +604,9 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     } finally {
       admin.dropTable(namespace1, TABLE4, true);
     }
+  }
+
+  protected boolean isIndexOnBooleanColumnSupported() {
+    return true;
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -22,6 +22,11 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are
   // different from the other adapters. So disable several tests that check such behaviors
 
+  @Override
+  protected boolean isIndexOnBooleanColumnSupported() {
+    return false;
+  }
+
   @Disabled
   @Test
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -18,6 +18,11 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
     return DynamoEnv.getCreationOptions();
   }
 
+  @Override
+  protected boolean isIndexOnBooleanColumnSupported() {
+    return false;
+  }
+
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are
   // different from the other adapters. So disable several tests that check such behaviors
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
 import java.util.Properties;
 
 public class JdbcDatabaseIntegrationTest extends DistributedStorageIntegrationTestBase {
@@ -8,5 +9,18 @@ public class JdbcDatabaseIntegrationTest extends DistributedStorageIntegrationTe
   @Override
   protected Properties getProperties() {
     return JdbcEnv.getProperties();
+  }
+
+  @Override
+  protected int getLargeDataSizeInBytes() {
+    RdbEngine rdbEngine =
+        JdbcUtils.getRdbEngine(new JdbcConfig(new DatabaseConfig(getProperties())).getJdbcUrl());
+
+    if (rdbEngine == RdbEngine.ORACLE) {
+      // For Oracle, the max data size for BLOB is 2000 bytes
+      return 2000;
+    } else {
+      return super.getLargeDataSizeInBytes();
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -767,6 +767,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   public void createIndex(
       String namespace, String table, String columnName, Map<String, String> options)
       throws ExecutionException {
+    if (getTableMetadata(namespace, table).getColumnDataType(columnName) == DataType.BOOLEAN) {
+      throw new IllegalArgumentException(
+          "Currently, BOOLEAN type is not supported for a secondary index in DynamoDB: "
+              + columnName);
+    }
 
     long ru = Long.parseLong(options.getOrDefault(REQUEST_UNIT, DEFAULT_REQUEST_UNIT));
     TableMetadata metadata = getTableMetadata(namespace, table);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -83,7 +83,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                   .put(DataType.FLOAT, "BINARY_FLOAT")
                   .put(DataType.DOUBLE, "BINARY_DOUBLE")
                   .put(DataType.BOOLEAN, "NUMBER(1)")
-                  .put(DataType.BLOB, "BLOB")
+                  .put(DataType.BLOB, "RAW(2000)")
                   .build())
           .put(
               RdbEngine.SQL_SERVER,
@@ -777,12 +777,93 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   public void createIndex(
       String namespace, String table, String columnName, Map<String, String> options)
       throws ExecutionException {
+
     try (Connection connection = dataSource.getConnection()) {
+      alterToIndexColumnTypeIfNecessary(connection, namespace, table, columnName);
       createIndex(connection, namespace, table, columnName);
       updateTableMetadata(connection, namespace, table, columnName, true);
-    } catch (SQLException e) {
+    } catch (ExecutionException | SQLException e) {
       throw new ExecutionException("creating the secondary index failed", e);
     }
+  }
+
+  private void alterToIndexColumnTypeIfNecessary(
+      Connection connection, String namespace, String table, String columnName)
+      throws ExecutionException, SQLException {
+    DataType indexType = getTableMetadata(namespace, table).getColumnDataType(columnName);
+    ImmutableMap<DataType, String> typeMappingForIndexes = DATA_TYPE_MAPPING_FOR_KEY.get(rdbEngine);
+    assert typeMappingForIndexes != null;
+
+    String indexedColumnType = typeMappingForIndexes.get(indexType);
+    if (indexedColumnType == null) {
+      // The column type does not need to be altered to be compatible with being secondary index
+      return;
+    }
+    String alterColumnStatement =
+        getAlterColumnTypeStatement(namespace, table, columnName, indexedColumnType);
+
+    execute(connection, alterColumnStatement);
+  }
+
+  private void alterToRegularColumnTypeIfNecessary(
+      Connection connection, String namespace, String table, String columnName)
+      throws ExecutionException, SQLException {
+    ImmutableMap<DataType, String> typeMappingForIndexes = DATA_TYPE_MAPPING_FOR_KEY.get(rdbEngine);
+    DataType indexType = getTableMetadata(namespace, table).getColumnDataType(columnName);
+    assert typeMappingForIndexes != null;
+
+    if (typeMappingForIndexes.get(indexType) == null) {
+      // The column type is already the type for a regular column. It was not altered to be
+      // compatible with being a secondary index, so no alteration is necessary.
+      return;
+    }
+
+    ImmutableMap<DataType, String> typeMappingForColumns = DATA_TYPE_MAPPING.get(rdbEngine);
+    assert typeMappingForColumns != null;
+    String regularColumnType = typeMappingForColumns.get(indexType);
+
+    String alterColumnStatement =
+        getAlterColumnTypeStatement(namespace, table, columnName, regularColumnType);
+
+    execute(connection, alterColumnStatement);
+  }
+
+  private String getAlterColumnTypeStatement(
+      String namespace, String table, String columnName, String newType) {
+    String alterColumnStatement;
+    switch (rdbEngine) {
+      case MYSQL:
+        alterColumnStatement =
+            "ALTER TABLE "
+                + encloseFullTableName(namespace, table)
+                + " MODIFY"
+                + enclose(columnName)
+                + " "
+                + newType;
+        break;
+      case POSTGRESQL:
+        alterColumnStatement =
+            "ALTER TABLE "
+                + encloseFullTableName(namespace, table)
+                + " ALTER COLUMN"
+                + enclose(columnName)
+                + " TYPE "
+                + newType;
+        break;
+      case ORACLE:
+        alterColumnStatement =
+            "ALTER TABLE "
+                + encloseFullTableName(namespace, table)
+                + " MODIFY ( "
+                + enclose(columnName)
+                + " "
+                + newType
+                + " )";
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return alterColumnStatement;
   }
 
   @Override
@@ -790,6 +871,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws ExecutionException {
     try (Connection connection = dataSource.getConnection()) {
       dropIndex(connection, namespace, table, columnName);
+      alterToRegularColumnTypeIfNecessary(connection, namespace, table, columnName);
       updateTableMetadata(connection, namespace, table, columnName, false);
     } catch (SQLException e) {
       throw new ExecutionException("dropping the secondary index failed", e);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -808,8 +808,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   private void alterToRegularColumnTypeIfNecessary(
       Connection connection, String namespace, String table, String columnName)
       throws ExecutionException, SQLException {
-    ImmutableMap<DataType, String> typeMappingForIndexes = DATA_TYPE_MAPPING_FOR_KEY.get(rdbEngine);
     DataType indexType = getTableMetadata(namespace, table).getColumnDataType(columnName);
+    ImmutableMap<DataType, String> typeMappingForIndexes = DATA_TYPE_MAPPING_FOR_KEY.get(rdbEngine);
     assert typeMappingForIndexes != null;
 
     if (typeMappingForIndexes.get(indexType) == null) {

--- a/schema-loader/README.md
+++ b/schema-loader/README.md
@@ -356,15 +356,15 @@ By default, the schema loader enables auto-scaling of RU for all tables: RU is s
 
 When creating tables for a JDBC database with this tool, Scalar DB data types are converted to RDB-specific data types as shown below.
 
-| ScalarDB | MySQL | PostgreSQL | Oracle | SQL Server |
-| ---- | ---- |  ---- |  ---- |  ---- | 
-| INT | INT | INT | INT | INT |
-| BIGINT | BIGINT | BIGINT | NUMBER(19) | BIGINT |
+| ScalarDB | MySQL | PostgreSQL | Oracle         | SQL Server |
+| ---- | ---- |  ---- |----------------|  ---- | 
+| INT | INT | INT | INT            | INT |
+| BIGINT | BIGINT | BIGINT | NUMBER(19)     | BIGINT |
 | TEXT | LONGTEXT | TEXT | VARCHAR2(4000) | VARCHAR(8000) |
-| FLOAT | DOUBLE | FLOAT | BINARY_FLOAT | FLOAT(24) |
-| DOUBLE | DOUBLE | DOUBLE PRECISION | BINARY_DOUBLE | FLOAT |
-| BOOLEAN | BOOLEAN | BOOLEAN | NUMBER(1) | BIT |
-| BLOB | LONGBLOB | BYTEA | BLOB | VARBINARY(8000) |
+| FLOAT | DOUBLE | FLOAT | BINARY_FLOAT   | FLOAT(24) |
+| DOUBLE | DOUBLE | DOUBLE PRECISION | BINARY_DOUBLE  | FLOAT |
+| BOOLEAN | BOOLEAN | BOOLEAN | NUMBER(1)      | BIT |
+| BLOB | LONGBLOB | BYTEA | RAW(2000)      | VARBINARY(8000) |
 
 However, the following types are converted differently when they are used as a primary key or a secondary index key due to the limitations of RDB data types.
 


### PR DESCRIPTION
**Problem**
Creating a secondary index using the `Admin.createIndex()` will fail for the storage and Scalar DB column type combination below because the current native RDB column type is not compatible with becoming an index.
- MySQL:  TEXT and BLOB
- PostgreSQL : TEXT
- Oracle: TEXT and BLOB

**Implemented fixes**
- Update the `JdbcAdmin.createIndex()` implementation to alter the column type if necessary to be compatible with a secondary index and then create the index. If the column holds data whose size is too big for the new altered type, an exception will be thrown.
- When an index is deleted using `JdbcAdmin.dropIndex()` the column type will be altered from the index compatible type back to the regular column type if necessary.
- Since Oracle does not natively support the column type alteration from BLOB (Scalar DB BLOB regular column type) to RAW(64) (Scalar DB BLOB primary key/index column type) which is something we wanted to be able to do if a column were to converted to a secondary index. We decided to change the regular default column type from `BLOB` to `RAW(2000)`.
