### PR TITLE
Admin "repairTable()" handle metadata corruption

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
@@ -134,4 +134,17 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
     assertThat(admin.tableExists(getNamespace(), getTable())).isTrue();
     assertThat(admin.getTableMetadata(getNamespace(), getTable())).isEqualTo(TABLE_METADATA);
   }
+
+  @Test
+  public void repairTable_ForCorruptedMetadataTable_ShouldRepairProperly() throws Exception {
+    // Arrange
+    adminTestUtils.corruptMetadata(getNamespace(), getTable());
+
+    // Act
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
+
+    // Assert
+    assertThat(admin.tableExists(getNamespace(), getTable())).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), getTable())).isEqualTo(TABLE_METADATA);
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
@@ -152,6 +152,22 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
     }
   }
 
+  @Test
+  public void repairTable_ForCorruptedMetadataTable_ShouldRepairProperly() throws Exception {
+    // Arrange
+    adminTestUtils.corruptMetadata(getNamespace(), getTable());
+
+    // Act
+    admin.repairTable(getNamespace(), getTable(), TABLE_METADATA, getCreationOptions());
+
+    // Assert
+    assertThat(admin.tableExists(getNamespace(), getTable())).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), getTable())).isEqualTo(TABLE_METADATA);
+    if (hasCoordinatorTables()) {
+      assertTableMetadataForCoordinatorTableArePresent();
+    }
+  }
+
   private void assertTableMetadataForCoordinatorTableArePresent() throws Exception {
     Properties properties = TestUtils.addSuffix(getStorageProperties(), TEST_NAME);
     String coordinatorNamespace =

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminRepairTableIntegrationTest.java
@@ -28,6 +28,11 @@ public class CassandraAdminRepairTableIntegrationTest
   public void repairTable_ForTruncatedMetadataTable_ShouldRepairProperly() {}
 
   @Test
+  @Disabled("there is no metadata table for Cassandra")
+  @Override
+  public void repairTable_ForCorruptedMetadataTable_ShouldRepairProperly() {}
+
+  @Test
   public void repairTable_ShouldDoNothing() throws ExecutionException {
     // Act
     assertThatCode(

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminRepairTableIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminRepairTableIntegrationTestWithCassandra.java
@@ -28,6 +28,11 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCassandra
   public void repairTableAndCoordinatorTable_ForTruncatedMetadataTable_ShouldRepairProperly() {}
 
   @Test
+  @Disabled("there is no metadata table for Cassandra")
+  @Override
+  public void repairTable_ForCorruptedMetadataTable_ShouldRepairProperly() {}
+
+  @Test
   public void repairTableAndCoordinatorTable_ShouldDoNothing() throws ExecutionException {
     // Act
     assertThatCode(

--- a/core/src/integration-test/java/com/scalar/db/util/AdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/AdminTestUtils.java
@@ -38,4 +38,13 @@ public abstract class AdminTestUtils {
    * @throws Exception if an error occurs
    */
   public abstract void truncateMetadataTable() throws Exception;
+
+  /**
+   * Modify the metadata the table in a way that it will fail if the metadata are parsed
+   *
+   * @param namespace a namespace
+   * @param table a table
+   * @throws Exception if an error occurs
+   */
+  public abstract void corruptMetadata(String namespace, String table) throws Exception;
 }

--- a/core/src/integration-test/java/com/scalar/db/util/CassandraAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/CassandraAdminTestUtils.java
@@ -15,4 +15,9 @@ public class CassandraAdminTestUtils extends AdminTestUtils {
   public void truncateMetadataTable() {
     // Do nothing
   }
+
+  @Override
+  public void corruptMetadata(String namespace, String table) throws Exception {
+    // Do nothing
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/util/CosmosAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/CosmosAdminTestUtils.java
@@ -1,5 +1,7 @@
 package com.scalar.db.util;
 
+import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
@@ -10,9 +12,11 @@ import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.util.CosmosPagedIterable;
+import com.google.common.collect.ImmutableList;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cosmos.CosmosAdmin;
 import com.scalar.db.storage.cosmos.CosmosConfig;
+import com.scalar.db.storage.cosmos.CosmosTableMetadata;
 import com.scalar.db.storage.cosmos.Record;
 import java.util.Properties;
 
@@ -59,6 +63,16 @@ public class CosmosAdminTestUtils extends AdminTestUtils {
         record ->
             container.deleteItem(
                 record.getId(), new PartitionKey(record.getId()), new CosmosItemRequestOptions()));
+  }
+
+  @Override
+  public void corruptMetadata(String namespace, String table) {
+    CosmosTableMetadata corruptedMetadata = new CosmosTableMetadata();
+    corruptedMetadata.setId(getFullTableName(namespace, table));
+    corruptedMetadata.setPartitionKeyNames(ImmutableList.of("corrupted"));
+
+    CosmosContainer container = client.getDatabase(metadataNamespace).getContainer(metadataTable);
+    container.upsertItem(corruptedMetadata);
   }
 
   /**

--- a/core/src/integration-test/java/com/scalar/db/util/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/JdbcAdminTestUtils.java
@@ -1,11 +1,15 @@
 package com.scalar.db.util;
 
+import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
+import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.query.QueryUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -27,9 +31,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
 
   @Override
   public void dropMetadataTable() throws SQLException {
-    execute(
-        "DROP TABLE "
-            + QueryUtils.enclosedFullTableName(metadataNamespace, metadataTable, rdbEngine));
+    execute("DROP TABLE " + enclosedFullTableName(metadataNamespace, metadataTable, rdbEngine));
 
     String dropNamespaceStatement;
     if (rdbEngine == RdbEngine.ORACLE) {
@@ -43,9 +45,20 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   @Override
   public void truncateMetadataTable() throws Exception {
     String truncateTableStatement =
-        "TRUNCATE TABLE "
-            + QueryUtils.enclosedFullTableName(metadataNamespace, metadataTable, rdbEngine);
+        "TRUNCATE TABLE " + enclosedFullTableName(metadataNamespace, metadataTable, rdbEngine);
     execute(truncateTableStatement);
+  }
+
+  @Override
+  @SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
+  public void corruptMetadata(String namespace, String table) throws Exception {
+    String insertCorruptedMetadataStatement =
+        "INSERT INTO "
+            + enclosedFullTableName(metadataNamespace, metadataTable, rdbEngine)
+            + " VALUES ('"
+            + getFullTableName(namespace, table)
+            + "','corrupted','corrupted','corrupted','corrupted','0','0')";
+    execute(insertCorruptedMetadataStatement);
   }
 
   private void execute(String sql) throws SQLException {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1126,14 +1126,19 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   public void repairTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
-    if (!tableExists(namespace, table)) {
-      throw new IllegalArgumentException(
-          "The table " + getFullTableName(namespace, table) + "  does not exist");
-    }
-    boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
-    createMetadataTableIfNotExists(noBackup);
-    if (getTableMetadata(namespace, table) == null) {
+    try {
+      if (!tableExists(namespace, table)) {
+        throw new IllegalArgumentException(
+            "The table " + getFullTableName(namespace, table) + "  does not exist");
+      }
+      boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
+      createMetadataTableIfNotExists(noBackup);
       putTableMetadata(namespace, table, metadata);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ExecutionException(
+          String.format("repairing the table %s.%s failed", namespace, table), e);
     }
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -1518,59 +1518,8 @@ public class JdbcAdminTest {
   public void
       repairTable_WithMissingMetadataTableForMysql_shouldCreateMetadataTableAndAddMetadataForTable()
           throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForMysql(false);
-  }
-
-  @Test
-  public void
-      repairTable_WithMissingMetadataTableForOracle_shouldCreateMetadataTableAndAddMetadataForTable()
-          throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForOracle(false);
-  }
-
-  @Test
-  public void
-      repairTable_WithMissingMetadataTableForPostgresql_shouldCreateMetadataTableAndAddMetadataForTable()
-          throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForPostgresql(false);
-  }
-
-  @Test
-  public void
-      repairTable_WithMissingMetadataTableForSqlServer_shouldCreateMetadataTableAndAddMetadataForTable()
-          throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForSqlServer(false);
-  }
-
-  @Test
-  public void repairTable_WithEmptyMetadataTableForMysql_shouldAddMetadataForTable()
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForMysql(true);
-  }
-
-  @Test
-  public void repairTable_WithEmptyMetadataTableForOracle_shouldAddMetadataForTable()
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForOracle(true);
-  }
-
-  @Test
-  public void repairTable_WithEmptyMetadataTableForPostgresql_shouldAddMetadataForTable()
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForPostgresql(true);
-  }
-
-  @Test
-  public void repairTable_WithEmptyMetadataTableForSqlServer_shouldAddMetadataForTable()
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForSqlServer(true);
-  }
-
-  private void repairTable_WithMissingMetadataForMysql(boolean isMetadataTableExisting)
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForX_shouldAddMetadataForTable(
+    repairTable_WithMissingMetadataTableForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.MYSQL,
-        isMetadataTableExisting,
         "SELECT 1 FROM `my_ns`.`foo_table` LIMIT 1",
         "SELECT 1 FROM `scalardb`.`metadata` LIMIT 1",
         "CREATE SCHEMA IF NOT EXISTS `scalardb`",
@@ -1578,11 +1527,12 @@ public class JdbcAdminTest {
         "INSERT INTO `scalardb`.`metadata` VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,false,1)");
   }
 
-  private void repairTable_WithMissingMetadataForOracle(boolean isMetadataTableExisting)
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForX_shouldAddMetadataForTable(
+  @Test
+  public void
+      repairTable_WithMissingMetadataTableForOracle_shouldCreateMetadataTableAndAddMetadataForTable()
+          throws SQLException, ExecutionException {
+    repairTable_WithMissingMetadataTableForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.ORACLE,
-        isMetadataTableExisting,
         "SELECT 1 FROM \"my_ns\".\"foo_table\" FETCH FIRST 1 ROWS ONLY",
         "SELECT 1 FROM \"scalardb\".\"metadata\" FETCH FIRST 1 ROWS ONLY",
         "CREATE USER \"scalardb\" IDENTIFIED BY \"oracle\"",
@@ -1591,11 +1541,12 @@ public class JdbcAdminTest {
         "INSERT INTO \"scalardb\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,0,1)");
   }
 
-  private void repairTable_WithMissingMetadataForPostgresql(boolean isMetadataTableExisting)
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForX_shouldAddMetadataForTable(
+  @Test
+  public void
+      repairTable_WithMissingMetadataTableForPostgresql_shouldCreateMetadataTableAndAddMetadataForTable()
+          throws SQLException, ExecutionException {
+    repairTable_WithMissingMetadataTableForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.POSTGRESQL,
-        isMetadataTableExisting,
         "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1",
         "SELECT 1 FROM \"scalardb\".\"metadata\" LIMIT 1",
         "CREATE SCHEMA IF NOT EXISTS \"scalardb\"",
@@ -1603,11 +1554,12 @@ public class JdbcAdminTest {
         "INSERT INTO \"scalardb\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,false,1)");
   }
 
-  private void repairTable_WithMissingMetadataForSqlServer(boolean isMetadataTableExisting)
-      throws SQLException, ExecutionException {
-    repairTable_WithMissingMetadataForX_shouldAddMetadataForTable(
+  @Test
+  public void
+      repairTable_WithMissingMetadataTableForSqlServer_shouldCreateMetadataTableAndAddMetadataForTable()
+          throws SQLException, ExecutionException {
+    repairTable_WithMissingMetadataTableForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.SQL_SERVER,
-        isMetadataTableExisting,
         "SELECT TOP 1 1 FROM [my_ns].[foo_table]",
         "SELECT TOP 1 1 FROM [scalardb].[metadata]",
         "CREATE SCHEMA [scalardb]",
@@ -1615,9 +1567,10 @@ public class JdbcAdminTest {
         "INSERT INTO [scalardb].[metadata] VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,0,1)");
   }
 
-  private void repairTable_WithMissingMetadataForX_shouldAddMetadataForTable(
-      RdbEngine rdbEngine, boolean isMetadataTableExisting, String... expectedSqlStatements)
-      throws SQLException, ExecutionException {
+  private void
+      repairTable_WithMissingMetadataTableForX_shouldCreateMetadataTableAndAddMetadataForTable(
+          RdbEngine rdbEngine, String... expectedSqlStatements)
+          throws SQLException, ExecutionException {
     // Arrange
     String namespace = "my_ns";
     String table = "foo_table";
@@ -1635,29 +1588,20 @@ public class JdbcAdminTest {
             mockedStatements.subList(1, mockedStatements.size()).toArray(new Statement[0]));
     when(dataSource.getConnection()).thenReturn(connection);
 
-    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
-
-    if (isMetadataTableExisting) {
-      // Mock that the metadata table exists but it is empty
-      PreparedStatement selectStatement = mock(PreparedStatement.class);
-      ResultSet resultSet = mock(ResultSet.class);
-      when(resultSet.next()).thenReturn(false);
-      when(selectStatement.executeQuery()).thenReturn(resultSet);
-      when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    // Mock that the metadata table does not exist
+    SQLException sqlException = mock(SQLException.class);
+    if (rdbEngine == RdbEngine.MYSQL) {
+      when(sqlException.getErrorCode()).thenReturn(1049);
+    } else if (rdbEngine == RdbEngine.POSTGRESQL) {
+      when(sqlException.getSQLState()).thenReturn("42P01");
+    } else if (rdbEngine == RdbEngine.ORACLE) {
+      when(sqlException.getErrorCode()).thenReturn(942);
     } else {
-      // Mock that the metadata table does not exist
-      SQLException sqlException = mock(SQLException.class);
-      if (rdbEngine == RdbEngine.MYSQL) {
-        when(sqlException.getErrorCode()).thenReturn(1049);
-      } else if (rdbEngine == RdbEngine.POSTGRESQL) {
-        when(sqlException.getSQLState()).thenReturn("42P01");
-      } else if (rdbEngine == RdbEngine.ORACLE) {
-        when(sqlException.getErrorCode()).thenReturn(942);
-      } else {
-        when(sqlException.getErrorCode()).thenReturn(208);
-      }
-      when(mockedStatements.get(1).execute(anyString())).thenThrow(sqlException);
+      when(sqlException.getErrorCode()).thenReturn(208);
     }
+    when(mockedStatements.get(1).execute(anyString())).thenThrow(sqlException);
+
+    JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
 
     // Act
     admin.repairTable(namespace, table, metadata, new HashMap<>());
@@ -1669,42 +1613,50 @@ public class JdbcAdminTest {
   }
 
   @Test
-  public void repairTable_WithExistingMetadataForTableForMySql_shouldNotAddMetadata()
+  public void repairTable_ExistingMetadataTableForMysql_shouldDeleteThenAddMetadataForTable()
       throws SQLException, ExecutionException {
-    repairTable_WithExistingMetadataForTableForX_shouldNotAddMetadata(
+    repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
         RdbEngine.MYSQL,
         "SELECT 1 FROM `my_ns`.`foo_table` LIMIT 1",
-        "SELECT 1 FROM `scalardb`.`metadata` LIMIT 1");
+        "SELECT 1 FROM `scalardb`.`metadata` LIMIT 1",
+        "DELETE FROM `scalardb`.`metadata` WHERE `full_table_name` = 'my_ns.foo_table'",
+        "INSERT INTO `scalardb`.`metadata` VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,false,1)");
   }
 
   @Test
-  public void repairTable_WithExistingMetadataForTableForOracle_shouldNotAddMetadata()
+  public void repairTable_ExistingMetadataTableForOracle_shouldDeleteThenAddMetadataForTable()
       throws SQLException, ExecutionException {
-    repairTable_WithExistingMetadataForTableForX_shouldNotAddMetadata(
+    repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
         RdbEngine.ORACLE,
         "SELECT 1 FROM \"my_ns\".\"foo_table\" FETCH FIRST 1 ROWS ONLY",
-        "SELECT 1 FROM \"scalardb\".\"metadata\" FETCH FIRST 1 ROWS ONLY");
+        "SELECT 1 FROM \"scalardb\".\"metadata\" FETCH FIRST 1 ROWS ONLY",
+        "DELETE FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "INSERT INTO \"scalardb\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,0,1)");
   }
 
   @Test
-  public void repairTable_WithExistingMetadataForTableForPostgresql_shouldNotAddMetadata()
+  public void repairTable_ExistingMetadataTableForPosgresql_shouldDeleteThenAddMetadataForTable()
       throws SQLException, ExecutionException {
-    repairTable_WithExistingMetadataForTableForX_shouldNotAddMetadata(
+    repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
         RdbEngine.POSTGRESQL,
         "SELECT 1 FROM \"my_ns\".\"foo_table\" LIMIT 1",
-        "SELECT 1 FROM \"scalardb\".\"metadata\" LIMIT 1");
+        "SELECT 1 FROM \"scalardb\".\"metadata\" LIMIT 1",
+        "DELETE FROM \"scalardb\".\"metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "INSERT INTO \"scalardb\".\"metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,false,1)");
   }
 
   @Test
-  public void repairTable_WithExistingMetadataForTableForSqlServer_shouldNotAddMetadata()
+  public void repairTable_ExistingMetadataTableForSqlServer_shouldDeleteThenAddMetadataForTable()
       throws SQLException, ExecutionException {
-    repairTable_WithExistingMetadataForTableForX_shouldNotAddMetadata(
+    repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
         RdbEngine.SQL_SERVER,
         "SELECT TOP 1 1 FROM [my_ns].[foo_table]",
-        "SELECT TOP 1 1 FROM [scalardb].[metadata]");
+        "SELECT TOP 1 1 FROM [scalardb].[metadata]",
+        "DELETE FROM [scalardb].[metadata] WHERE [full_table_name] = 'my_ns.foo_table'",
+        "INSERT INTO [scalardb].[metadata] VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,0,1)");
   }
 
-  private void repairTable_WithExistingMetadataForTableForX_shouldNotAddMetadata(
+  private void repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
       RdbEngine rdbEngine, String... expectedSqlStatements)
       throws SQLException, ExecutionException {
     // Arrange
@@ -1725,14 +1677,6 @@ public class JdbcAdminTest {
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = new JdbcAdmin(dataSource, rdbEngine, config);
-
-    PreparedStatement selectStatement = mock(PreparedStatement.class);
-    ResultSet resultSet =
-        mockResultSet(
-            Collections.singletonList(
-                new Row("c1", DataType.TEXT.toString(), "PARTITION", null, false)));
-    when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
 
     // Act
     admin.repairTable(namespace, table, metadata, new HashMap<>());


### PR DESCRIPTION
This updates the `Admin.repairTable()` method implementation to handle the case if the metadata for the table is corrupted. 
So far, the method implementation was only creating the metadata for the table if it did not exist. This PR updates it so that if the metadata are present, they are : 
- for the `JdbcAdmin`, they are deleted and then added
- for the `CosmosAdmin` and `DynamoAdmin`, they are upserted.