### PR TITLE
Fix CVE-2022-31197 affecting PostgreSQL driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         awssdkVersion = '2.17.69'
         commonsDbcp2Version = '2.8.0'
         mysqlDriverVersion = '8.0.22'
-        postgresqlDriverVersion = '42.3.3'
+        postgresqlDriverVersion = '42.4.1'
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'
         grpcVersion = '1.46.0'


### PR DESCRIPTION
This fixes CVE-2022-31197
![image](https://user-images.githubusercontent.com/3835021/183329383-a53aa0e6-89ae-4d8c-a898-6979b1ab4501.png)

The docker CI is failing because of another CVE located in the JRE image, cf. https://github.com/scalar-labs/docker/pull/9