### PR TITLE
Add begin() and abort() to Two-phase Commit Transaction API

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -146,7 +146,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void get_GetGivenForCommittedRecord_ShouldReturnRecord() throws TransactionException {
     // Arrange
     populate(TABLE_1);
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     Optional<Result> result = transaction.get(prepareGet(0, 0, TABLE_1));
@@ -162,7 +162,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void scan_ScanGivenForCommittedRecord_ShouldReturnRecord() throws TransactionException {
     // Arrange
     populate(TABLE_1);
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     List<Result> results = transaction.scan(prepareScan(0, 0, 0, TABLE_1));
@@ -179,7 +179,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       get_CalledTwiceAndAnotherTransactionCommitsInBetween_ShouldReturnFromSnapshotInSecondTime()
           throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     Optional<Result> result1 = transaction.get(prepareGet(0, 0, TABLE_1));
@@ -194,7 +194,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void get_GetGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
     // Arrange
     populate(TABLE_1);
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     Optional<Result> result = transaction.get(prepareGet(0, 4, TABLE_1));
@@ -207,7 +207,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
     // Arrange
     populate(TABLE_1);
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     List<Result> results = transaction.scan(prepareScan(0, 4, 4, TABLE_1));
@@ -224,7 +224,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.PREPARED, current, TransactionState.COMMITTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -281,7 +281,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.PREPARED, current, TransactionState.ABORTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -338,7 +338,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.PREPARED, prepared_at, null);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -382,7 +382,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.PREPARED, prepared_at, null);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -444,11 +444,11 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.PREPARED, current, TransactionState.COMMITTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     transaction.setBeforeRecoveryHook(
         () -> {
-          TwoPhaseConsensusCommit another = manager.start();
+          TwoPhaseConsensusCommit another = manager.begin();
           assertThatThrownBy(
                   () -> {
                     if (selectionType == SelectionType.GET) {
@@ -520,11 +520,11 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.PREPARED, current, TransactionState.ABORTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     transaction.setBeforeRecoveryHook(
         () -> {
-          TwoPhaseConsensusCommit another = manager.start();
+          TwoPhaseConsensusCommit another = manager.begin();
           assertThatThrownBy(
                   () -> {
                     if (selectionType == SelectionType.GET) {
@@ -595,7 +595,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.DELETED, current, TransactionState.COMMITTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -646,7 +646,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.DELETED, current, TransactionState.ABORTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -702,7 +702,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.DELETED, prepared_at, null);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -746,7 +746,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.DELETED, prepared_at, null);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act Assert
     assertThatThrownBy(
@@ -808,11 +808,11 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.DELETED, current, TransactionState.COMMITTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     transaction.setBeforeRecoveryHook(
         () -> {
-          TwoPhaseConsensusCommit another = manager.start();
+          TwoPhaseConsensusCommit another = manager.begin();
           assertThatThrownBy(
                   () -> {
                     if (selectionType == SelectionType.GET) {
@@ -878,11 +878,11 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populatePreparedRecordAndCoordinatorStateRecord(
         TABLE_1, TransactionState.DELETED, current, TransactionState.ABORTED);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     transaction.setBeforeRecoveryHook(
         () -> {
-          TwoPhaseConsensusCommit another = manager.start();
+          TwoPhaseConsensusCommit another = manager.begin();
           assertThatThrownBy(
                   () -> {
                     if (selectionType == SelectionType.GET) {
@@ -949,15 +949,15 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void getAndScan_CommitHappenedInBetween_ShouldReadRepeatably()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     Optional<Result> result1 = transaction1.get(prepareGet(0, 0, TABLE_1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start();
+    TwoPhaseConsensusCommit transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0, TABLE_1));
     transaction2.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 2));
     transaction2.prepare();
@@ -977,7 +977,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void putAndCommit_PutGivenForNonExisting_ShouldCreateRecord() throws TransactionException {
     // Arrange
     int expected = INITIAL_BALANCE;
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, expected));
@@ -985,7 +985,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(0, 0, TABLE_1));
 
     assertThat(result).isPresent();
@@ -1000,7 +1000,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     populate(TABLE_1);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     Optional<Result> result = transaction.get(prepareGet(0, 0, TABLE_1));
@@ -1012,7 +1012,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     result = another.get(prepareGet(0, 0, TABLE_1));
 
     assertThat(result).isPresent();
@@ -1027,7 +1027,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Arrange
     populate(TABLE_1);
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1100));
 
     // Act Assert
@@ -1035,7 +1035,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(0, 0, TABLE_1));
 
     assertThat(result).isPresent();
@@ -1058,7 +1058,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     int toId = 1;
     int toType = 0;
 
-    TwoPhaseConsensusCommit fromTx = manager.start();
+    TwoPhaseConsensusCommit fromTx = manager.begin();
     TwoPhaseConsensusCommit toTx = manager.join(fromTx.getId());
     transfer(fromId, fromType, TABLE_1, fromTx, toId, toType, TABLE_2, toTx, amount);
 
@@ -1073,7 +1073,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         .doesNotThrowAnyException();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(fromId, fromType, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(fromBalance);
@@ -1097,7 +1097,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     int anotherToId = 2;
     int anotherToType = 0;
 
-    TwoPhaseConsensusCommit fromTx = manager.start();
+    TwoPhaseConsensusCommit fromTx = manager.begin();
     TwoPhaseConsensusCommit toTx = manager.join(fromTx.getId());
     fromTx.put(preparePut(fromId, fromType, TABLE_1).withValue(BALANCE, expected));
     toTx.put(preparePut(toId, toType, TABLE_2).withValue(BALANCE, expected));
@@ -1106,7 +1106,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit anotherFromTx = manager.start();
+                      TwoPhaseConsensusCommit anotherFromTx = manager.begin();
                       TwoPhaseConsensusCommit anotherToTx = manager.join(anotherFromTx.getId());
                       anotherFromTx.put(
                           preparePut(anotherFromId, anotherFromType, TABLE_2)
@@ -1132,7 +1132,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     toTx.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(fromId, fromType, TABLE_1));
     assertThat(result).isNotPresent();
 
@@ -1162,7 +1162,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populate(TABLE_1);
     populate(TABLE_2);
 
-    TwoPhaseConsensusCommit fromTx = manager.start();
+    TwoPhaseConsensusCommit fromTx = manager.begin();
     TwoPhaseConsensusCommit toTx = manager.join(fromTx.getId());
     fromTx.get(prepareGet(fromId, fromType, TABLE_1));
     fromTx.delete(prepareDelete(fromId, fromType, TABLE_1));
@@ -1173,7 +1173,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit anotherFromTx = manager.start();
+                      TwoPhaseConsensusCommit anotherFromTx = manager.begin();
                       TwoPhaseConsensusCommit anotherToTx = manager.join(anotherFromTx.getId());
                       transfer(
                           anotherFromId,
@@ -1204,7 +1204,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     toTx.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(fromId, fromType, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE);
@@ -1236,7 +1236,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populate(TABLE_1);
     populate(TABLE_2);
 
-    TwoPhaseConsensusCommit fromTx = manager.start();
+    TwoPhaseConsensusCommit fromTx = manager.begin();
     TwoPhaseConsensusCommit toTx = manager.join(fromTx.getId());
     transfer(fromId, fromType, TABLE_1, fromTx, toId, toType, TABLE_2, toTx, amount1);
 
@@ -1244,7 +1244,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit anotherFromTx = manager.start();
+                      TwoPhaseConsensusCommit anotherFromTx = manager.begin();
                       TwoPhaseConsensusCommit anotherToTx = manager.join(anotherFromTx.getId());
                       transfer(
                           anotherFromId,
@@ -1275,7 +1275,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     toTx.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(fromId, fromType, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE);
@@ -1307,7 +1307,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populate(TABLE_1);
     populate(TABLE_2);
 
-    TwoPhaseConsensusCommit fromTx = manager.start();
+    TwoPhaseConsensusCommit fromTx = manager.begin();
     TwoPhaseConsensusCommit toTx = manager.join(fromTx.getId());
     transfer(fromId, fromType, TABLE_1, fromTx, toId, toType, TABLE_2, toTx, amount1);
 
@@ -1315,7 +1315,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit anotherFromTx = manager.start();
+                      TwoPhaseConsensusCommit anotherFromTx = manager.begin();
                       TwoPhaseConsensusCommit anotherToTx = manager.join(anotherFromTx.getId());
                       transfer(
                           anotherFromId,
@@ -1346,7 +1346,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         .doesNotThrowAnyException();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(fromId, fromType, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE - amount1);
@@ -1378,7 +1378,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     int anotherToId = toId;
     int anotherToType = toType;
 
-    TwoPhaseConsensusCommit fromTx = manager.start();
+    TwoPhaseConsensusCommit fromTx = manager.begin();
     TwoPhaseConsensusCommit toTx = manager.join(fromTx.getId());
     fromTx.put(preparePut(fromId, fromType, TABLE_1).withValue(BALANCE, expected));
     toTx.put(preparePut(toId, toType, TABLE_2).withValue(BALANCE, expected));
@@ -1387,7 +1387,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit anotherFromTx = manager.start();
+                      TwoPhaseConsensusCommit anotherFromTx = manager.begin();
                       TwoPhaseConsensusCommit anotherToTx = manager.join(anotherFromTx.getId());
                       anotherFromTx.put(
                           preparePut(anotherFromId, anotherFromType, TABLE_2)
@@ -1414,7 +1414,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         .doesNotThrowAnyException();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(fromId, fromType, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(expected);
@@ -1435,7 +1435,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void prepare_DeleteGivenWithoutRead_ShouldNotThrowAnyExceptions() {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.delete(prepareDelete(0, 0, TABLE_1));
 
     // Act Assert
@@ -1446,7 +1446,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void prepare_DeleteGivenForNonExisting_ShouldNotThrowAnyExceptions()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.get(prepareGet(0, 0, TABLE_1));
     transaction.delete(prepareDelete(0, 0, TABLE_1));
 
@@ -1459,7 +1459,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     populate(TABLE_1);
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     Optional<Result> result = transaction.get(prepareGet(0, 0, TABLE_1));
@@ -1470,7 +1470,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Assert
     assertThat(result.isPresent()).isTrue();
 
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     result = another.get(prepareGet(0, 0, TABLE_1));
     assertThat(result.isPresent()).isFalse();
   }
@@ -1489,7 +1489,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populate(TABLE_1);
     populate(TABLE_2);
 
-    TwoPhaseConsensusCommit tx1 = manager.start();
+    TwoPhaseConsensusCommit tx1 = manager.begin();
     TwoPhaseConsensusCommit tx2 = manager.join(tx1.getId());
     deletes(account1Id, account1Type, TABLE_1, tx1, account2Id, account2Type, TABLE_2, tx2);
 
@@ -1497,7 +1497,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit tx3 = manager.start();
+                      TwoPhaseConsensusCommit tx3 = manager.begin();
                       TwoPhaseConsensusCommit tx4 = manager.join(tx3.getId());
                       deletes(
                           account2Id,
@@ -1527,7 +1527,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx2.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(account1Id, account1Type, TABLE_1));
     assertThat(result).isPresent();
 
@@ -1554,7 +1554,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     populate(TABLE_1);
     populate(TABLE_2);
 
-    TwoPhaseConsensusCommit tx1 = manager.start();
+    TwoPhaseConsensusCommit tx1 = manager.begin();
     TwoPhaseConsensusCommit tx2 = manager.join(tx1.getId());
     deletes(account1Id, account1Type, TABLE_1, tx1, account2Id, account2Type, TABLE_2, tx2);
 
@@ -1562,7 +1562,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         () ->
             assertThatCode(
                     () -> {
-                      TwoPhaseConsensusCommit tx3 = manager.start();
+                      TwoPhaseConsensusCommit tx3 = manager.begin();
                       TwoPhaseConsensusCommit tx4 = manager.join(tx3.getId());
                       deletes(
                           account3Id,
@@ -1592,7 +1592,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         .doesNotThrowAnyException();
 
     // Assert
-    TwoPhaseConsensusCommit another = manager.start();
+    TwoPhaseConsensusCommit another = manager.begin();
     Optional<Result> result = another.get(prepareGet(account1Id, account1Type, TABLE_1));
     assertThat(result).isNotPresent();
 
@@ -1610,14 +1610,14 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void commit_WriteSkewOnExistingRecordsWithSnapshot_ShouldProduceNonSerializableResult()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.put(preparePut(1, 0, TABLE_2).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit tx1Sub1 = manager.start();
+    TwoPhaseConsensusCommit tx1Sub1 = manager.begin();
     TwoPhaseConsensusCommit tx1Sub2 = manager.join(tx1Sub1.getId());
     Optional<Result> result = tx1Sub2.get(prepareGet(1, 0, TABLE_2));
     assertThat(result).isPresent();
@@ -1625,7 +1625,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx1Sub1.get(prepareGet(0, 0, TABLE_1));
     tx1Sub1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, current1 + 1));
 
-    TwoPhaseConsensusCommit tx2Sub1 = manager.start();
+    TwoPhaseConsensusCommit tx2Sub1 = manager.begin();
     TwoPhaseConsensusCommit tx2Sub2 = manager.join(tx2Sub1.getId());
     result = tx2Sub1.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
@@ -1644,7 +1644,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx2Sub2.commit();
 
     // Assert
-    transaction = manager.start();
+    transaction = manager.begin();
     // the results can not be produced by executing the transactions serially
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
@@ -1659,7 +1659,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       commit_WriteSkewOnExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowPreparationException()
           throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.put(preparePut(1, 0, TABLE_2).withValue(BALANCE, 1));
     transaction.prepare();
@@ -1669,7 +1669,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_WRITE;
 
     // Act Assert
-    TwoPhaseConsensusCommit tx1Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx1Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx1Sub2 = manager.join(tx1Sub1.getId(), isolation, strategy);
     Optional<Result> result = tx1Sub2.get(prepareGet(1, 0, TABLE_2));
     assertThat(result).isPresent();
@@ -1677,7 +1677,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx1Sub1.get(prepareGet(0, 0, TABLE_1));
     tx1Sub1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, current1 + 1));
 
-    TwoPhaseConsensusCommit tx2Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx2Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx2Sub2 = manager.join(tx2Sub1.getId(), isolation, strategy);
     result = tx2Sub1.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
@@ -1700,7 +1700,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx2Sub2.rollback();
 
     // Assert
-    transaction = manager.start();
+    transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(current1 + 1);
@@ -1714,7 +1714,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       commit_WriteSkewOnExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowValidationException()
           throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.put(preparePut(1, 0, TABLE_2).withValue(BALANCE, 1));
     transaction.prepare();
@@ -1724,7 +1724,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_READ;
 
     // Act Assert
-    TwoPhaseConsensusCommit tx1Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx1Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx1Sub2 = manager.join(tx1Sub1.getId(), isolation, strategy);
     Optional<Result> result = tx1Sub2.get(prepareGet(1, 0, TABLE_2));
     assertThat(result).isPresent();
@@ -1732,7 +1732,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx1Sub1.get(prepareGet(0, 0, TABLE_1));
     tx1Sub1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, current1 + 1));
 
-    TwoPhaseConsensusCommit tx2Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx2Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx2Sub2 = manager.join(tx2Sub1.getId(), isolation, strategy);
     result = tx2Sub1.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
@@ -1759,7 +1759,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx2Sub2.rollback();
 
     // Assert
-    transaction = manager.start();
+    transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(current1 + 1);
@@ -1777,7 +1777,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_WRITE;
 
     // Act Assert
-    TwoPhaseConsensusCommit tx1Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx1Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx1Sub2 = manager.join(tx1Sub1.getId(), isolation, strategy);
     Optional<Result> result = tx1Sub2.get(prepareGet(1, 0, TABLE_2));
     assertThat(result).isNotPresent();
@@ -1785,7 +1785,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx1Sub1.get(prepareGet(0, 0, TABLE_1));
     tx1Sub1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, current1 + 1));
 
-    TwoPhaseConsensusCommit tx2Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx2Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx2Sub2 = manager.join(tx2Sub1.getId(), isolation, strategy);
     result = tx2Sub1.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isNotPresent();
@@ -1808,7 +1808,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx2Sub2.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(current1 + 1);
@@ -1828,7 +1828,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_WRITE;
 
     // Act
-    TwoPhaseConsensusCommit txSub1 = manager.start(ANY_ID_1, isolation, strategy);
+    TwoPhaseConsensusCommit txSub1 = manager.begin(ANY_ID_1, isolation, strategy);
     TwoPhaseConsensusCommit txSub2 = manager.join(txSub1.getId(), isolation, strategy);
 
     Optional<Result> result = txSub2.get(prepareGet(1, 0, TABLE_2));
@@ -1850,7 +1850,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     txSub2.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isNotPresent();
     result = transaction.get(prepareGet(1, 0, TABLE_2));
@@ -1866,7 +1866,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_READ;
 
     // Act
-    TwoPhaseConsensusCommit tx1Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx1Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx1Sub2 = manager.join(tx1Sub1.getId(), isolation, strategy);
     Optional<Result> result = tx1Sub2.get(prepareGet(1, 0, TABLE_2));
     assertThat(result).isNotPresent();
@@ -1874,7 +1874,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx1Sub1.get(prepareGet(0, 0, TABLE_1));
     tx1Sub1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, current1 + 1));
 
-    TwoPhaseConsensusCommit tx2Sub1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit tx2Sub1 = manager.begin(isolation, strategy);
     TwoPhaseConsensusCommit tx2Sub2 = manager.join(tx2Sub1.getId(), isolation, strategy);
     result = tx2Sub1.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isNotPresent();
@@ -1901,7 +1901,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     tx2Sub2.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(current1 + 1);
@@ -1918,13 +1918,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_WRITE;
 
     // Act Assert
-    TwoPhaseConsensusCommit transaction1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit transaction1 = manager.begin(isolation, strategy);
     List<Result> results = transaction1.scan(prepareScan(0, 0, 1, TABLE_1));
     assertThat(results).isEmpty();
     int count1 = 0;
     transaction1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, count1 + 1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit transaction2 = manager.begin(isolation, strategy);
     results = transaction2.scan(prepareScan(0, 0, 1, TABLE_1));
     assertThat(results).isEmpty();
     int count2 = 0;
@@ -1937,7 +1937,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction2.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     Optional<Result> result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isNotPresent();
     result = transaction.get(prepareGet(0, 1, TABLE_1));
@@ -1953,13 +1953,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_READ;
 
     // Act Assert
-    TwoPhaseConsensusCommit transaction1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit transaction1 = manager.begin(isolation, strategy);
     List<Result> results = transaction1.scan(prepareScan(0, 0, 1, TABLE_1));
     assertThat(results).isEmpty();
     int count1 = 0;
     transaction1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, count1 + 1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit transaction2 = manager.begin(isolation, strategy);
     results = transaction2.scan(prepareScan(0, 0, 1, TABLE_1));
     assertThat(results).isEmpty();
     int count2 = 0;
@@ -1978,7 +1978,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction2.rollback();
 
     // Assert
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     Optional<Result> result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(count1 + 1);
@@ -1991,7 +1991,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       commit_WriteSkewWithScanOnExistingRecordsWithSerializableWithExtraRead_ShouldThrowValidationException()
           throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.put(preparePut(0, 1, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
@@ -2001,13 +2001,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     SerializableStrategy strategy = SerializableStrategy.EXTRA_READ;
 
     // Act Assert
-    TwoPhaseConsensusCommit transaction1 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit transaction1 = manager.begin(isolation, strategy);
     List<Result> results = transaction1.scan(prepareScan(0, 0, 1, TABLE_1));
     assertThat(results.size()).isEqualTo(2);
     int count1 = results.size();
     transaction1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, count1 + 1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start(isolation, strategy);
+    TwoPhaseConsensusCommit transaction2 = manager.begin(isolation, strategy);
     results = transaction2.scan(prepareScan(0, 0, 1, TABLE_1));
     assertThat(results.size()).isEqualTo(2);
     int count2 = results.size();
@@ -2026,7 +2026,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction2.rollback();
 
     // Assert
-    transaction = manager.start();
+    transaction = manager.begin();
     Optional<Result> result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(count1 + 1);
@@ -2043,7 +2043,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     // Act Assert
     TwoPhaseConsensusCommit transaction =
-        manager.start(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     transaction.scan(prepareScan(0, TABLE_1));
     transaction.scan(prepareScan(1, TABLE_1));
     assertThatCode(
@@ -2059,26 +2059,26 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void putAndCommit_DeleteGivenInBetweenTransactions_ShouldProduceSerializableResults()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 2));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     Optional<Result> result = transaction1.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     int balance1 = getBalance(result.get());
     transaction1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, balance1 + 1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start();
+    TwoPhaseConsensusCommit transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0, TABLE_1));
     transaction2.delete(prepareDelete(0, 0, TABLE_1));
     transaction2.prepare();
     transaction2.commit();
 
     // the same transaction processing as transaction1
-    TwoPhaseConsensusCommit transaction3 = manager.start();
+    TwoPhaseConsensusCommit transaction3 = manager.begin();
     result = transaction3.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isNotPresent();
     int balance3 = 0;
@@ -2090,7 +2090,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction1.rollback();
 
     // Assert
-    transaction = manager.start();
+    transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(1);
@@ -2100,23 +2100,23 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void deleteAndCommit_DeleteGivenInBetweenTransactions_ShouldProduceSerializableResults()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 2));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     transaction1.get(prepareGet(0, 0, TABLE_1));
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start();
+    TwoPhaseConsensusCommit transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0, TABLE_1));
     transaction2.delete(prepareDelete(0, 0, TABLE_1));
     transaction2.prepare();
     transaction2.commit();
 
-    TwoPhaseConsensusCommit transaction3 = manager.start();
+    TwoPhaseConsensusCommit transaction3 = manager.begin();
     Optional<Result> result = transaction3.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isNotPresent();
     int balance3 = 0;
@@ -2128,7 +2128,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction1.rollback();
 
     // Assert
-    transaction = manager.start();
+    transaction = manager.begin();
     result = transaction.get(prepareGet(0, 0, TABLE_1));
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(1);
@@ -2137,7 +2137,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void get_PutCalledBefore_ShouldGet() throws CrudException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
 
     // Act
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
@@ -2158,13 +2158,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void get_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     Optional<Result> resultBefore = transaction1.get(prepareGet(0, 0, TABLE_1));
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
     Optional<Result> resultAfter = transaction1.get(prepareGet(0, 0, TABLE_1));
@@ -2184,13 +2184,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scan_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act Assert
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     List<Result> resultBefore = transaction1.scan(prepareScan(0, 0, 0, TABLE_1));
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
     List<Result> resultAfter = transaction1.scan(prepareScan(0, 0, 0, TABLE_1));
@@ -2210,13 +2210,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void delete_PutCalledBefore_ShouldDelete() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act Assert
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     Optional<Result> resultBefore = transaction1.get(prepareGet(0, 0, TABLE_1));
     transaction1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 2));
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
@@ -2229,7 +2229,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
         .doesNotThrowAnyException();
 
     // Assert
-    TwoPhaseConsensusCommit transaction2 = manager.start();
+    TwoPhaseConsensusCommit transaction2 = manager.begin();
     Optional<Result> resultAfter = transaction2.get(prepareGet(0, 0, TABLE_1));
 
     assertThat(resultBefore.isPresent()).isTrue();
@@ -2240,13 +2240,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void put_DeleteCalledBefore_ShouldThrowIllegalArgumentException()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     Get get = prepareGet(0, 0, TABLE_1);
     transaction1.get(get);
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
@@ -2261,7 +2261,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scan_OverlappingPutGivenBefore_ShouldIllegalArgumentException() {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
 
     // Act Assert
@@ -2272,7 +2272,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scan_NonOverlappingPutGivenBefore_ShouldScan() {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
 
     // Act Assert
@@ -2283,14 +2283,14 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scan_DeleteGivenBefore_ShouldScan() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.put(preparePut(0, 1, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
     Scan scan = prepareScan(0, 0, 1, TABLE_1);
     List<Result> results = transaction1.scan(scan);
@@ -2313,7 +2313,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     // Act Assert
     assertThatCode(
             () -> {
-              TwoPhaseConsensusCommit transaction = manager.start(transactionId);
+              TwoPhaseConsensusCommit transaction = manager.begin(transactionId);
               transaction.prepare();
               transaction.commit();
             })
@@ -2326,7 +2326,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     String transactionId = "";
 
     // Act Assert
-    assertThatThrownBy(() -> manager.start(transactionId))
+    assertThatThrownBy(() -> manager.begin(transactionId))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -2334,7 +2334,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   public void getState_forSuccessfulTransaction_ShouldReturnCommittedState()
       throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.get(prepareGet(0, 0, TABLE_1));
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction.prepare();
@@ -2350,11 +2350,11 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void getState_forFailedTransaction_ShouldReturnAbortedState() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     transaction1.get(prepareGet(0, 0, TABLE_1));
     transaction1.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
 
-    TwoPhaseConsensusCommit transaction2 = manager.start();
+    TwoPhaseConsensusCommit transaction2 = manager.begin();
     transaction2.get(prepareGet(0, 0, TABLE_1));
     transaction2.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
     transaction2.prepare();
@@ -2373,7 +2373,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void abort_forOngoingTransaction_ShouldAbortCorrectly() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.get(prepareGet(0, 0, TABLE_1));
     transaction.put(preparePut(0, 0, TABLE_1).withValue(BALANCE, 1));
 
@@ -2392,13 +2392,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scanAll_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
     // Arrange
-    TwoPhaseCommitTransaction transaction = manager.start();
+    TwoPhaseCommitTransaction transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withIntValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseCommitTransaction transaction1 = manager.start();
+    TwoPhaseCommitTransaction transaction1 = manager.begin();
     ScanAll scanAll = prepareScanAll(TABLE_1);
     List<Result> resultBefore = transaction1.scan(scanAll);
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
@@ -2418,14 +2418,14 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scanAll_DeleteGivenBefore_ShouldScanAll() throws TransactionException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withIntValue(BALANCE, 1));
     transaction.put(preparePut(0, 1, TABLE_1).withIntValue(BALANCE, 1));
     transaction.prepare();
     transaction.commit();
 
     // Act
-    TwoPhaseConsensusCommit transaction1 = manager.start();
+    TwoPhaseConsensusCommit transaction1 = manager.begin();
     transaction1.delete(prepareDelete(0, 0, TABLE_1));
     ScanAll scanAll = prepareScanAll(TABLE_1);
     List<Result> results = transaction1.scan(scanAll);
@@ -2443,7 +2443,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scanAll_NonOverlappingPutGivenBefore_ShouldScanAll() {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withIntValue(BALANCE, 1));
 
     // Act
@@ -2453,7 +2453,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   @Test
   public void scanAll_OverlappingPutGivenBefore_ShouldThrowIllegalArgumentException() {
     // Arrange
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     transaction.put(preparePut(0, 0, TABLE_1).withIntValue(BALANCE, 1));
 
     // Act
@@ -2466,7 +2466,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     populate(TABLE_1);
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     ScanAll scanAll = prepareScanAll(TABLE_1).withLimit(1);
 
     // Act
@@ -2530,12 +2530,12 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
       throws CrudException, CommitException, UnknownTransactionStatusException,
           PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit putTransaction = manager.start();
+    TwoPhaseConsensusCommit putTransaction = manager.begin();
     putTransaction.put(preparePut(0, 0, TABLE_1));
     putTransaction.prepare();
     putTransaction.commit();
 
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     ScanAll scanAll =
         new ScanAll()
             .forNamespace(namespace)
@@ -2596,7 +2596,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   private void populate(String table) throws TransactionException {
-    TwoPhaseConsensusCommit transaction = manager.start();
+    TwoPhaseConsensusCommit transaction = manager.begin();
     for (int i = 0; i < NUM_ACCOUNTS; i++) {
       for (int j = 0; j < NUM_TYPES; j++) {
         transaction.put(preparePut(i, j, table).withValue(BALANCE, INITIAL_BALANCE));

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
@@ -1,5 +1,6 @@
 package com.scalar.db.api;
 
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
@@ -104,4 +105,17 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    * @throws RollbackException if the operation fails
    */
   void rollback() throws RollbackException;
+
+  /**
+   * Aborts a transaction. This method is an alias of {@link #rollback()}.
+   *
+   * @throws AbortException if the operation fails
+   */
+  default void abort() throws AbortException {
+    try {
+      rollback();
+    } catch (RollbackException e) {
+      throw new AbortException(e.getMessage(), e);
+    }
+  }
 }

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
@@ -61,23 +61,45 @@ public interface TwoPhaseCommitTransactionManager {
   Optional<String> getTable();
 
   /**
-   * Starts a new transaction. This method is assumed to be called by a coordinator process.
+   * Begins a new transaction. This method is assumed to be called by a coordinator process.
    *
-   * @return {@link TwoPhaseCommitTransaction}
+   * @return {@link DistributedTransaction}
    * @throws TransactionException if starting the transaction failed
    */
-  TwoPhaseCommitTransaction start() throws TransactionException;
+  TwoPhaseCommitTransaction begin() throws TransactionException;
 
   /**
-   * Starts a new transaction with the specified transaction ID. It is users' responsibility to
+   * Begins a new transaction with the specified transaction ID. It is users' responsibility to
    * guarantee uniqueness of the ID so it is not recommended to use this method unless you know
    * exactly what you are doing. This method is assumed to be called by a coordinator process.
    *
    * @param txId an user-provided unique transaction ID
-   * @return {@link TwoPhaseCommitTransaction}
+   * @return {@link DistributedTransaction}
    * @throws TransactionException if starting the transaction failed
    */
-  TwoPhaseCommitTransaction start(String txId) throws TransactionException;
+  TwoPhaseCommitTransaction begin(String txId) throws TransactionException;
+
+  /**
+   * Starts a new transaction. This method is an alias of {@link #begin()}.
+   *
+   * @return {@link DistributedTransaction}
+   * @throws TransactionException if starting the transaction failed
+   */
+  default TwoPhaseCommitTransaction start() throws TransactionException {
+    return begin();
+  }
+
+  /**
+   * Starts a new transaction with the specified transaction ID. This method is an alias of {@link
+   * #begin(String)}.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionException if starting the transaction failed
+   */
+  default TwoPhaseCommitTransaction start(String txId) throws TransactionException {
+    return begin(txId);
+  }
 
   /**
    * Joins a transaction associated with the specified transaction ID. The transaction should be
@@ -116,13 +138,24 @@ public interface TwoPhaseCommitTransactionManager {
   TransactionState getState(String txId) throws TransactionException;
 
   /**
-   * Aborts a given transaction.
+   * Rolls back a given transaction.
    *
    * @param txId a transaction ID
    * @return {@link TransactionState}
    * @throws TransactionException if aborting the given transaction failed
    */
-  TransactionState abort(String txId) throws TransactionException;
+  TransactionState rollback(String txId) throws TransactionException;
+
+  /**
+   * Aborts a given transaction. This method is an alias of {@link #rollback(String)}.
+   *
+   * @param txId a transaction ID
+   * @return {@link TransactionState}
+   * @throws TransactionException if aborting the given transaction failed
+   */
+  default TransactionState abort(String txId) throws TransactionException {
+    return rollback(txId);
+  }
 
   /**
    * Closes connections to the cluster. The connections are shared among multiple services such as

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -55,6 +55,16 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   }
 
   @Override
+  public TwoPhaseCommitTransaction begin() throws TransactionException {
+    return manager.start();
+  }
+
+  @Override
+  public TwoPhaseCommitTransaction begin(String txId) throws TransactionException {
+    return manager.start(txId);
+  }
+
+  @Override
   public TwoPhaseCommitTransaction start() throws TransactionException {
     return manager.start();
   }
@@ -82,6 +92,11 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   @Override
   public TransactionState getState(String txId) throws TransactionException {
     return manager.getState(txId);
+  }
+
+  @Override
+  public TransactionState rollback(String txId) throws TransactionException {
+    return manager.rollback(txId);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -93,25 +93,35 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
   }
 
   @Override
-  public TwoPhaseConsensusCommit start() {
+  public TwoPhaseConsensusCommit begin() {
     String txId = UUID.randomUUID().toString();
-    return start(txId, config.getIsolation(), config.getSerializableStrategy());
+    return begin(txId, config.getIsolation(), config.getSerializableStrategy());
   }
 
   @Override
-  public TwoPhaseConsensusCommit start(String txId) {
+  public TwoPhaseConsensusCommit begin(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
-    return start(txId, config.getIsolation(), config.getSerializableStrategy());
+    return begin(txId, config.getIsolation(), config.getSerializableStrategy());
+  }
+
+  @Override
+  public TwoPhaseConsensusCommit start() throws TransactionException {
+    return (TwoPhaseConsensusCommit) super.start();
+  }
+
+  @Override
+  public TwoPhaseConsensusCommit start(String txId) throws TransactionException {
+    return (TwoPhaseConsensusCommit) super.start(txId);
   }
 
   @VisibleForTesting
-  TwoPhaseConsensusCommit start(Isolation isolation, SerializableStrategy strategy) {
+  TwoPhaseConsensusCommit begin(Isolation isolation, SerializableStrategy strategy) {
     String txId = UUID.randomUUID().toString();
-    return start(txId, isolation, strategy);
+    return begin(txId, isolation, strategy);
   }
 
   @VisibleForTesting
-  TwoPhaseConsensusCommit start(String txId, Isolation isolation, SerializableStrategy strategy) {
+  TwoPhaseConsensusCommit begin(String txId, Isolation isolation, SerializableStrategy strategy) {
     return createNewTransaction(txId, true, isolation, strategy);
   }
 
@@ -176,7 +186,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
   }
 
   @Override
-  public TransactionState abort(String txId) {
+  public TransactionState rollback(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     try {
       return commit.abort(txId);

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransaction.java
@@ -6,6 +6,7 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
@@ -92,5 +93,10 @@ public class GrpcTwoPhaseCommitTransaction extends AbstractTwoPhaseCommitTransac
   @Override
   public void rollback() throws RollbackException {
     stream.rollback();
+  }
+
+  @Override
+  public void abort() throws AbortException {
+    stream.abort();
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionOnBidirectionalStream.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionOnBidirectionalStream.java
@@ -9,6 +9,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
@@ -115,6 +116,24 @@ public class GrpcTwoPhaseCommitTransactionOnBidirectionalStream
     }
   }
 
+  public String beginTransaction(@Nullable String transactionId) throws TransactionException {
+    throwIfTransactionFinished();
+
+    TwoPhaseCommitTransactionRequest.BeginRequest request;
+    if (transactionId == null) {
+      request = TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+    } else {
+      request =
+          TwoPhaseCommitTransactionRequest.BeginRequest.newBuilder()
+              .setTransactionId(transactionId)
+              .build();
+    }
+    ResponseOrError responseOrError =
+        sendRequest(TwoPhaseCommitTransactionRequest.newBuilder().setBeginRequest(request).build());
+    throwIfErrorForBeginOrStartOrJoin(responseOrError, "begin");
+    return responseOrError.getResponse().getBeginResponse().getTransactionId();
+  }
+
   public String startTransaction(@Nullable String transactionId) throws TransactionException {
     throwIfTransactionFinished();
 
@@ -126,7 +145,7 @@ public class GrpcTwoPhaseCommitTransactionOnBidirectionalStream
     }
     ResponseOrError responseOrError =
         sendRequest(TwoPhaseCommitTransactionRequest.newBuilder().setStartRequest(request).build());
-    throwIfErrorForStartOrJoin(responseOrError, true);
+    throwIfErrorForBeginOrStartOrJoin(responseOrError, "start");
     return responseOrError.getResponse().getStartResponse().getTransactionId();
   }
 
@@ -138,10 +157,10 @@ public class GrpcTwoPhaseCommitTransactionOnBidirectionalStream
             TwoPhaseCommitTransactionRequest.newBuilder()
                 .setJoinRequest(JoinRequest.newBuilder().setTransactionId(transactionId).build())
                 .build());
-    throwIfErrorForStartOrJoin(responseOrError, false);
+    throwIfErrorForBeginOrStartOrJoin(responseOrError, "join");
   }
 
-  private void throwIfErrorForStartOrJoin(ResponseOrError responseOrError, boolean start)
+  private void throwIfErrorForBeginOrStartOrJoin(ResponseOrError responseOrError, String command)
       throws TransactionException {
     if (responseOrError.isError()) {
       finished.set(true);
@@ -158,7 +177,7 @@ public class GrpcTwoPhaseCommitTransactionOnBidirectionalStream
       if (error instanceof Error) {
         throw (Error) error;
       }
-      throw new TransactionException("failed to " + (start ? "start" : "join"), error);
+      throw new TransactionException("failed to " + command, error);
     }
   }
 
@@ -377,6 +396,34 @@ public class GrpcTwoPhaseCommitTransactionOnBidirectionalStream
     TwoPhaseCommitTransactionResponse response = responseOrError.getResponse();
     if (response.hasError()) {
       throw new RollbackException(response.getError().getMessage());
+    }
+  }
+
+  public void abort() throws AbortException {
+    if (finished.get()) {
+      return;
+    }
+
+    ResponseOrError responseOrError =
+        sendRequest(
+            TwoPhaseCommitTransactionRequest.newBuilder()
+                .setRollbackRequest(RollbackRequest.getDefaultInstance())
+                .build());
+    finished.set(true);
+    throwIfErrorForAbort(responseOrError);
+  }
+
+  private void throwIfErrorForAbort(ResponseOrError responseOrError) throws AbortException {
+    if (responseOrError.isError()) {
+      Throwable error = responseOrError.getError();
+      if (error instanceof Error) {
+        throw (Error) error;
+      }
+      throw new AbortException("failed to abort", error);
+    }
+    TwoPhaseCommitTransactionResponse response = responseOrError.getResponse();
+    if (response.hasError()) {
+      throw new AbortException(response.getError().getMessage());
     }
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.rpc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -7,11 +8,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.rpc.AbortRequest;
 import com.scalar.db.rpc.AbortResponse;
+import com.scalar.db.rpc.GetTransactionStateRequest;
 import com.scalar.db.rpc.GetTransactionStateResponse;
-import com.scalar.db.rpc.TransactionState;
+import com.scalar.db.rpc.RollbackRequest;
+import com.scalar.db.rpc.RollbackResponse;
 import com.scalar.db.rpc.TwoPhaseCommitTransactionGrpc;
 import com.scalar.db.storage.rpc.GrpcConfig;
 import io.grpc.Status;
@@ -46,14 +51,17 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
       throws TransactionException {
     // Arrange
     GetTransactionStateResponse response = mock(GetTransactionStateResponse.class);
-    when(response.getState()).thenReturn(TransactionState.TRANSACTION_STATE_COMMITTED);
+    when(response.getState())
+        .thenReturn(com.scalar.db.rpc.TransactionState.TRANSACTION_STATE_COMMITTED);
     when(blockingStub.getState(any())).thenReturn(response);
 
     // Act
-    manager.getState(ANY_ID);
+    TransactionState state = manager.getState(ANY_ID);
 
     // Assert
-    verify(blockingStub).getState(any());
+    assertThat(state).isEqualTo(TransactionState.COMMITTED);
+    verify(blockingStub)
+        .getState(GetTransactionStateRequest.newBuilder().setTransactionId(ANY_ID).build());
   }
 
   @Test
@@ -75,18 +83,55 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
   }
 
   @Test
+  public void rollback_IsCalledWithoutAnyArguments_StubShouldBeCalledProperly()
+      throws TransactionException {
+    // Arrange
+    RollbackResponse response = mock(RollbackResponse.class);
+    when(response.getState())
+        .thenReturn(com.scalar.db.rpc.TransactionState.TRANSACTION_STATE_ABORTED);
+    when(blockingStub.rollback(any())).thenReturn(response);
+
+    // Act
+    TransactionState state = manager.rollback(ANY_ID);
+
+    // Assert
+    assertThat(state).isEqualTo(TransactionState.ABORTED);
+    verify(blockingStub).rollback(RollbackRequest.newBuilder().setTransactionId(ANY_ID).build());
+  }
+
+  @Test
+  public void rollback_StubThrowsInvalidArgumentError_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    when(blockingStub.rollback(any())).thenThrow(Status.INVALID_ARGUMENT.asRuntimeException());
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.rollback(ANY_ID)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void rollback_StubThrowsInternalError_ShouldThrowTransactionException() {
+    // Arrange
+    when(blockingStub.rollback(any())).thenThrow(Status.INTERNAL.asRuntimeException());
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.rollback(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void abort_IsCalledWithoutAnyArguments_StubShouldBeCalledProperly()
       throws TransactionException {
     // Arrange
     AbortResponse response = mock(AbortResponse.class);
-    when(response.getState()).thenReturn(TransactionState.TRANSACTION_STATE_ABORTED);
+    when(response.getState())
+        .thenReturn(com.scalar.db.rpc.TransactionState.TRANSACTION_STATE_ABORTED);
     when(blockingStub.abort(any())).thenReturn(response);
 
     // Act
-    manager.abort(ANY_ID);
+    TransactionState state = manager.abort(ANY_ID);
 
     // Assert
-    verify(blockingStub).abort(any());
+    assertThat(state).isEqualTo(TransactionState.ABORTED);
+    verify(blockingStub).abort(AbortRequest.newBuilder().setTransactionId(ANY_ID).build());
   }
 
   @Test

--- a/rpc/src/main/grpc/com/scalar/db/rpc/TwoPhaseCommitTransactionGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/TwoPhaseCommitTransactionGrpc.java
@@ -77,6 +77,37 @@ public final class TwoPhaseCommitTransactionGrpc {
     return getGetStateMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.RollbackRequest,
+      com.scalar.db.rpc.RollbackResponse> getRollbackMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "Rollback",
+      requestType = com.scalar.db.rpc.RollbackRequest.class,
+      responseType = com.scalar.db.rpc.RollbackResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.scalar.db.rpc.RollbackRequest,
+      com.scalar.db.rpc.RollbackResponse> getRollbackMethod() {
+    io.grpc.MethodDescriptor<com.scalar.db.rpc.RollbackRequest, com.scalar.db.rpc.RollbackResponse> getRollbackMethod;
+    if ((getRollbackMethod = TwoPhaseCommitTransactionGrpc.getRollbackMethod) == null) {
+      synchronized (TwoPhaseCommitTransactionGrpc.class) {
+        if ((getRollbackMethod = TwoPhaseCommitTransactionGrpc.getRollbackMethod) == null) {
+          TwoPhaseCommitTransactionGrpc.getRollbackMethod = getRollbackMethod =
+              io.grpc.MethodDescriptor.<com.scalar.db.rpc.RollbackRequest, com.scalar.db.rpc.RollbackResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Rollback"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.scalar.db.rpc.RollbackRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.scalar.db.rpc.RollbackResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new TwoPhaseCommitTransactionMethodDescriptorSupplier("Rollback"))
+              .build();
+        }
+      }
+    }
+    return getRollbackMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.AbortRequest,
       com.scalar.db.rpc.AbortResponse> getAbortMethod;
 
@@ -172,6 +203,13 @@ public final class TwoPhaseCommitTransactionGrpc {
 
     /**
      */
+    public void rollback(com.scalar.db.rpc.RollbackRequest request,
+        io.grpc.stub.StreamObserver<com.scalar.db.rpc.RollbackResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getRollbackMethod(), responseObserver);
+    }
+
+    /**
+     */
     public void abort(com.scalar.db.rpc.AbortRequest request,
         io.grpc.stub.StreamObserver<com.scalar.db.rpc.AbortResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getAbortMethod(), responseObserver);
@@ -193,6 +231,13 @@ public final class TwoPhaseCommitTransactionGrpc {
                 com.scalar.db.rpc.GetTransactionStateRequest,
                 com.scalar.db.rpc.GetTransactionStateResponse>(
                   this, METHODID_GET_STATE)))
+          .addMethod(
+            getRollbackMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.scalar.db.rpc.RollbackRequest,
+                com.scalar.db.rpc.RollbackResponse>(
+                  this, METHODID_ROLLBACK)))
           .addMethod(
             getAbortMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -236,6 +281,14 @@ public final class TwoPhaseCommitTransactionGrpc {
 
     /**
      */
+    public void rollback(com.scalar.db.rpc.RollbackRequest request,
+        io.grpc.stub.StreamObserver<com.scalar.db.rpc.RollbackResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getRollbackMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
     public void abort(com.scalar.db.rpc.AbortRequest request,
         io.grpc.stub.StreamObserver<com.scalar.db.rpc.AbortResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
@@ -262,6 +315,13 @@ public final class TwoPhaseCommitTransactionGrpc {
     public com.scalar.db.rpc.GetTransactionStateResponse getState(com.scalar.db.rpc.GetTransactionStateRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getGetStateMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public com.scalar.db.rpc.RollbackResponse rollback(com.scalar.db.rpc.RollbackRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getRollbackMethod(), getCallOptions(), request);
     }
 
     /**
@@ -296,6 +356,14 @@ public final class TwoPhaseCommitTransactionGrpc {
 
     /**
      */
+    public com.google.common.util.concurrent.ListenableFuture<com.scalar.db.rpc.RollbackResponse> rollback(
+        com.scalar.db.rpc.RollbackRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getRollbackMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.scalar.db.rpc.AbortResponse> abort(
         com.scalar.db.rpc.AbortRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
@@ -304,8 +372,9 @@ public final class TwoPhaseCommitTransactionGrpc {
   }
 
   private static final int METHODID_GET_STATE = 0;
-  private static final int METHODID_ABORT = 1;
-  private static final int METHODID_TWO_PHASE_COMMIT_TRANSACTION = 2;
+  private static final int METHODID_ROLLBACK = 1;
+  private static final int METHODID_ABORT = 2;
+  private static final int METHODID_TWO_PHASE_COMMIT_TRANSACTION = 3;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -327,6 +396,10 @@ public final class TwoPhaseCommitTransactionGrpc {
         case METHODID_GET_STATE:
           serviceImpl.getState((com.scalar.db.rpc.GetTransactionStateRequest) request,
               (io.grpc.stub.StreamObserver<com.scalar.db.rpc.GetTransactionStateResponse>) responseObserver);
+          break;
+        case METHODID_ROLLBACK:
+          serviceImpl.rollback((com.scalar.db.rpc.RollbackRequest) request,
+              (io.grpc.stub.StreamObserver<com.scalar.db.rpc.RollbackResponse>) responseObserver);
           break;
         case METHODID_ABORT:
           serviceImpl.abort((com.scalar.db.rpc.AbortRequest) request,
@@ -398,6 +471,7 @@ public final class TwoPhaseCommitTransactionGrpc {
               .setSchemaDescriptor(new TwoPhaseCommitTransactionFileDescriptorSupplier())
               .addMethod(getTwoPhaseCommitTransactionMethod())
               .addMethod(getGetStateMethod())
+              .addMethod(getRollbackMethod())
               .addMethod(getAbortMethod())
               .build();
         }

--- a/rpc/src/main/java/com/scalar/db/rpc/ScalarDbProto.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScalarDbProto.java
@@ -320,6 +320,11 @@ public final class ScalarDbProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -365,10 +370,20 @@ public final class ScalarDbProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
   static final 
@@ -605,7 +620,7 @@ public final class ScalarDbProto {
       "2\036.scalardb.rpc.TransactionState\"&\n\014Abor" +
       "tRequest\022\026\n\016transaction_id\030\001 \001(\t\">\n\rAbor" +
       "tResponse\022-\n\005state\030\001 \001(\0162\036.scalardb.rpc." +
-      "TransactionState\"\212\t\n TwoPhaseCommitTrans" +
+      "TransactionState\"\206\013\n TwoPhaseCommitTrans" +
       "actionRequest\022T\n\rstart_request\030\001 \001(\0132;.s" +
       "calardb.rpc.TwoPhaseCommitTransactionReq" +
       "uest.StartRequestH\000\022R\n\014join_request\030\002 \001(" +
@@ -625,147 +640,158 @@ public final class ScalarDbProto {
       "\001(\0132<.scalardb.rpc.TwoPhaseCommitTransac" +
       "tionRequest.CommitRequestH\000\022Z\n\020rollback_" +
       "request\030\t \001(\0132>.scalardb.rpc.TwoPhaseCom" +
-      "mitTransactionRequest.RollbackRequestH\000\032" +
-      ">\n\014StartRequest\022\033\n\016transaction_id\030\001 \001(\tH" +
-      "\000\210\001\001B\021\n\017_transaction_id\032%\n\013JoinRequest\022\026" +
-      "\n\016transaction_id\030\001 \001(\t\032,\n\nGetRequest\022\036\n\003" +
-      "get\030\002 \001(\0132\021.scalardb.rpc.Get\032/\n\013ScanRequ" +
-      "est\022 \n\004scan\030\002 \001(\0132\022.scalardb.rpc.Scan\032:\n" +
-      "\rMutateRequest\022)\n\tmutations\030\002 \003(\0132\026.scal" +
-      "ardb.rpc.Mutation\032\020\n\016PrepareRequest\032\021\n\017V" +
-      "alidateRequest\032\017\n\rCommitRequest\032\021\n\017Rollb" +
-      "ackRequestB\t\n\007request\"\351\005\n!TwoPhaseCommit" +
-      "TransactionResponse\022W\n\016start_response\030\001 " +
-      "\001(\0132=.scalardb.rpc.TwoPhaseCommitTransac" +
-      "tionResponse.StartResponseH\000\022S\n\014get_resp" +
-      "onse\030\002 \001(\0132;.scalardb.rpc.TwoPhaseCommit" +
-      "TransactionResponse.GetResponseH\000\022U\n\rsca" +
-      "n_response\030\003 \001(\0132<.scalardb.rpc.TwoPhase" +
-      "CommitTransactionResponse.ScanResponseH\000" +
-      "\022F\n\005error\030\004 \001(\01325.scalardb.rpc.TwoPhaseC" +
-      "ommitTransactionResponse.ErrorH\000\032\'\n\rStar" +
-      "tResponse\022\026\n\016transaction_id\030\001 \001(\t\0323\n\013Get" +
-      "Response\022$\n\006result\030\001 \001(\0132\024.scalardb.rpc." +
-      "Result\0325\n\014ScanResponse\022%\n\007results\030\001 \003(\0132" +
-      "\024.scalardb.rpc.Result\032\325\001\n\005Error\022S\n\nerror" +
-      "_code\030\001 \001(\0162?.scalardb.rpc.TwoPhaseCommi" +
-      "tTransactionResponse.Error.ErrorCode\022\017\n\007" +
-      "message\030\002 \001(\t\"f\n\tErrorCode\022\024\n\020INVALID_AR" +
-      "GUMENT\020\000\022\030\n\024TRANSACTION_CONFLICT\020\001\022\036\n\032UN" +
-      "KNOWN_TRANSACTION_STATUS\020\002\022\t\n\005OTHER\020\003B\n\n" +
-      "\010response\"\262\001\n\036CreateCoordinatorTablesReq" +
-      "uest\022J\n\007options\030\001 \003(\01329.scalardb.rpc.Cre" +
-      "ateCoordinatorTablesRequest.OptionsEntry" +
-      "\022\024\n\014if_not_exist\030\002 \001(\010\032.\n\014OptionsEntry\022\013" +
-      "\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"0\n\034DropCo" +
-      "ordinatorTablesRequest\022\020\n\010if_exist\030\001 \001(\010" +
-      "\"\"\n TruncateCoordinatorTablesRequest\"\037\n\035" +
-      "CoordinatorTablesExistRequest\"/\n\036Coordin" +
-      "atorTablesExistResponse\022\r\n\005exist\030\001 \001(\010\"\234" +
-      "\001\n\036RepairCoordinatorTablesRequest\022J\n\007opt" +
-      "ions\030\001 \003(\01329.scalardb.rpc.RepairCoordina" +
-      "torTablesRequest.OptionsEntry\032.\n\014Options" +
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001*a\n" +
-      "\013Consistency\022\032\n\026CONSISTENCY_SEQUENTIAL\020\000" +
-      "\022\030\n\024CONSISTENCY_EVENTUAL\020\001\022\034\n\030CONSISTENC" +
-      "Y_LINEARIZABLE\020\002*&\n\005Order\022\r\n\tORDER_ASC\020\000" +
-      "\022\016\n\nORDER_DESC\020\001*\235\001\n\010DataType\022\025\n\021DATA_TY" +
-      "PE_BOOLEAN\020\000\022\021\n\rDATA_TYPE_INT\020\001\022\024\n\020DATA_" +
-      "TYPE_BIGINT\020\002\022\023\n\017DATA_TYPE_FLOAT\020\003\022\024\n\020DA" +
-      "TA_TYPE_DOUBLE\020\004\022\022\n\016DATA_TYPE_TEXT\020\005\022\022\n\016" +
-      "DATA_TYPE_BLOB\020\006*q\n\020TransactionState\022\037\n\033" +
-      "TRANSACTION_STATE_COMMITTED\020\000\022\035\n\031TRANSAC" +
-      "TION_STATE_ABORTED\020\001\022\035\n\031TRANSACTION_STAT" +
-      "E_UNKNOWN\020\0022\330\001\n\022DistributedStorage\022<\n\003Ge" +
-      "t\022\030.scalardb.rpc.GetRequest\032\031.scalardb.r" +
-      "pc.GetResponse\"\000\022C\n\004Scan\022\031.scalardb.rpc." +
-      "ScanRequest\032\032.scalardb.rpc.ScanResponse\"" +
-      "\000(\0010\001\022?\n\006Mutate\022\033.scalardb.rpc.MutateReq" +
-      "uest\032\026.google.protobuf.Empty\"\0002\222\010\n\027Distr" +
-      "ibutedStorageAdmin\022Q\n\017CreateNamespace\022$." +
-      "scalardb.rpc.CreateNamespaceRequest\032\026.go" +
-      "ogle.protobuf.Empty\"\000\022M\n\rDropNamespace\022\"" +
-      ".scalardb.rpc.DropNamespaceRequest\032\026.goo" +
-      "gle.protobuf.Empty\"\000\022I\n\013CreateTable\022 .sc" +
-      "alardb.rpc.CreateTableRequest\032\026.google.p" +
-      "rotobuf.Empty\"\000\022E\n\tDropTable\022\036.scalardb." +
-      "rpc.DropTableRequest\032\026.google.protobuf.E" +
-      "mpty\"\000\022M\n\rTruncateTable\022\".scalardb.rpc.T" +
-      "runcateTableRequest\032\026.google.protobuf.Em" +
-      "pty\"\000\022I\n\013CreateIndex\022 .scalardb.rpc.Crea" +
-      "teIndexRequest\032\026.google.protobuf.Empty\"\000" +
-      "\022E\n\tDropIndex\022\036.scalardb.rpc.DropIndexRe" +
-      "quest\032\026.google.protobuf.Empty\"\000\022c\n\020GetTa" +
-      "bleMetadata\022%.scalardb.rpc.GetTableMetad" +
-      "ataRequest\032&.scalardb.rpc.GetTableMetada" +
-      "taResponse\"\000\022u\n\026GetNamespaceTableNames\022+" +
-      ".scalardb.rpc.GetNamespaceTableNamesRequ" +
-      "est\032,.scalardb.rpc.GetNamespaceTableName" +
-      "sResponse\"\000\022`\n\017NamespaceExists\022$.scalard" +
-      "b.rpc.NamespaceExistsRequest\032%.scalardb." +
-      "rpc.NamespaceExistsResponse\"\000\022I\n\013RepairT" +
-      "able\022 .scalardb.rpc.RepairTableRequest\032\026" +
-      ".google.protobuf.Empty\"\000\022Y\n\023AddNewColumn" +
-      "ToTable\022(.scalardb.rpc.AddNewColumnToTab" +
-      "leRequest\032\026.google.protobuf.Empty\"\0002\346\002\n\026" +
-      "DistributedTransaction\022X\n\013Transaction\022 ." +
-      "scalardb.rpc.TransactionRequest\032!.scalar" +
-      "db.rpc.TransactionResponse\"\000(\0010\001\022a\n\010GetS" +
-      "tate\022(.scalardb.rpc.GetTransactionStateR" +
-      "equest\032).scalardb.rpc.GetTransactionStat" +
-      "eResponse\"\000\022K\n\010Rollback\022\035.scalardb.rpc.R" +
-      "ollbackRequest\032\036.scalardb.rpc.RollbackRe" +
-      "sponse\"\000\022B\n\005Abort\022\032.scalardb.rpc.AbortRe" +
-      "quest\032\033.scalardb.rpc.AbortResponse\"\0002\307\002\n" +
-      "\031TwoPhaseCommitTransaction\022\202\001\n\031TwoPhaseC" +
-      "ommitTransaction\022..scalardb.rpc.TwoPhase" +
-      "CommitTransactionRequest\032/.scalardb.rpc." +
-      "TwoPhaseCommitTransactionResponse\"\000(\0010\001\022" +
-      "a\n\010GetState\022(.scalardb.rpc.GetTransactio" +
-      "nStateRequest\032).scalardb.rpc.GetTransact" +
-      "ionStateResponse\"\000\022B\n\005Abort\022\032.scalardb.r" +
-      "pc.AbortRequest\032\033.scalardb.rpc.AbortResp" +
-      "onse\"\0002\231\014\n\033DistributedTransactionAdmin\022Q" +
-      "\n\017CreateNamespace\022$.scalardb.rpc.CreateN" +
-      "amespaceRequest\032\026.google.protobuf.Empty\"" +
-      "\000\022M\n\rDropNamespace\022\".scalardb.rpc.DropNa" +
-      "mespaceRequest\032\026.google.protobuf.Empty\"\000" +
-      "\022I\n\013CreateTable\022 .scalardb.rpc.CreateTab" +
-      "leRequest\032\026.google.protobuf.Empty\"\000\022E\n\tD" +
-      "ropTable\022\036.scalardb.rpc.DropTableRequest" +
-      "\032\026.google.protobuf.Empty\"\000\022M\n\rTruncateTa" +
-      "ble\022\".scalardb.rpc.TruncateTableRequest\032" +
-      "\026.google.protobuf.Empty\"\000\022I\n\013CreateIndex" +
-      "\022 .scalardb.rpc.CreateIndexRequest\032\026.goo" +
-      "gle.protobuf.Empty\"\000\022E\n\tDropIndex\022\036.scal" +
-      "ardb.rpc.DropIndexRequest\032\026.google.proto" +
-      "buf.Empty\"\000\022c\n\020GetTableMetadata\022%.scalar" +
-      "db.rpc.GetTableMetadataRequest\032&.scalard" +
-      "b.rpc.GetTableMetadataResponse\"\000\022u\n\026GetN" +
-      "amespaceTableNames\022+.scalardb.rpc.GetNam" +
-      "espaceTableNamesRequest\032,.scalardb.rpc.G" +
-      "etNamespaceTableNamesResponse\"\000\022`\n\017Names" +
-      "paceExists\022$.scalardb.rpc.NamespaceExist" +
-      "sRequest\032%.scalardb.rpc.NamespaceExistsR" +
-      "esponse\"\000\022a\n\027CreateCoordinatorTables\022,.s" +
-      "calardb.rpc.CreateCoordinatorTablesReque" +
-      "st\032\026.google.protobuf.Empty\"\000\022]\n\025DropCoor" +
-      "dinatorTables\022*.scalardb.rpc.DropCoordin" +
-      "atorTablesRequest\032\026.google.protobuf.Empt" +
-      "y\"\000\022e\n\031TruncateCoordinatorTables\022..scala" +
-      "rdb.rpc.TruncateCoordinatorTablesRequest" +
-      "\032\026.google.protobuf.Empty\"\000\022u\n\026Coordinato" +
-      "rTablesExist\022+.scalardb.rpc.CoordinatorT" +
-      "ablesExistRequest\032,.scalardb.rpc.Coordin" +
-      "atorTablesExistResponse\"\000\022I\n\013RepairTable" +
-      "\022 .scalardb.rpc.RepairTableRequest\032\026.goo" +
-      "gle.protobuf.Empty\"\000\022a\n\027RepairCoordinato" +
-      "rTables\022,.scalardb.rpc.RepairCoordinator" +
-      "TablesRequest\032\026.google.protobuf.Empty\"\000\022" +
-      "Y\n\023AddNewColumnToTable\022(.scalardb.rpc.Ad" +
-      "dNewColumnToTableRequest\032\026.google.protob" +
-      "uf.Empty\"\000B$\n\021com.scalar.db.rpcB\rScalarD" +
-      "bProtoP\001b\006proto3"
+      "mitTransactionRequest.RollbackRequestH\000\022" +
+      "T\n\rbegin_request\030\n \001(\0132;.scalardb.rpc.Tw" +
+      "oPhaseCommitTransactionRequest.BeginRequ" +
+      "estH\000\022T\n\rabort_request\030\013 \001(\0132;.scalardb." +
+      "rpc.TwoPhaseCommitTransactionRequest.Abo" +
+      "rtRequestH\000\032>\n\014BeginRequest\022\033\n\016transacti" +
+      "on_id\030\001 \001(\tH\000\210\001\001B\021\n\017_transaction_id\032>\n\014S" +
+      "tartRequest\022\033\n\016transaction_id\030\001 \001(\tH\000\210\001\001" +
+      "B\021\n\017_transaction_id\032%\n\013JoinRequest\022\026\n\016tr" +
+      "ansaction_id\030\001 \001(\t\032,\n\nGetRequest\022\036\n\003get\030" +
+      "\002 \001(\0132\021.scalardb.rpc.Get\032/\n\013ScanRequest\022" +
+      " \n\004scan\030\002 \001(\0132\022.scalardb.rpc.Scan\032:\n\rMut" +
+      "ateRequest\022)\n\tmutations\030\002 \003(\0132\026.scalardb" +
+      ".rpc.Mutation\032\020\n\016PrepareRequest\032\021\n\017Valid" +
+      "ateRequest\032\017\n\rCommitRequest\032\021\n\017RollbackR" +
+      "equest\032\016\n\014AbortRequestB\t\n\007request\"\353\006\n!Tw" +
+      "oPhaseCommitTransactionResponse\022W\n\016start" +
+      "_response\030\001 \001(\0132=.scalardb.rpc.TwoPhaseC" +
+      "ommitTransactionResponse.StartResponseH\000" +
+      "\022S\n\014get_response\030\002 \001(\0132;.scalardb.rpc.Tw" +
+      "oPhaseCommitTransactionResponse.GetRespo" +
+      "nseH\000\022U\n\rscan_response\030\003 \001(\0132<.scalardb." +
+      "rpc.TwoPhaseCommitTransactionResponse.Sc" +
+      "anResponseH\000\022F\n\005error\030\004 \001(\01325.scalardb.r" +
+      "pc.TwoPhaseCommitTransactionResponse.Err" +
+      "orH\000\022W\n\016begin_response\030\005 \001(\0132=.scalardb." +
+      "rpc.TwoPhaseCommitTransactionResponse.Be" +
+      "ginResponseH\000\032\'\n\rBeginResponse\022\026\n\016transa" +
+      "ction_id\030\001 \001(\t\032\'\n\rStartResponse\022\026\n\016trans" +
+      "action_id\030\001 \001(\t\0323\n\013GetResponse\022$\n\006result" +
+      "\030\001 \001(\0132\024.scalardb.rpc.Result\0325\n\014ScanResp" +
+      "onse\022%\n\007results\030\001 \003(\0132\024.scalardb.rpc.Res" +
+      "ult\032\325\001\n\005Error\022S\n\nerror_code\030\001 \001(\0162?.scal" +
+      "ardb.rpc.TwoPhaseCommitTransactionRespon" +
+      "se.Error.ErrorCode\022\017\n\007message\030\002 \001(\t\"f\n\tE" +
+      "rrorCode\022\024\n\020INVALID_ARGUMENT\020\000\022\030\n\024TRANSA" +
+      "CTION_CONFLICT\020\001\022\036\n\032UNKNOWN_TRANSACTION_" +
+      "STATUS\020\002\022\t\n\005OTHER\020\003B\n\n\010response\"\262\001\n\036Crea" +
+      "teCoordinatorTablesRequest\022J\n\007options\030\001 " +
+      "\003(\01329.scalardb.rpc.CreateCoordinatorTabl" +
+      "esRequest.OptionsEntry\022\024\n\014if_not_exist\030\002" +
+      " \001(\010\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005val" +
+      "ue\030\002 \001(\t:\0028\001\"0\n\034DropCoordinatorTablesReq" +
+      "uest\022\020\n\010if_exist\030\001 \001(\010\"\"\n TruncateCoordi" +
+      "natorTablesRequest\"\037\n\035CoordinatorTablesE" +
+      "xistRequest\"/\n\036CoordinatorTablesExistRes" +
+      "ponse\022\r\n\005exist\030\001 \001(\010\"\234\001\n\036RepairCoordinat" +
+      "orTablesRequest\022J\n\007options\030\001 \003(\01329.scala" +
+      "rdb.rpc.RepairCoordinatorTablesRequest.O" +
+      "ptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t" +
+      "\022\r\n\005value\030\002 \001(\t:\0028\001*a\n\013Consistency\022\032\n\026CO" +
+      "NSISTENCY_SEQUENTIAL\020\000\022\030\n\024CONSISTENCY_EV" +
+      "ENTUAL\020\001\022\034\n\030CONSISTENCY_LINEARIZABLE\020\002*&" +
+      "\n\005Order\022\r\n\tORDER_ASC\020\000\022\016\n\nORDER_DESC\020\001*\235" +
+      "\001\n\010DataType\022\025\n\021DATA_TYPE_BOOLEAN\020\000\022\021\n\rDA" +
+      "TA_TYPE_INT\020\001\022\024\n\020DATA_TYPE_BIGINT\020\002\022\023\n\017D" +
+      "ATA_TYPE_FLOAT\020\003\022\024\n\020DATA_TYPE_DOUBLE\020\004\022\022" +
+      "\n\016DATA_TYPE_TEXT\020\005\022\022\n\016DATA_TYPE_BLOB\020\006*q" +
+      "\n\020TransactionState\022\037\n\033TRANSACTION_STATE_" +
+      "COMMITTED\020\000\022\035\n\031TRANSACTION_STATE_ABORTED" +
+      "\020\001\022\035\n\031TRANSACTION_STATE_UNKNOWN\020\0022\330\001\n\022Di" +
+      "stributedStorage\022<\n\003Get\022\030.scalardb.rpc.G" +
+      "etRequest\032\031.scalardb.rpc.GetResponse\"\000\022C" +
+      "\n\004Scan\022\031.scalardb.rpc.ScanRequest\032\032.scal" +
+      "ardb.rpc.ScanResponse\"\000(\0010\001\022?\n\006Mutate\022\033." +
+      "scalardb.rpc.MutateRequest\032\026.google.prot" +
+      "obuf.Empty\"\0002\222\010\n\027DistributedStorageAdmin" +
+      "\022Q\n\017CreateNamespace\022$.scalardb.rpc.Creat" +
+      "eNamespaceRequest\032\026.google.protobuf.Empt" +
+      "y\"\000\022M\n\rDropNamespace\022\".scalardb.rpc.Drop" +
+      "NamespaceRequest\032\026.google.protobuf.Empty" +
+      "\"\000\022I\n\013CreateTable\022 .scalardb.rpc.CreateT" +
+      "ableRequest\032\026.google.protobuf.Empty\"\000\022E\n" +
+      "\tDropTable\022\036.scalardb.rpc.DropTableReque" +
+      "st\032\026.google.protobuf.Empty\"\000\022M\n\rTruncate" +
+      "Table\022\".scalardb.rpc.TruncateTableReques" +
+      "t\032\026.google.protobuf.Empty\"\000\022I\n\013CreateInd" +
+      "ex\022 .scalardb.rpc.CreateIndexRequest\032\026.g" +
+      "oogle.protobuf.Empty\"\000\022E\n\tDropIndex\022\036.sc" +
+      "alardb.rpc.DropIndexRequest\032\026.google.pro" +
+      "tobuf.Empty\"\000\022c\n\020GetTableMetadata\022%.scal" +
+      "ardb.rpc.GetTableMetadataRequest\032&.scala" +
+      "rdb.rpc.GetTableMetadataResponse\"\000\022u\n\026Ge" +
+      "tNamespaceTableNames\022+.scalardb.rpc.GetN" +
+      "amespaceTableNamesRequest\032,.scalardb.rpc" +
+      ".GetNamespaceTableNamesResponse\"\000\022`\n\017Nam" +
+      "espaceExists\022$.scalardb.rpc.NamespaceExi" +
+      "stsRequest\032%.scalardb.rpc.NamespaceExist" +
+      "sResponse\"\000\022I\n\013RepairTable\022 .scalardb.rp" +
+      "c.RepairTableRequest\032\026.google.protobuf.E" +
+      "mpty\"\000\022Y\n\023AddNewColumnToTable\022(.scalardb" +
+      ".rpc.AddNewColumnToTableRequest\032\026.google" +
+      ".protobuf.Empty\"\0002\346\002\n\026DistributedTransac" +
+      "tion\022X\n\013Transaction\022 .scalardb.rpc.Trans" +
+      "actionRequest\032!.scalardb.rpc.Transaction" +
+      "Response\"\000(\0010\001\022a\n\010GetState\022(.scalardb.rp" +
+      "c.GetTransactionStateRequest\032).scalardb." +
+      "rpc.GetTransactionStateResponse\"\000\022K\n\010Rol" +
+      "lback\022\035.scalardb.rpc.RollbackRequest\032\036.s" +
+      "calardb.rpc.RollbackResponse\"\000\022B\n\005Abort\022" +
+      "\032.scalardb.rpc.AbortRequest\032\033.scalardb.r" +
+      "pc.AbortResponse\"\0002\224\003\n\031TwoPhaseCommitTra" +
+      "nsaction\022\202\001\n\031TwoPhaseCommitTransaction\022." +
+      ".scalardb.rpc.TwoPhaseCommitTransactionR" +
+      "equest\032/.scalardb.rpc.TwoPhaseCommitTran" +
+      "sactionResponse\"\000(\0010\001\022a\n\010GetState\022(.scal" +
+      "ardb.rpc.GetTransactionStateRequest\032).sc" +
+      "alardb.rpc.GetTransactionStateResponse\"\000" +
+      "\022K\n\010Rollback\022\035.scalardb.rpc.RollbackRequ" +
+      "est\032\036.scalardb.rpc.RollbackResponse\"\000\022B\n" +
+      "\005Abort\022\032.scalardb.rpc.AbortRequest\032\033.sca" +
+      "lardb.rpc.AbortResponse\"\0002\231\014\n\033Distribute" +
+      "dTransactionAdmin\022Q\n\017CreateNamespace\022$.s" +
+      "calardb.rpc.CreateNamespaceRequest\032\026.goo" +
+      "gle.protobuf.Empty\"\000\022M\n\rDropNamespace\022\"." +
+      "scalardb.rpc.DropNamespaceRequest\032\026.goog" +
+      "le.protobuf.Empty\"\000\022I\n\013CreateTable\022 .sca" +
+      "lardb.rpc.CreateTableRequest\032\026.google.pr" +
+      "otobuf.Empty\"\000\022E\n\tDropTable\022\036.scalardb.r" +
+      "pc.DropTableRequest\032\026.google.protobuf.Em" +
+      "pty\"\000\022M\n\rTruncateTable\022\".scalardb.rpc.Tr" +
+      "uncateTableRequest\032\026.google.protobuf.Emp" +
+      "ty\"\000\022I\n\013CreateIndex\022 .scalardb.rpc.Creat" +
+      "eIndexRequest\032\026.google.protobuf.Empty\"\000\022" +
+      "E\n\tDropIndex\022\036.scalardb.rpc.DropIndexReq" +
+      "uest\032\026.google.protobuf.Empty\"\000\022c\n\020GetTab" +
+      "leMetadata\022%.scalardb.rpc.GetTableMetada" +
+      "taRequest\032&.scalardb.rpc.GetTableMetadat" +
+      "aResponse\"\000\022u\n\026GetNamespaceTableNames\022+." +
+      "scalardb.rpc.GetNamespaceTableNamesReque" +
+      "st\032,.scalardb.rpc.GetNamespaceTableNames" +
+      "Response\"\000\022`\n\017NamespaceExists\022$.scalardb" +
+      ".rpc.NamespaceExistsRequest\032%.scalardb.r" +
+      "pc.NamespaceExistsResponse\"\000\022a\n\027CreateCo" +
+      "ordinatorTables\022,.scalardb.rpc.CreateCoo" +
+      "rdinatorTablesRequest\032\026.google.protobuf." +
+      "Empty\"\000\022]\n\025DropCoordinatorTables\022*.scala" +
+      "rdb.rpc.DropCoordinatorTablesRequest\032\026.g" +
+      "oogle.protobuf.Empty\"\000\022e\n\031TruncateCoordi" +
+      "natorTables\022..scalardb.rpc.TruncateCoord" +
+      "inatorTablesRequest\032\026.google.protobuf.Em" +
+      "pty\"\000\022u\n\026CoordinatorTablesExist\022+.scalar" +
+      "db.rpc.CoordinatorTablesExistRequest\032,.s" +
+      "calardb.rpc.CoordinatorTablesExistRespon" +
+      "se\"\000\022I\n\013RepairTable\022 .scalardb.rpc.Repai" +
+      "rTableRequest\032\026.google.protobuf.Empty\"\000\022" +
+      "a\n\027RepairCoordinatorTables\022,.scalardb.rp" +
+      "c.RepairCoordinatorTablesRequest\032\026.googl" +
+      "e.protobuf.Empty\"\000\022Y\n\023AddNewColumnToTabl" +
+      "e\022(.scalardb.rpc.AddNewColumnToTableRequ" +
+      "est\032\026.google.protobuf.Empty\"\000B$\n\021com.sca" +
+      "lar.db.rpcB\rScalarDbProtoP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -1137,87 +1163,105 @@ public final class ScalarDbProto {
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor,
-        new java.lang.String[] { "StartRequest", "JoinRequest", "GetRequest", "ScanRequest", "MutateRequest", "PrepareRequest", "ValidateRequest", "CommitRequest", "RollbackRequest", "Request", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor =
+        new java.lang.String[] { "StartRequest", "JoinRequest", "GetRequest", "ScanRequest", "MutateRequest", "PrepareRequest", "ValidateRequest", "CommitRequest", "RollbackRequest", "BeginRequest", "AbortRequest", "Request", });
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_descriptor =
       internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(0);
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_descriptor,
+        new java.lang.String[] { "TransactionId", "TransactionId", });
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor =
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(1);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor,
         new java.lang.String[] { "TransactionId", "TransactionId", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(1);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(2);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor,
         new java.lang.String[] { "TransactionId", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(2);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(3);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor,
         new java.lang.String[] { "Get", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(3);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(4);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor,
         new java.lang.String[] { "Scan", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(4);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(5);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor,
         new java.lang.String[] { "Mutations", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(5);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(6);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor,
         new java.lang.String[] { });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(6);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(7);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor,
         new java.lang.String[] { });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(7);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(8);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor,
         new java.lang.String[] { });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(8);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(9);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor,
+        new java.lang.String[] { });
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_descriptor =
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(10);
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_descriptor,
         new java.lang.String[] { });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor =
       getDescriptor().getMessageTypes().get(40);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor,
-        new java.lang.String[] { "StartResponse", "GetResponse", "ScanResponse", "Error", "Response", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor =
+        new java.lang.String[] { "StartResponse", "GetResponse", "ScanResponse", "Error", "BeginResponse", "Response", });
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_descriptor =
       internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(0);
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_descriptor,
+        new java.lang.String[] { "TransactionId", });
+    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor =
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(1);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor,
         new java.lang.String[] { "TransactionId", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(1);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(2);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor,
         new java.lang.String[] { "Result", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(2);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(3);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor,
         new java.lang.String[] { "Results", });
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(3);
+      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(4);
     internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor,

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
@@ -174,6 +174,34 @@ private static final long serialVersionUID = 0L;
             requestCase_ = 9;
             break;
           }
+          case 82: {
+            com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder subBuilder = null;
+            if (requestCase_ == 10) {
+              subBuilder = ((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_).toBuilder();
+            }
+            request_ =
+                input.readMessage(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.parser(), extensionRegistry);
+            if (subBuilder != null) {
+              subBuilder.mergeFrom((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_);
+              request_ = subBuilder.buildPartial();
+            }
+            requestCase_ = 10;
+            break;
+          }
+          case 90: {
+            com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder subBuilder = null;
+            if (requestCase_ == 11) {
+              subBuilder = ((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_).toBuilder();
+            }
+            request_ =
+                input.readMessage(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.parser(), extensionRegistry);
+            if (subBuilder != null) {
+              subBuilder.mergeFrom((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_);
+              request_ = subBuilder.buildPartial();
+            }
+            requestCase_ = 11;
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -206,6 +234,611 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.Builder.class);
+  }
+
+  public interface BeginRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return Whether the transactionId field is set.
+     */
+    boolean hasTransactionId();
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The transactionId.
+     */
+    java.lang.String getTransactionId();
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The bytes for transactionId.
+     */
+    com.google.protobuf.ByteString
+        getTransactionIdBytes();
+  }
+  /**
+   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest}
+   */
+  public static final class BeginRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)
+      BeginRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use BeginRequest.newBuilder() to construct.
+    private BeginRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private BeginRequest() {
+      transactionId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new BeginRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private BeginRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+              bitField0_ |= 0x00000001;
+              transactionId_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object transactionId_;
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return Whether the transactionId field is set.
+     */
+    @java.lang.Override
+    public boolean hasTransactionId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The transactionId.
+     */
+    @java.lang.Override
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        transactionId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The bytes for transactionId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)) {
+        return super.equals(obj);
+      }
+      com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest other = (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) obj;
+
+      if (hasTransactionId() != other.hasTransactionId()) return false;
+      if (hasTransactionId()) {
+        if (!getTransactionId()
+            .equals(other.getTransactionId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTransactionId()) {
+        hash = (37 * hash) + TRANSACTION_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getTransactionId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder.class);
+      }
+
+      // Construct using com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        transactionId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_BeginRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest getDefaultInstanceForType() {
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest build() {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest buildPartial() {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.transactionId_ = transactionId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) {
+          return mergeFrom((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest other) {
+        if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance()) return this;
+        if (other.hasTransactionId()) {
+          bitField0_ |= 0x00000001;
+          transactionId_ = other.transactionId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object transactionId_ = "";
+      /**
+       * <code>optional string transaction_id = 1;</code>
+       * @return Whether the transactionId field is set.
+       */
+      public boolean hasTransactionId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional string transaction_id = 1;</code>
+       * @return The transactionId.
+       */
+      public java.lang.String getTransactionId() {
+        java.lang.Object ref = transactionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          transactionId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string transaction_id = 1;</code>
+       * @return The bytes for transactionId.
+       */
+      public com.google.protobuf.ByteString
+          getTransactionIdBytes() {
+        java.lang.Object ref = transactionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          transactionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string transaction_id = 1;</code>
+       * @param value The transactionId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTransactionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string transaction_id = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTransactionId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        transactionId_ = getDefaultInstance().getTransactionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string transaction_id = 1;</code>
+       * @param value The bytes for transactionId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTransactionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        bitField0_ |= 0x00000001;
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest)
+    private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest();
+    }
+
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<BeginRequest>
+        PARSER = new com.google.protobuf.AbstractParser<BeginRequest>() {
+      @java.lang.Override
+      public BeginRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new BeginRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<BeginRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<BeginRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface StartRequestOrBuilder extends
@@ -5104,6 +5737,426 @@ private static final long serialVersionUID = 0L;
 
   }
 
+  public interface AbortRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest}
+   */
+  public static final class AbortRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)
+      AbortRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use AbortRequest.newBuilder() to construct.
+    private AbortRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private AbortRequest() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new AbortRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AbortRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)) {
+        return super.equals(obj);
+      }
+      com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest other = (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder.class);
+      }
+
+      // Construct using com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_AbortRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest getDefaultInstanceForType() {
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest build() {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest buildPartial() {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) {
+          return mergeFrom((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest other) {
+        if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest)
+    private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest();
+    }
+
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<AbortRequest>
+        PARSER = new com.google.protobuf.AbstractParser<AbortRequest>() {
+      @java.lang.Override
+      public AbortRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AbortRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<AbortRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AbortRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private int requestCase_ = 0;
   private java.lang.Object request_;
   public enum RequestCase
@@ -5118,6 +6171,8 @@ private static final long serialVersionUID = 0L;
     VALIDATE_REQUEST(7),
     COMMIT_REQUEST(8),
     ROLLBACK_REQUEST(9),
+    BEGIN_REQUEST(10),
+    ABORT_REQUEST(11),
     REQUEST_NOT_SET(0);
     private final int value;
     private RequestCase(int value) {
@@ -5144,6 +6199,8 @@ private static final long serialVersionUID = 0L;
         case 7: return VALIDATE_REQUEST;
         case 8: return COMMIT_REQUEST;
         case 9: return ROLLBACK_REQUEST;
+        case 10: return BEGIN_REQUEST;
+        case 11: return ABORT_REQUEST;
         case 0: return REQUEST_NOT_SET;
         default: return null;
       }
@@ -5438,6 +6495,68 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.getDefaultInstance();
   }
 
+  public static final int BEGIN_REQUEST_FIELD_NUMBER = 10;
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+   * @return Whether the beginRequest field is set.
+   */
+  @java.lang.Override
+  public boolean hasBeginRequest() {
+    return requestCase_ == 10;
+  }
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+   * @return The beginRequest.
+   */
+  @java.lang.Override
+  public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest getBeginRequest() {
+    if (requestCase_ == 10) {
+       return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_;
+    }
+    return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+  }
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+   */
+  @java.lang.Override
+  public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder getBeginRequestOrBuilder() {
+    if (requestCase_ == 10) {
+       return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_;
+    }
+    return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+  }
+
+  public static final int ABORT_REQUEST_FIELD_NUMBER = 11;
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+   * @return Whether the abortRequest field is set.
+   */
+  @java.lang.Override
+  public boolean hasAbortRequest() {
+    return requestCase_ == 11;
+  }
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+   * @return The abortRequest.
+   */
+  @java.lang.Override
+  public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest getAbortRequest() {
+    if (requestCase_ == 11) {
+       return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_;
+    }
+    return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+  }
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+   */
+  @java.lang.Override
+  public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder getAbortRequestOrBuilder() {
+    if (requestCase_ == 11) {
+       return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_;
+    }
+    return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -5478,6 +6597,12 @@ private static final long serialVersionUID = 0L;
     }
     if (requestCase_ == 9) {
       output.writeMessage(9, (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest) request_);
+    }
+    if (requestCase_ == 10) {
+      output.writeMessage(10, (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_);
+    }
+    if (requestCase_ == 11) {
+      output.writeMessage(11, (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_);
     }
     unknownFields.writeTo(output);
   }
@@ -5523,6 +6648,14 @@ private static final long serialVersionUID = 0L;
     if (requestCase_ == 9) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(9, (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest) request_);
+    }
+    if (requestCase_ == 10) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(10, (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_);
+    }
+    if (requestCase_ == 11) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(11, (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -5577,6 +6710,14 @@ private static final long serialVersionUID = 0L;
         if (!getRollbackRequest()
             .equals(other.getRollbackRequest())) return false;
         break;
+      case 10:
+        if (!getBeginRequest()
+            .equals(other.getBeginRequest())) return false;
+        break;
+      case 11:
+        if (!getAbortRequest()
+            .equals(other.getAbortRequest())) return false;
+        break;
       case 0:
       default:
     }
@@ -5627,6 +6768,14 @@ private static final long serialVersionUID = 0L;
       case 9:
         hash = (37 * hash) + ROLLBACK_REQUEST_FIELD_NUMBER;
         hash = (53 * hash) + getRollbackRequest().hashCode();
+        break;
+      case 10:
+        hash = (37 * hash) + BEGIN_REQUEST_FIELD_NUMBER;
+        hash = (53 * hash) + getBeginRequest().hashCode();
+        break;
+      case 11:
+        hash = (37 * hash) + ABORT_REQUEST_FIELD_NUMBER;
+        hash = (53 * hash) + getAbortRequest().hashCode();
         break;
       case 0:
       default:
@@ -5855,6 +7004,20 @@ private static final long serialVersionUID = 0L;
           result.request_ = rollbackRequestBuilder_.build();
         }
       }
+      if (requestCase_ == 10) {
+        if (beginRequestBuilder_ == null) {
+          result.request_ = request_;
+        } else {
+          result.request_ = beginRequestBuilder_.build();
+        }
+      }
+      if (requestCase_ == 11) {
+        if (abortRequestBuilder_ == null) {
+          result.request_ = request_;
+        } else {
+          result.request_ = abortRequestBuilder_.build();
+        }
+      }
       result.requestCase_ = requestCase_;
       onBuilt();
       return result;
@@ -5939,6 +7102,14 @@ private static final long serialVersionUID = 0L;
         }
         case ROLLBACK_REQUEST: {
           mergeRollbackRequest(other.getRollbackRequest());
+          break;
+        }
+        case BEGIN_REQUEST: {
+          mergeBeginRequest(other.getBeginRequest());
+          break;
+        }
+        case ABORT_REQUEST: {
+          mergeAbortRequest(other.getAbortRequest());
           break;
         }
         case REQUEST_NOT_SET: {
@@ -7265,6 +8436,290 @@ private static final long serialVersionUID = 0L;
       requestCase_ = 9;
       onChanged();;
       return rollbackRequestBuilder_;
+    }
+
+    private com.google.protobuf.SingleFieldBuilderV3<
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder> beginRequestBuilder_;
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     * @return Whether the beginRequest field is set.
+     */
+    @java.lang.Override
+    public boolean hasBeginRequest() {
+      return requestCase_ == 10;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     * @return The beginRequest.
+     */
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest getBeginRequest() {
+      if (beginRequestBuilder_ == null) {
+        if (requestCase_ == 10) {
+          return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_;
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+      } else {
+        if (requestCase_ == 10) {
+          return beginRequestBuilder_.getMessage();
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+      }
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    public Builder setBeginRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest value) {
+      if (beginRequestBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        request_ = value;
+        onChanged();
+      } else {
+        beginRequestBuilder_.setMessage(value);
+      }
+      requestCase_ = 10;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    public Builder setBeginRequest(
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder builderForValue) {
+      if (beginRequestBuilder_ == null) {
+        request_ = builderForValue.build();
+        onChanged();
+      } else {
+        beginRequestBuilder_.setMessage(builderForValue.build());
+      }
+      requestCase_ = 10;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    public Builder mergeBeginRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest value) {
+      if (beginRequestBuilder_ == null) {
+        if (requestCase_ == 10 &&
+            request_ != com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance()) {
+          request_ = com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.newBuilder((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_)
+              .mergeFrom(value).buildPartial();
+        } else {
+          request_ = value;
+        }
+        onChanged();
+      } else {
+        if (requestCase_ == 10) {
+          beginRequestBuilder_.mergeFrom(value);
+        } else {
+          beginRequestBuilder_.setMessage(value);
+        }
+      }
+      requestCase_ = 10;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    public Builder clearBeginRequest() {
+      if (beginRequestBuilder_ == null) {
+        if (requestCase_ == 10) {
+          requestCase_ = 0;
+          request_ = null;
+          onChanged();
+        }
+      } else {
+        if (requestCase_ == 10) {
+          requestCase_ = 0;
+          request_ = null;
+        }
+        beginRequestBuilder_.clear();
+      }
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder getBeginRequestBuilder() {
+      return getBeginRequestFieldBuilder().getBuilder();
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder getBeginRequestOrBuilder() {
+      if ((requestCase_ == 10) && (beginRequestBuilder_ != null)) {
+        return beginRequestBuilder_.getMessageOrBuilder();
+      } else {
+        if (requestCase_ == 10) {
+          return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_;
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+      }
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder> 
+        getBeginRequestFieldBuilder() {
+      if (beginRequestBuilder_ == null) {
+        if (!(requestCase_ == 10)) {
+          request_ = com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance();
+        }
+        beginRequestBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder>(
+                (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest) request_,
+                getParentForChildren(),
+                isClean());
+        request_ = null;
+      }
+      requestCase_ = 10;
+      onChanged();;
+      return beginRequestBuilder_;
+    }
+
+    private com.google.protobuf.SingleFieldBuilderV3<
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder> abortRequestBuilder_;
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     * @return Whether the abortRequest field is set.
+     */
+    @java.lang.Override
+    public boolean hasAbortRequest() {
+      return requestCase_ == 11;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     * @return The abortRequest.
+     */
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest getAbortRequest() {
+      if (abortRequestBuilder_ == null) {
+        if (requestCase_ == 11) {
+          return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_;
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+      } else {
+        if (requestCase_ == 11) {
+          return abortRequestBuilder_.getMessage();
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+      }
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    public Builder setAbortRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest value) {
+      if (abortRequestBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        request_ = value;
+        onChanged();
+      } else {
+        abortRequestBuilder_.setMessage(value);
+      }
+      requestCase_ = 11;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    public Builder setAbortRequest(
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder builderForValue) {
+      if (abortRequestBuilder_ == null) {
+        request_ = builderForValue.build();
+        onChanged();
+      } else {
+        abortRequestBuilder_.setMessage(builderForValue.build());
+      }
+      requestCase_ = 11;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    public Builder mergeAbortRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest value) {
+      if (abortRequestBuilder_ == null) {
+        if (requestCase_ == 11 &&
+            request_ != com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance()) {
+          request_ = com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.newBuilder((com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_)
+              .mergeFrom(value).buildPartial();
+        } else {
+          request_ = value;
+        }
+        onChanged();
+      } else {
+        if (requestCase_ == 11) {
+          abortRequestBuilder_.mergeFrom(value);
+        } else {
+          abortRequestBuilder_.setMessage(value);
+        }
+      }
+      requestCase_ = 11;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    public Builder clearAbortRequest() {
+      if (abortRequestBuilder_ == null) {
+        if (requestCase_ == 11) {
+          requestCase_ = 0;
+          request_ = null;
+          onChanged();
+        }
+      } else {
+        if (requestCase_ == 11) {
+          requestCase_ = 0;
+          request_ = null;
+        }
+        abortRequestBuilder_.clear();
+      }
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder getAbortRequestBuilder() {
+      return getAbortRequestFieldBuilder().getBuilder();
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder getAbortRequestOrBuilder() {
+      if ((requestCase_ == 11) && (abortRequestBuilder_ != null)) {
+        return abortRequestBuilder_.getMessageOrBuilder();
+      } else {
+        if (requestCase_ == 11) {
+          return (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_;
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+      }
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder> 
+        getAbortRequestFieldBuilder() {
+      if (abortRequestBuilder_ == null) {
+        if (!(requestCase_ == 11)) {
+          request_ = com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance();
+        }
+        abortRequestBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder>(
+                (com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest) request_,
+                getParentForChildren(),
+                isClean());
+        request_ = null;
+      }
+      requestCase_ = 11;
+      onChanged();;
+      return abortRequestBuilder_;
     }
     @java.lang.Override
     public final Builder setUnknownFields(

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequestOrBuilder.java
@@ -142,5 +142,35 @@ public interface TwoPhaseCommitTransactionRequestOrBuilder extends
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder();
 
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+   * @return Whether the beginRequest field is set.
+   */
+  boolean hasBeginRequest();
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+   * @return The beginRequest.
+   */
+  com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest getBeginRequest();
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.BeginRequest begin_request = 10;</code>
+   */
+  com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequestOrBuilder getBeginRequestOrBuilder();
+
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+   * @return Whether the abortRequest field is set.
+   */
+  boolean hasAbortRequest();
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+   * @return The abortRequest.
+   */
+  com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequest getAbortRequest();
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.AbortRequest abort_request = 11;</code>
+   */
+  com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.AbortRequestOrBuilder getAbortRequestOrBuilder();
+
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RequestCase getRequestCase();
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
@@ -104,6 +104,20 @@ private static final long serialVersionUID = 0L;
             responseCase_ = 4;
             break;
           }
+          case 42: {
+            com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder subBuilder = null;
+            if (responseCase_ == 5) {
+              subBuilder = ((com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_).toBuilder();
+            }
+            response_ =
+                input.readMessage(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.parser(), extensionRegistry);
+            if (subBuilder != null) {
+              subBuilder.mergeFrom((com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_);
+              response_ = subBuilder.buildPartial();
+            }
+            responseCase_ = 5;
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -136,6 +150,576 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Builder.class);
+  }
+
+  public interface BeginResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string transaction_id = 1;</code>
+     * @return The transactionId.
+     */
+    java.lang.String getTransactionId();
+    /**
+     * <code>string transaction_id = 1;</code>
+     * @return The bytes for transactionId.
+     */
+    com.google.protobuf.ByteString
+        getTransactionIdBytes();
+  }
+  /**
+   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse}
+   */
+  public static final class BeginResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)
+      BeginResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use BeginResponse.newBuilder() to construct.
+    private BeginResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private BeginResponse() {
+      transactionId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new BeginResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private BeginResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              transactionId_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder.class);
+    }
+
+    public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object transactionId_;
+    /**
+     * <code>string transaction_id = 1;</code>
+     * @return The transactionId.
+     */
+    @java.lang.Override
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        transactionId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string transaction_id = 1;</code>
+     * @return The bytes for transactionId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(transactionId_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)) {
+        return super.equals(obj);
+      }
+      com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse other = (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) obj;
+
+      if (!getTransactionId()
+          .equals(other.getTransactionId())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + TRANSACTION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getTransactionId().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder.class);
+      }
+
+      // Construct using com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        transactionId_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_BeginResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse getDefaultInstanceForType() {
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse build() {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse buildPartial() {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse(this);
+        result.transactionId_ = transactionId_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) {
+          return mergeFrom((com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse other) {
+        if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance()) return this;
+        if (!other.getTransactionId().isEmpty()) {
+          transactionId_ = other.transactionId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object transactionId_ = "";
+      /**
+       * <code>string transaction_id = 1;</code>
+       * @return The transactionId.
+       */
+      public java.lang.String getTransactionId() {
+        java.lang.Object ref = transactionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          transactionId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string transaction_id = 1;</code>
+       * @return The bytes for transactionId.
+       */
+      public com.google.protobuf.ByteString
+          getTransactionIdBytes() {
+        java.lang.Object ref = transactionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          transactionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string transaction_id = 1;</code>
+       * @param value The transactionId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTransactionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string transaction_id = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTransactionId() {
+        
+        transactionId_ = getDefaultInstance().getTransactionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string transaction_id = 1;</code>
+       * @param value The bytes for transactionId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTransactionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse)
+    private static final com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse();
+    }
+
+    public static com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<BeginResponse>
+        PARSER = new com.google.protobuf.AbstractParser<BeginResponse>() {
+      @java.lang.Override
+      public BeginResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new BeginResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<BeginResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<BeginResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface StartResponseOrBuilder extends
@@ -2938,6 +3522,7 @@ private static final long serialVersionUID = 0L;
     GET_RESPONSE(2),
     SCAN_RESPONSE(3),
     ERROR(4),
+    BEGIN_RESPONSE(5),
     RESPONSE_NOT_SET(0);
     private final int value;
     private ResponseCase(int value) {
@@ -2959,6 +3544,7 @@ private static final long serialVersionUID = 0L;
         case 2: return GET_RESPONSE;
         case 3: return SCAN_RESPONSE;
         case 4: return ERROR;
+        case 5: return BEGIN_RESPONSE;
         case 0: return RESPONSE_NOT_SET;
         default: return null;
       }
@@ -3098,6 +3684,37 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.getDefaultInstance();
   }
 
+  public static final int BEGIN_RESPONSE_FIELD_NUMBER = 5;
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+   * @return Whether the beginResponse field is set.
+   */
+  @java.lang.Override
+  public boolean hasBeginResponse() {
+    return responseCase_ == 5;
+  }
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+   * @return The beginResponse.
+   */
+  @java.lang.Override
+  public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse getBeginResponse() {
+    if (responseCase_ == 5) {
+       return (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_;
+    }
+    return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+  }
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+   */
+  @java.lang.Override
+  public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder getBeginResponseOrBuilder() {
+    if (responseCase_ == 5) {
+       return (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_;
+    }
+    return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -3124,6 +3741,9 @@ private static final long serialVersionUID = 0L;
     if (responseCase_ == 4) {
       output.writeMessage(4, (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error) response_);
     }
+    if (responseCase_ == 5) {
+      output.writeMessage(5, (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -3148,6 +3768,10 @@ private static final long serialVersionUID = 0L;
     if (responseCase_ == 4) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(4, (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error) response_);
+    }
+    if (responseCase_ == 5) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(5, (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -3182,6 +3806,10 @@ private static final long serialVersionUID = 0L;
         if (!getError()
             .equals(other.getError())) return false;
         break;
+      case 5:
+        if (!getBeginResponse()
+            .equals(other.getBeginResponse())) return false;
+        break;
       case 0:
       default:
     }
@@ -3212,6 +3840,10 @@ private static final long serialVersionUID = 0L;
       case 4:
         hash = (37 * hash) + ERROR_FIELD_NUMBER;
         hash = (53 * hash) + getError().hashCode();
+        break;
+      case 5:
+        hash = (37 * hash) + BEGIN_RESPONSE_FIELD_NUMBER;
+        hash = (53 * hash) + getBeginResponse().hashCode();
         break;
       case 0:
       default:
@@ -3405,6 +4037,13 @@ private static final long serialVersionUID = 0L;
           result.response_ = errorBuilder_.build();
         }
       }
+      if (responseCase_ == 5) {
+        if (beginResponseBuilder_ == null) {
+          result.response_ = response_;
+        } else {
+          result.response_ = beginResponseBuilder_.build();
+        }
+      }
       result.responseCase_ = responseCase_;
       onBuilt();
       return result;
@@ -3469,6 +4108,10 @@ private static final long serialVersionUID = 0L;
         }
         case ERROR: {
           mergeError(other.getError());
+          break;
+        }
+        case BEGIN_RESPONSE: {
+          mergeBeginResponse(other.getBeginResponse());
           break;
         }
         case RESPONSE_NOT_SET: {
@@ -4085,6 +4728,148 @@ private static final long serialVersionUID = 0L;
       responseCase_ = 4;
       onChanged();;
       return errorBuilder_;
+    }
+
+    private com.google.protobuf.SingleFieldBuilderV3<
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder> beginResponseBuilder_;
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     * @return Whether the beginResponse field is set.
+     */
+    @java.lang.Override
+    public boolean hasBeginResponse() {
+      return responseCase_ == 5;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     * @return The beginResponse.
+     */
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse getBeginResponse() {
+      if (beginResponseBuilder_ == null) {
+        if (responseCase_ == 5) {
+          return (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_;
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+      } else {
+        if (responseCase_ == 5) {
+          return beginResponseBuilder_.getMessage();
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+      }
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    public Builder setBeginResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse value) {
+      if (beginResponseBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        response_ = value;
+        onChanged();
+      } else {
+        beginResponseBuilder_.setMessage(value);
+      }
+      responseCase_ = 5;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    public Builder setBeginResponse(
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder builderForValue) {
+      if (beginResponseBuilder_ == null) {
+        response_ = builderForValue.build();
+        onChanged();
+      } else {
+        beginResponseBuilder_.setMessage(builderForValue.build());
+      }
+      responseCase_ = 5;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    public Builder mergeBeginResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse value) {
+      if (beginResponseBuilder_ == null) {
+        if (responseCase_ == 5 &&
+            response_ != com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance()) {
+          response_ = com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.newBuilder((com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_)
+              .mergeFrom(value).buildPartial();
+        } else {
+          response_ = value;
+        }
+        onChanged();
+      } else {
+        if (responseCase_ == 5) {
+          beginResponseBuilder_.mergeFrom(value);
+        } else {
+          beginResponseBuilder_.setMessage(value);
+        }
+      }
+      responseCase_ = 5;
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    public Builder clearBeginResponse() {
+      if (beginResponseBuilder_ == null) {
+        if (responseCase_ == 5) {
+          responseCase_ = 0;
+          response_ = null;
+          onChanged();
+        }
+      } else {
+        if (responseCase_ == 5) {
+          responseCase_ = 0;
+          response_ = null;
+        }
+        beginResponseBuilder_.clear();
+      }
+      return this;
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder getBeginResponseBuilder() {
+      return getBeginResponseFieldBuilder().getBuilder();
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    @java.lang.Override
+    public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder getBeginResponseOrBuilder() {
+      if ((responseCase_ == 5) && (beginResponseBuilder_ != null)) {
+        return beginResponseBuilder_.getMessageOrBuilder();
+      } else {
+        if (responseCase_ == 5) {
+          return (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_;
+        }
+        return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+      }
+    }
+    /**
+     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder> 
+        getBeginResponseFieldBuilder() {
+      if (beginResponseBuilder_ == null) {
+        if (!(responseCase_ == 5)) {
+          response_ = com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance();
+        }
+        beginResponseBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder>(
+                (com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse) response_,
+                getParentForChildren(),
+                isClean());
+        response_ = null;
+      }
+      responseCase_ = 5;
+      onChanged();;
+      return beginResponseBuilder_;
     }
     @java.lang.Override
     public final Builder setUnknownFields(

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponseOrBuilder.java
@@ -67,5 +67,20 @@ public interface TwoPhaseCommitTransactionResponseOrBuilder extends
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder getErrorOrBuilder();
 
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+   * @return Whether the beginResponse field is set.
+   */
+  boolean hasBeginResponse();
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+   * @return The beginResponse.
+   */
+  com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse getBeginResponse();
+  /**
+   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.BeginResponse begin_response = 5;</code>
+   */
+  com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponseOrBuilder getBeginResponseOrBuilder();
+
   public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ResponseCase getResponseCase();
 }

--- a/rpc/src/main/proto/scalardb.proto
+++ b/rpc/src/main/proto/scalardb.proto
@@ -431,11 +431,17 @@ service TwoPhaseCommitTransaction {
   }
   rpc GetState(GetTransactionStateRequest) returns (GetTransactionStateResponse) {
   }
+  rpc Rollback(RollbackRequest) returns (RollbackResponse) {
+  }
   rpc Abort(AbortRequest) returns (AbortResponse) {
   }
 }
 
 message TwoPhaseCommitTransactionRequest {
+  message BeginRequest {
+    optional string transaction_id = 1;
+  }
+
   message StartRequest {
     optional string transaction_id = 1;
   }
@@ -468,6 +474,9 @@ message TwoPhaseCommitTransactionRequest {
   message RollbackRequest {
   }
 
+  message AbortRequest {
+  }
+
   oneof request {
     StartRequest start_request = 1;
     JoinRequest join_request = 2;
@@ -478,10 +487,16 @@ message TwoPhaseCommitTransactionRequest {
     ValidateRequest validate_request = 7;
     CommitRequest commit_request = 8;
     RollbackRequest rollback_request = 9;
+    BeginRequest begin_request = 10;
+    AbortRequest abort_request = 11;
   }
 }
 
 message TwoPhaseCommitTransactionResponse {
+  message BeginResponse {
+    string transaction_id = 1;
+  }
+
   message StartResponse {
     string transaction_id = 1;
   }
@@ -510,6 +525,7 @@ message TwoPhaseCommitTransactionResponse {
     GetResponse get_response = 2;
     ScanResponse scan_response = 3;
     Error error = 4;
+    BeginResponse begin_response = 5;
   }
 }
 


### PR DESCRIPTION
This PR adds `begin()` and `abort()` methods to Two-phase Commit Transaction API. I'll add inline comments for the details. Please take a look!