### PR TITLE
Add namespace prefix support for Dynamo

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -36,6 +36,7 @@ public class BatchHandler {
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
   private final String namespacePrefix;
+
   /**
    * Constructs a {@code BatchHandler} with the specified {@link DynamoDbClient} and {@link
    * TableMetadataManager}

--- a/core/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
@@ -12,6 +13,8 @@ import com.scalar.db.exception.storage.RetriableExecutionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -32,7 +35,7 @@ import software.amazon.awssdk.services.dynamodb.model.Update;
 public class BatchHandler {
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
-
+  private final String namespacePrefix;
   /**
    * Constructs a {@code BatchHandler} with the specified {@link DynamoDbClient} and {@link
    * TableMetadataManager}
@@ -40,9 +43,13 @@ public class BatchHandler {
    * @param client {@code DynamoDbClient} to create a statement with
    * @param metadataManager {@code TableMetadataManager}
    */
-  public BatchHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public BatchHandler(
+      DynamoDbClient client,
+      TableMetadataManager metadataManager,
+      Optional<String> namespacePrefix) {
     this.client = client;
     this.metadataManager = metadataManager;
+    this.namespacePrefix = namespacePrefix.orElse("");
   }
 
   /**
@@ -59,6 +66,7 @@ public class BatchHandler {
     }
 
     TableMetadata tableMetadata = metadataManager.getTableMetadata(mutations.get(0));
+    mutations = copyAndAppendNamespacePrefix(mutations);
 
     TransactWriteItemsRequest.Builder builder = TransactWriteItemsRequest.builder();
     List<TransactWriteItem> transactItems = new ArrayList<>();
@@ -162,5 +170,34 @@ public class BatchHandler {
     }
 
     return deleteBuilder.build();
+  }
+
+  private List<? extends Mutation> copyAndAppendNamespacePrefix(
+      List<? extends Mutation> mutations) {
+    return mutations.stream()
+        .map(
+            m -> {
+              if (m instanceof Put) {
+                return copyAndAppendNamespacePrefix((Put) m);
+              } else if (m instanceof com.scalar.db.api.Delete) {
+                return copyAndAppendNamespacePrefix((com.scalar.db.api.Delete) m);
+              } else {
+                throw new IllegalArgumentException(
+                    "unexpected mutation type: " + m.getClass().getName());
+              }
+            })
+        .collect(Collectors.toList());
+  }
+
+  private Put copyAndAppendNamespacePrefix(Put put) {
+    assert put.forNamespace().isPresent();
+    return Put.newBuilder(put).namespace(namespacePrefix + put.forNamespace().get()).build();
+  }
+
+  private com.scalar.db.api.Delete copyAndAppendNamespacePrefix(com.scalar.db.api.Delete delete) {
+    assert delete.forNamespace().isPresent();
+    return com.scalar.db.api.Delete.newBuilder(delete)
+        .namespace(namespacePrefix + delete.forNamespace().get())
+        .build();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -66,10 +66,13 @@ public class Dynamo extends AbstractDistributedStorage {
             new DynamoAdmin(client, config), databaseConfig.getMetadataCacheExpirationTimeSecs());
     operationChecker = new DynamoOperationChecker(metadataManager);
 
-    selectStatementHandler = new SelectStatementHandler(client, metadataManager);
-    putStatementHandler = new PutStatementHandler(client, metadataManager);
-    deleteStatementHandler = new DeleteStatementHandler(client, metadataManager);
-    batchHandler = new BatchHandler(client, metadataManager);
+    selectStatementHandler =
+        new SelectStatementHandler(client, metadataManager, config.getNamespacePrefix());
+    putStatementHandler =
+        new PutStatementHandler(client, metadataManager, config.getNamespacePrefix());
+    deleteStatementHandler =
+        new DeleteStatementHandler(client, metadataManager, config.getNamespacePrefix());
+    batchHandler = new BatchHandler(client, metadataManager, config.getNamespacePrefix());
 
     logger.info("DynamoDB object is created properly.");
   }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -13,6 +13,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
+import com.scalar.db.util.ScalarDbUtils;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -96,11 +97,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   public static final String DEFAULT_NO_SCALING = "false";
   public static final String DEFAULT_NO_BACKUP = "false";
   public static final String DEFAULT_REQUEST_UNIT = "10";
+  private static final int DEFAULT_WAITING_DURATION_SECS = 3;
 
   @VisibleForTesting static final String PARTITION_KEY = "concatenatedPartitionKey";
   @VisibleForTesting static final String CLUSTERING_KEY = "concatenatedClusteringKey";
   private static final String GLOBAL_INDEX_NAME_PREFIX = "global_index";
-  private static final int WAITING_DURATION_SECS = 3;
   private static final int COOL_DOWN_DURATION_SECS = 60;
   private static final double TARGET_USAGE_RATE = 70.0;
   private static final int DELETE_BATCH_SIZE = 100;
@@ -153,6 +154,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   private final DynamoDbClient client;
   private final ApplicationAutoScalingClient applicationAutoScalingClient;
   private final String metadataNamespace;
+  private final String namespacePrefix;
+  private final int waitingDurationSecs;
 
   @Inject
   public DynamoAdmin(DatabaseConfig databaseConfig) {
@@ -168,13 +171,35 @@ public class DynamoAdmin implements DistributedStorageAdmin {
             .build();
 
     applicationAutoScalingClient = createApplicationAutoScalingClient(config);
-    metadataNamespace = config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+    metadataNamespace =
+        config.getNamespacePrefix().orElse("")
+            + config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+    namespacePrefix = config.getNamespacePrefix().orElse("");
+    waitingDurationSecs = DEFAULT_WAITING_DURATION_SECS;
   }
 
   public DynamoAdmin(DynamoDbClient client, DynamoConfig config) {
     this.client = client;
     applicationAutoScalingClient = createApplicationAutoScalingClient(config);
-    metadataNamespace = config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+    metadataNamespace =
+        config.getNamespacePrefix().orElse("")
+            + config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+    namespacePrefix = config.getNamespacePrefix().orElse("");
+    waitingDurationSecs = DEFAULT_WAITING_DURATION_SECS;
+  }
+
+  @VisibleForTesting
+  DynamoAdmin(
+      DynamoDbClient client,
+      ApplicationAutoScalingClient applicationAutoScalingClient,
+      DynamoConfig config) {
+    this.client = client;
+    this.applicationAutoScalingClient = applicationAutoScalingClient;
+    metadataNamespace =
+        config.getNamespacePrefix().orElse("")
+            + config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+    namespacePrefix = config.getNamespacePrefix().orElse("");
+    waitingDurationSecs = 0;
   }
 
   private AwsCredentialsProvider createCredentialsProvider(DynamoConfig config) {
@@ -191,26 +216,20 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         .build();
   }
 
-  @VisibleForTesting
-  DynamoAdmin(
-      DynamoDbClient client,
-      ApplicationAutoScalingClient applicationAutoScalingClient,
-      DynamoConfig config) {
-    this.client = client;
-    this.applicationAutoScalingClient = applicationAutoScalingClient;
-    metadataNamespace = config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
-  }
-
   @Override
-  public void createNamespace(String namespace, Map<String, String> options) {
+  public void createNamespace(String nonPrefixedNamespace, Map<String, String> options) {
     // In Dynamo DB storage, namespace will be added to table name as prefix along with dot
     // separator.
   }
 
   @Override
   public void createTable(
-      String namespace, String table, TableMetadata metadata, Map<String, String> options)
+      String nonPrefixedNamespace,
+      String table,
+      TableMetadata metadata,
+      Map<String, String> options)
       throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     checkMetadata(metadata);
 
     long ru = Long.parseLong(options.getOrDefault(REQUEST_UNIT, DEFAULT_REQUEST_UNIT));
@@ -318,7 +337,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   private void buildSecondaryIndexes(
-      String namespace,
+      Namespace namespace,
       String table,
       CreateTableRequest.Builder requestBuilder,
       TableMetadata metadata,
@@ -346,11 +365,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private String getGlobalIndexName(String namespace, String tableName, String keyName) {
+  private String getGlobalIndexName(Namespace namespace, String tableName, String keyName) {
     return getFullTableName(namespace, tableName) + "." + GLOBAL_INDEX_NAME_PREFIX + "." + keyName;
   }
 
-  private void putTableMetadata(String namespace, String table, TableMetadata metadata)
+  private void putTableMetadata(Namespace namespace, String table, TableMetadata metadata)
       throws ExecutionException {
     // Add metadata
     Map<String, AttributeValue> itemValues = new HashMap<>();
@@ -403,7 +422,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     try {
       client.putItem(
           PutItemRequest.builder()
-              .tableName(getFullTableName(metadataNamespace, METADATA_TABLE))
+              .tableName(ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE))
               .item(itemValues)
               .build());
     } catch (Exception e) {
@@ -437,15 +456,15 @@ public class DynamoAdmin implements DistributedStorageAdmin {
                       .readCapacityUnits(METADATA_TABLE_REQUEST_UNIT)
                       .writeCapacityUnits(METADATA_TABLE_REQUEST_UNIT)
                       .build())
-              .tableName(getFullTableName(metadataNamespace, METADATA_TABLE))
+              .tableName(ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE))
               .build());
     } catch (Exception e) {
       throw new ExecutionException("creating the metadata table failed", e);
     }
-    waitForTableCreation(metadataNamespace, METADATA_TABLE);
+    waitForTableCreation(Namespace.of(metadataNamespace), METADATA_TABLE);
 
     if (!noBackup) {
-      enableContinuousBackup(metadataNamespace, METADATA_TABLE);
+      enableContinuousBackup(Namespace.of(metadataNamespace), METADATA_TABLE);
     }
   }
 
@@ -453,7 +472,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     try {
       client.describeTable(
           DescribeTableRequest.builder()
-              .tableName(getFullTableName(metadataNamespace, METADATA_TABLE))
+              .tableName(ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE))
               .build());
       return true;
     } catch (Exception e) {
@@ -465,10 +484,10 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private void waitForTableCreation(String namespace, String table) throws ExecutionException {
+  private void waitForTableCreation(Namespace namespace, String table) throws ExecutionException {
     try {
       while (true) {
-        Uninterruptibles.sleepUninterruptibly(WAITING_DURATION_SECS, TimeUnit.SECONDS);
+        Uninterruptibles.sleepUninterruptibly(waitingDurationSecs, TimeUnit.SECONDS);
         DescribeTableResponse describeTableResponse =
             client.describeTable(
                 DescribeTableRequest.builder()
@@ -484,7 +503,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   private void enableAutoScaling(
-      String namespace, String table, Set<String> secondaryIndexes, long ru)
+      Namespace namespace, String table, Set<String> secondaryIndexes, long ru)
       throws ExecutionException {
     List<RegisterScalableTargetRequest> registerScalableTargetRequestList = new ArrayList<>();
     List<PutScalingPolicyRequest> putScalingPolicyRequestList = new ArrayList<>();
@@ -536,11 +555,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         .build();
   }
 
-  private String getTableResourceID(String namespace, String table) {
+  private String getTableResourceID(Namespace namespace, String table) {
     return "table/" + getFullTableName(namespace, table);
   }
 
-  private String getGlobalIndexResourceID(String namespace, String table, String globalIndex) {
+  private String getGlobalIndexResourceID(Namespace namespace, String table, String globalIndex) {
     return "table/"
         + getFullTableName(namespace, table)
         + "/index/"
@@ -563,7 +582,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         .build();
   }
 
-  private void enableContinuousBackup(String namespace, String table) throws ExecutionException {
+  private void enableContinuousBackup(Namespace namespace, String table) throws ExecutionException {
     waitForTableBackupEnabledAtCreation(namespace, table);
 
     try {
@@ -574,11 +593,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private void waitForTableBackupEnabledAtCreation(String namespace, String table)
+  private void waitForTableBackupEnabledAtCreation(Namespace namespace, String table)
       throws ExecutionException {
     try {
       while (true) {
-        Uninterruptibles.sleepUninterruptibly(WAITING_DURATION_SECS, TimeUnit.SECONDS);
+        Uninterruptibles.sleepUninterruptibly(waitingDurationSecs, TimeUnit.SECONDS);
         DescribeContinuousBackupsResponse describeContinuousBackupsResponse =
             client.describeContinuousBackups(
                 DescribeContinuousBackupsRequest.builder()
@@ -601,7 +620,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   private UpdateContinuousBackupsRequest buildUpdateContinuousBackupsRequest(
-      String namespace, String table) {
+      Namespace namespace, String table) {
     return UpdateContinuousBackupsRequest.builder()
         .tableName(getFullTableName(namespace, table))
         .pointInTimeRecoverySpecification(buildPointInTimeRecoverySpecification())
@@ -609,21 +628,22 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void dropTable(String namespace, String table) throws ExecutionException {
-    disableAutoScaling(namespace, table);
+  public void dropTable(String nonPrefixedNamespace, String table) throws ExecutionException {
+    Namespace prefixedNamespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+    disableAutoScaling(prefixedNamespace, table);
 
-    String fullTableName = getFullTableName(namespace, table);
+    String fullTableName = getFullTableName(prefixedNamespace, table);
     try {
       client.deleteTable(DeleteTableRequest.builder().tableName(fullTableName).build());
     } catch (Exception e) {
       throw new ExecutionException("deleting table " + fullTableName + " failed", e);
     }
-    waitForTableDeletion(namespace, table);
-    deleteTableMetadata(namespace, table);
+    waitForTableDeletion(prefixedNamespace, table);
+    deleteTableMetadata(prefixedNamespace, table);
   }
 
-  private void disableAutoScaling(String namespace, String table) throws ExecutionException {
-    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+  private void disableAutoScaling(Namespace namespace, String table) throws ExecutionException {
+    TableMetadata tableMetadata = getTableMetadata(namespace.nonPrefixed(), table);
     if (tableMetadata == null) {
       return;
     }
@@ -675,8 +695,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         .build();
   }
 
-  private void deleteTableMetadata(String namespace, String table) throws ExecutionException {
-    String metadataTable = getFullTableName(metadataNamespace, METADATA_TABLE);
+  private void deleteTableMetadata(Namespace namespace, String table) throws ExecutionException {
+    String metadataTable = ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE);
 
     Map<String, AttributeValue> keyToDelete = new HashMap<>();
     keyToDelete.put(
@@ -702,15 +722,16 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       } catch (Exception e) {
         throw new ExecutionException("deleting the empty metadata table failed", e);
       }
-      waitForTableDeletion(metadataNamespace, METADATA_TABLE);
+      waitForTableDeletion(Namespace.of(metadataNamespace), METADATA_TABLE);
     }
   }
 
-  private void waitForTableDeletion(String namespace, String tableName) throws ExecutionException {
+  private void waitForTableDeletion(Namespace namespace, String tableName)
+      throws ExecutionException {
     try {
       while (true) {
-        Uninterruptibles.sleepUninterruptibly(WAITING_DURATION_SECS, TimeUnit.SECONDS);
-        Set<String> tableSet = getNamespaceTableNames(namespace);
+        Uninterruptibles.sleepUninterruptibly(waitingDurationSecs, TimeUnit.SECONDS);
+        Set<String> tableSet = getNamespaceTableNames(namespace.nonPrefixed());
         if (!tableSet.contains(tableName)) {
           break;
         }
@@ -721,16 +742,17 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void dropNamespace(String namespace) throws ExecutionException {
-    Set<String> tables = getNamespaceTableNames(namespace);
+  public void dropNamespace(String nonPrefixedNamespace) throws ExecutionException {
+    Set<String> tables = getNamespaceTableNames(nonPrefixedNamespace);
     for (String table : tables) {
-      dropTable(namespace, table);
+      dropTable(nonPrefixedNamespace, table);
     }
   }
 
   @Override
-  public void truncateTable(String namespace, String table) throws ExecutionException {
-    String fullTableName = getFullTableName(namespace, table);
+  public void truncateTable(String nonPrefixedNamespace, String table) throws ExecutionException {
+    String fullTableName =
+        getFullTableName(Namespace.of(namespacePrefix, nonPrefixedNamespace), table);
     Map<String, AttributeValue> lastKeyEvaluated = null;
     do {
       ScanResponse scanResponse;
@@ -765,16 +787,19 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   @Override
   public void createIndex(
-      String namespace, String table, String columnName, Map<String, String> options)
+      String nonPrefixedNamespace, String table, String columnName, Map<String, String> options)
       throws ExecutionException {
-    if (getTableMetadata(namespace, table).getColumnDataType(columnName) == DataType.BOOLEAN) {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+    if (getTableMetadata(nonPrefixedNamespace, table).getColumnDataType(columnName)
+        == DataType.BOOLEAN) {
       throw new IllegalArgumentException(
           "Currently, BOOLEAN type is not supported for a secondary index in DynamoDB: "
               + columnName);
     }
 
     long ru = Long.parseLong(options.getOrDefault(REQUEST_UNIT, DEFAULT_REQUEST_UNIT));
-    TableMetadata metadata = getTableMetadata(namespace, table);
+    TableMetadata metadata = getTableMetadata(nonPrefixedNamespace, table);
+
     try {
       client.updateTable(
           UpdateTableRequest.builder()
@@ -832,19 +857,19 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
 
     // update metadata
-    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+    TableMetadata tableMetadata = getTableMetadata(nonPrefixedNamespace, table);
     putTableMetadata(
         namespace,
         table,
         TableMetadata.newBuilder(tableMetadata).addSecondaryIndex(columnName).build());
   }
 
-  private void waitForIndexCreation(String namespace, String table, String columnName)
+  private void waitForIndexCreation(Namespace namespace, String table, String columnName)
       throws ExecutionException {
     try {
       String indexName = getGlobalIndexName(namespace, table, columnName);
       while (true) {
-        Uninterruptibles.sleepUninterruptibly(WAITING_DURATION_SECS, TimeUnit.SECONDS);
+        Uninterruptibles.sleepUninterruptibly(waitingDurationSecs, TimeUnit.SECONDS);
         DescribeTableResponse response =
             client.describeTable(
                 DescribeTableRequest.builder()
@@ -892,8 +917,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void dropIndex(String namespace, String table, String columnName)
+  public void dropIndex(String nonPrefixedNamespace, String table, String columnName)
       throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     try {
       client.updateTable(
           UpdateTableRequest.builder()
@@ -929,19 +955,19 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     deregisterScalableTarget(deregisterScalableTargetRequestList);
 
     // update metadata
-    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+    TableMetadata tableMetadata = getTableMetadata(nonPrefixedNamespace, table);
     putTableMetadata(
         namespace,
         table,
         TableMetadata.newBuilder(tableMetadata).removeSecondaryIndex(columnName).build());
   }
 
-  private void waitForIndexDeletion(String namespace, String table, String columnName)
+  private void waitForIndexDeletion(Namespace namespace, String table, String columnName)
       throws ExecutionException {
     try {
       String indexName = getGlobalIndexName(namespace, table, columnName);
       while (true) {
-        Uninterruptibles.sleepUninterruptibly(WAITING_DURATION_SECS, TimeUnit.SECONDS);
+        Uninterruptibles.sleepUninterruptibly(waitingDurationSecs, TimeUnit.SECONDS);
         DescribeTableResponse response =
             client.describeTable(
                 DescribeTableRequest.builder()
@@ -996,9 +1022,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getTableMetadata(String namespace, String table) throws ExecutionException {
+  public TableMetadata getTableMetadata(String nonPrefixedNamespace, String table)
+      throws ExecutionException {
     try {
-      String fullName = getFullTableName(namespace, table);
+      String fullName =
+          getFullTableName(Namespace.of(namespacePrefix, nonPrefixedNamespace), table);
       return readMetadata(fullName);
     } catch (RuntimeException e) {
       throw new ExecutionException("getting a table metadata failed", e);
@@ -1014,7 +1042,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
           client
               .getItem(
                   GetItemRequest.builder()
-                      .tableName(getFullTableName(metadataNamespace, METADATA_TABLE))
+                      .tableName(ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE))
                       .key(key)
                       .consistentRead(true)
                       .build())
@@ -1073,7 +1101,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public Set<String> getNamespaceTableNames(String namespace) throws ExecutionException {
+  public Set<String> getNamespaceTableNames(String nonPrefixedNamespace) throws ExecutionException {
     try {
       Set<String> tableSet = new HashSet<>();
       String lastEvaluatedTableName = null;
@@ -1083,7 +1111,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         ListTablesResponse listTablesResponse = client.listTables(listTablesRequest);
         lastEvaluatedTableName = listTablesResponse.lastEvaluatedTableName();
         List<String> tableNames = listTablesResponse.tableNames();
-        String prefix = namespace + ".";
+        Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+        String prefix = namespace.prefixed() + ".";
         for (String tableName : tableNames) {
           if (tableName.startsWith(prefix)) {
             tableSet.add(tableName.substring(prefix.length()));
@@ -1098,7 +1127,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public boolean namespaceExists(String namespace) throws ExecutionException {
+  public boolean namespaceExists(String nonPrefixedNamespace) throws ExecutionException {
     try {
       boolean namespaceExists = false;
       String lastEvaluatedTableName = null;
@@ -1108,8 +1137,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         ListTablesResponse listTablesResponse = client.listTables(listTablesRequest);
         lastEvaluatedTableName = listTablesResponse.lastEvaluatedTableName();
         List<String> tableNames = listTablesResponse.tableNames();
+        Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
         for (String tableName : tableNames) {
-          if (tableName.startsWith(namespace)) {
+          if (tableName.startsWith(namespace.prefixed())) {
             namespaceExists = true;
             break;
           }
@@ -1124,10 +1154,14 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   @Override
   public void repairTable(
-      String namespace, String table, TableMetadata metadata, Map<String, String> options)
+      String nonPrefixedNamespace,
+      String table,
+      TableMetadata metadata,
+      Map<String, String> options)
       throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     try {
-      if (!tableExists(namespace, table)) {
+      if (!tableExists(nonPrefixedNamespace, table)) {
         throw new IllegalArgumentException(
             "The table " + getFullTableName(namespace, table) + "  does not exist");
       }
@@ -1144,10 +1178,10 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   @Override
   public void addNewColumnToTable(
-      String namespace, String table, String columnName, DataType columnType)
+      String nonPrefixedNamespace, String table, String columnName, DataType columnType)
       throws ExecutionException {
     try {
-      TableMetadata currentTableMetadata = getTableMetadata(namespace, table);
+      TableMetadata currentTableMetadata = getTableMetadata(nonPrefixedNamespace, table);
       if (currentTableMetadata.getColumnNames().contains(columnName)) {
         throw new IllegalArgumentException(
             String.format("The column %s already exists", columnName));
@@ -1155,13 +1189,19 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
       TableMetadata updatedTableMetadata =
           TableMetadata.newBuilder(currentTableMetadata).addColumn(columnName, columnType).build();
+      Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
       putTableMetadata(namespace, table, updatedTableMetadata);
     } catch (ExecutionException e) {
       throw new ExecutionException(
           String.format(
-              "Adding the new column %s to the %s.%s table failed", columnName, namespace, table),
+              "Adding the new column %s to the %s.%s table failed",
+              columnName, nonPrefixedNamespace, table),
           e);
     }
+  }
+
+  private String getFullTableName(Namespace namespace, String table) {
+    return ScalarDbUtils.getFullTableName(namespace.prefixed(), table);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1,7 +1,5 @@
 package com.scalar.db.storage.dynamo;
 
-import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -629,17 +629,17 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   @Override
   public void dropTable(String nonPrefixedNamespace, String table) throws ExecutionException {
-    Namespace prefixedNamespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
-    disableAutoScaling(prefixedNamespace, table);
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+    disableAutoScaling(namespace, table);
 
-    String fullTableName = getFullTableName(prefixedNamespace, table);
+    String fullTableName = getFullTableName(namespace, table);
     try {
       client.deleteTable(DeleteTableRequest.builder().tableName(fullTableName).build());
     } catch (Exception e) {
       throw new ExecutionException("deleting table " + fullTableName + " failed", e);
     }
-    waitForTableDeletion(prefixedNamespace, table);
-    deleteTableMetadata(prefixedNamespace, table);
+    waitForTableDeletion(namespace, table);
+    deleteTableMetadata(namespace, table);
   }
 
   private void disableAutoScaling(Namespace namespace, String table) throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
@@ -13,12 +13,14 @@ public class DynamoConfig {
   public static final String PREFIX = DatabaseConfig.PREFIX + "dynamo.";
   public static final String ENDPOINT_OVERRIDE = PREFIX + "endpoint-override";
   public static final String TABLE_METADATA_NAMESPACE = PREFIX + "table_metadata.namespace";
+  public static final String NAMESPACE_PREFIX = PREFIX + "namespace.prefix";
 
   private final String region;
   private final String accessKeyId;
   private final String secretAccessKey;
   @Nullable private final String endpointOverride;
   @Nullable private final String tableMetadataNamespace;
+  @Nullable private final String namespacePrefix;
 
   public DynamoConfig(DatabaseConfig databaseConfig) {
     String storage = databaseConfig.getProperties().getProperty(DatabaseConfig.STORAGE);
@@ -32,6 +34,7 @@ public class DynamoConfig {
     endpointOverride = getString(databaseConfig.getProperties(), ENDPOINT_OVERRIDE, null);
     tableMetadataNamespace =
         getString(databaseConfig.getProperties(), TABLE_METADATA_NAMESPACE, null);
+    namespacePrefix = getString(databaseConfig.getProperties(), NAMESPACE_PREFIX, null);
   }
 
   public String getRegion() {
@@ -52,5 +55,9 @@ public class DynamoConfig {
 
   public Optional<String> getTableMetadataNamespace() {
     return Optional.ofNullable(tableMetadataNamespace);
+  }
+
+  public Optional<String> getNamespacePrefix() {
+    return Optional.ofNullable(namespacePrefix);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Namespace.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Namespace.java
@@ -1,0 +1,38 @@
+package com.scalar.db.storage.dynamo;
+
+public class Namespace {
+  private final String prefix;
+  private final String name;
+
+  private Namespace(String prefix, String name) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("The prefix cannot be null");
+    }
+    if (name == null) {
+      throw new IllegalArgumentException("The namespace name cannot be null");
+    }
+    this.prefix = prefix;
+    this.name = name;
+  }
+
+  public static Namespace of(String prefix, String name) {
+    return new Namespace(prefix, name);
+  }
+
+  public static Namespace of(String name) {
+    return new Namespace("", name);
+  }
+
+  public String prefixed() {
+    return prefix + name;
+  }
+
+  public String nonPrefixed() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return prefixed();
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
@@ -11,6 +11,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -28,14 +29,21 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 public class PutStatementHandler {
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
+  private final String namespacePrefix;
 
-  public PutStatementHandler(DynamoDbClient client, TableMetadataManager metadataManager) {
+  public PutStatementHandler(
+      DynamoDbClient client,
+      TableMetadataManager metadataManager,
+      Optional<String> namespacePrefix) {
     this.client = checkNotNull(client);
     this.metadataManager = checkNotNull(metadataManager);
+    this.namespacePrefix = namespacePrefix.orElse("");
   }
 
   public void handle(Put put) throws ExecutionException {
     TableMetadata tableMetadata = metadataManager.getTableMetadata(put);
+    put = copyAndAppendNamespacePrefix(put);
+
     try {
       execute(put, tableMetadata);
     } catch (ConditionalCheckFailedException e) {
@@ -86,5 +94,10 @@ public class PutStatementHandler {
             .expressionAttributeValues(bindMap)
             .expressionAttributeNames(expressionAttributeNameMap)
             .build());
+  }
+
+  private Put copyAndAppendNamespacePrefix(Put put) {
+    assert put.forNamespace().isPresent();
+    return Put.newBuilder(put).namespace(namespacePrefix + put.forNamespace().get()).build();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -47,6 +47,7 @@ public class SelectStatementHandler {
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
   private final String namespacePrefix;
+
   /**
    * Constructs a {@code SelectStatementHandler} with the specified {@link DynamoDbClient} and a new
    * {@link TableMetadataManager}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandleWithNamespacePrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandleWithNamespacePrefixTest.java
@@ -1,0 +1,10 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class BatchHandleWithNamespacePrefixTest extends BatchHandlerTestBase {
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.of("my_prefix_");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandleWithoutNamespacePrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandleWithoutNamespacePrefixTest.java
@@ -1,0 +1,10 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class BatchHandleWithoutNamespacePrefixTest extends BatchHandlerTestBase {
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerWithPrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerWithPrefixTest.java
@@ -1,0 +1,10 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class DeleteStatementHandlerWithPrefixTest extends DeleteStatementHandlerTestBase {
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.of("my_prefix_");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerWithoutPrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DeleteStatementHandlerWithoutPrefixTest.java
@@ -1,0 +1,10 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class DeleteStatementHandlerWithoutPrefixTest extends DeleteStatementHandlerTestBase {
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestWithDefaultConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestWithDefaultConfigTest.java
@@ -1,0 +1,16 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class DynamoAdminTestWithDefaultConfigTest extends DynamoAdminTestBase {
+
+  @Override
+  Optional<String> getTableMetadataNamespaceConfig() {
+    return Optional.empty();
+  }
+
+  @Override
+  Optional<String> getNamespacePrefixConfig() {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminWithDefaultConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminWithDefaultConfigTest.java
@@ -2,7 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import java.util.Optional;
 
-public class DynamoAdminTestWithDefaultConfigTest extends DynamoAdminTestBase {
+public class DynamoAdminWithDefaultConfigTest extends DynamoAdminTestBase {
 
   @Override
   Optional<String> getTableMetadataNamespaceConfig() {

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminWithNamespacePrefixAndTableMetadataNamespaceConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminWithNamespacePrefixAndTableMetadataNamespaceConfigTest.java
@@ -1,0 +1,16 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class DynamoAdminWithNamespacePrefixAndTableMetadataNamespaceConfigTest
+    extends DynamoAdminTestBase {
+  @Override
+  Optional<String> getTableMetadataNamespaceConfig() {
+    return Optional.of("my_meta_ns");
+  }
+
+  @Override
+  Optional<String> getNamespacePrefixConfig() {
+    return Optional.of("my_prefix_");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminWithNamespacePrefixConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminWithNamespacePrefixConfigTest.java
@@ -1,0 +1,16 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class DynamoAdminWithNamespacePrefixConfigTest extends DynamoAdminTestBase {
+
+  @Override
+  Optional<String> getTableMetadataNamespaceConfig() {
+    return Optional.empty();
+  }
+
+  @Override
+  Optional<String> getNamespacePrefixConfig() {
+    return Optional.of("my_prefix_");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
@@ -15,6 +15,7 @@ public class DynamoConfigTest {
   private static final String DYNAMO_STORAGE = "dynamo";
   private static final String ANY_ENDPOINT_OVERRIDE = "http://localhost:8000";
   private static final String ANY_TABLE_METADATA_NAMESPACE = "any_namespace";
+  private static final String ANY_NAMESPACE_PREFIX = "any_prefix";
 
   @Test
   public void constructor_AllPropertiesGiven_ShouldLoadProperly() {
@@ -26,6 +27,7 @@ public class DynamoConfigTest {
     props.setProperty(DatabaseConfig.STORAGE, DYNAMO_STORAGE);
     props.setProperty(DynamoConfig.ENDPOINT_OVERRIDE, ANY_ENDPOINT_OVERRIDE);
     props.setProperty(DynamoConfig.TABLE_METADATA_NAMESPACE, ANY_TABLE_METADATA_NAMESPACE);
+    props.setProperty(DynamoConfig.NAMESPACE_PREFIX, ANY_NAMESPACE_PREFIX);
 
     // Act
     DynamoConfig config = new DynamoConfig(new DatabaseConfig(props));
@@ -38,6 +40,8 @@ public class DynamoConfigTest {
     assertThat(config.getEndpointOverride().get()).isEqualTo(ANY_ENDPOINT_OVERRIDE);
     assertThat(config.getTableMetadataNamespace()).isPresent();
     assertThat(config.getTableMetadataNamespace().get()).isEqualTo(ANY_TABLE_METADATA_NAMESPACE);
+    assertThat(config.getNamespacePrefix()).isPresent();
+    assertThat(config.getNamespacePrefix().get()).isEqualTo(ANY_NAMESPACE_PREFIX);
   }
 
   @Test
@@ -97,5 +101,24 @@ public class DynamoConfigTest {
     assertThat(config.getEndpointOverride().isPresent()).isTrue();
     assertThat(config.getEndpointOverride().get()).isEqualTo(ANY_ENDPOINT_OVERRIDE);
     assertThat(config.getTableMetadataNamespace()).isNotPresent();
+  }
+
+  @Test
+  public void constructor_PropertiesWithoutNamespacePrefixGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_REGION);
+    props.setProperty(DatabaseConfig.USERNAME, ANY_ACCESS_KEY_ID);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_SECRET_ACCESS_ID);
+    props.setProperty(DatabaseConfig.STORAGE, DYNAMO_STORAGE);
+
+    // Act
+    DynamoConfig config = new DynamoConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getRegion()).isEqualTo(ANY_REGION);
+    assertThat(config.getAccessKeyId()).isEqualTo(ANY_ACCESS_KEY_ID);
+    assertThat(config.getSecretAccessKey()).isEqualTo(ANY_SECRET_ACCESS_ID);
+    assertThat(config.getNamespacePrefix()).isEmpty();
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerTestBase.java
@@ -21,6 +21,7 @@ import com.scalar.db.io.Key;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -33,7 +34,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
 
-public class PutStatementHandlerTest {
+public abstract class PutStatementHandlerTestBase {
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -55,11 +56,17 @@ public class PutStatementHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new PutStatementHandler(client, metadataManager);
+    handler = new PutStatementHandler(client, metadataManager, getNamespacePrefix());
 
     when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
     when(metadata.getPartitionKeyNames())
         .thenReturn(new LinkedHashSet<>(Collections.singletonList(ANY_NAME_1)));
+  }
+
+  abstract Optional<String> getNamespacePrefix();
+
+  private String getFullTableName() {
+    return getNamespacePrefix().orElse("") + ANY_NAMESPACE_NAME + "." + ANY_TABLE_NAME;
   }
 
   private Put preparePut() {
@@ -93,6 +100,7 @@ public class PutStatementHandlerTest {
     assertThat(actualRequest.updateExpression()).isEqualTo(updateExpression);
     assertThat(actualRequest.conditionExpression()).isNull();
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -122,6 +130,7 @@ public class PutStatementHandlerTest {
     assertThat(actualRequest.updateExpression()).isEqualTo(updateExpression);
     assertThat(actualRequest.conditionExpression()).isNull();
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -161,6 +170,7 @@ public class PutStatementHandlerTest {
     assertThat(actualRequest.updateExpression()).isEqualTo(updateExpression);
     assertThat(actualRequest.conditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -185,6 +195,7 @@ public class PutStatementHandlerTest {
     assertThat(actualRequest.updateExpression()).isEqualTo(updateExpression);
     assertThat(actualRequest.conditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerWithPrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerWithPrefixTest.java
@@ -1,0 +1,10 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class PutStatementHandlerWithPrefixTest extends PutStatementHandlerTestBase {
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.of("my_prefix_");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerWithoutPrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/PutStatementHandlerWithoutPrefixTest.java
@@ -1,0 +1,10 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class PutStatementHandlerWithoutPrefixTest extends PutStatementHandlerTestBase {
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,7 +48,7 @@ import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
-public class SelectStatementHandlerTest {
+public abstract class SelectStatementHandlerTestBase {
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -73,7 +74,7 @@ public class SelectStatementHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new SelectStatementHandler(client, metadataManager);
+    handler = new SelectStatementHandler(client, metadataManager, getNamespacePrefix());
 
     when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
     when(metadata.getPartitionKeyNames())
@@ -84,6 +85,12 @@ public class SelectStatementHandlerTest {
     when(metadata.getClusteringOrders()).thenReturn(ImmutableMap.of(ANY_NAME_2, Order.ASC));
     when(metadata.getSecondaryIndexNames())
         .thenReturn(new HashSet<>(Collections.singletonList(ANY_NAME_3)));
+  }
+
+  abstract Optional<String> getNamespacePrefix();
+
+  private String getFullTableName() {
+    return getNamespacePrefix().orElse("") + ANY_NAMESPACE_NAME + "." + ANY_TABLE_NAME;
   }
 
   private Get prepareGet() {
@@ -123,6 +130,7 @@ public class SelectStatementHandlerTest {
     GetItemRequest actualRequest = captor.getValue();
     assertThat(actualRequest.key()).isEqualTo(expectedKeys);
     assertThat(actualRequest.projectionExpression()).isNull();
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -166,6 +174,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedKeyCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -206,6 +215,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedKeyCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -231,6 +241,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedKeyCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -270,6 +281,7 @@ public class SelectStatementHandlerTest {
     assertThat(actualRequest.projectionExpression())
         .isEqualTo(
             DynamoOperation.COLUMN_NAME_ALIAS + "1," + DynamoOperation.COLUMN_NAME_ALIAS + "2");
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -342,6 +354,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -408,6 +421,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -453,6 +467,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -498,6 +513,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -543,6 +559,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -588,6 +605,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -658,6 +676,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -729,6 +748,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -803,6 +823,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -878,6 +899,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -948,6 +970,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1018,6 +1041,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1088,6 +1112,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1155,6 +1180,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1227,6 +1253,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1296,6 +1323,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1349,6 +1377,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1406,6 +1435,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1472,6 +1502,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1543,6 +1574,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1611,6 +1643,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1684,6 +1717,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1741,6 +1775,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1794,6 +1829,7 @@ public class SelectStatementHandlerTest {
     QueryRequest actualRequest = captor.getValue();
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1842,6 +1878,7 @@ public class SelectStatementHandlerTest {
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.scanIndexForward()).isNull();
     assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1891,6 +1928,7 @@ public class SelectStatementHandlerTest {
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.scanIndexForward()).isNull();
     assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1909,6 +1947,7 @@ public class SelectStatementHandlerTest {
     verify(client).scan(captor.capture());
     ScanRequest actualRequest = captor.getValue();
     assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1927,6 +1966,7 @@ public class SelectStatementHandlerTest {
     verify(client).scan(captor.capture());
     ScanRequest actualRequest = captor.getValue();
     assertThat(actualRequest.limit()).isEqualTo(null);
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
   @Test
@@ -1958,5 +1998,6 @@ public class SelectStatementHandlerTest {
     assertThat(actualRequest.projectionExpression())
         .isEqualTo(
             DynamoOperation.COLUMN_NAME_ALIAS + "0," + DynamoOperation.COLUMN_NAME_ALIAS + "1");
+    assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerWithPrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerWithPrefixTest.java
@@ -1,0 +1,11 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class SelectStatementHandlerWithPrefixTest extends SelectStatementHandlerTestBase {
+
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.of("my_prefix_");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerWithoutPrefixTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerWithoutPrefixTest.java
@@ -1,0 +1,11 @@
+package com.scalar.db.storage.dynamo;
+
+import java.util.Optional;
+
+public class SelectStatementHandlerWithoutPrefixTest extends SelectStatementHandlerTestBase {
+
+  @Override
+  Optional<String> getNamespacePrefix() {
+    return Optional.empty();
+  }
+}

--- a/docs/getting-started-with-scalardb-on-dynamodb.md
+++ b/docs/getting-started-with-scalardb-on-dynamodb.md
@@ -32,6 +32,11 @@ scalar.db.dynamo.endpoint-override=
 
 # The namespace name for the table metadata (used as a table prefix of the table metadata)
 scalar.db.dynamo.table_metadata.namespace=
+
+# Set a prefix for the user namespaces and metadata namespace names. Since AWS requires to have unique 
+# tables names in a single AWS region, this is useful if you want to use multiple Scalar DB environments 
+# (development, production, etc.) in a single AWS region.
+scalar.db.dynamo.namespace.prefix=
 ```
 
 Please follow [Getting Started with Scalar DB](getting-started-with-scalardb.md) to run the application.


### PR DESCRIPTION
This PR adds a new configuration when using DynamoDB to be able to set a namespace prefix 
```
scalar.db.dynamo.namespace.prefix=my_prefix_
```
