### PR TITLE
Fix CVE-2021-46828 by bumping the jre8 dependency version

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.4
+FROM ghcr.io/scalar-labs/jre8:1.1.5
 
 COPY scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM ghcr.io/scalar-labs/jre8:1.1.4
+FROM ghcr.io/scalar-labs/jre8:1.1.5
 
 COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/


### PR DESCRIPTION
This PR updates the JRE image to `jre8:1.1.5` to fix the CVE-2021-46828. 
The docker CI is failing because of the other CVE affecting the PosgreSQL driver. The driver is being updated in https://github.com/scalar-labs/scalardb/pull/650