### PR TITLE
Revert Proto package name

### DIFF
--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageAdminGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageAdminGrpc.java
@@ -12,7 +12,7 @@ public final class DistributedStorageAdminGrpc {
 
   private DistributedStorageAdminGrpc() {}
 
-  public static final String SERVICE_NAME = "scalardb.rpc.DistributedStorageAdmin";
+  public static final String SERVICE_NAME = "rpc.DistributedStorageAdmin";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.CreateNamespaceRequest,

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedStorageGrpc.java
@@ -12,7 +12,7 @@ public final class DistributedStorageGrpc {
 
   private DistributedStorageGrpc() {}
 
-  public static final String SERVICE_NAME = "scalardb.rpc.DistributedStorage";
+  public static final String SERVICE_NAME = "rpc.DistributedStorage";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.GetRequest,

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionAdminGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionAdminGrpc.java
@@ -12,7 +12,7 @@ public final class DistributedTransactionAdminGrpc {
 
   private DistributedTransactionAdminGrpc() {}
 
-  public static final String SERVICE_NAME = "scalardb.rpc.DistributedTransactionAdmin";
+  public static final String SERVICE_NAME = "rpc.DistributedTransactionAdmin";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.CreateNamespaceRequest,

--- a/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/DistributedTransactionGrpc.java
@@ -12,7 +12,7 @@ public final class DistributedTransactionGrpc {
 
   private DistributedTransactionGrpc() {}
 
-  public static final String SERVICE_NAME = "scalardb.rpc.DistributedTransaction";
+  public static final String SERVICE_NAME = "rpc.DistributedTransaction";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.TransactionRequest,

--- a/rpc/src/main/grpc/com/scalar/db/rpc/TwoPhaseCommitTransactionGrpc.java
+++ b/rpc/src/main/grpc/com/scalar/db/rpc/TwoPhaseCommitTransactionGrpc.java
@@ -12,7 +12,7 @@ public final class TwoPhaseCommitTransactionGrpc {
 
   private TwoPhaseCommitTransactionGrpc() {}
 
-  public static final String SERVICE_NAME = "scalardb.rpc.TwoPhaseCommitTransaction";
+  public static final String SERVICE_NAME = "rpc.TwoPhaseCommitTransaction";
 
   // Static method descriptors that strictly reflect the proto.
   private static volatile io.grpc.MethodDescriptor<com.scalar.db.rpc.TwoPhaseCommitTransactionRequest,

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.AbortRequest}
+ * Protobuf type {@code rpc.AbortRequest}
  */
 public final class AbortRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.AbortRequest)
+    // @@protoc_insertion_point(message_implements:rpc.AbortRequest)
     AbortRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use AbortRequest.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.AbortRequest.class, com.scalar.db.rpc.AbortRequest.Builder.class);
   }
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.AbortRequest}
+   * Protobuf type {@code rpc.AbortRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.AbortRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.AbortRequest)
       com.scalar.db.rpc.AbortRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.AbortRequest.class, com.scalar.db.rpc.AbortRequest.Builder.class);
     }
@@ -327,7 +327,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortRequest_descriptor;
     }
 
     @java.lang.Override
@@ -517,10 +517,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.AbortRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.AbortRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.AbortRequest)
+  // @@protoc_insertion_point(class_scope:rpc.AbortRequest)
   private static final com.scalar.db.rpc.AbortRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.AbortRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface AbortRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.AbortRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.AbortRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.AbortResponse}
+ * Protobuf type {@code rpc.AbortResponse}
  */
 public final class AbortResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.AbortResponse)
+    // @@protoc_insertion_point(message_implements:rpc.AbortResponse)
     AbortResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use AbortResponse.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.AbortResponse.class, com.scalar.db.rpc.AbortResponse.Builder.class);
   }
@@ -92,14 +92,14 @@ private static final long serialVersionUID = 0L;
   public static final int STATE_FIELD_NUMBER = 1;
   private int state_;
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
    */
   @java.lang.Override public int getStateValue() {
     return state_;
   }
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The state.
    */
   @java.lang.Override public com.scalar.db.rpc.TransactionState getState() {
@@ -263,21 +263,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.AbortResponse}
+   * Protobuf type {@code rpc.AbortResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.AbortResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.AbortResponse)
       com.scalar.db.rpc.AbortResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.AbortResponse.class, com.scalar.db.rpc.AbortResponse.Builder.class);
     }
@@ -308,7 +308,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AbortResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AbortResponse_descriptor;
     }
 
     @java.lang.Override
@@ -411,14 +411,14 @@ private static final long serialVersionUID = 0L;
 
     private int state_ = 0;
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return The enum numeric value on the wire for state.
      */
     @java.lang.Override public int getStateValue() {
       return state_;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @param value The enum numeric value on the wire for state to set.
      * @return This builder for chaining.
      */
@@ -429,7 +429,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return The state.
      */
     @java.lang.Override
@@ -439,7 +439,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @param value The state to set.
      * @return This builder for chaining.
      */
@@ -453,7 +453,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return This builder for chaining.
      */
     public Builder clearState() {
@@ -475,10 +475,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.AbortResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.AbortResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.AbortResponse)
+  // @@protoc_insertion_point(class_scope:rpc.AbortResponse)
   private static final com.scalar.db.rpc.AbortResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.AbortResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortResponseOrBuilder.java
@@ -4,16 +4,16 @@
 package com.scalar.db.rpc;
 
 public interface AbortResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.AbortResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.AbortResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
    */
   int getStateValue();
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The state.
    */
   com.scalar.db.rpc.TransactionState getState();

--- a/rpc/src/main/java/com/scalar/db/rpc/AddNewColumnToTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AddNewColumnToTableRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.AddNewColumnToTableRequest}
+ * Protobuf type {@code rpc.AddNewColumnToTableRequest}
  */
 public final class AddNewColumnToTableRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.AddNewColumnToTableRequest)
+    // @@protoc_insertion_point(message_implements:rpc.AddNewColumnToTableRequest)
     AddNewColumnToTableRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use AddNewColumnToTableRequest.newBuilder() to construct.
@@ -99,13 +99,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AddNewColumnToTableRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AddNewColumnToTableRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AddNewColumnToTableRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AddNewColumnToTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.AddNewColumnToTableRequest.class, com.scalar.db.rpc.AddNewColumnToTableRequest.Builder.class);
   }
@@ -227,14 +227,14 @@ private static final long serialVersionUID = 0L;
   public static final int COLUMN_TYPE_FIELD_NUMBER = 4;
   private int columnType_;
   /**
-   * <code>.scalardb.rpc.DataType column_type = 4;</code>
+   * <code>.rpc.DataType column_type = 4;</code>
    * @return The enum numeric value on the wire for columnType.
    */
   @java.lang.Override public int getColumnTypeValue() {
     return columnType_;
   }
   /**
-   * <code>.scalardb.rpc.DataType column_type = 4;</code>
+   * <code>.rpc.DataType column_type = 4;</code>
    * @return The columnType.
    */
   @java.lang.Override public com.scalar.db.rpc.DataType getColumnType() {
@@ -428,21 +428,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.AddNewColumnToTableRequest}
+   * Protobuf type {@code rpc.AddNewColumnToTableRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.AddNewColumnToTableRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.AddNewColumnToTableRequest)
       com.scalar.db.rpc.AddNewColumnToTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AddNewColumnToTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AddNewColumnToTableRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AddNewColumnToTableRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AddNewColumnToTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.AddNewColumnToTableRequest.class, com.scalar.db.rpc.AddNewColumnToTableRequest.Builder.class);
     }
@@ -479,7 +479,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_AddNewColumnToTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_AddNewColumnToTableRequest_descriptor;
     }
 
     @java.lang.Override
@@ -825,14 +825,14 @@ private static final long serialVersionUID = 0L;
 
     private int columnType_ = 0;
     /**
-     * <code>.scalardb.rpc.DataType column_type = 4;</code>
+     * <code>.rpc.DataType column_type = 4;</code>
      * @return The enum numeric value on the wire for columnType.
      */
     @java.lang.Override public int getColumnTypeValue() {
       return columnType_;
     }
     /**
-     * <code>.scalardb.rpc.DataType column_type = 4;</code>
+     * <code>.rpc.DataType column_type = 4;</code>
      * @param value The enum numeric value on the wire for columnType to set.
      * @return This builder for chaining.
      */
@@ -843,7 +843,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.DataType column_type = 4;</code>
+     * <code>.rpc.DataType column_type = 4;</code>
      * @return The columnType.
      */
     @java.lang.Override
@@ -853,7 +853,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.DataType.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.DataType column_type = 4;</code>
+     * <code>.rpc.DataType column_type = 4;</code>
      * @param value The columnType to set.
      * @return This builder for chaining.
      */
@@ -867,7 +867,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.DataType column_type = 4;</code>
+     * <code>.rpc.DataType column_type = 4;</code>
      * @return This builder for chaining.
      */
     public Builder clearColumnType() {
@@ -889,10 +889,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.AddNewColumnToTableRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.AddNewColumnToTableRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.AddNewColumnToTableRequest)
+  // @@protoc_insertion_point(class_scope:rpc.AddNewColumnToTableRequest)
   private static final com.scalar.db.rpc.AddNewColumnToTableRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.AddNewColumnToTableRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/AddNewColumnToTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AddNewColumnToTableRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface AddNewColumnToTableRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.AddNewColumnToTableRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.AddNewColumnToTableRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -44,12 +44,12 @@ public interface AddNewColumnToTableRequestOrBuilder extends
       getColumnNameBytes();
 
   /**
-   * <code>.scalardb.rpc.DataType column_type = 4;</code>
+   * <code>.rpc.DataType column_type = 4;</code>
    * @return The enum numeric value on the wire for columnType.
    */
   int getColumnTypeValue();
   /**
-   * <code>.scalardb.rpc.DataType column_type = 4;</code>
+   * <code>.rpc.DataType column_type = 4;</code>
    * @return The columnType.
    */
   com.scalar.db.rpc.DataType getColumnType();

--- a/rpc/src/main/java/com/scalar/db/rpc/Column.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Column.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Column}
+ * Protobuf type {@code rpc.Column}
  */
 public final class Column extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Column)
+    // @@protoc_insertion_point(message_implements:rpc.Column)
     ColumnOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Column.newBuilder() to construct.
@@ -114,13 +114,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Column_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Column_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Column_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Column_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Column.class, com.scalar.db.rpc.Column.Builder.class);
   }
@@ -678,21 +678,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Column}
+   * Protobuf type {@code rpc.Column}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Column)
+      // @@protoc_insertion_point(builder_implements:rpc.Column)
       com.scalar.db.rpc.ColumnOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Column_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Column_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Column_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Column_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Column.class, com.scalar.db.rpc.Column.Builder.class);
     }
@@ -725,7 +725,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Column_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Column_descriptor;
     }
 
     @java.lang.Override
@@ -1333,10 +1333,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Column)
+    // @@protoc_insertion_point(builder_scope:rpc.Column)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Column)
+  // @@protoc_insertion_point(class_scope:rpc.Column)
   private static final com.scalar.db.rpc.Column DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Column();

--- a/rpc/src/main/java/com/scalar/db/rpc/ColumnOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ColumnOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface ColumnOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Column)
+    // @@protoc_insertion_point(interface_extends:rpc.Column)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpression.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpression.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.ConditionalExpression}
+ * Protobuf type {@code rpc.ConditionalExpression}
  */
 public final class ConditionalExpression extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.ConditionalExpression)
+    // @@protoc_insertion_point(message_implements:rpc.ConditionalExpression)
     ConditionalExpressionOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use ConditionalExpression.newBuilder() to construct.
@@ -111,19 +111,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ConditionalExpression_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ConditionalExpression_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ConditionalExpression_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ConditionalExpression_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.ConditionalExpression.class, com.scalar.db.rpc.ConditionalExpression.Builder.class);
   }
 
   /**
-   * Protobuf enum {@code scalardb.rpc.ConditionalExpression.Operator}
+   * Protobuf enum {@code rpc.ConditionalExpression.Operator}
    */
   public enum Operator
       implements com.google.protobuf.ProtocolMessageEnum {
@@ -281,14 +281,14 @@ private static final long serialVersionUID = 0L;
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:scalardb.rpc.ConditionalExpression.Operator)
+    // @@protoc_insertion_point(enum_scope:rpc.ConditionalExpression.Operator)
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
    * <code>string name = 1 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+   * @deprecated rpc.ConditionalExpression.name is deprecated.
    *     See scalardb.proto;l=91
    * @return The name.
    */
@@ -307,7 +307,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string name = 1 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+   * @deprecated rpc.ConditionalExpression.name is deprecated.
    *     See scalardb.proto;l=91
    * @return The bytes for name.
    */
@@ -329,8 +329,8 @@ private static final long serialVersionUID = 0L;
   public static final int VALUE_FIELD_NUMBER = 2;
   private com.scalar.db.rpc.Value value_;
   /**
-   * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.value is deprecated.
+   * <code>.rpc.Value value = 2 [deprecated = true];</code>
+   * @deprecated rpc.ConditionalExpression.value is deprecated.
    *     See scalardb.proto;l=92
    * @return Whether the value field is set.
    */
@@ -339,8 +339,8 @@ private static final long serialVersionUID = 0L;
     return value_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.value is deprecated.
+   * <code>.rpc.Value value = 2 [deprecated = true];</code>
+   * @deprecated rpc.ConditionalExpression.value is deprecated.
    *     See scalardb.proto;l=92
    * @return The value.
    */
@@ -349,7 +349,7 @@ private static final long serialVersionUID = 0L;
     return value_ == null ? com.scalar.db.rpc.Value.getDefaultInstance() : value_;
   }
   /**
-   * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+   * <code>.rpc.Value value = 2 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder() {
@@ -359,14 +359,14 @@ private static final long serialVersionUID = 0L;
   public static final int OPERATOR_FIELD_NUMBER = 3;
   private int operator_;
   /**
-   * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+   * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
    * @return The enum numeric value on the wire for operator.
    */
   @java.lang.Override public int getOperatorValue() {
     return operator_;
   }
   /**
-   * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+   * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
    * @return The operator.
    */
   @java.lang.Override public com.scalar.db.rpc.ConditionalExpression.Operator getOperator() {
@@ -378,7 +378,7 @@ private static final long serialVersionUID = 0L;
   public static final int COLUMN_FIELD_NUMBER = 4;
   private com.scalar.db.rpc.Column column_;
   /**
-   * <code>.scalardb.rpc.Column column = 4;</code>
+   * <code>.rpc.Column column = 4;</code>
    * @return Whether the column field is set.
    */
   @java.lang.Override
@@ -386,7 +386,7 @@ private static final long serialVersionUID = 0L;
     return column_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Column column = 4;</code>
+   * <code>.rpc.Column column = 4;</code>
    * @return The column.
    */
   @java.lang.Override
@@ -394,7 +394,7 @@ private static final long serialVersionUID = 0L;
     return column_ == null ? com.scalar.db.rpc.Column.getDefaultInstance() : column_;
   }
   /**
-   * <code>.scalardb.rpc.Column column = 4;</code>
+   * <code>.rpc.Column column = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ColumnOrBuilder getColumnOrBuilder() {
@@ -598,21 +598,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.ConditionalExpression}
+   * Protobuf type {@code rpc.ConditionalExpression}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.ConditionalExpression)
+      // @@protoc_insertion_point(builder_implements:rpc.ConditionalExpression)
       com.scalar.db.rpc.ConditionalExpressionOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ConditionalExpression_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ConditionalExpression_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ConditionalExpression_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ConditionalExpression_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.ConditionalExpression.class, com.scalar.db.rpc.ConditionalExpression.Builder.class);
     }
@@ -657,7 +657,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ConditionalExpression_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ConditionalExpression_descriptor;
     }
 
     @java.lang.Override
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object name_ = "";
     /**
      * <code>string name = 1 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+     * @deprecated rpc.ConditionalExpression.name is deprecated.
      *     See scalardb.proto;l=91
      * @return The name.
      */
@@ -800,7 +800,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string name = 1 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+     * @deprecated rpc.ConditionalExpression.name is deprecated.
      *     See scalardb.proto;l=91
      * @return The bytes for name.
      */
@@ -819,7 +819,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string name = 1 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+     * @deprecated rpc.ConditionalExpression.name is deprecated.
      *     See scalardb.proto;l=91
      * @param value The name to set.
      * @return This builder for chaining.
@@ -836,7 +836,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string name = 1 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+     * @deprecated rpc.ConditionalExpression.name is deprecated.
      *     See scalardb.proto;l=91
      * @return This builder for chaining.
      */
@@ -848,7 +848,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string name = 1 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+     * @deprecated rpc.ConditionalExpression.name is deprecated.
      *     See scalardb.proto;l=91
      * @param value The bytes for name to set.
      * @return This builder for chaining.
@@ -869,8 +869,8 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Value, com.scalar.db.rpc.Value.Builder, com.scalar.db.rpc.ValueOrBuilder> valueBuilder_;
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.value is deprecated.
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
+     * @deprecated rpc.ConditionalExpression.value is deprecated.
      *     See scalardb.proto;l=92
      * @return Whether the value field is set.
      */
@@ -878,8 +878,8 @@ private static final long serialVersionUID = 0L;
       return valueBuilder_ != null || value_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
-     * @deprecated scalardb.rpc.ConditionalExpression.value is deprecated.
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
+     * @deprecated rpc.ConditionalExpression.value is deprecated.
      *     See scalardb.proto;l=92
      * @return The value.
      */
@@ -891,7 +891,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(com.scalar.db.rpc.Value value) {
       if (valueBuilder_ == null) {
@@ -907,7 +907,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -921,7 +921,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder mergeValue(com.scalar.db.rpc.Value value) {
       if (valueBuilder_ == null) {
@@ -939,7 +939,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder clearValue() {
       if (valueBuilder_ == null) {
@@ -953,7 +953,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder getValueBuilder() {
       
@@ -961,7 +961,7 @@ private static final long serialVersionUID = 0L;
       return getValueFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder() {
       if (valueBuilder_ != null) {
@@ -972,7 +972,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+     * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Value, com.scalar.db.rpc.Value.Builder, com.scalar.db.rpc.ValueOrBuilder> 
@@ -990,14 +990,14 @@ private static final long serialVersionUID = 0L;
 
     private int operator_ = 0;
     /**
-     * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+     * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
      * @return The enum numeric value on the wire for operator.
      */
     @java.lang.Override public int getOperatorValue() {
       return operator_;
     }
     /**
-     * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+     * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
      * @param value The enum numeric value on the wire for operator to set.
      * @return This builder for chaining.
      */
@@ -1008,7 +1008,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+     * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
      * @return The operator.
      */
     @java.lang.Override
@@ -1018,7 +1018,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.ConditionalExpression.Operator.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+     * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
      * @param value The operator to set.
      * @return This builder for chaining.
      */
@@ -1032,7 +1032,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+     * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
      * @return This builder for chaining.
      */
     public Builder clearOperator() {
@@ -1046,14 +1046,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Column, com.scalar.db.rpc.Column.Builder, com.scalar.db.rpc.ColumnOrBuilder> columnBuilder_;
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      * @return Whether the column field is set.
      */
     public boolean hasColumn() {
       return columnBuilder_ != null || column_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      * @return The column.
      */
     public com.scalar.db.rpc.Column getColumn() {
@@ -1064,7 +1064,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     public Builder setColumn(com.scalar.db.rpc.Column value) {
       if (columnBuilder_ == null) {
@@ -1080,7 +1080,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     public Builder setColumn(
         com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -1094,7 +1094,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     public Builder mergeColumn(com.scalar.db.rpc.Column value) {
       if (columnBuilder_ == null) {
@@ -1112,7 +1112,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     public Builder clearColumn() {
       if (columnBuilder_ == null) {
@@ -1126,7 +1126,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     public com.scalar.db.rpc.Column.Builder getColumnBuilder() {
       
@@ -1134,7 +1134,7 @@ private static final long serialVersionUID = 0L;
       return getColumnFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     public com.scalar.db.rpc.ColumnOrBuilder getColumnOrBuilder() {
       if (columnBuilder_ != null) {
@@ -1145,7 +1145,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Column column = 4;</code>
+     * <code>.rpc.Column column = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Column, com.scalar.db.rpc.Column.Builder, com.scalar.db.rpc.ColumnOrBuilder> 
@@ -1173,10 +1173,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.ConditionalExpression)
+    // @@protoc_insertion_point(builder_scope:rpc.ConditionalExpression)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.ConditionalExpression)
+  // @@protoc_insertion_point(class_scope:rpc.ConditionalExpression)
   private static final com.scalar.db.rpc.ConditionalExpression DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.ConditionalExpression();

--- a/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpressionOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpressionOrBuilder.java
@@ -4,19 +4,19 @@
 package com.scalar.db.rpc;
 
 public interface ConditionalExpressionOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.ConditionalExpression)
+    // @@protoc_insertion_point(interface_extends:rpc.ConditionalExpression)
     com.google.protobuf.MessageOrBuilder {
 
   /**
    * <code>string name = 1 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+   * @deprecated rpc.ConditionalExpression.name is deprecated.
    *     See scalardb.proto;l=91
    * @return The name.
    */
   @java.lang.Deprecated java.lang.String getName();
   /**
    * <code>string name = 1 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.name is deprecated.
+   * @deprecated rpc.ConditionalExpression.name is deprecated.
    *     See scalardb.proto;l=91
    * @return The bytes for name.
    */
@@ -24,47 +24,47 @@ public interface ConditionalExpressionOrBuilder extends
       getNameBytes();
 
   /**
-   * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.value is deprecated.
+   * <code>.rpc.Value value = 2 [deprecated = true];</code>
+   * @deprecated rpc.ConditionalExpression.value is deprecated.
    *     See scalardb.proto;l=92
    * @return Whether the value field is set.
    */
   @java.lang.Deprecated boolean hasValue();
   /**
-   * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
-   * @deprecated scalardb.rpc.ConditionalExpression.value is deprecated.
+   * <code>.rpc.Value value = 2 [deprecated = true];</code>
+   * @deprecated rpc.ConditionalExpression.value is deprecated.
    *     See scalardb.proto;l=92
    * @return The value.
    */
   @java.lang.Deprecated com.scalar.db.rpc.Value getValue();
   /**
-   * <code>.scalardb.rpc.Value value = 2 [deprecated = true];</code>
+   * <code>.rpc.Value value = 2 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+   * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
    * @return The enum numeric value on the wire for operator.
    */
   int getOperatorValue();
   /**
-   * <code>.scalardb.rpc.ConditionalExpression.Operator operator = 3;</code>
+   * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
    * @return The operator.
    */
   com.scalar.db.rpc.ConditionalExpression.Operator getOperator();
 
   /**
-   * <code>.scalardb.rpc.Column column = 4;</code>
+   * <code>.rpc.Column column = 4;</code>
    * @return Whether the column field is set.
    */
   boolean hasColumn();
   /**
-   * <code>.scalardb.rpc.Column column = 4;</code>
+   * <code>.rpc.Column column = 4;</code>
    * @return The column.
    */
   com.scalar.db.rpc.Column getColumn();
   /**
-   * <code>.scalardb.rpc.Column column = 4;</code>
+   * <code>.rpc.Column column = 4;</code>
    */
   com.scalar.db.rpc.ColumnOrBuilder getColumnOrBuilder();
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/Consistency.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Consistency.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf enum {@code scalardb.rpc.Consistency}
+ * Protobuf enum {@code rpc.Consistency}
  */
 public enum Consistency
     implements com.google.protobuf.ProtocolMessageEnum {
@@ -117,6 +117,6 @@ public enum Consistency
     this.value = value;
   }
 
-  // @@protoc_insertion_point(enum_scope:scalardb.rpc.Consistency)
+  // @@protoc_insertion_point(enum_scope:rpc.Consistency)
 }
 

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.CoordinatorTablesExistRequest}
+ * Protobuf type {@code rpc.CoordinatorTablesExistRequest}
  */
 public final class CoordinatorTablesExistRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.CoordinatorTablesExistRequest)
+    // @@protoc_insertion_point(message_implements:rpc.CoordinatorTablesExistRequest)
     CoordinatorTablesExistRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use CoordinatorTablesExistRequest.newBuilder() to construct.
@@ -71,13 +71,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.CoordinatorTablesExistRequest.class, com.scalar.db.rpc.CoordinatorTablesExistRequest.Builder.class);
   }
@@ -227,21 +227,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.CoordinatorTablesExistRequest}
+   * Protobuf type {@code rpc.CoordinatorTablesExistRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.CoordinatorTablesExistRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.CoordinatorTablesExistRequest)
       com.scalar.db.rpc.CoordinatorTablesExistRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.CoordinatorTablesExistRequest.class, com.scalar.db.rpc.CoordinatorTablesExistRequest.Builder.class);
     }
@@ -270,7 +270,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistRequest_descriptor;
     }
 
     @java.lang.Override
@@ -379,10 +379,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.CoordinatorTablesExistRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.CoordinatorTablesExistRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.CoordinatorTablesExistRequest)
+  // @@protoc_insertion_point(class_scope:rpc.CoordinatorTablesExistRequest)
   private static final com.scalar.db.rpc.CoordinatorTablesExistRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.CoordinatorTablesExistRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistRequestOrBuilder.java
@@ -4,6 +4,6 @@
 package com.scalar.db.rpc;
 
 public interface CoordinatorTablesExistRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.CoordinatorTablesExistRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.CoordinatorTablesExistRequest)
     com.google.protobuf.MessageOrBuilder {
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.CoordinatorTablesExistResponse}
+ * Protobuf type {@code rpc.CoordinatorTablesExistResponse}
  */
 public final class CoordinatorTablesExistResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.CoordinatorTablesExistResponse)
+    // @@protoc_insertion_point(message_implements:rpc.CoordinatorTablesExistResponse)
     CoordinatorTablesExistResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use CoordinatorTablesExistResponse.newBuilder() to construct.
@@ -76,13 +76,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.CoordinatorTablesExistResponse.class, com.scalar.db.rpc.CoordinatorTablesExistResponse.Builder.class);
   }
@@ -255,21 +255,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.CoordinatorTablesExistResponse}
+   * Protobuf type {@code rpc.CoordinatorTablesExistResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.CoordinatorTablesExistResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.CoordinatorTablesExistResponse)
       com.scalar.db.rpc.CoordinatorTablesExistResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.CoordinatorTablesExistResponse.class, com.scalar.db.rpc.CoordinatorTablesExistResponse.Builder.class);
     }
@@ -300,7 +300,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CoordinatorTablesExistResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CoordinatorTablesExistResponse_descriptor;
     }
 
     @java.lang.Override
@@ -444,10 +444,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.CoordinatorTablesExistResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.CoordinatorTablesExistResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.CoordinatorTablesExistResponse)
+  // @@protoc_insertion_point(class_scope:rpc.CoordinatorTablesExistResponse)
   private static final com.scalar.db.rpc.CoordinatorTablesExistResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.CoordinatorTablesExistResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponseOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface CoordinatorTablesExistResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.CoordinatorTablesExistResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.CoordinatorTablesExistResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.CreateCoordinatorTablesRequest}
+ * Protobuf type {@code rpc.CreateCoordinatorTablesRequest}
  */
 public final class CreateCoordinatorTablesRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.CreateCoordinatorTablesRequest)
+    // @@protoc_insertion_point(message_implements:rpc.CreateCoordinatorTablesRequest)
     CreateCoordinatorTablesRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use CreateCoordinatorTablesRequest.newBuilder() to construct.
@@ -90,7 +90,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateCoordinatorTablesRequest_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -108,7 +108,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.CreateCoordinatorTablesRequest.class, com.scalar.db.rpc.CreateCoordinatorTablesRequest.Builder.class);
   }
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.String> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.String>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.STRING,
@@ -384,15 +384,15 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.CreateCoordinatorTablesRequest}
+   * Protobuf type {@code rpc.CreateCoordinatorTablesRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.CreateCoordinatorTablesRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.CreateCoordinatorTablesRequest)
       com.scalar.db.rpc.CreateCoordinatorTablesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateCoordinatorTablesRequest_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -420,7 +420,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.CreateCoordinatorTablesRequest.class, com.scalar.db.rpc.CreateCoordinatorTablesRequest.Builder.class);
     }
@@ -452,7 +452,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateCoordinatorTablesRequest_descriptor;
     }
 
     @java.lang.Override
@@ -733,10 +733,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.CreateCoordinatorTablesRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.CreateCoordinatorTablesRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.CreateCoordinatorTablesRequest)
+  // @@protoc_insertion_point(class_scope:rpc.CreateCoordinatorTablesRequest)
   private static final com.scalar.db.rpc.CreateCoordinatorTablesRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.CreateCoordinatorTablesRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface CreateCoordinatorTablesRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.CreateCoordinatorTablesRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.CreateCoordinatorTablesRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.CreateIndexRequest}
+ * Protobuf type {@code rpc.CreateIndexRequest}
  */
 public final class CreateIndexRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.CreateIndexRequest)
+    // @@protoc_insertion_point(message_implements:rpc.CreateIndexRequest)
     CreateIndexRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use CreateIndexRequest.newBuilder() to construct.
@@ -111,7 +111,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateIndexRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateIndexRequest_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -129,7 +129,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateIndexRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateIndexRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.CreateIndexRequest.class, com.scalar.db.rpc.CreateIndexRequest.Builder.class);
   }
@@ -254,7 +254,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.String> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.String>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateIndexRequest_OptionsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateIndexRequest_OptionsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.STRING,
@@ -549,15 +549,15 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.CreateIndexRequest}
+   * Protobuf type {@code rpc.CreateIndexRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.CreateIndexRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.CreateIndexRequest)
       com.scalar.db.rpc.CreateIndexRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateIndexRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateIndexRequest_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -585,7 +585,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateIndexRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateIndexRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.CreateIndexRequest.class, com.scalar.db.rpc.CreateIndexRequest.Builder.class);
     }
@@ -623,7 +623,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateIndexRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateIndexRequest_descriptor;
     }
 
     @java.lang.Override
@@ -1147,10 +1147,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.CreateIndexRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.CreateIndexRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.CreateIndexRequest)
+  // @@protoc_insertion_point(class_scope:rpc.CreateIndexRequest)
   private static final com.scalar.db.rpc.CreateIndexRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.CreateIndexRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface CreateIndexRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.CreateIndexRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.CreateIndexRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.CreateNamespaceRequest}
+ * Protobuf type {@code rpc.CreateNamespaceRequest}
  */
 public final class CreateNamespaceRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.CreateNamespaceRequest)
+    // @@protoc_insertion_point(message_implements:rpc.CreateNamespaceRequest)
     CreateNamespaceRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use CreateNamespaceRequest.newBuilder() to construct.
@@ -97,7 +97,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateNamespaceRequest_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -115,7 +115,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateNamespaceRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateNamespaceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.CreateNamespaceRequest.class, com.scalar.db.rpc.CreateNamespaceRequest.Builder.class);
   }
@@ -164,7 +164,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.String> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.String>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateNamespaceRequest_OptionsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateNamespaceRequest_OptionsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.STRING,
@@ -439,15 +439,15 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.CreateNamespaceRequest}
+   * Protobuf type {@code rpc.CreateNamespaceRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.CreateNamespaceRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.CreateNamespaceRequest)
       com.scalar.db.rpc.CreateNamespaceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateNamespaceRequest_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -475,7 +475,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateNamespaceRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateNamespaceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.CreateNamespaceRequest.class, com.scalar.db.rpc.CreateNamespaceRequest.Builder.class);
     }
@@ -509,7 +509,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateNamespaceRequest_descriptor;
     }
 
     @java.lang.Override
@@ -871,10 +871,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.CreateNamespaceRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.CreateNamespaceRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.CreateNamespaceRequest)
+  // @@protoc_insertion_point(class_scope:rpc.CreateNamespaceRequest)
   private static final com.scalar.db.rpc.CreateNamespaceRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.CreateNamespaceRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface CreateNamespaceRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.CreateNamespaceRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.CreateNamespaceRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.CreateTableRequest}
+ * Protobuf type {@code rpc.CreateTableRequest}
  */
 public final class CreateTableRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.CreateTableRequest)
+    // @@protoc_insertion_point(message_implements:rpc.CreateTableRequest)
     CreateTableRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use CreateTableRequest.newBuilder() to construct.
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateTableRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateTableRequest_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -135,7 +135,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateTableRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.CreateTableRequest.class, com.scalar.db.rpc.CreateTableRequest.Builder.class);
   }
@@ -219,7 +219,7 @@ private static final long serialVersionUID = 0L;
   public static final int TABLE_METADATA_FIELD_NUMBER = 3;
   private com.scalar.db.rpc.TableMetadata tableMetadata_;
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return Whether the tableMetadata field is set.
    */
   @java.lang.Override
@@ -227,7 +227,7 @@ private static final long serialVersionUID = 0L;
     return tableMetadata_ != null;
   }
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return The tableMetadata.
    */
   @java.lang.Override
@@ -235,7 +235,7 @@ private static final long serialVersionUID = 0L;
     return tableMetadata_ == null ? com.scalar.db.rpc.TableMetadata.getDefaultInstance() : tableMetadata_;
   }
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
@@ -248,7 +248,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.String> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.String>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateTableRequest_OptionsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateTableRequest_OptionsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.STRING,
@@ -549,15 +549,15 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.CreateTableRequest}
+   * Protobuf type {@code rpc.CreateTableRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.CreateTableRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.CreateTableRequest)
       com.scalar.db.rpc.CreateTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateTableRequest_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -585,7 +585,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateTableRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.CreateTableRequest.class, com.scalar.db.rpc.CreateTableRequest.Builder.class);
     }
@@ -627,7 +627,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_CreateTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_CreateTableRequest_descriptor;
     }
 
     @java.lang.Override
@@ -908,14 +908,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TableMetadata, com.scalar.db.rpc.TableMetadata.Builder, com.scalar.db.rpc.TableMetadataOrBuilder> tableMetadataBuilder_;
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      * @return Whether the tableMetadata field is set.
      */
     public boolean hasTableMetadata() {
       return tableMetadataBuilder_ != null || tableMetadata_ != null;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      * @return The tableMetadata.
      */
     public com.scalar.db.rpc.TableMetadata getTableMetadata() {
@@ -926,7 +926,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder setTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
@@ -942,7 +942,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder setTableMetadata(
         com.scalar.db.rpc.TableMetadata.Builder builderForValue) {
@@ -956,7 +956,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder mergeTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
@@ -974,7 +974,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder clearTableMetadata() {
       if (tableMetadataBuilder_ == null) {
@@ -988,7 +988,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public com.scalar.db.rpc.TableMetadata.Builder getTableMetadataBuilder() {
       
@@ -996,7 +996,7 @@ private static final long serialVersionUID = 0L;
       return getTableMetadataFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
       if (tableMetadataBuilder_ != null) {
@@ -1007,7 +1007,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TableMetadata, com.scalar.db.rpc.TableMetadata.Builder, com.scalar.db.rpc.TableMetadataOrBuilder> 
@@ -1197,10 +1197,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.CreateTableRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.CreateTableRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.CreateTableRequest)
+  // @@protoc_insertion_point(class_scope:rpc.CreateTableRequest)
   private static final com.scalar.db.rpc.CreateTableRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.CreateTableRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface CreateTableRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.CreateTableRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.CreateTableRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -32,17 +32,17 @@ public interface CreateTableRequestOrBuilder extends
       getTableBytes();
 
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return Whether the tableMetadata field is set.
    */
   boolean hasTableMetadata();
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return The tableMetadata.
    */
   com.scalar.db.rpc.TableMetadata getTableMetadata();
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    */
   com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/DataType.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DataType.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf enum {@code scalardb.rpc.DataType}
+ * Protobuf enum {@code rpc.DataType}
  */
 public enum DataType
     implements com.google.protobuf.ProtocolMessageEnum {
@@ -153,6 +153,6 @@ public enum DataType
     this.value = value;
   }
 
-  // @@protoc_insertion_point(enum_scope:scalardb.rpc.DataType)
+  // @@protoc_insertion_point(enum_scope:rpc.DataType)
 }
 

--- a/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.DropCoordinatorTablesRequest}
+ * Protobuf type {@code rpc.DropCoordinatorTablesRequest}
  */
 public final class DropCoordinatorTablesRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.DropCoordinatorTablesRequest)
+    // @@protoc_insertion_point(message_implements:rpc.DropCoordinatorTablesRequest)
     DropCoordinatorTablesRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use DropCoordinatorTablesRequest.newBuilder() to construct.
@@ -76,13 +76,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropCoordinatorTablesRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropCoordinatorTablesRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropCoordinatorTablesRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropCoordinatorTablesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.DropCoordinatorTablesRequest.class, com.scalar.db.rpc.DropCoordinatorTablesRequest.Builder.class);
   }
@@ -255,21 +255,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.DropCoordinatorTablesRequest}
+   * Protobuf type {@code rpc.DropCoordinatorTablesRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.DropCoordinatorTablesRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.DropCoordinatorTablesRequest)
       com.scalar.db.rpc.DropCoordinatorTablesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropCoordinatorTablesRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropCoordinatorTablesRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropCoordinatorTablesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.DropCoordinatorTablesRequest.class, com.scalar.db.rpc.DropCoordinatorTablesRequest.Builder.class);
     }
@@ -300,7 +300,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropCoordinatorTablesRequest_descriptor;
     }
 
     @java.lang.Override
@@ -444,10 +444,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.DropCoordinatorTablesRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.DropCoordinatorTablesRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.DropCoordinatorTablesRequest)
+  // @@protoc_insertion_point(class_scope:rpc.DropCoordinatorTablesRequest)
   private static final com.scalar.db.rpc.DropCoordinatorTablesRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.DropCoordinatorTablesRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface DropCoordinatorTablesRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.DropCoordinatorTablesRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.DropCoordinatorTablesRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.DropIndexRequest}
+ * Protobuf type {@code rpc.DropIndexRequest}
  */
 public final class DropIndexRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.DropIndexRequest)
+    // @@protoc_insertion_point(message_implements:rpc.DropIndexRequest)
     DropIndexRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use DropIndexRequest.newBuilder() to construct.
@@ -97,13 +97,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropIndexRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropIndexRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropIndexRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropIndexRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.DropIndexRequest.class, com.scalar.db.rpc.DropIndexRequest.Builder.class);
   }
@@ -420,21 +420,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.DropIndexRequest}
+   * Protobuf type {@code rpc.DropIndexRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.DropIndexRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.DropIndexRequest)
       com.scalar.db.rpc.DropIndexRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropIndexRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropIndexRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropIndexRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropIndexRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.DropIndexRequest.class, com.scalar.db.rpc.DropIndexRequest.Builder.class);
     }
@@ -471,7 +471,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropIndexRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropIndexRequest_descriptor;
     }
 
     @java.lang.Override
@@ -858,10 +858,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.DropIndexRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.DropIndexRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.DropIndexRequest)
+  // @@protoc_insertion_point(class_scope:rpc.DropIndexRequest)
   private static final com.scalar.db.rpc.DropIndexRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.DropIndexRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface DropIndexRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.DropIndexRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.DropIndexRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.DropNamespaceRequest}
+ * Protobuf type {@code rpc.DropNamespaceRequest}
  */
 public final class DropNamespaceRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.DropNamespaceRequest)
+    // @@protoc_insertion_point(message_implements:rpc.DropNamespaceRequest)
     DropNamespaceRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use DropNamespaceRequest.newBuilder() to construct.
@@ -83,13 +83,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropNamespaceRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropNamespaceRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropNamespaceRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropNamespaceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.DropNamespaceRequest.class, com.scalar.db.rpc.DropNamespaceRequest.Builder.class);
   }
@@ -310,21 +310,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.DropNamespaceRequest}
+   * Protobuf type {@code rpc.DropNamespaceRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.DropNamespaceRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.DropNamespaceRequest)
       com.scalar.db.rpc.DropNamespaceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropNamespaceRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropNamespaceRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropNamespaceRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropNamespaceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.DropNamespaceRequest.class, com.scalar.db.rpc.DropNamespaceRequest.Builder.class);
     }
@@ -357,7 +357,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropNamespaceRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropNamespaceRequest_descriptor;
     }
 
     @java.lang.Override
@@ -582,10 +582,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.DropNamespaceRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.DropNamespaceRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.DropNamespaceRequest)
+  // @@protoc_insertion_point(class_scope:rpc.DropNamespaceRequest)
   private static final com.scalar.db.rpc.DropNamespaceRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.DropNamespaceRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface DropNamespaceRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.DropNamespaceRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.DropNamespaceRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/DropTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropTableRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.DropTableRequest}
+ * Protobuf type {@code rpc.DropTableRequest}
  */
 public final class DropTableRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.DropTableRequest)
+    // @@protoc_insertion_point(message_implements:rpc.DropTableRequest)
     DropTableRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use DropTableRequest.newBuilder() to construct.
@@ -90,13 +90,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropTableRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropTableRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropTableRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.DropTableRequest.class, com.scalar.db.rpc.DropTableRequest.Builder.class);
   }
@@ -365,21 +365,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.DropTableRequest}
+   * Protobuf type {@code rpc.DropTableRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.DropTableRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.DropTableRequest)
       com.scalar.db.rpc.DropTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropTableRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropTableRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.DropTableRequest.class, com.scalar.db.rpc.DropTableRequest.Builder.class);
     }
@@ -414,7 +414,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_DropTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_DropTableRequest_descriptor;
     }
 
     @java.lang.Override
@@ -720,10 +720,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.DropTableRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.DropTableRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.DropTableRequest)
+  // @@protoc_insertion_point(class_scope:rpc.DropTableRequest)
   private static final com.scalar.db.rpc.DropTableRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.DropTableRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/DropTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropTableRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface DropTableRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.DropTableRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.DropTableRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/Get.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Get.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Get}
+ * Protobuf type {@code rpc.Get}
  */
 public final class Get extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Get)
+    // @@protoc_insertion_point(message_implements:rpc.Get)
     GetOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Get.newBuilder() to construct.
@@ -132,13 +132,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Get_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Get_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Get_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Get_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Get.class, com.scalar.db.rpc.Get.Builder.class);
   }
@@ -222,7 +222,7 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_KEY_FIELD_NUMBER = 3;
   private com.scalar.db.rpc.Key partitionKey_;
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return Whether the partitionKey field is set.
    */
   @java.lang.Override
@@ -230,7 +230,7 @@ private static final long serialVersionUID = 0L;
     return partitionKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return The partitionKey.
    */
   @java.lang.Override
@@ -238,7 +238,7 @@ private static final long serialVersionUID = 0L;
     return partitionKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : partitionKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
@@ -248,7 +248,7 @@ private static final long serialVersionUID = 0L;
   public static final int CLUSTERING_KEY_FIELD_NUMBER = 4;
   private com.scalar.db.rpc.Key clusteringKey_;
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return Whether the clusteringKey field is set.
    */
   @java.lang.Override
@@ -256,7 +256,7 @@ private static final long serialVersionUID = 0L;
     return clusteringKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return The clusteringKey.
    */
   @java.lang.Override
@@ -264,7 +264,7 @@ private static final long serialVersionUID = 0L;
     return clusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : clusteringKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder() {
@@ -274,14 +274,14 @@ private static final long serialVersionUID = 0L;
   public static final int CONSISTENCY_FIELD_NUMBER = 5;
   private int consistency_;
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The enum numeric value on the wire for consistency.
    */
   @java.lang.Override public int getConsistencyValue() {
     return consistency_;
   }
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The consistency.
    */
   @java.lang.Override public com.scalar.db.rpc.Consistency getConsistency() {
@@ -549,21 +549,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Get}
+   * Protobuf type {@code rpc.Get}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Get)
+      // @@protoc_insertion_point(builder_implements:rpc.Get)
       com.scalar.db.rpc.GetOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Get_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Get_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Get_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Get_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Get.class, com.scalar.db.rpc.Get.Builder.class);
     }
@@ -612,7 +612,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Get_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Get_descriptor;
     }
 
     @java.lang.Override
@@ -912,14 +912,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> partitionKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      * @return Whether the partitionKey field is set.
      */
     public boolean hasPartitionKey() {
       return partitionKeyBuilder_ != null || partitionKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      * @return The partitionKey.
      */
     public com.scalar.db.rpc.Key getPartitionKey() {
@@ -930,7 +930,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder setPartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
@@ -946,7 +946,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder setPartitionKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -960,7 +960,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder mergePartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
@@ -978,7 +978,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder clearPartitionKey() {
       if (partitionKeyBuilder_ == null) {
@@ -992,7 +992,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.Key.Builder getPartitionKeyBuilder() {
       
@@ -1000,7 +1000,7 @@ private static final long serialVersionUID = 0L;
       return getPartitionKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
       if (partitionKeyBuilder_ != null) {
@@ -1011,7 +1011,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1031,14 +1031,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> clusteringKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      * @return Whether the clusteringKey field is set.
      */
     public boolean hasClusteringKey() {
       return clusteringKeyBuilder_ != null || clusteringKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      * @return The clusteringKey.
      */
     public com.scalar.db.rpc.Key getClusteringKey() {
@@ -1049,7 +1049,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder setClusteringKey(com.scalar.db.rpc.Key value) {
       if (clusteringKeyBuilder_ == null) {
@@ -1065,7 +1065,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder setClusteringKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -1079,7 +1079,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder mergeClusteringKey(com.scalar.db.rpc.Key value) {
       if (clusteringKeyBuilder_ == null) {
@@ -1097,7 +1097,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder clearClusteringKey() {
       if (clusteringKeyBuilder_ == null) {
@@ -1111,7 +1111,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public com.scalar.db.rpc.Key.Builder getClusteringKeyBuilder() {
       
@@ -1119,7 +1119,7 @@ private static final long serialVersionUID = 0L;
       return getClusteringKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder() {
       if (clusteringKeyBuilder_ != null) {
@@ -1130,7 +1130,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1148,14 +1148,14 @@ private static final long serialVersionUID = 0L;
 
     private int consistency_ = 0;
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @return The enum numeric value on the wire for consistency.
      */
     @java.lang.Override public int getConsistencyValue() {
       return consistency_;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @param value The enum numeric value on the wire for consistency to set.
      * @return This builder for chaining.
      */
@@ -1166,7 +1166,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @return The consistency.
      */
     @java.lang.Override
@@ -1176,7 +1176,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @param value The consistency to set.
      * @return This builder for chaining.
      */
@@ -1190,7 +1190,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @return This builder for chaining.
      */
     public Builder clearConsistency() {
@@ -1322,10 +1322,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Get)
+    // @@protoc_insertion_point(builder_scope:rpc.Get)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Get)
+  // @@protoc_insertion_point(class_scope:rpc.Get)
   private static final com.scalar.db.rpc.Get DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Get();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetNamespaceTableNamesRequest}
+ * Protobuf type {@code rpc.GetNamespaceTableNamesRequest}
  */
 public final class GetNamespaceTableNamesRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetNamespaceTableNamesRequest)
+    // @@protoc_insertion_point(message_implements:rpc.GetNamespaceTableNamesRequest)
     GetNamespaceTableNamesRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetNamespaceTableNamesRequest.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetNamespaceTableNamesRequest.class, com.scalar.db.rpc.GetNamespaceTableNamesRequest.Builder.class);
   }
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetNamespaceTableNamesRequest}
+   * Protobuf type {@code rpc.GetNamespaceTableNamesRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetNamespaceTableNamesRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.GetNamespaceTableNamesRequest)
       com.scalar.db.rpc.GetNamespaceTableNamesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetNamespaceTableNamesRequest.class, com.scalar.db.rpc.GetNamespaceTableNamesRequest.Builder.class);
     }
@@ -327,7 +327,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesRequest_descriptor;
     }
 
     @java.lang.Override
@@ -517,10 +517,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetNamespaceTableNamesRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.GetNamespaceTableNamesRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetNamespaceTableNamesRequest)
+  // @@protoc_insertion_point(class_scope:rpc.GetNamespaceTableNamesRequest)
   private static final com.scalar.db.rpc.GetNamespaceTableNamesRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetNamespaceTableNamesRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface GetNamespaceTableNamesRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetNamespaceTableNamesRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.GetNamespaceTableNamesRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetNamespaceTableNamesResponse}
+ * Protobuf type {@code rpc.GetNamespaceTableNamesResponse}
  */
 public final class GetNamespaceTableNamesResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetNamespaceTableNamesResponse)
+    // @@protoc_insertion_point(message_implements:rpc.GetNamespaceTableNamesResponse)
     GetNamespaceTableNamesResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetNamespaceTableNamesResponse.newBuilder() to construct.
@@ -85,13 +85,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetNamespaceTableNamesResponse.class, com.scalar.db.rpc.GetNamespaceTableNamesResponse.Builder.class);
   }
@@ -293,21 +293,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetNamespaceTableNamesResponse}
+   * Protobuf type {@code rpc.GetNamespaceTableNamesResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetNamespaceTableNamesResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.GetNamespaceTableNamesResponse)
       com.scalar.db.rpc.GetNamespaceTableNamesResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetNamespaceTableNamesResponse.class, com.scalar.db.rpc.GetNamespaceTableNamesResponse.Builder.class);
     }
@@ -338,7 +338,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetNamespaceTableNamesResponse_descriptor;
     }
 
     @java.lang.Override
@@ -574,10 +574,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetNamespaceTableNamesResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.GetNamespaceTableNamesResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetNamespaceTableNamesResponse)
+  // @@protoc_insertion_point(class_scope:rpc.GetNamespaceTableNamesResponse)
   private static final com.scalar.db.rpc.GetNamespaceTableNamesResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetNamespaceTableNamesResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponseOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface GetNamespaceTableNamesResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetNamespaceTableNamesResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.GetNamespaceTableNamesResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/GetOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface GetOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Get)
+    // @@protoc_insertion_point(interface_extends:rpc.Get)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -32,42 +32,42 @@ public interface GetOrBuilder extends
       getTableBytes();
 
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return Whether the partitionKey field is set.
    */
   boolean hasPartitionKey();
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return The partitionKey.
    */
   com.scalar.db.rpc.Key getPartitionKey();
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return Whether the clusteringKey field is set.
    */
   boolean hasClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return The clusteringKey.
    */
   com.scalar.db.rpc.Key getClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The enum numeric value on the wire for consistency.
    */
   int getConsistencyValue();
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The consistency.
    */
   com.scalar.db.rpc.Consistency getConsistency();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetRequest}
+ * Protobuf type {@code rpc.GetRequest}
  */
 public final class GetRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetRequest)
+    // @@protoc_insertion_point(message_implements:rpc.GetRequest)
     GetRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetRequest.newBuilder() to construct.
@@ -84,13 +84,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetRequest.class, com.scalar.db.rpc.GetRequest.Builder.class);
   }
@@ -98,7 +98,7 @@ private static final long serialVersionUID = 0L;
   public static final int GET_FIELD_NUMBER = 1;
   private com.scalar.db.rpc.Get get_;
   /**
-   * <code>.scalardb.rpc.Get get = 1;</code>
+   * <code>.rpc.Get get = 1;</code>
    * @return Whether the get field is set.
    */
   @java.lang.Override
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
     return get_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Get get = 1;</code>
+   * <code>.rpc.Get get = 1;</code>
    * @return The get.
    */
   @java.lang.Override
@@ -114,7 +114,7 @@ private static final long serialVersionUID = 0L;
     return get_ == null ? com.scalar.db.rpc.Get.getDefaultInstance() : get_;
   }
   /**
-   * <code>.scalardb.rpc.Get get = 1;</code>
+   * <code>.rpc.Get get = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetRequest}
+   * Protobuf type {@code rpc.GetRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.GetRequest)
       com.scalar.db.rpc.GetRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetRequest.class, com.scalar.db.rpc.GetRequest.Builder.class);
     }
@@ -331,7 +331,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetRequest_descriptor;
     }
 
     @java.lang.Override
@@ -440,14 +440,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Get, com.scalar.db.rpc.Get.Builder, com.scalar.db.rpc.GetOrBuilder> getBuilder_;
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      * @return Whether the get field is set.
      */
     public boolean hasGet() {
       return getBuilder_ != null || get_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      * @return The get.
      */
     public com.scalar.db.rpc.Get getGet() {
@@ -458,7 +458,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     public Builder setGet(com.scalar.db.rpc.Get value) {
       if (getBuilder_ == null) {
@@ -474,7 +474,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     public Builder setGet(
         com.scalar.db.rpc.Get.Builder builderForValue) {
@@ -488,7 +488,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     public Builder mergeGet(com.scalar.db.rpc.Get value) {
       if (getBuilder_ == null) {
@@ -506,7 +506,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     public Builder clearGet() {
       if (getBuilder_ == null) {
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     public com.scalar.db.rpc.Get.Builder getGetBuilder() {
       
@@ -528,7 +528,7 @@ private static final long serialVersionUID = 0L;
       return getGetFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
       if (getBuilder_ != null) {
@@ -539,7 +539,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Get get = 1;</code>
+     * <code>.rpc.Get get = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Get, com.scalar.db.rpc.Get.Builder, com.scalar.db.rpc.GetOrBuilder> 
@@ -567,10 +567,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.GetRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetRequest)
+  // @@protoc_insertion_point(class_scope:rpc.GetRequest)
   private static final com.scalar.db.rpc.GetRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetRequestOrBuilder.java
@@ -4,21 +4,21 @@
 package com.scalar.db.rpc;
 
 public interface GetRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.GetRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.Get get = 1;</code>
+   * <code>.rpc.Get get = 1;</code>
    * @return Whether the get field is set.
    */
   boolean hasGet();
   /**
-   * <code>.scalardb.rpc.Get get = 1;</code>
+   * <code>.rpc.Get get = 1;</code>
    * @return The get.
    */
   com.scalar.db.rpc.Get getGet();
   /**
-   * <code>.scalardb.rpc.Get get = 1;</code>
+   * <code>.rpc.Get get = 1;</code>
    */
   com.scalar.db.rpc.GetOrBuilder getGetOrBuilder();
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetResponse}
+ * Protobuf type {@code rpc.GetResponse}
  */
 public final class GetResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetResponse)
+    // @@protoc_insertion_point(message_implements:rpc.GetResponse)
     GetResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetResponse.newBuilder() to construct.
@@ -84,13 +84,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetResponse.class, com.scalar.db.rpc.GetResponse.Builder.class);
   }
@@ -98,7 +98,7 @@ private static final long serialVersionUID = 0L;
   public static final int RESULT_FIELD_NUMBER = 1;
   private com.scalar.db.rpc.Result result_;
   /**
-   * <code>.scalardb.rpc.Result result = 1;</code>
+   * <code>.rpc.Result result = 1;</code>
    * @return Whether the result field is set.
    */
   @java.lang.Override
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
     return result_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Result result = 1;</code>
+   * <code>.rpc.Result result = 1;</code>
    * @return The result.
    */
   @java.lang.Override
@@ -114,7 +114,7 @@ private static final long serialVersionUID = 0L;
     return result_ == null ? com.scalar.db.rpc.Result.getDefaultInstance() : result_;
   }
   /**
-   * <code>.scalardb.rpc.Result result = 1;</code>
+   * <code>.rpc.Result result = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetResponse}
+   * Protobuf type {@code rpc.GetResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.GetResponse)
       com.scalar.db.rpc.GetResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetResponse.class, com.scalar.db.rpc.GetResponse.Builder.class);
     }
@@ -331,7 +331,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetResponse_descriptor;
     }
 
     @java.lang.Override
@@ -440,14 +440,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> resultBuilder_;
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return Whether the result field is set.
      */
     public boolean hasResult() {
       return resultBuilder_ != null || result_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return The result.
      */
     public com.scalar.db.rpc.Result getResult() {
@@ -458,7 +458,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     public Builder setResult(com.scalar.db.rpc.Result value) {
       if (resultBuilder_ == null) {
@@ -474,7 +474,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     public Builder setResult(
         com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -488,7 +488,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     public Builder mergeResult(com.scalar.db.rpc.Result value) {
       if (resultBuilder_ == null) {
@@ -506,7 +506,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     public Builder clearResult() {
       if (resultBuilder_ == null) {
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     public com.scalar.db.rpc.Result.Builder getResultBuilder() {
       
@@ -528,7 +528,7 @@ private static final long serialVersionUID = 0L;
       return getResultFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
       if (resultBuilder_ != null) {
@@ -539,7 +539,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> 
@@ -567,10 +567,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.GetResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetResponse)
+  // @@protoc_insertion_point(class_scope:rpc.GetResponse)
   private static final com.scalar.db.rpc.GetResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetResponseOrBuilder.java
@@ -4,21 +4,21 @@
 package com.scalar.db.rpc;
 
 public interface GetResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.GetResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.Result result = 1;</code>
+   * <code>.rpc.Result result = 1;</code>
    * @return Whether the result field is set.
    */
   boolean hasResult();
   /**
-   * <code>.scalardb.rpc.Result result = 1;</code>
+   * <code>.rpc.Result result = 1;</code>
    * @return The result.
    */
   com.scalar.db.rpc.Result getResult();
   /**
-   * <code>.scalardb.rpc.Result result = 1;</code>
+   * <code>.rpc.Result result = 1;</code>
    */
   com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder();
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetTableMetadataRequest}
+ * Protobuf type {@code rpc.GetTableMetadataRequest}
  */
 public final class GetTableMetadataRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetTableMetadataRequest)
+    // @@protoc_insertion_point(message_implements:rpc.GetTableMetadataRequest)
     GetTableMetadataRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetTableMetadataRequest.newBuilder() to construct.
@@ -85,13 +85,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetTableMetadataRequest.class, com.scalar.db.rpc.GetTableMetadataRequest.Builder.class);
   }
@@ -337,21 +337,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetTableMetadataRequest}
+   * Protobuf type {@code rpc.GetTableMetadataRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetTableMetadataRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.GetTableMetadataRequest)
       com.scalar.db.rpc.GetTableMetadataRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetTableMetadataRequest.class, com.scalar.db.rpc.GetTableMetadataRequest.Builder.class);
     }
@@ -384,7 +384,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataRequest_descriptor;
     }
 
     @java.lang.Override
@@ -655,10 +655,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetTableMetadataRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.GetTableMetadataRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetTableMetadataRequest)
+  // @@protoc_insertion_point(class_scope:rpc.GetTableMetadataRequest)
   private static final com.scalar.db.rpc.GetTableMetadataRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetTableMetadataRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface GetTableMetadataRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetTableMetadataRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.GetTableMetadataRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetTableMetadataResponse}
+ * Protobuf type {@code rpc.GetTableMetadataResponse}
  */
 public final class GetTableMetadataResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetTableMetadataResponse)
+    // @@protoc_insertion_point(message_implements:rpc.GetTableMetadataResponse)
     GetTableMetadataResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetTableMetadataResponse.newBuilder() to construct.
@@ -84,13 +84,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetTableMetadataResponse.class, com.scalar.db.rpc.GetTableMetadataResponse.Builder.class);
   }
@@ -98,7 +98,7 @@ private static final long serialVersionUID = 0L;
   public static final int TABLE_METADATA_FIELD_NUMBER = 1;
   private com.scalar.db.rpc.TableMetadata tableMetadata_;
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+   * <code>.rpc.TableMetadata table_metadata = 1;</code>
    * @return Whether the tableMetadata field is set.
    */
   @java.lang.Override
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
     return tableMetadata_ != null;
   }
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+   * <code>.rpc.TableMetadata table_metadata = 1;</code>
    * @return The tableMetadata.
    */
   @java.lang.Override
@@ -114,7 +114,7 @@ private static final long serialVersionUID = 0L;
     return tableMetadata_ == null ? com.scalar.db.rpc.TableMetadata.getDefaultInstance() : tableMetadata_;
   }
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+   * <code>.rpc.TableMetadata table_metadata = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetTableMetadataResponse}
+   * Protobuf type {@code rpc.GetTableMetadataResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetTableMetadataResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.GetTableMetadataResponse)
       com.scalar.db.rpc.GetTableMetadataResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetTableMetadataResponse.class, com.scalar.db.rpc.GetTableMetadataResponse.Builder.class);
     }
@@ -331,7 +331,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTableMetadataResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTableMetadataResponse_descriptor;
     }
 
     @java.lang.Override
@@ -440,14 +440,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TableMetadata, com.scalar.db.rpc.TableMetadata.Builder, com.scalar.db.rpc.TableMetadataOrBuilder> tableMetadataBuilder_;
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      * @return Whether the tableMetadata field is set.
      */
     public boolean hasTableMetadata() {
       return tableMetadataBuilder_ != null || tableMetadata_ != null;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      * @return The tableMetadata.
      */
     public com.scalar.db.rpc.TableMetadata getTableMetadata() {
@@ -458,7 +458,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public Builder setTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
@@ -474,7 +474,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public Builder setTableMetadata(
         com.scalar.db.rpc.TableMetadata.Builder builderForValue) {
@@ -488,7 +488,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public Builder mergeTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
@@ -506,7 +506,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public Builder clearTableMetadata() {
       if (tableMetadataBuilder_ == null) {
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public com.scalar.db.rpc.TableMetadata.Builder getTableMetadataBuilder() {
       
@@ -528,7 +528,7 @@ private static final long serialVersionUID = 0L;
       return getTableMetadataFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
       if (tableMetadataBuilder_ != null) {
@@ -539,7 +539,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+     * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TableMetadata, com.scalar.db.rpc.TableMetadata.Builder, com.scalar.db.rpc.TableMetadataOrBuilder> 
@@ -567,10 +567,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetTableMetadataResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.GetTableMetadataResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetTableMetadataResponse)
+  // @@protoc_insertion_point(class_scope:rpc.GetTableMetadataResponse)
   private static final com.scalar.db.rpc.GetTableMetadataResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetTableMetadataResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponseOrBuilder.java
@@ -4,21 +4,21 @@
 package com.scalar.db.rpc;
 
 public interface GetTableMetadataResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetTableMetadataResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.GetTableMetadataResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+   * <code>.rpc.TableMetadata table_metadata = 1;</code>
    * @return Whether the tableMetadata field is set.
    */
   boolean hasTableMetadata();
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+   * <code>.rpc.TableMetadata table_metadata = 1;</code>
    * @return The tableMetadata.
    */
   com.scalar.db.rpc.TableMetadata getTableMetadata();
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 1;</code>
+   * <code>.rpc.TableMetadata table_metadata = 1;</code>
    */
   com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder();
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetTransactionStateRequest}
+ * Protobuf type {@code rpc.GetTransactionStateRequest}
  */
 public final class GetTransactionStateRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetTransactionStateRequest)
+    // @@protoc_insertion_point(message_implements:rpc.GetTransactionStateRequest)
     GetTransactionStateRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetTransactionStateRequest.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetTransactionStateRequest.class, com.scalar.db.rpc.GetTransactionStateRequest.Builder.class);
   }
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetTransactionStateRequest}
+   * Protobuf type {@code rpc.GetTransactionStateRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetTransactionStateRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.GetTransactionStateRequest)
       com.scalar.db.rpc.GetTransactionStateRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetTransactionStateRequest.class, com.scalar.db.rpc.GetTransactionStateRequest.Builder.class);
     }
@@ -327,7 +327,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateRequest_descriptor;
     }
 
     @java.lang.Override
@@ -517,10 +517,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetTransactionStateRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.GetTransactionStateRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetTransactionStateRequest)
+  // @@protoc_insertion_point(class_scope:rpc.GetTransactionStateRequest)
   private static final com.scalar.db.rpc.GetTransactionStateRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetTransactionStateRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface GetTransactionStateRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetTransactionStateRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.GetTransactionStateRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.GetTransactionStateResponse}
+ * Protobuf type {@code rpc.GetTransactionStateResponse}
  */
 public final class GetTransactionStateResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.GetTransactionStateResponse)
+    // @@protoc_insertion_point(message_implements:rpc.GetTransactionStateResponse)
     GetTransactionStateResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use GetTransactionStateResponse.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.GetTransactionStateResponse.class, com.scalar.db.rpc.GetTransactionStateResponse.Builder.class);
   }
@@ -92,14 +92,14 @@ private static final long serialVersionUID = 0L;
   public static final int STATE_FIELD_NUMBER = 1;
   private int state_;
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
    */
   @java.lang.Override public int getStateValue() {
     return state_;
   }
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The state.
    */
   @java.lang.Override public com.scalar.db.rpc.TransactionState getState() {
@@ -263,21 +263,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.GetTransactionStateResponse}
+   * Protobuf type {@code rpc.GetTransactionStateResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.GetTransactionStateResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.GetTransactionStateResponse)
       com.scalar.db.rpc.GetTransactionStateResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.GetTransactionStateResponse.class, com.scalar.db.rpc.GetTransactionStateResponse.Builder.class);
     }
@@ -308,7 +308,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_GetTransactionStateResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_GetTransactionStateResponse_descriptor;
     }
 
     @java.lang.Override
@@ -411,14 +411,14 @@ private static final long serialVersionUID = 0L;
 
     private int state_ = 0;
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return The enum numeric value on the wire for state.
      */
     @java.lang.Override public int getStateValue() {
       return state_;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @param value The enum numeric value on the wire for state to set.
      * @return This builder for chaining.
      */
@@ -429,7 +429,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return The state.
      */
     @java.lang.Override
@@ -439,7 +439,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @param value The state to set.
      * @return This builder for chaining.
      */
@@ -453,7 +453,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return This builder for chaining.
      */
     public Builder clearState() {
@@ -475,10 +475,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.GetTransactionStateResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.GetTransactionStateResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.GetTransactionStateResponse)
+  // @@protoc_insertion_point(class_scope:rpc.GetTransactionStateResponse)
   private static final com.scalar.db.rpc.GetTransactionStateResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.GetTransactionStateResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponseOrBuilder.java
@@ -4,16 +4,16 @@
 package com.scalar.db.rpc;
 
 public interface GetTransactionStateResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.GetTransactionStateResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.GetTransactionStateResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
    */
   int getStateValue();
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The state.
    */
   com.scalar.db.rpc.TransactionState getState();

--- a/rpc/src/main/java/com/scalar/db/rpc/Key.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Key.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Key}
+ * Protobuf type {@code rpc.Key}
  */
 public final class Key extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Key)
+    // @@protoc_insertion_point(message_implements:rpc.Key)
     KeyOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Key.newBuilder() to construct.
@@ -98,13 +98,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Key_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Key_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Key_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Key_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Key.class, com.scalar.db.rpc.Key.Builder.class);
   }
@@ -112,14 +112,14 @@ private static final long serialVersionUID = 0L;
   public static final int VALUE_FIELD_NUMBER = 1;
   private java.util.List<com.scalar.db.rpc.Value> value_;
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value> getValueList() {
     return value_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
@@ -127,21 +127,21 @@ private static final long serialVersionUID = 0L;
     return value_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public int getValueCount() {
     return value_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.Value getValue(int index) {
     return value_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
@@ -152,14 +152,14 @@ private static final long serialVersionUID = 0L;
   public static final int COLUMNS_FIELD_NUMBER = 2;
   private java.util.List<com.scalar.db.rpc.Column> columns_;
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.Column> getColumnsList() {
     return columns_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
@@ -167,21 +167,21 @@ private static final long serialVersionUID = 0L;
     return columns_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public int getColumnsCount() {
     return columns_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Column getColumns(int index) {
     return columns_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
@@ -360,21 +360,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Key}
+   * Protobuf type {@code rpc.Key}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Key)
+      // @@protoc_insertion_point(builder_implements:rpc.Key)
       com.scalar.db.rpc.KeyOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Key_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Key_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Key_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Key_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Key.class, com.scalar.db.rpc.Key.Builder.class);
     }
@@ -417,7 +417,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Key_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Key_descriptor;
     }
 
     @java.lang.Override
@@ -599,7 +599,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Value, com.scalar.db.rpc.Value.Builder, com.scalar.db.rpc.ValueOrBuilder> valueBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value> getValueList() {
       if (valueBuilder_ == null) {
@@ -609,7 +609,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public int getValueCount() {
       if (valueBuilder_ == null) {
@@ -619,7 +619,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value getValue(int index) {
       if (valueBuilder_ == null) {
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         int index, com.scalar.db.rpc.Value value) {
@@ -646,7 +646,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         int index, com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(com.scalar.db.rpc.Value value) {
       if (valueBuilder_ == null) {
@@ -676,7 +676,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         int index, com.scalar.db.rpc.Value value) {
@@ -693,7 +693,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -707,7 +707,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         int index, com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -721,7 +721,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addAllValue(
         java.lang.Iterable<? extends com.scalar.db.rpc.Value> values) {
@@ -736,7 +736,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder clearValue() {
       if (valueBuilder_ == null) {
@@ -749,7 +749,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder removeValue(int index) {
       if (valueBuilder_ == null) {
@@ -762,14 +762,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder getValueBuilder(
         int index) {
       return getValueFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
         int index) {
@@ -779,7 +779,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
          getValueOrBuilderList() {
@@ -790,14 +790,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder addValueBuilder() {
       return getValueFieldBuilder().addBuilder(
           com.scalar.db.rpc.Value.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder addValueBuilder(
         int index) {
@@ -805,7 +805,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Value.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value.Builder> 
          getValueBuilderList() {
@@ -839,7 +839,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Column, com.scalar.db.rpc.Column.Builder, com.scalar.db.rpc.ColumnOrBuilder> columnsBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.Column> getColumnsList() {
       if (columnsBuilder_ == null) {
@@ -849,7 +849,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public int getColumnsCount() {
       if (columnsBuilder_ == null) {
@@ -859,7 +859,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column getColumns(int index) {
       if (columnsBuilder_ == null) {
@@ -869,7 +869,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder setColumns(
         int index, com.scalar.db.rpc.Column value) {
@@ -886,7 +886,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder setColumns(
         int index, com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -900,7 +900,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(com.scalar.db.rpc.Column value) {
       if (columnsBuilder_ == null) {
@@ -916,7 +916,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(
         int index, com.scalar.db.rpc.Column value) {
@@ -933,7 +933,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(
         com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -947,7 +947,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(
         int index, com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -961,7 +961,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addAllColumns(
         java.lang.Iterable<? extends com.scalar.db.rpc.Column> values) {
@@ -976,7 +976,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder clearColumns() {
       if (columnsBuilder_ == null) {
@@ -989,7 +989,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder removeColumns(int index) {
       if (columnsBuilder_ == null) {
@@ -1002,14 +1002,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column.Builder getColumnsBuilder(
         int index) {
       return getColumnsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
         int index) {
@@ -1019,7 +1019,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
          getColumnsOrBuilderList() {
@@ -1030,14 +1030,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column.Builder addColumnsBuilder() {
       return getColumnsFieldBuilder().addBuilder(
           com.scalar.db.rpc.Column.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column.Builder addColumnsBuilder(
         int index) {
@@ -1045,7 +1045,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Column.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.Column.Builder> 
          getColumnsBuilderList() {
@@ -1078,10 +1078,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Key)
+    // @@protoc_insertion_point(builder_scope:rpc.Key)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Key)
+  // @@protoc_insertion_point(class_scope:rpc.Key)
   private static final com.scalar.db.rpc.Key DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Key();

--- a/rpc/src/main/java/com/scalar/db/rpc/KeyOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/KeyOrBuilder.java
@@ -4,53 +4,53 @@
 package com.scalar.db.rpc;
 
 public interface KeyOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Key)
+    // @@protoc_insertion_point(interface_extends:rpc.Key)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated java.util.List<com.scalar.db.rpc.Value> 
       getValueList();
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.Value getValue(int index);
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated int getValueCount();
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
       getValueOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
       int index);
 
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   java.util.List<com.scalar.db.rpc.Column> 
       getColumnsList();
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   com.scalar.db.rpc.Column getColumns(int index);
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   int getColumnsCount();
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
       getColumnsOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateCondition.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateCondition.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.MutateCondition}
+ * Protobuf type {@code rpc.MutateCondition}
  */
 public final class MutateCondition extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.MutateCondition)
+    // @@protoc_insertion_point(message_implements:rpc.MutateCondition)
     MutateConditionOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use MutateCondition.newBuilder() to construct.
@@ -92,19 +92,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateCondition_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateCondition_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateCondition_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateCondition_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.MutateCondition.class, com.scalar.db.rpc.MutateCondition.Builder.class);
   }
 
   /**
-   * Protobuf enum {@code scalardb.rpc.MutateCondition.Type}
+   * Protobuf enum {@code rpc.MutateCondition.Type}
    */
   public enum Type
       implements com.google.protobuf.ProtocolMessageEnum {
@@ -235,20 +235,20 @@ private static final long serialVersionUID = 0L;
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:scalardb.rpc.MutateCondition.Type)
+    // @@protoc_insertion_point(enum_scope:rpc.MutateCondition.Type)
   }
 
   public static final int TYPE_FIELD_NUMBER = 1;
   private int type_;
   /**
-   * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+   * <code>.rpc.MutateCondition.Type type = 1;</code>
    * @return The enum numeric value on the wire for type.
    */
   @java.lang.Override public int getTypeValue() {
     return type_;
   }
   /**
-   * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+   * <code>.rpc.MutateCondition.Type type = 1;</code>
    * @return The type.
    */
   @java.lang.Override public com.scalar.db.rpc.MutateCondition.Type getType() {
@@ -260,14 +260,14 @@ private static final long serialVersionUID = 0L;
   public static final int EXPRESSIONS_FIELD_NUMBER = 2;
   private java.util.List<com.scalar.db.rpc.ConditionalExpression> expressions_;
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.ConditionalExpression> getExpressionsList() {
     return expressions_;
   }
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.ConditionalExpressionOrBuilder> 
@@ -275,21 +275,21 @@ private static final long serialVersionUID = 0L;
     return expressions_;
   }
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   @java.lang.Override
   public int getExpressionsCount() {
     return expressions_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ConditionalExpression getExpressions(int index) {
     return expressions_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ConditionalExpressionOrBuilder getExpressionsOrBuilder(
@@ -465,21 +465,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.MutateCondition}
+   * Protobuf type {@code rpc.MutateCondition}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.MutateCondition)
+      // @@protoc_insertion_point(builder_implements:rpc.MutateCondition)
       com.scalar.db.rpc.MutateConditionOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateCondition_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateCondition_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateCondition_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateCondition_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.MutateCondition.class, com.scalar.db.rpc.MutateCondition.Builder.class);
     }
@@ -517,7 +517,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateCondition_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateCondition_descriptor;
     }
 
     @java.lang.Override
@@ -657,14 +657,14 @@ private static final long serialVersionUID = 0L;
 
     private int type_ = 0;
     /**
-     * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+     * <code>.rpc.MutateCondition.Type type = 1;</code>
      * @return The enum numeric value on the wire for type.
      */
     @java.lang.Override public int getTypeValue() {
       return type_;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+     * <code>.rpc.MutateCondition.Type type = 1;</code>
      * @param value The enum numeric value on the wire for type to set.
      * @return This builder for chaining.
      */
@@ -675,7 +675,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+     * <code>.rpc.MutateCondition.Type type = 1;</code>
      * @return The type.
      */
     @java.lang.Override
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.MutateCondition.Type.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+     * <code>.rpc.MutateCondition.Type type = 1;</code>
      * @param value The type to set.
      * @return This builder for chaining.
      */
@@ -699,7 +699,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+     * <code>.rpc.MutateCondition.Type type = 1;</code>
      * @return This builder for chaining.
      */
     public Builder clearType() {
@@ -722,7 +722,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.ConditionalExpression, com.scalar.db.rpc.ConditionalExpression.Builder, com.scalar.db.rpc.ConditionalExpressionOrBuilder> expressionsBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.ConditionalExpression> getExpressionsList() {
       if (expressionsBuilder_ == null) {
@@ -732,7 +732,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public int getExpressionsCount() {
       if (expressionsBuilder_ == null) {
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public com.scalar.db.rpc.ConditionalExpression getExpressions(int index) {
       if (expressionsBuilder_ == null) {
@@ -752,7 +752,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder setExpressions(
         int index, com.scalar.db.rpc.ConditionalExpression value) {
@@ -769,7 +769,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder setExpressions(
         int index, com.scalar.db.rpc.ConditionalExpression.Builder builderForValue) {
@@ -783,7 +783,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder addExpressions(com.scalar.db.rpc.ConditionalExpression value) {
       if (expressionsBuilder_ == null) {
@@ -799,7 +799,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder addExpressions(
         int index, com.scalar.db.rpc.ConditionalExpression value) {
@@ -816,7 +816,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder addExpressions(
         com.scalar.db.rpc.ConditionalExpression.Builder builderForValue) {
@@ -830,7 +830,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder addExpressions(
         int index, com.scalar.db.rpc.ConditionalExpression.Builder builderForValue) {
@@ -844,7 +844,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder addAllExpressions(
         java.lang.Iterable<? extends com.scalar.db.rpc.ConditionalExpression> values) {
@@ -859,7 +859,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder clearExpressions() {
       if (expressionsBuilder_ == null) {
@@ -872,7 +872,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public Builder removeExpressions(int index) {
       if (expressionsBuilder_ == null) {
@@ -885,14 +885,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public com.scalar.db.rpc.ConditionalExpression.Builder getExpressionsBuilder(
         int index) {
       return getExpressionsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public com.scalar.db.rpc.ConditionalExpressionOrBuilder getExpressionsOrBuilder(
         int index) {
@@ -902,7 +902,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.ConditionalExpressionOrBuilder> 
          getExpressionsOrBuilderList() {
@@ -913,14 +913,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public com.scalar.db.rpc.ConditionalExpression.Builder addExpressionsBuilder() {
       return getExpressionsFieldBuilder().addBuilder(
           com.scalar.db.rpc.ConditionalExpression.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public com.scalar.db.rpc.ConditionalExpression.Builder addExpressionsBuilder(
         int index) {
@@ -928,7 +928,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.ConditionalExpression.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+     * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.ConditionalExpression.Builder> 
          getExpressionsBuilderList() {
@@ -961,10 +961,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.MutateCondition)
+    // @@protoc_insertion_point(builder_scope:rpc.MutateCondition)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.MutateCondition)
+  // @@protoc_insertion_point(class_scope:rpc.MutateCondition)
   private static final com.scalar.db.rpc.MutateCondition DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.MutateCondition();

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateConditionOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateConditionOrBuilder.java
@@ -4,40 +4,40 @@
 package com.scalar.db.rpc;
 
 public interface MutateConditionOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.MutateCondition)
+    // @@protoc_insertion_point(interface_extends:rpc.MutateCondition)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+   * <code>.rpc.MutateCondition.Type type = 1;</code>
    * @return The enum numeric value on the wire for type.
    */
   int getTypeValue();
   /**
-   * <code>.scalardb.rpc.MutateCondition.Type type = 1;</code>
+   * <code>.rpc.MutateCondition.Type type = 1;</code>
    * @return The type.
    */
   com.scalar.db.rpc.MutateCondition.Type getType();
 
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   java.util.List<com.scalar.db.rpc.ConditionalExpression> 
       getExpressionsList();
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   com.scalar.db.rpc.ConditionalExpression getExpressions(int index);
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   int getExpressionsCount();
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.ConditionalExpressionOrBuilder> 
       getExpressionsOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.ConditionalExpression expressions = 2;</code>
+   * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
    */
   com.scalar.db.rpc.ConditionalExpressionOrBuilder getExpressionsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.MutateRequest}
+ * Protobuf type {@code rpc.MutateRequest}
  */
 public final class MutateRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.MutateRequest)
+    // @@protoc_insertion_point(message_implements:rpc.MutateRequest)
     MutateRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use MutateRequest.newBuilder() to construct.
@@ -85,13 +85,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.MutateRequest.class, com.scalar.db.rpc.MutateRequest.Builder.class);
   }
@@ -99,14 +99,14 @@ private static final long serialVersionUID = 0L;
   public static final int MUTATIONS_FIELD_NUMBER = 1;
   private java.util.List<com.scalar.db.rpc.Mutation> mutations_;
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.Mutation> getMutationsList() {
     return mutations_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
@@ -114,21 +114,21 @@ private static final long serialVersionUID = 0L;
     return mutations_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   @java.lang.Override
   public int getMutationsCount() {
     return mutations_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Mutation getMutations(int index) {
     return mutations_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
@@ -294,21 +294,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.MutateRequest}
+   * Protobuf type {@code rpc.MutateRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.MutateRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.MutateRequest)
       com.scalar.db.rpc.MutateRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.MutateRequest.class, com.scalar.db.rpc.MutateRequest.Builder.class);
     }
@@ -344,7 +344,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_MutateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_MutateRequest_descriptor;
     }
 
     @java.lang.Override
@@ -491,7 +491,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Mutation, com.scalar.db.rpc.Mutation.Builder, com.scalar.db.rpc.MutationOrBuilder> mutationsBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public java.util.List<com.scalar.db.rpc.Mutation> getMutationsList() {
       if (mutationsBuilder_ == null) {
@@ -501,7 +501,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public int getMutationsCount() {
       if (mutationsBuilder_ == null) {
@@ -511,7 +511,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public com.scalar.db.rpc.Mutation getMutations(int index) {
       if (mutationsBuilder_ == null) {
@@ -521,7 +521,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder setMutations(
         int index, com.scalar.db.rpc.Mutation value) {
@@ -538,7 +538,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder setMutations(
         int index, com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -552,7 +552,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder addMutations(com.scalar.db.rpc.Mutation value) {
       if (mutationsBuilder_ == null) {
@@ -568,7 +568,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder addMutations(
         int index, com.scalar.db.rpc.Mutation value) {
@@ -585,7 +585,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder addMutations(
         com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -599,7 +599,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder addMutations(
         int index, com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -613,7 +613,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder addAllMutations(
         java.lang.Iterable<? extends com.scalar.db.rpc.Mutation> values) {
@@ -628,7 +628,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder clearMutations() {
       if (mutationsBuilder_ == null) {
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public Builder removeMutations(int index) {
       if (mutationsBuilder_ == null) {
@@ -654,14 +654,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public com.scalar.db.rpc.Mutation.Builder getMutationsBuilder(
         int index) {
       return getMutationsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
         int index) {
@@ -671,7 +671,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
          getMutationsOrBuilderList() {
@@ -682,14 +682,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public com.scalar.db.rpc.Mutation.Builder addMutationsBuilder() {
       return getMutationsFieldBuilder().addBuilder(
           com.scalar.db.rpc.Mutation.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public com.scalar.db.rpc.Mutation.Builder addMutationsBuilder(
         int index) {
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Mutation.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+     * <code>repeated .rpc.Mutation mutations = 1;</code>
      */
     public java.util.List<com.scalar.db.rpc.Mutation.Builder> 
          getMutationsBuilderList() {
@@ -730,10 +730,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.MutateRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.MutateRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.MutateRequest)
+  // @@protoc_insertion_point(class_scope:rpc.MutateRequest)
   private static final com.scalar.db.rpc.MutateRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.MutateRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateRequestOrBuilder.java
@@ -4,29 +4,29 @@
 package com.scalar.db.rpc;
 
 public interface MutateRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.MutateRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.MutateRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   java.util.List<com.scalar.db.rpc.Mutation> 
       getMutationsList();
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   com.scalar.db.rpc.Mutation getMutations(int index);
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   int getMutationsCount();
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
       getMutationsOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Mutation mutations = 1;</code>
+   * <code>repeated .rpc.Mutation mutations = 1;</code>
    */
   com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/Mutation.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Mutation.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Mutation}
+ * Protobuf type {@code rpc.Mutation}
  */
 public final class Mutation extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Mutation)
+    // @@protoc_insertion_point(message_implements:rpc.Mutation)
     MutationOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Mutation.newBuilder() to construct.
@@ -165,19 +165,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Mutation_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Mutation_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Mutation_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Mutation_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Mutation.class, com.scalar.db.rpc.Mutation.Builder.class);
   }
 
   /**
-   * Protobuf enum {@code scalardb.rpc.Mutation.Type}
+   * Protobuf enum {@code rpc.Mutation.Type}
    */
   public enum Type
       implements com.google.protobuf.ProtocolMessageEnum {
@@ -281,7 +281,7 @@ private static final long serialVersionUID = 0L;
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:scalardb.rpc.Mutation.Type)
+    // @@protoc_insertion_point(enum_scope:rpc.Mutation.Type)
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
@@ -363,7 +363,7 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_KEY_FIELD_NUMBER = 3;
   private com.scalar.db.rpc.Key partitionKey_;
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return Whether the partitionKey field is set.
    */
   @java.lang.Override
@@ -371,7 +371,7 @@ private static final long serialVersionUID = 0L;
     return partitionKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return The partitionKey.
    */
   @java.lang.Override
@@ -379,7 +379,7 @@ private static final long serialVersionUID = 0L;
     return partitionKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : partitionKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
@@ -389,7 +389,7 @@ private static final long serialVersionUID = 0L;
   public static final int CLUSTERING_KEY_FIELD_NUMBER = 4;
   private com.scalar.db.rpc.Key clusteringKey_;
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return Whether the clusteringKey field is set.
    */
   @java.lang.Override
@@ -397,7 +397,7 @@ private static final long serialVersionUID = 0L;
     return clusteringKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return The clusteringKey.
    */
   @java.lang.Override
@@ -405,7 +405,7 @@ private static final long serialVersionUID = 0L;
     return clusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : clusteringKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder() {
@@ -415,14 +415,14 @@ private static final long serialVersionUID = 0L;
   public static final int CONSISTENCY_FIELD_NUMBER = 5;
   private int consistency_;
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The enum numeric value on the wire for consistency.
    */
   @java.lang.Override public int getConsistencyValue() {
     return consistency_;
   }
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The consistency.
    */
   @java.lang.Override public com.scalar.db.rpc.Consistency getConsistency() {
@@ -434,7 +434,7 @@ private static final long serialVersionUID = 0L;
   public static final int CONDITION_FIELD_NUMBER = 6;
   private com.scalar.db.rpc.MutateCondition condition_;
   /**
-   * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+   * <code>.rpc.MutateCondition condition = 6;</code>
    * @return Whether the condition field is set.
    */
   @java.lang.Override
@@ -442,7 +442,7 @@ private static final long serialVersionUID = 0L;
     return condition_ != null;
   }
   /**
-   * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+   * <code>.rpc.MutateCondition condition = 6;</code>
    * @return The condition.
    */
   @java.lang.Override
@@ -450,7 +450,7 @@ private static final long serialVersionUID = 0L;
     return condition_ == null ? com.scalar.db.rpc.MutateCondition.getDefaultInstance() : condition_;
   }
   /**
-   * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+   * <code>.rpc.MutateCondition condition = 6;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.MutateConditionOrBuilder getConditionOrBuilder() {
@@ -460,14 +460,14 @@ private static final long serialVersionUID = 0L;
   public static final int TYPE_FIELD_NUMBER = 7;
   private int type_;
   /**
-   * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+   * <code>.rpc.Mutation.Type type = 7;</code>
    * @return The enum numeric value on the wire for type.
    */
   @java.lang.Override public int getTypeValue() {
     return type_;
   }
   /**
-   * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+   * <code>.rpc.Mutation.Type type = 7;</code>
    * @return The type.
    */
   @java.lang.Override public com.scalar.db.rpc.Mutation.Type getType() {
@@ -483,7 +483,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value> getValueList() {
@@ -494,7 +494,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
@@ -506,7 +506,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public int getValueCount() {
@@ -517,7 +517,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.Value getValue(int index) {
@@ -528,7 +528,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
@@ -543,7 +543,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.Column> getColumnsList() {
@@ -554,7 +554,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
@@ -566,7 +566,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   @java.lang.Override
   public int getColumnsCount() {
@@ -577,7 +577,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Column getColumns(int index) {
@@ -588,7 +588,7 @@ private static final long serialVersionUID = 0L;
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
@@ -855,21 +855,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Mutation}
+   * Protobuf type {@code rpc.Mutation}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Mutation)
+      // @@protoc_insertion_point(builder_implements:rpc.Mutation)
       com.scalar.db.rpc.MutationOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Mutation_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Mutation_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Mutation_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Mutation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Mutation.class, com.scalar.db.rpc.Mutation.Builder.class);
     }
@@ -938,7 +938,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Mutation_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Mutation_descriptor;
     }
 
     @java.lang.Override
@@ -1305,14 +1305,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> partitionKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      * @return Whether the partitionKey field is set.
      */
     public boolean hasPartitionKey() {
       return partitionKeyBuilder_ != null || partitionKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      * @return The partitionKey.
      */
     public com.scalar.db.rpc.Key getPartitionKey() {
@@ -1323,7 +1323,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder setPartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
@@ -1339,7 +1339,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder setPartitionKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -1353,7 +1353,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder mergePartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
@@ -1371,7 +1371,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder clearPartitionKey() {
       if (partitionKeyBuilder_ == null) {
@@ -1385,7 +1385,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.Key.Builder getPartitionKeyBuilder() {
       
@@ -1393,7 +1393,7 @@ private static final long serialVersionUID = 0L;
       return getPartitionKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
       if (partitionKeyBuilder_ != null) {
@@ -1404,7 +1404,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1424,14 +1424,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> clusteringKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      * @return Whether the clusteringKey field is set.
      */
     public boolean hasClusteringKey() {
       return clusteringKeyBuilder_ != null || clusteringKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      * @return The clusteringKey.
      */
     public com.scalar.db.rpc.Key getClusteringKey() {
@@ -1442,7 +1442,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder setClusteringKey(com.scalar.db.rpc.Key value) {
       if (clusteringKeyBuilder_ == null) {
@@ -1458,7 +1458,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder setClusteringKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -1472,7 +1472,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder mergeClusteringKey(com.scalar.db.rpc.Key value) {
       if (clusteringKeyBuilder_ == null) {
@@ -1490,7 +1490,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder clearClusteringKey() {
       if (clusteringKeyBuilder_ == null) {
@@ -1504,7 +1504,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public com.scalar.db.rpc.Key.Builder getClusteringKeyBuilder() {
       
@@ -1512,7 +1512,7 @@ private static final long serialVersionUID = 0L;
       return getClusteringKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder() {
       if (clusteringKeyBuilder_ != null) {
@@ -1523,7 +1523,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+     * <code>.rpc.Key clustering_key = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1541,14 +1541,14 @@ private static final long serialVersionUID = 0L;
 
     private int consistency_ = 0;
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @return The enum numeric value on the wire for consistency.
      */
     @java.lang.Override public int getConsistencyValue() {
       return consistency_;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @param value The enum numeric value on the wire for consistency to set.
      * @return This builder for chaining.
      */
@@ -1559,7 +1559,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @return The consistency.
      */
     @java.lang.Override
@@ -1569,7 +1569,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @param value The consistency to set.
      * @return This builder for chaining.
      */
@@ -1583,7 +1583,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+     * <code>.rpc.Consistency consistency = 5;</code>
      * @return This builder for chaining.
      */
     public Builder clearConsistency() {
@@ -1597,14 +1597,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.MutateCondition, com.scalar.db.rpc.MutateCondition.Builder, com.scalar.db.rpc.MutateConditionOrBuilder> conditionBuilder_;
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      * @return Whether the condition field is set.
      */
     public boolean hasCondition() {
       return conditionBuilder_ != null || condition_ != null;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      * @return The condition.
      */
     public com.scalar.db.rpc.MutateCondition getCondition() {
@@ -1615,7 +1615,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public Builder setCondition(com.scalar.db.rpc.MutateCondition value) {
       if (conditionBuilder_ == null) {
@@ -1631,7 +1631,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public Builder setCondition(
         com.scalar.db.rpc.MutateCondition.Builder builderForValue) {
@@ -1645,7 +1645,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public Builder mergeCondition(com.scalar.db.rpc.MutateCondition value) {
       if (conditionBuilder_ == null) {
@@ -1663,7 +1663,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public Builder clearCondition() {
       if (conditionBuilder_ == null) {
@@ -1677,7 +1677,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public com.scalar.db.rpc.MutateCondition.Builder getConditionBuilder() {
       
@@ -1685,7 +1685,7 @@ private static final long serialVersionUID = 0L;
       return getConditionFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public com.scalar.db.rpc.MutateConditionOrBuilder getConditionOrBuilder() {
       if (conditionBuilder_ != null) {
@@ -1696,7 +1696,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+     * <code>.rpc.MutateCondition condition = 6;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.MutateCondition, com.scalar.db.rpc.MutateCondition.Builder, com.scalar.db.rpc.MutateConditionOrBuilder> 
@@ -1714,14 +1714,14 @@ private static final long serialVersionUID = 0L;
 
     private int type_ = 0;
     /**
-     * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+     * <code>.rpc.Mutation.Type type = 7;</code>
      * @return The enum numeric value on the wire for type.
      */
     @java.lang.Override public int getTypeValue() {
       return type_;
     }
     /**
-     * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+     * <code>.rpc.Mutation.Type type = 7;</code>
      * @param value The enum numeric value on the wire for type to set.
      * @return This builder for chaining.
      */
@@ -1732,7 +1732,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+     * <code>.rpc.Mutation.Type type = 7;</code>
      * @return The type.
      */
     @java.lang.Override
@@ -1742,7 +1742,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.Mutation.Type.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+     * <code>.rpc.Mutation.Type type = 7;</code>
      * @param value The type to set.
      * @return This builder for chaining.
      */
@@ -1756,7 +1756,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+     * <code>.rpc.Mutation.Type type = 7;</code>
      * @return This builder for chaining.
      */
     public Builder clearType() {
@@ -1783,7 +1783,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value> getValueList() {
       if (valueBuilder_ == null) {
@@ -1797,7 +1797,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public int getValueCount() {
       if (valueBuilder_ == null) {
@@ -1811,7 +1811,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value getValue(int index) {
       if (valueBuilder_ == null) {
@@ -1825,7 +1825,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         int index, com.scalar.db.rpc.Value value) {
@@ -1846,7 +1846,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         int index, com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -1864,7 +1864,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(com.scalar.db.rpc.Value value) {
       if (valueBuilder_ == null) {
@@ -1884,7 +1884,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         int index, com.scalar.db.rpc.Value value) {
@@ -1905,7 +1905,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -1923,7 +1923,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         int index, com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -1941,7 +1941,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addAllValue(
         java.lang.Iterable<? extends com.scalar.db.rpc.Value> values) {
@@ -1960,7 +1960,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder clearValue() {
       if (valueBuilder_ == null) {
@@ -1977,7 +1977,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder removeValue(int index) {
       if (valueBuilder_ == null) {
@@ -1994,7 +1994,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder getValueBuilder(
         int index) {
@@ -2005,7 +2005,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
         int index) {
@@ -2019,7 +2019,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
          getValueOrBuilderList() {
@@ -2034,7 +2034,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder addValueBuilder() {
       return getValueFieldBuilder().addBuilder(
@@ -2045,7 +2045,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder addValueBuilder(
         int index) {
@@ -2057,7 +2057,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value.Builder> 
          getValueBuilderList() {
@@ -2095,7 +2095,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public java.util.List<com.scalar.db.rpc.Column> getColumnsList() {
       if (columnsBuilder_ == null) {
@@ -2109,7 +2109,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public int getColumnsCount() {
       if (columnsBuilder_ == null) {
@@ -2123,7 +2123,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public com.scalar.db.rpc.Column getColumns(int index) {
       if (columnsBuilder_ == null) {
@@ -2137,7 +2137,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder setColumns(
         int index, com.scalar.db.rpc.Column value) {
@@ -2158,7 +2158,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder setColumns(
         int index, com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -2176,7 +2176,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder addColumns(com.scalar.db.rpc.Column value) {
       if (columnsBuilder_ == null) {
@@ -2196,7 +2196,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder addColumns(
         int index, com.scalar.db.rpc.Column value) {
@@ -2217,7 +2217,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder addColumns(
         com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -2235,7 +2235,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder addColumns(
         int index, com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -2253,7 +2253,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder addAllColumns(
         java.lang.Iterable<? extends com.scalar.db.rpc.Column> values) {
@@ -2272,7 +2272,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder clearColumns() {
       if (columnsBuilder_ == null) {
@@ -2289,7 +2289,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public Builder removeColumns(int index) {
       if (columnsBuilder_ == null) {
@@ -2306,7 +2306,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public com.scalar.db.rpc.Column.Builder getColumnsBuilder(
         int index) {
@@ -2317,7 +2317,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
         int index) {
@@ -2331,7 +2331,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
          getColumnsOrBuilderList() {
@@ -2346,7 +2346,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public com.scalar.db.rpc.Column.Builder addColumnsBuilder() {
       return getColumnsFieldBuilder().addBuilder(
@@ -2357,7 +2357,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public com.scalar.db.rpc.Column.Builder addColumnsBuilder(
         int index) {
@@ -2369,7 +2369,7 @@ private static final long serialVersionUID = 0L;
      * only for Put operations
      * </pre>
      *
-     * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+     * <code>repeated .rpc.Column columns = 9;</code>
      */
     public java.util.List<com.scalar.db.rpc.Column.Builder> 
          getColumnsBuilderList() {
@@ -2402,10 +2402,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Mutation)
+    // @@protoc_insertion_point(builder_scope:rpc.Mutation)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Mutation)
+  // @@protoc_insertion_point(class_scope:rpc.Mutation)
   private static final com.scalar.db.rpc.Mutation DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Mutation();

--- a/rpc/src/main/java/com/scalar/db/rpc/MutationOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutationOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface MutationOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Mutation)
+    // @@protoc_insertion_point(interface_extends:rpc.Mutation)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -32,68 +32,68 @@ public interface MutationOrBuilder extends
       getTableBytes();
 
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return Whether the partitionKey field is set.
    */
   boolean hasPartitionKey();
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return The partitionKey.
    */
   com.scalar.db.rpc.Key getPartitionKey();
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return Whether the clusteringKey field is set.
    */
   boolean hasClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    * @return The clusteringKey.
    */
   com.scalar.db.rpc.Key getClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key clustering_key = 4;</code>
+   * <code>.rpc.Key clustering_key = 4;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The enum numeric value on the wire for consistency.
    */
   int getConsistencyValue();
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 5;</code>
+   * <code>.rpc.Consistency consistency = 5;</code>
    * @return The consistency.
    */
   com.scalar.db.rpc.Consistency getConsistency();
 
   /**
-   * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+   * <code>.rpc.MutateCondition condition = 6;</code>
    * @return Whether the condition field is set.
    */
   boolean hasCondition();
   /**
-   * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+   * <code>.rpc.MutateCondition condition = 6;</code>
    * @return The condition.
    */
   com.scalar.db.rpc.MutateCondition getCondition();
   /**
-   * <code>.scalardb.rpc.MutateCondition condition = 6;</code>
+   * <code>.rpc.MutateCondition condition = 6;</code>
    */
   com.scalar.db.rpc.MutateConditionOrBuilder getConditionOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+   * <code>.rpc.Mutation.Type type = 7;</code>
    * @return The enum numeric value on the wire for type.
    */
   int getTypeValue();
   /**
-   * <code>.scalardb.rpc.Mutation.Type type = 7;</code>
+   * <code>.rpc.Mutation.Type type = 7;</code>
    * @return The type.
    */
   com.scalar.db.rpc.Mutation.Type getType();
@@ -103,7 +103,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Deprecated java.util.List<com.scalar.db.rpc.Value> 
       getValueList();
@@ -112,7 +112,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.Value getValue(int index);
   /**
@@ -120,7 +120,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Deprecated int getValueCount();
   /**
@@ -128,7 +128,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Deprecated java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
       getValueOrBuilderList();
@@ -137,7 +137,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Value value = 8 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 8 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
       int index);
@@ -147,7 +147,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   java.util.List<com.scalar.db.rpc.Column> 
       getColumnsList();
@@ -156,7 +156,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   com.scalar.db.rpc.Column getColumns(int index);
   /**
@@ -164,7 +164,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   int getColumnsCount();
   /**
@@ -172,7 +172,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
       getColumnsOrBuilderList();
@@ -181,7 +181,7 @@ public interface MutationOrBuilder extends
    * only for Put operations
    * </pre>
    *
-   * <code>repeated .scalardb.rpc.Column columns = 9;</code>
+   * <code>repeated .rpc.Column columns = 9;</code>
    */
   com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.NamespaceExistsRequest}
+ * Protobuf type {@code rpc.NamespaceExistsRequest}
  */
 public final class NamespaceExistsRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.NamespaceExistsRequest)
+    // @@protoc_insertion_point(message_implements:rpc.NamespaceExistsRequest)
     NamespaceExistsRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use NamespaceExistsRequest.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.NamespaceExistsRequest.class, com.scalar.db.rpc.NamespaceExistsRequest.Builder.class);
   }
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.NamespaceExistsRequest}
+   * Protobuf type {@code rpc.NamespaceExistsRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.NamespaceExistsRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.NamespaceExistsRequest)
       com.scalar.db.rpc.NamespaceExistsRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.NamespaceExistsRequest.class, com.scalar.db.rpc.NamespaceExistsRequest.Builder.class);
     }
@@ -327,7 +327,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsRequest_descriptor;
     }
 
     @java.lang.Override
@@ -517,10 +517,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.NamespaceExistsRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.NamespaceExistsRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.NamespaceExistsRequest)
+  // @@protoc_insertion_point(class_scope:rpc.NamespaceExistsRequest)
   private static final com.scalar.db.rpc.NamespaceExistsRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.NamespaceExistsRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface NamespaceExistsRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.NamespaceExistsRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.NamespaceExistsRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.NamespaceExistsResponse}
+ * Protobuf type {@code rpc.NamespaceExistsResponse}
  */
 public final class NamespaceExistsResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.NamespaceExistsResponse)
+    // @@protoc_insertion_point(message_implements:rpc.NamespaceExistsResponse)
     NamespaceExistsResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use NamespaceExistsResponse.newBuilder() to construct.
@@ -76,13 +76,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.NamespaceExistsResponse.class, com.scalar.db.rpc.NamespaceExistsResponse.Builder.class);
   }
@@ -255,21 +255,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.NamespaceExistsResponse}
+   * Protobuf type {@code rpc.NamespaceExistsResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.NamespaceExistsResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.NamespaceExistsResponse)
       com.scalar.db.rpc.NamespaceExistsResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.NamespaceExistsResponse.class, com.scalar.db.rpc.NamespaceExistsResponse.Builder.class);
     }
@@ -300,7 +300,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_NamespaceExistsResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_NamespaceExistsResponse_descriptor;
     }
 
     @java.lang.Override
@@ -444,10 +444,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.NamespaceExistsResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.NamespaceExistsResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.NamespaceExistsResponse)
+  // @@protoc_insertion_point(class_scope:rpc.NamespaceExistsResponse)
   private static final com.scalar.db.rpc.NamespaceExistsResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.NamespaceExistsResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponseOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface NamespaceExistsResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.NamespaceExistsResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.NamespaceExistsResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/Order.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Order.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf enum {@code scalardb.rpc.Order}
+ * Protobuf enum {@code rpc.Order}
  */
 public enum Order
     implements com.google.protobuf.ProtocolMessageEnum {
@@ -108,6 +108,6 @@ public enum Order
     this.value = value;
   }
 
-  // @@protoc_insertion_point(enum_scope:scalardb.rpc.Order)
+  // @@protoc_insertion_point(enum_scope:rpc.Order)
 }
 

--- a/rpc/src/main/java/com/scalar/db/rpc/Ordering.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Ordering.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Ordering}
+ * Protobuf type {@code rpc.Ordering}
  */
 public final class Ordering extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Ordering)
+    // @@protoc_insertion_point(message_implements:rpc.Ordering)
     OrderingOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Ordering.newBuilder() to construct.
@@ -85,13 +85,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Ordering_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Ordering_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Ordering_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Ordering_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Ordering.class, com.scalar.db.rpc.Ordering.Builder.class);
   }
@@ -137,14 +137,14 @@ private static final long serialVersionUID = 0L;
   public static final int ORDER_FIELD_NUMBER = 2;
   private int order_;
   /**
-   * <code>.scalardb.rpc.Order order = 2;</code>
+   * <code>.rpc.Order order = 2;</code>
    * @return The enum numeric value on the wire for order.
    */
   @java.lang.Override public int getOrderValue() {
     return order_;
   }
   /**
-   * <code>.scalardb.rpc.Order order = 2;</code>
+   * <code>.rpc.Order order = 2;</code>
    * @return The order.
    */
   @java.lang.Override public com.scalar.db.rpc.Order getOrder() {
@@ -318,21 +318,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Ordering}
+   * Protobuf type {@code rpc.Ordering}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Ordering)
+      // @@protoc_insertion_point(builder_implements:rpc.Ordering)
       com.scalar.db.rpc.OrderingOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Ordering_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Ordering_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Ordering_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Ordering_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Ordering.class, com.scalar.db.rpc.Ordering.Builder.class);
     }
@@ -365,7 +365,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Ordering_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Ordering_descriptor;
     }
 
     @java.lang.Override
@@ -549,14 +549,14 @@ private static final long serialVersionUID = 0L;
 
     private int order_ = 0;
     /**
-     * <code>.scalardb.rpc.Order order = 2;</code>
+     * <code>.rpc.Order order = 2;</code>
      * @return The enum numeric value on the wire for order.
      */
     @java.lang.Override public int getOrderValue() {
       return order_;
     }
     /**
-     * <code>.scalardb.rpc.Order order = 2;</code>
+     * <code>.rpc.Order order = 2;</code>
      * @param value The enum numeric value on the wire for order to set.
      * @return This builder for chaining.
      */
@@ -567,7 +567,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Order order = 2;</code>
+     * <code>.rpc.Order order = 2;</code>
      * @return The order.
      */
     @java.lang.Override
@@ -577,7 +577,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.Order.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.Order order = 2;</code>
+     * <code>.rpc.Order order = 2;</code>
      * @param value The order to set.
      * @return This builder for chaining.
      */
@@ -591,7 +591,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Order order = 2;</code>
+     * <code>.rpc.Order order = 2;</code>
      * @return This builder for chaining.
      */
     public Builder clearOrder() {
@@ -613,10 +613,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Ordering)
+    // @@protoc_insertion_point(builder_scope:rpc.Ordering)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Ordering)
+  // @@protoc_insertion_point(class_scope:rpc.Ordering)
   private static final com.scalar.db.rpc.Ordering DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Ordering();

--- a/rpc/src/main/java/com/scalar/db/rpc/OrderingOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/OrderingOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface OrderingOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Ordering)
+    // @@protoc_insertion_point(interface_extends:rpc.Ordering)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -20,12 +20,12 @@ public interface OrderingOrBuilder extends
       getNameBytes();
 
   /**
-   * <code>.scalardb.rpc.Order order = 2;</code>
+   * <code>.rpc.Order order = 2;</code>
    * @return The enum numeric value on the wire for order.
    */
   int getOrderValue();
   /**
-   * <code>.scalardb.rpc.Order order = 2;</code>
+   * <code>.rpc.Order order = 2;</code>
    * @return The order.
    */
   com.scalar.db.rpc.Order getOrder();

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.RepairCoordinatorTablesRequest}
+ * Protobuf type {@code rpc.RepairCoordinatorTablesRequest}
  */
 public final class RepairCoordinatorTablesRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.RepairCoordinatorTablesRequest)
+    // @@protoc_insertion_point(message_implements:rpc.RepairCoordinatorTablesRequest)
     RepairCoordinatorTablesRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use RepairCoordinatorTablesRequest.newBuilder() to construct.
@@ -85,7 +85,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairCoordinatorTablesRequest_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -103,7 +103,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.RepairCoordinatorTablesRequest.class, com.scalar.db.rpc.RepairCoordinatorTablesRequest.Builder.class);
   }
@@ -114,7 +114,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.String> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.String>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.STRING,
@@ -356,15 +356,15 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.RepairCoordinatorTablesRequest}
+   * Protobuf type {@code rpc.RepairCoordinatorTablesRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.RepairCoordinatorTablesRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.RepairCoordinatorTablesRequest)
       com.scalar.db.rpc.RepairCoordinatorTablesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairCoordinatorTablesRequest_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -392,7 +392,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.RepairCoordinatorTablesRequest.class, com.scalar.db.rpc.RepairCoordinatorTablesRequest.Builder.class);
     }
@@ -422,7 +422,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairCoordinatorTablesRequest_descriptor;
     }
 
     @java.lang.Override
@@ -668,10 +668,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.RepairCoordinatorTablesRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.RepairCoordinatorTablesRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.RepairCoordinatorTablesRequest)
+  // @@protoc_insertion_point(class_scope:rpc.RepairCoordinatorTablesRequest)
   private static final com.scalar.db.rpc.RepairCoordinatorTablesRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.RepairCoordinatorTablesRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface RepairCoordinatorTablesRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.RepairCoordinatorTablesRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.RepairCoordinatorTablesRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.RepairTableRequest}
+ * Protobuf type {@code rpc.RepairTableRequest}
  */
 public final class RepairTableRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.RepairTableRequest)
+    // @@protoc_insertion_point(message_implements:rpc.RepairTableRequest)
     RepairTableRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use RepairTableRequest.newBuilder() to construct.
@@ -112,7 +112,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairTableRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairTableRequest_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -130,7 +130,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairTableRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.RepairTableRequest.class, com.scalar.db.rpc.RepairTableRequest.Builder.class);
   }
@@ -214,7 +214,7 @@ private static final long serialVersionUID = 0L;
   public static final int TABLE_METADATA_FIELD_NUMBER = 3;
   private com.scalar.db.rpc.TableMetadata tableMetadata_;
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return Whether the tableMetadata field is set.
    */
   @java.lang.Override
@@ -222,7 +222,7 @@ private static final long serialVersionUID = 0L;
     return tableMetadata_ != null;
   }
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return The tableMetadata.
    */
   @java.lang.Override
@@ -230,7 +230,7 @@ private static final long serialVersionUID = 0L;
     return tableMetadata_ == null ? com.scalar.db.rpc.TableMetadata.getDefaultInstance() : tableMetadata_;
   }
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
@@ -243,7 +243,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.String> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.String>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairTableRequest_OptionsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairTableRequest_OptionsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.STRING,
@@ -521,15 +521,15 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.RepairTableRequest}
+   * Protobuf type {@code rpc.RepairTableRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.RepairTableRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.RepairTableRequest)
       com.scalar.db.rpc.RepairTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairTableRequest_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -557,7 +557,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairTableRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.RepairTableRequest.class, com.scalar.db.rpc.RepairTableRequest.Builder.class);
     }
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RepairTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RepairTableRequest_descriptor;
     }
 
     @java.lang.Override
@@ -874,14 +874,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TableMetadata, com.scalar.db.rpc.TableMetadata.Builder, com.scalar.db.rpc.TableMetadataOrBuilder> tableMetadataBuilder_;
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      * @return Whether the tableMetadata field is set.
      */
     public boolean hasTableMetadata() {
       return tableMetadataBuilder_ != null || tableMetadata_ != null;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      * @return The tableMetadata.
      */
     public com.scalar.db.rpc.TableMetadata getTableMetadata() {
@@ -892,7 +892,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder setTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
@@ -908,7 +908,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder setTableMetadata(
         com.scalar.db.rpc.TableMetadata.Builder builderForValue) {
@@ -922,7 +922,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder mergeTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
@@ -940,7 +940,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder clearTableMetadata() {
       if (tableMetadataBuilder_ == null) {
@@ -954,7 +954,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public com.scalar.db.rpc.TableMetadata.Builder getTableMetadataBuilder() {
       
@@ -962,7 +962,7 @@ private static final long serialVersionUID = 0L;
       return getTableMetadataFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
       if (tableMetadataBuilder_ != null) {
@@ -973,7 +973,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+     * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TableMetadata, com.scalar.db.rpc.TableMetadata.Builder, com.scalar.db.rpc.TableMetadataOrBuilder> 
@@ -1132,10 +1132,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.RepairTableRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.RepairTableRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.RepairTableRequest)
+  // @@protoc_insertion_point(class_scope:rpc.RepairTableRequest)
   private static final com.scalar.db.rpc.RepairTableRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.RepairTableRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface RepairTableRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.RepairTableRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.RepairTableRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -32,17 +32,17 @@ public interface RepairTableRequestOrBuilder extends
       getTableBytes();
 
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return Whether the tableMetadata field is set.
    */
   boolean hasTableMetadata();
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    * @return The tableMetadata.
    */
   com.scalar.db.rpc.TableMetadata getTableMetadata();
   /**
-   * <code>.scalardb.rpc.TableMetadata table_metadata = 3;</code>
+   * <code>.rpc.TableMetadata table_metadata = 3;</code>
    */
   com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/Result.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Result.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Result}
+ * Protobuf type {@code rpc.Result}
  */
 public final class Result extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Result)
+    // @@protoc_insertion_point(message_implements:rpc.Result)
     ResultOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Result.newBuilder() to construct.
@@ -98,13 +98,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Result_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Result_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Result_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Result_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Result.class, com.scalar.db.rpc.Result.Builder.class);
   }
@@ -112,14 +112,14 @@ private static final long serialVersionUID = 0L;
   public static final int VALUE_FIELD_NUMBER = 1;
   private java.util.List<com.scalar.db.rpc.Value> value_;
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value> getValueList() {
     return value_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
@@ -127,21 +127,21 @@ private static final long serialVersionUID = 0L;
     return value_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public int getValueCount() {
     return value_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.Value getValue(int index) {
     return value_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
@@ -152,14 +152,14 @@ private static final long serialVersionUID = 0L;
   public static final int COLUMNS_FIELD_NUMBER = 2;
   private java.util.List<com.scalar.db.rpc.Column> columns_;
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.Column> getColumnsList() {
     return columns_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
@@ -167,21 +167,21 @@ private static final long serialVersionUID = 0L;
     return columns_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public int getColumnsCount() {
     return columns_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Column getColumns(int index) {
     return columns_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
@@ -360,21 +360,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Result}
+   * Protobuf type {@code rpc.Result}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Result)
+      // @@protoc_insertion_point(builder_implements:rpc.Result)
       com.scalar.db.rpc.ResultOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Result_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Result_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Result_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Result_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Result.class, com.scalar.db.rpc.Result.Builder.class);
     }
@@ -417,7 +417,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Result_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Result_descriptor;
     }
 
     @java.lang.Override
@@ -599,7 +599,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Value, com.scalar.db.rpc.Value.Builder, com.scalar.db.rpc.ValueOrBuilder> valueBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value> getValueList() {
       if (valueBuilder_ == null) {
@@ -609,7 +609,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public int getValueCount() {
       if (valueBuilder_ == null) {
@@ -619,7 +619,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value getValue(int index) {
       if (valueBuilder_ == null) {
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         int index, com.scalar.db.rpc.Value value) {
@@ -646,7 +646,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder setValue(
         int index, com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(com.scalar.db.rpc.Value value) {
       if (valueBuilder_ == null) {
@@ -676,7 +676,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         int index, com.scalar.db.rpc.Value value) {
@@ -693,7 +693,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -707,7 +707,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addValue(
         int index, com.scalar.db.rpc.Value.Builder builderForValue) {
@@ -721,7 +721,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder addAllValue(
         java.lang.Iterable<? extends com.scalar.db.rpc.Value> values) {
@@ -736,7 +736,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder clearValue() {
       if (valueBuilder_ == null) {
@@ -749,7 +749,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder removeValue(int index) {
       if (valueBuilder_ == null) {
@@ -762,14 +762,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder getValueBuilder(
         int index) {
       return getValueFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
         int index) {
@@ -779,7 +779,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
          getValueOrBuilderList() {
@@ -790,14 +790,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder addValueBuilder() {
       return getValueFieldBuilder().addBuilder(
           com.scalar.db.rpc.Value.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder addValueBuilder(
         int index) {
@@ -805,7 +805,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Value.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+     * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public java.util.List<com.scalar.db.rpc.Value.Builder> 
          getValueBuilderList() {
@@ -839,7 +839,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Column, com.scalar.db.rpc.Column.Builder, com.scalar.db.rpc.ColumnOrBuilder> columnsBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.Column> getColumnsList() {
       if (columnsBuilder_ == null) {
@@ -849,7 +849,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public int getColumnsCount() {
       if (columnsBuilder_ == null) {
@@ -859,7 +859,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column getColumns(int index) {
       if (columnsBuilder_ == null) {
@@ -869,7 +869,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder setColumns(
         int index, com.scalar.db.rpc.Column value) {
@@ -886,7 +886,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder setColumns(
         int index, com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -900,7 +900,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(com.scalar.db.rpc.Column value) {
       if (columnsBuilder_ == null) {
@@ -916,7 +916,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(
         int index, com.scalar.db.rpc.Column value) {
@@ -933,7 +933,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(
         com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -947,7 +947,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addColumns(
         int index, com.scalar.db.rpc.Column.Builder builderForValue) {
@@ -961,7 +961,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder addAllColumns(
         java.lang.Iterable<? extends com.scalar.db.rpc.Column> values) {
@@ -976,7 +976,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder clearColumns() {
       if (columnsBuilder_ == null) {
@@ -989,7 +989,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public Builder removeColumns(int index) {
       if (columnsBuilder_ == null) {
@@ -1002,14 +1002,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column.Builder getColumnsBuilder(
         int index) {
       return getColumnsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
         int index) {
@@ -1019,7 +1019,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
          getColumnsOrBuilderList() {
@@ -1030,14 +1030,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column.Builder addColumnsBuilder() {
       return getColumnsFieldBuilder().addBuilder(
           com.scalar.db.rpc.Column.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public com.scalar.db.rpc.Column.Builder addColumnsBuilder(
         int index) {
@@ -1045,7 +1045,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Column.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+     * <code>repeated .rpc.Column columns = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.Column.Builder> 
          getColumnsBuilderList() {
@@ -1078,10 +1078,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Result)
+    // @@protoc_insertion_point(builder_scope:rpc.Result)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Result)
+  // @@protoc_insertion_point(class_scope:rpc.Result)
   private static final com.scalar.db.rpc.Result DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Result();

--- a/rpc/src/main/java/com/scalar/db/rpc/ResultOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ResultOrBuilder.java
@@ -4,53 +4,53 @@
 package com.scalar.db.rpc;
 
 public interface ResultOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Result)
+    // @@protoc_insertion_point(interface_extends:rpc.Result)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated java.util.List<com.scalar.db.rpc.Value> 
       getValueList();
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.Value getValue(int index);
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated int getValueCount();
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated java.util.List<? extends com.scalar.db.rpc.ValueOrBuilder> 
       getValueOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Value value = 1 [deprecated = true];</code>
+   * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
    */
   @java.lang.Deprecated com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder(
       int index);
 
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   java.util.List<com.scalar.db.rpc.Column> 
       getColumnsList();
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   com.scalar.db.rpc.Column getColumns(int index);
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   int getColumnsCount();
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.ColumnOrBuilder> 
       getColumnsOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Column columns = 2;</code>
+   * <code>repeated .rpc.Column columns = 2;</code>
    */
   com.scalar.db.rpc.ColumnOrBuilder getColumnsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/RollbackRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RollbackRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.RollbackRequest}
+ * Protobuf type {@code rpc.RollbackRequest}
  */
 public final class RollbackRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.RollbackRequest)
+    // @@protoc_insertion_point(message_implements:rpc.RollbackRequest)
     RollbackRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use RollbackRequest.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.RollbackRequest.class, com.scalar.db.rpc.RollbackRequest.Builder.class);
   }
@@ -282,21 +282,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.RollbackRequest}
+   * Protobuf type {@code rpc.RollbackRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.RollbackRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.RollbackRequest)
       com.scalar.db.rpc.RollbackRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.RollbackRequest.class, com.scalar.db.rpc.RollbackRequest.Builder.class);
     }
@@ -327,7 +327,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackRequest_descriptor;
     }
 
     @java.lang.Override
@@ -517,10 +517,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.RollbackRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.RollbackRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.RollbackRequest)
+  // @@protoc_insertion_point(class_scope:rpc.RollbackRequest)
   private static final com.scalar.db.rpc.RollbackRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.RollbackRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/RollbackRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RollbackRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface RollbackRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.RollbackRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.RollbackRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/RollbackResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RollbackResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.RollbackResponse}
+ * Protobuf type {@code rpc.RollbackResponse}
  */
 public final class RollbackResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.RollbackResponse)
+    // @@protoc_insertion_point(message_implements:rpc.RollbackResponse)
     RollbackResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use RollbackResponse.newBuilder() to construct.
@@ -78,13 +78,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.RollbackResponse.class, com.scalar.db.rpc.RollbackResponse.Builder.class);
   }
@@ -92,14 +92,14 @@ private static final long serialVersionUID = 0L;
   public static final int STATE_FIELD_NUMBER = 1;
   private int state_;
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
    */
   @java.lang.Override public int getStateValue() {
     return state_;
   }
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The state.
    */
   @java.lang.Override public com.scalar.db.rpc.TransactionState getState() {
@@ -263,21 +263,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.RollbackResponse}
+   * Protobuf type {@code rpc.RollbackResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.RollbackResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.RollbackResponse)
       com.scalar.db.rpc.RollbackResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.RollbackResponse.class, com.scalar.db.rpc.RollbackResponse.Builder.class);
     }
@@ -308,7 +308,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_RollbackResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_RollbackResponse_descriptor;
     }
 
     @java.lang.Override
@@ -411,14 +411,14 @@ private static final long serialVersionUID = 0L;
 
     private int state_ = 0;
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return The enum numeric value on the wire for state.
      */
     @java.lang.Override public int getStateValue() {
       return state_;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @param value The enum numeric value on the wire for state to set.
      * @return This builder for chaining.
      */
@@ -429,7 +429,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return The state.
      */
     @java.lang.Override
@@ -439,7 +439,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @param value The state to set.
      * @return This builder for chaining.
      */
@@ -453,7 +453,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionState state = 1;</code>
+     * <code>.rpc.TransactionState state = 1;</code>
      * @return This builder for chaining.
      */
     public Builder clearState() {
@@ -475,10 +475,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.RollbackResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.RollbackResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.RollbackResponse)
+  // @@protoc_insertion_point(class_scope:rpc.RollbackResponse)
   private static final com.scalar.db.rpc.RollbackResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.RollbackResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/RollbackResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RollbackResponseOrBuilder.java
@@ -4,16 +4,16 @@
 package com.scalar.db.rpc;
 
 public interface RollbackResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.RollbackResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.RollbackResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
    */
   int getStateValue();
   /**
-   * <code>.scalardb.rpc.TransactionState state = 1;</code>
+   * <code>.rpc.TransactionState state = 1;</code>
    * @return The state.
    */
   com.scalar.db.rpc.TransactionState getState();

--- a/rpc/src/main/java/com/scalar/db/rpc/ScalarDbProto.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScalarDbProto.java
@@ -15,420 +15,420 @@ public final class ScalarDbProto {
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Value_descriptor;
+    internal_static_rpc_Value_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Value_fieldAccessorTable;
+      internal_static_rpc_Value_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Value_TextValue_descriptor;
+    internal_static_rpc_Value_TextValue_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Value_TextValue_fieldAccessorTable;
+      internal_static_rpc_Value_TextValue_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Value_BlobValue_descriptor;
+    internal_static_rpc_Value_BlobValue_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Value_BlobValue_fieldAccessorTable;
+      internal_static_rpc_Value_BlobValue_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Column_descriptor;
+    internal_static_rpc_Column_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Column_fieldAccessorTable;
+      internal_static_rpc_Column_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Key_descriptor;
+    internal_static_rpc_Key_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Key_fieldAccessorTable;
+      internal_static_rpc_Key_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Get_descriptor;
+    internal_static_rpc_Get_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Get_fieldAccessorTable;
+      internal_static_rpc_Get_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Ordering_descriptor;
+    internal_static_rpc_Ordering_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Ordering_fieldAccessorTable;
+      internal_static_rpc_Ordering_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Scan_descriptor;
+    internal_static_rpc_Scan_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Scan_fieldAccessorTable;
+      internal_static_rpc_Scan_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_ConditionalExpression_descriptor;
+    internal_static_rpc_ConditionalExpression_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_ConditionalExpression_fieldAccessorTable;
+      internal_static_rpc_ConditionalExpression_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_MutateCondition_descriptor;
+    internal_static_rpc_MutateCondition_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_MutateCondition_fieldAccessorTable;
+      internal_static_rpc_MutateCondition_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Mutation_descriptor;
+    internal_static_rpc_Mutation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Mutation_fieldAccessorTable;
+      internal_static_rpc_Mutation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_Result_descriptor;
+    internal_static_rpc_Result_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_Result_fieldAccessorTable;
+      internal_static_rpc_Result_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetRequest_descriptor;
+    internal_static_rpc_GetRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetRequest_fieldAccessorTable;
+      internal_static_rpc_GetRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetResponse_descriptor;
+    internal_static_rpc_GetResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetResponse_fieldAccessorTable;
+      internal_static_rpc_GetResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_ScanRequest_descriptor;
+    internal_static_rpc_ScanRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_ScanRequest_fieldAccessorTable;
+      internal_static_rpc_ScanRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_ScanResponse_descriptor;
+    internal_static_rpc_ScanResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_ScanResponse_fieldAccessorTable;
+      internal_static_rpc_ScanResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_MutateRequest_descriptor;
+    internal_static_rpc_MutateRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_MutateRequest_fieldAccessorTable;
+      internal_static_rpc_MutateRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TableMetadata_descriptor;
+    internal_static_rpc_TableMetadata_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TableMetadata_fieldAccessorTable;
+      internal_static_rpc_TableMetadata_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TableMetadata_ColumnsEntry_descriptor;
+    internal_static_rpc_TableMetadata_ColumnsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TableMetadata_ColumnsEntry_fieldAccessorTable;
+      internal_static_rpc_TableMetadata_ColumnsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TableMetadata_ClusteringOrdersEntry_descriptor;
+    internal_static_rpc_TableMetadata_ClusteringOrdersEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TableMetadata_ClusteringOrdersEntry_fieldAccessorTable;
+      internal_static_rpc_TableMetadata_ClusteringOrdersEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor;
+    internal_static_rpc_CreateNamespaceRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateNamespaceRequest_fieldAccessorTable;
+      internal_static_rpc_CreateNamespaceRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateNamespaceRequest_OptionsEntry_descriptor;
+    internal_static_rpc_CreateNamespaceRequest_OptionsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateNamespaceRequest_OptionsEntry_fieldAccessorTable;
+      internal_static_rpc_CreateNamespaceRequest_OptionsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_DropNamespaceRequest_descriptor;
+    internal_static_rpc_DropNamespaceRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_DropNamespaceRequest_fieldAccessorTable;
+      internal_static_rpc_DropNamespaceRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateTableRequest_descriptor;
+    internal_static_rpc_CreateTableRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateTableRequest_fieldAccessorTable;
+      internal_static_rpc_CreateTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateTableRequest_OptionsEntry_descriptor;
+    internal_static_rpc_CreateTableRequest_OptionsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateTableRequest_OptionsEntry_fieldAccessorTable;
+      internal_static_rpc_CreateTableRequest_OptionsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_DropTableRequest_descriptor;
+    internal_static_rpc_DropTableRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_DropTableRequest_fieldAccessorTable;
+      internal_static_rpc_DropTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TruncateTableRequest_descriptor;
+    internal_static_rpc_TruncateTableRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TruncateTableRequest_fieldAccessorTable;
+      internal_static_rpc_TruncateTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateIndexRequest_descriptor;
+    internal_static_rpc_CreateIndexRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateIndexRequest_fieldAccessorTable;
+      internal_static_rpc_CreateIndexRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateIndexRequest_OptionsEntry_descriptor;
+    internal_static_rpc_CreateIndexRequest_OptionsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateIndexRequest_OptionsEntry_fieldAccessorTable;
+      internal_static_rpc_CreateIndexRequest_OptionsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_DropIndexRequest_descriptor;
+    internal_static_rpc_DropIndexRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_DropIndexRequest_fieldAccessorTable;
+      internal_static_rpc_DropIndexRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetTableMetadataRequest_descriptor;
+    internal_static_rpc_GetTableMetadataRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetTableMetadataRequest_fieldAccessorTable;
+      internal_static_rpc_GetTableMetadataRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetTableMetadataResponse_descriptor;
+    internal_static_rpc_GetTableMetadataResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetTableMetadataResponse_fieldAccessorTable;
+      internal_static_rpc_GetTableMetadataResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_descriptor;
+    internal_static_rpc_GetNamespaceTableNamesRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable;
+      internal_static_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_descriptor;
+    internal_static_rpc_GetNamespaceTableNamesResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable;
+      internal_static_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_NamespaceExistsRequest_descriptor;
+    internal_static_rpc_NamespaceExistsRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_NamespaceExistsRequest_fieldAccessorTable;
+      internal_static_rpc_NamespaceExistsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_NamespaceExistsResponse_descriptor;
+    internal_static_rpc_NamespaceExistsResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_NamespaceExistsResponse_fieldAccessorTable;
+      internal_static_rpc_NamespaceExistsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_RepairTableRequest_descriptor;
+    internal_static_rpc_RepairTableRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_RepairTableRequest_fieldAccessorTable;
+      internal_static_rpc_RepairTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_RepairTableRequest_OptionsEntry_descriptor;
+    internal_static_rpc_RepairTableRequest_OptionsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_RepairTableRequest_OptionsEntry_fieldAccessorTable;
+      internal_static_rpc_RepairTableRequest_OptionsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_AddNewColumnToTableRequest_descriptor;
+    internal_static_rpc_AddNewColumnToTableRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_AddNewColumnToTableRequest_fieldAccessorTable;
+      internal_static_rpc_AddNewColumnToTableRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_descriptor;
+    internal_static_rpc_TransactionRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_BeginRequest_descriptor;
+    internal_static_rpc_TransactionRequest_BeginRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_BeginRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_BeginRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_StartRequest_descriptor;
+    internal_static_rpc_TransactionRequest_StartRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_StartRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_StartRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_GetRequest_descriptor;
+    internal_static_rpc_TransactionRequest_GetRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_GetRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_GetRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_ScanRequest_descriptor;
+    internal_static_rpc_TransactionRequest_ScanRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_ScanRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_ScanRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_MutateRequest_descriptor;
+    internal_static_rpc_TransactionRequest_MutateRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_MutateRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_MutateRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_CommitRequest_descriptor;
+    internal_static_rpc_TransactionRequest_CommitRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_CommitRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_CommitRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_descriptor;
+    internal_static_rpc_TransactionRequest_RollbackRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionRequest_AbortRequest_descriptor;
+    internal_static_rpc_TransactionRequest_AbortRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionRequest_AbortRequest_fieldAccessorTable;
+      internal_static_rpc_TransactionRequest_AbortRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionResponse_descriptor;
+    internal_static_rpc_TransactionResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionResponse_fieldAccessorTable;
+      internal_static_rpc_TransactionResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionResponse_BeginResponse_descriptor;
+    internal_static_rpc_TransactionResponse_BeginResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionResponse_BeginResponse_fieldAccessorTable;
+      internal_static_rpc_TransactionResponse_BeginResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionResponse_StartResponse_descriptor;
+    internal_static_rpc_TransactionResponse_StartResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionResponse_StartResponse_fieldAccessorTable;
+      internal_static_rpc_TransactionResponse_StartResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionResponse_GetResponse_descriptor;
+    internal_static_rpc_TransactionResponse_GetResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionResponse_GetResponse_fieldAccessorTable;
+      internal_static_rpc_TransactionResponse_GetResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionResponse_ScanResponse_descriptor;
+    internal_static_rpc_TransactionResponse_ScanResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionResponse_ScanResponse_fieldAccessorTable;
+      internal_static_rpc_TransactionResponse_ScanResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TransactionResponse_Error_descriptor;
+    internal_static_rpc_TransactionResponse_Error_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TransactionResponse_Error_fieldAccessorTable;
+      internal_static_rpc_TransactionResponse_Error_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetTransactionStateRequest_descriptor;
+    internal_static_rpc_GetTransactionStateRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetTransactionStateRequest_fieldAccessorTable;
+      internal_static_rpc_GetTransactionStateRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_GetTransactionStateResponse_descriptor;
+    internal_static_rpc_GetTransactionStateResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_GetTransactionStateResponse_fieldAccessorTable;
+      internal_static_rpc_GetTransactionStateResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_RollbackRequest_descriptor;
+    internal_static_rpc_RollbackRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_RollbackRequest_fieldAccessorTable;
+      internal_static_rpc_RollbackRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_RollbackResponse_descriptor;
+    internal_static_rpc_RollbackResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_RollbackResponse_fieldAccessorTable;
+      internal_static_rpc_RollbackResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_AbortRequest_descriptor;
+    internal_static_rpc_AbortRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_AbortRequest_fieldAccessorTable;
+      internal_static_rpc_AbortRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_AbortResponse_descriptor;
+    internal_static_rpc_AbortResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_AbortResponse_fieldAccessorTable;
+      internal_static_rpc_AbortResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable;
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor;
+    internal_static_rpc_CreateCoordinatorTablesRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable;
+      internal_static_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor;
+    internal_static_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable;
+      internal_static_rpc_CreateCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_DropCoordinatorTablesRequest_descriptor;
+    internal_static_rpc_DropCoordinatorTablesRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_DropCoordinatorTablesRequest_fieldAccessorTable;
+      internal_static_rpc_DropCoordinatorTablesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_descriptor;
+    internal_static_rpc_TruncateCoordinatorTablesRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable;
+      internal_static_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CoordinatorTablesExistRequest_descriptor;
+    internal_static_rpc_CoordinatorTablesExistRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CoordinatorTablesExistRequest_fieldAccessorTable;
+      internal_static_rpc_CoordinatorTablesExistRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_CoordinatorTablesExistResponse_descriptor;
+    internal_static_rpc_CoordinatorTablesExistResponse_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_CoordinatorTablesExistResponse_fieldAccessorTable;
+      internal_static_rpc_CoordinatorTablesExistResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor;
+    internal_static_rpc_RepairCoordinatorTablesRequest_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable;
+      internal_static_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor;
+    internal_static_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable;
+      internal_static_rpc_RepairCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -438,837 +438,805 @@ public final class ScalarDbProto {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\016scalardb.proto\022\014scalardb.rpc\032\033google/p" +
-      "rotobuf/empty.proto\"\327\002\n\005Value\022\014\n\004name\030\001 " +
+      "\n\016scalardb.proto\022\003rpc\032\033google/protobuf/e" +
+      "mpty.proto\"\305\002\n\005Value\022\014\n\004name\030\001 \001(\t\022\027\n\rbo" +
+      "olean_value\030\002 \001(\010H\000\022\023\n\tint_value\030\003 \001(\005H\000" +
+      "\022\026\n\014bigint_value\030\004 \001(\003H\000\022\025\n\013float_value\030" +
+      "\005 \001(\002H\000\022\026\n\014double_value\030\006 \001(\001H\000\022*\n\ntext_" +
+      "value\030\007 \001(\0132\024.rpc.Value.TextValueH\000\022*\n\nb" +
+      "lob_value\030\010 \001(\0132\024.rpc.Value.BlobValueH\000\032" +
+      ")\n\tTextValue\022\022\n\005value\030\001 \001(\tH\000\210\001\001B\010\n\006_val" +
+      "ue\032)\n\tBlobValue\022\022\n\005value\030\001 \001(\014H\000\210\001\001B\010\n\006_" +
+      "value:\002\030\001B\007\n\005value\"\300\001\n\006Column\022\014\n\004name\030\001 " +
       "\001(\t\022\027\n\rboolean_value\030\002 \001(\010H\000\022\023\n\tint_valu" +
       "e\030\003 \001(\005H\000\022\026\n\014bigint_value\030\004 \001(\003H\000\022\025\n\013flo" +
       "at_value\030\005 \001(\002H\000\022\026\n\014double_value\030\006 \001(\001H\000" +
-      "\0223\n\ntext_value\030\007 \001(\0132\035.scalardb.rpc.Valu" +
-      "e.TextValueH\000\0223\n\nblob_value\030\010 \001(\0132\035.scal" +
-      "ardb.rpc.Value.BlobValueH\000\032)\n\tTextValue\022" +
-      "\022\n\005value\030\001 \001(\tH\000\210\001\001B\010\n\006_value\032)\n\tBlobVal" +
-      "ue\022\022\n\005value\030\001 \001(\014H\000\210\001\001B\010\n\006_value:\002\030\001B\007\n\005" +
-      "value\"\300\001\n\006Column\022\014\n\004name\030\001 \001(\t\022\027\n\rboolea" +
-      "n_value\030\002 \001(\010H\000\022\023\n\tint_value\030\003 \001(\005H\000\022\026\n\014" +
-      "bigint_value\030\004 \001(\003H\000\022\025\n\013float_value\030\005 \001(" +
-      "\002H\000\022\026\n\014double_value\030\006 \001(\001H\000\022\024\n\ntext_valu" +
-      "e\030\007 \001(\tH\000\022\024\n\nblob_value\030\010 \001(\014H\000B\007\n\005value" +
-      "\"T\n\003Key\022&\n\005value\030\001 \003(\0132\023.scalardb.rpc.Va" +
-      "lueB\002\030\001\022%\n\007columns\030\002 \003(\0132\024.scalardb.rpc." +
-      "Column\"\301\001\n\003Get\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005tab" +
-      "le\030\002 \001(\t\022(\n\rpartition_key\030\003 \001(\0132\021.scalar" +
-      "db.rpc.Key\022)\n\016clustering_key\030\004 \001(\0132\021.sca" +
-      "lardb.rpc.Key\022.\n\013consistency\030\005 \001(\0162\031.sca" +
-      "lardb.rpc.Consistency\022\023\n\013projections\030\006 \003" +
-      "(\t\"<\n\010Ordering\022\014\n\004name\030\001 \001(\t\022\"\n\005order\030\002 " +
-      "\001(\0162\023.scalardb.rpc.Order\"\341\002\n\004Scan\022\021\n\tnam" +
-      "espace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\022(\n\rpartition" +
-      "_key\030\003 \001(\0132\021.scalardb.rpc.Key\022.\n\013consist" +
-      "ency\030\004 \001(\0162\031.scalardb.rpc.Consistency\022\023\n" +
-      "\013projections\030\005 \003(\t\022/\n\024start_clustering_k" +
-      "ey\030\006 \001(\0132\021.scalardb.rpc.Key\022\027\n\017start_inc" +
-      "lusive\030\007 \001(\010\022-\n\022end_clustering_key\030\010 \001(\013" +
-      "2\021.scalardb.rpc.Key\022\025\n\rend_inclusive\030\t \001" +
-      "(\010\022)\n\torderings\030\n \003(\0132\026.scalardb.rpc.Ord" +
-      "ering\022\r\n\005limit\030\013 \001(\005\"\223\002\n\025ConditionalExpr" +
-      "ession\022\020\n\004name\030\001 \001(\tB\002\030\001\022&\n\005value\030\002 \001(\0132" +
-      "\023.scalardb.rpc.ValueB\002\030\001\022>\n\010operator\030\003 \001" +
-      "(\0162,.scalardb.rpc.ConditionalExpression." +
-      "Operator\022$\n\006column\030\004 \001(\0132\024.scalardb.rpc." +
-      "Column\"Z\n\010Operator\022\006\n\002EQ\020\000\022\006\n\002NE\020\001\022\006\n\002GT" +
-      "\020\002\022\007\n\003GTE\020\003\022\006\n\002LT\020\004\022\007\n\003LTE\020\005\022\013\n\007IS_NULL\020" +
-      "\006\022\017\n\013IS_NOT_NULL\020\007\"\340\001\n\017MutateCondition\0220" +
-      "\n\004type\030\001 \001(\0162\".scalardb.rpc.MutateCondit" +
-      "ion.Type\0228\n\013expressions\030\002 \003(\0132#.scalardb" +
-      ".rpc.ConditionalExpression\"a\n\004Type\022\n\n\006PU" +
-      "T_IF\020\000\022\021\n\rPUT_IF_EXISTS\020\001\022\025\n\021PUT_IF_NOT_" +
-      "EXISTS\020\002\022\r\n\tDELETE_IF\020\003\022\024\n\020DELETE_IF_EXI" +
-      "STS\020\004\"\372\002\n\010Mutation\022\021\n\tnamespace\030\001 \001(\t\022\r\n" +
-      "\005table\030\002 \001(\t\022(\n\rpartition_key\030\003 \001(\0132\021.sc" +
-      "alardb.rpc.Key\022)\n\016clustering_key\030\004 \001(\0132\021" +
-      ".scalardb.rpc.Key\022.\n\013consistency\030\005 \001(\0162\031" +
-      ".scalardb.rpc.Consistency\0220\n\tcondition\030\006" +
-      " \001(\0132\035.scalardb.rpc.MutateCondition\022)\n\004t" +
-      "ype\030\007 \001(\0162\033.scalardb.rpc.Mutation.Type\022&" +
-      "\n\005value\030\010 \003(\0132\023.scalardb.rpc.ValueB\002\030\001\022%" +
-      "\n\007columns\030\t \003(\0132\024.scalardb.rpc.Column\"\033\n" +
-      "\004Type\022\007\n\003PUT\020\000\022\n\n\006DELETE\020\001\"W\n\006Result\022&\n\005" +
-      "value\030\001 \003(\0132\023.scalardb.rpc.ValueB\002\030\001\022%\n\007" +
-      "columns\030\002 \003(\0132\024.scalardb.rpc.Column\",\n\nG" +
-      "etRequest\022\036\n\003get\030\001 \001(\0132\021.scalardb.rpc.Ge" +
-      "t\"3\n\013GetResponse\022$\n\006result\030\001 \001(\0132\024.scala" +
-      "rdb.rpc.Result\"Y\n\013ScanRequest\022 \n\004scan\030\001 " +
-      "\001(\0132\022.scalardb.rpc.Scan\022\030\n\013fetch_count\030\002" +
-      " \001(\005H\000\210\001\001B\016\n\014_fetch_count\"O\n\014ScanRespons" +
-      "e\022%\n\007results\030\002 \003(\0132\024.scalardb.rpc.Result" +
-      "\022\030\n\020has_more_results\030\003 \001(\010\":\n\rMutateRequ" +
-      "est\022)\n\tmutations\030\001 \003(\0132\026.scalardb.rpc.Mu" +
-      "tation\"\210\003\n\rTableMetadata\0229\n\007columns\030\001 \003(" +
-      "\0132(.scalardb.rpc.TableMetadata.ColumnsEn" +
-      "try\022\033\n\023partition_key_names\030\002 \003(\t\022\034\n\024clus" +
-      "tering_key_names\030\003 \003(\t\022L\n\021clustering_ord" +
-      "ers\030\004 \003(\01321.scalardb.rpc.TableMetadata.C" +
-      "lusteringOrdersEntry\022\035\n\025secondary_index_" +
-      "names\030\005 \003(\t\032F\n\014ColumnsEntry\022\013\n\003key\030\001 \001(\t" +
-      "\022%\n\005value\030\002 \001(\0162\026.scalardb.rpc.DataType:" +
-      "\0028\001\032L\n\025ClusteringOrdersEntry\022\013\n\003key\030\001 \001(" +
-      "\t\022\"\n\005value\030\002 \001(\0162\023.scalardb.rpc.Order:\0028" +
-      "\001\"\266\001\n\026CreateNamespaceRequest\022\021\n\tnamespac" +
-      "e\030\001 \001(\t\022B\n\007options\030\002 \003(\01321.scalardb.rpc." +
-      "CreateNamespaceRequest.OptionsEntry\022\025\n\ri" +
-      "f_not_exists\030\003 \001(\010\032.\n\014OptionsEntry\022\013\n\003ke" +
-      "y\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"<\n\024DropNamesp" +
-      "aceRequest\022\021\n\tnamespace\030\001 \001(\t\022\021\n\tif_exis" +
-      "ts\030\002 \001(\010\"\362\001\n\022CreateTableRequest\022\021\n\tnames" +
-      "pace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\0223\n\016table_metad" +
-      "ata\030\003 \001(\0132\033.scalardb.rpc.TableMetadata\022>" +
-      "\n\007options\030\004 \003(\0132-.scalardb.rpc.CreateTab" +
+      "\022\024\n\ntext_value\030\007 \001(\tH\000\022\024\n\nblob_value\030\010 \001" +
+      "(\014H\000B\007\n\005value\"B\n\003Key\022\035\n\005value\030\001 \003(\0132\n.rp" +
+      "c.ValueB\002\030\001\022\034\n\007columns\030\002 \003(\0132\013.rpc.Colum" +
+      "n\"\246\001\n\003Get\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 " +
+      "\001(\t\022\037\n\rpartition_key\030\003 \001(\0132\010.rpc.Key\022 \n\016" +
+      "clustering_key\030\004 \001(\0132\010.rpc.Key\022%\n\013consis" +
+      "tency\030\005 \001(\0162\020.rpc.Consistency\022\023\n\013project" +
+      "ions\030\006 \003(\t\"3\n\010Ordering\022\014\n\004name\030\001 \001(\t\022\031\n\005" +
+      "order\030\002 \001(\0162\n.rpc.Order\"\264\002\n\004Scan\022\021\n\tname" +
+      "space\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\022\037\n\rpartition_" +
+      "key\030\003 \001(\0132\010.rpc.Key\022%\n\013consistency\030\004 \001(\016" +
+      "2\020.rpc.Consistency\022\023\n\013projections\030\005 \003(\t\022" +
+      "&\n\024start_clustering_key\030\006 \001(\0132\010.rpc.Key\022" +
+      "\027\n\017start_inclusive\030\007 \001(\010\022$\n\022end_clusteri" +
+      "ng_key\030\010 \001(\0132\010.rpc.Key\022\025\n\rend_inclusive\030" +
+      "\t \001(\010\022 \n\torderings\030\n \003(\0132\r.rpc.Ordering\022" +
+      "\r\n\005limit\030\013 \001(\005\"\370\001\n\025ConditionalExpression" +
+      "\022\020\n\004name\030\001 \001(\tB\002\030\001\022\035\n\005value\030\002 \001(\0132\n.rpc." +
+      "ValueB\002\030\001\0225\n\010operator\030\003 \001(\0162#.rpc.Condit" +
+      "ionalExpression.Operator\022\033\n\006column\030\004 \001(\013" +
+      "2\013.rpc.Column\"Z\n\010Operator\022\006\n\002EQ\020\000\022\006\n\002NE\020" +
+      "\001\022\006\n\002GT\020\002\022\007\n\003GTE\020\003\022\006\n\002LT\020\004\022\007\n\003LTE\020\005\022\013\n\007I" +
+      "S_NULL\020\006\022\017\n\013IS_NOT_NULL\020\007\"\316\001\n\017MutateCond" +
+      "ition\022\'\n\004type\030\001 \001(\0162\031.rpc.MutateConditio" +
+      "n.Type\022/\n\013expressions\030\002 \003(\0132\032.rpc.Condit" +
+      "ionalExpression\"a\n\004Type\022\n\n\006PUT_IF\020\000\022\021\n\rP" +
+      "UT_IF_EXISTS\020\001\022\025\n\021PUT_IF_NOT_EXISTS\020\002\022\r\n" +
+      "\tDELETE_IF\020\003\022\024\n\020DELETE_IF_EXISTS\020\004\"\273\002\n\010M" +
+      "utation\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 \001(" +
+      "\t\022\037\n\rpartition_key\030\003 \001(\0132\010.rpc.Key\022 \n\016cl" +
+      "ustering_key\030\004 \001(\0132\010.rpc.Key\022%\n\013consiste" +
+      "ncy\030\005 \001(\0162\020.rpc.Consistency\022\'\n\tcondition" +
+      "\030\006 \001(\0132\024.rpc.MutateCondition\022 \n\004type\030\007 \001" +
+      "(\0162\022.rpc.Mutation.Type\022\035\n\005value\030\010 \003(\0132\n." +
+      "rpc.ValueB\002\030\001\022\034\n\007columns\030\t \003(\0132\013.rpc.Col" +
+      "umn\"\033\n\004Type\022\007\n\003PUT\020\000\022\n\n\006DELETE\020\001\"E\n\006Resu" +
+      "lt\022\035\n\005value\030\001 \003(\0132\n.rpc.ValueB\002\030\001\022\034\n\007col" +
+      "umns\030\002 \003(\0132\013.rpc.Column\"#\n\nGetRequest\022\025\n" +
+      "\003get\030\001 \001(\0132\010.rpc.Get\"*\n\013GetResponse\022\033\n\006r" +
+      "esult\030\001 \001(\0132\013.rpc.Result\"P\n\013ScanRequest\022" +
+      "\027\n\004scan\030\001 \001(\0132\t.rpc.Scan\022\030\n\013fetch_count\030" +
+      "\002 \001(\005H\000\210\001\001B\016\n\014_fetch_count\"F\n\014ScanRespon" +
+      "se\022\034\n\007results\030\002 \003(\0132\013.rpc.Result\022\030\n\020has_" +
+      "more_results\030\003 \001(\010\"1\n\rMutateRequest\022 \n\tm" +
+      "utations\030\001 \003(\0132\r.rpc.Mutation\"\344\002\n\rTableM" +
+      "etadata\0220\n\007columns\030\001 \003(\0132\037.rpc.TableMeta" +
+      "data.ColumnsEntry\022\033\n\023partition_key_names" +
+      "\030\002 \003(\t\022\034\n\024clustering_key_names\030\003 \003(\t\022C\n\021" +
+      "clustering_orders\030\004 \003(\0132(.rpc.TableMetad" +
+      "ata.ClusteringOrdersEntry\022\035\n\025secondary_i" +
+      "ndex_names\030\005 \003(\t\032=\n\014ColumnsEntry\022\013\n\003key\030" +
+      "\001 \001(\t\022\034\n\005value\030\002 \001(\0162\r.rpc.DataType:\0028\001\032" +
+      "C\n\025ClusteringOrdersEntry\022\013\n\003key\030\001 \001(\t\022\031\n" +
+      "\005value\030\002 \001(\0162\n.rpc.Order:\0028\001\"\255\001\n\026CreateN" +
+      "amespaceRequest\022\021\n\tnamespace\030\001 \001(\t\0229\n\007op" +
+      "tions\030\002 \003(\0132(.rpc.CreateNamespaceRequest" +
+      ".OptionsEntry\022\025\n\rif_not_exists\030\003 \001(\010\032.\n\014" +
+      "OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t" +
+      ":\0028\001\"<\n\024DropNamespaceRequest\022\021\n\tnamespac" +
+      "e\030\001 \001(\t\022\021\n\tif_exists\030\002 \001(\010\"\340\001\n\022CreateTab" +
+      "leRequest\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 " +
+      "\001(\t\022*\n\016table_metadata\030\003 \001(\0132\022.rpc.TableM" +
+      "etadata\0225\n\007options\030\004 \003(\0132$.rpc.CreateTab" +
       "leRequest.OptionsEntry\022\025\n\rif_not_exists\030" +
       "\005 \001(\010\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va" +
       "lue\030\002 \001(\t:\0028\001\"G\n\020DropTableRequest\022\021\n\tnam" +
       "espace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\022\021\n\tif_exists" +
       "\030\003 \001(\010\"8\n\024TruncateTableRequest\022\021\n\tnamesp" +
-      "ace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\"\322\001\n\022CreateIndex" +
+      "ace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\"\311\001\n\022CreateIndex" +
       "Request\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 \001(" +
-      "\t\022\023\n\013column_name\030\003 \001(\t\022>\n\007options\030\004 \003(\0132" +
-      "-.scalardb.rpc.CreateIndexRequest.Option" +
-      "sEntry\022\025\n\rif_not_exists\030\005 \001(\010\032.\n\014Options" +
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\\\n" +
-      "\020DropIndexRequest\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005" +
-      "table\030\002 \001(\t\022\023\n\013column_name\030\003 \001(\t\022\021\n\tif_e" +
-      "xists\030\004 \001(\010\";\n\027GetTableMetadataRequest\022\021" +
-      "\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\"O\n\030GetT" +
-      "ableMetadataResponse\0223\n\016table_metadata\030\001" +
-      " \001(\0132\033.scalardb.rpc.TableMetadata\"2\n\035Get" +
-      "NamespaceTableNamesRequest\022\021\n\tnamespace\030" +
-      "\001 \001(\t\"5\n\036GetNamespaceTableNamesResponse\022" +
-      "\023\n\013table_names\030\001 \003(\t\"+\n\026NamespaceExistsR" +
-      "equest\022\021\n\tnamespace\030\001 \001(\t\")\n\027NamespaceEx" +
-      "istsResponse\022\016\n\006exists\030\001 \001(\010\"\333\001\n\022RepairT" +
-      "ableRequest\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030" +
-      "\002 \001(\t\0223\n\016table_metadata\030\003 \001(\0132\033.scalardb" +
-      ".rpc.TableMetadata\022>\n\007options\030\004 \003(\0132-.sc" +
-      "alardb.rpc.RepairTableRequest.OptionsEnt" +
-      "ry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value" +
-      "\030\002 \001(\t:\0028\001\"\200\001\n\032AddNewColumnToTableReques" +
-      "t\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\022\023\n\013c" +
-      "olumn_name\030\003 \001(\t\022+\n\013column_type\030\004 \001(\0162\026." +
-      "scalardb.rpc.DataType\"\262\007\n\022TransactionReq" +
-      "uest\022F\n\rstart_request\030\001 \001(\0132-.scalardb.r" +
-      "pc.TransactionRequest.StartRequestH\000\022B\n\013" +
-      "get_request\030\002 \001(\0132+.scalardb.rpc.Transac" +
-      "tionRequest.GetRequestH\000\022D\n\014scan_request" +
-      "\030\003 \001(\0132,.scalardb.rpc.TransactionRequest" +
-      ".ScanRequestH\000\022H\n\016mutate_request\030\004 \001(\0132." +
-      ".scalardb.rpc.TransactionRequest.MutateR" +
-      "equestH\000\022H\n\016commit_request\030\005 \001(\0132..scala" +
-      "rdb.rpc.TransactionRequest.CommitRequest" +
-      "H\000\022F\n\rabort_request\030\006 \001(\0132-.scalardb.rpc" +
-      ".TransactionRequest.AbortRequestH\000\022F\n\rbe" +
-      "gin_request\030\007 \001(\0132-.scalardb.rpc.Transac" +
-      "tionRequest.BeginRequestH\000\022L\n\020rollback_r" +
-      "equest\030\010 \001(\01320.scalardb.rpc.TransactionR" +
-      "equest.RollbackRequestH\000\032>\n\014BeginRequest" +
-      "\022\033\n\016transaction_id\030\001 \001(\tH\000\210\001\001B\021\n\017_transa" +
-      "ction_id\032>\n\014StartRequest\022\033\n\016transaction_" +
-      "id\030\001 \001(\tH\000\210\001\001B\021\n\017_transaction_id\032,\n\nGetR" +
-      "equest\022\036\n\003get\030\002 \001(\0132\021.scalardb.rpc.Get\032/" +
-      "\n\013ScanRequest\022 \n\004scan\030\002 \001(\0132\022.scalardb.r" +
-      "pc.Scan\032:\n\rMutateRequest\022)\n\tmutations\030\002 " +
-      "\003(\0132\026.scalardb.rpc.Mutation\032\017\n\rCommitReq" +
-      "uest\032\021\n\017RollbackRequest\032\016\n\014AbortRequestB" +
-      "\t\n\007request\"\211\006\n\023TransactionResponse\022I\n\016st" +
-      "art_response\030\001 \001(\0132/.scalardb.rpc.Transa" +
-      "ctionResponse.StartResponseH\000\022E\n\014get_res" +
-      "ponse\030\002 \001(\0132-.scalardb.rpc.TransactionRe" +
-      "sponse.GetResponseH\000\022G\n\rscan_response\030\003 " +
-      "\001(\0132..scalardb.rpc.TransactionResponse.S" +
-      "canResponseH\000\0228\n\005error\030\004 \001(\0132\'.scalardb." +
-      "rpc.TransactionResponse.ErrorH\000\022I\n\016begin" +
-      "_response\030\005 \001(\0132/.scalardb.rpc.Transacti" +
-      "onResponse.BeginResponseH\000\032\'\n\rBeginRespo" +
-      "nse\022\026\n\016transaction_id\030\001 \001(\t\032\'\n\rStartResp" +
-      "onse\022\026\n\016transaction_id\030\001 \001(\t\0323\n\013GetRespo" +
-      "nse\022$\n\006result\030\001 \001(\0132\024.scalardb.rpc.Resul" +
-      "t\0325\n\014ScanResponse\022%\n\007results\030\001 \003(\0132\024.sca" +
-      "lardb.rpc.Result\032\307\001\n\005Error\022E\n\nerror_code" +
-      "\030\001 \001(\01621.scalardb.rpc.TransactionRespons" +
-      "e.Error.ErrorCode\022\017\n\007message\030\002 \001(\t\"f\n\tEr" +
-      "rorCode\022\024\n\020INVALID_ARGUMENT\020\000\022\030\n\024TRANSAC" +
-      "TION_CONFLICT\020\001\022\036\n\032UNKNOWN_TRANSACTION_S" +
-      "TATUS\020\002\022\t\n\005OTHER\020\003B\n\n\010response\"4\n\032GetTra" +
-      "nsactionStateRequest\022\026\n\016transaction_id\030\001" +
-      " \001(\t\"L\n\033GetTransactionStateResponse\022-\n\005s" +
-      "tate\030\001 \001(\0162\036.scalardb.rpc.TransactionSta" +
-      "te\")\n\017RollbackRequest\022\026\n\016transaction_id\030" +
-      "\001 \001(\t\"A\n\020RollbackResponse\022-\n\005state\030\001 \001(\016" +
-      "2\036.scalardb.rpc.TransactionState\"&\n\014Abor" +
-      "tRequest\022\026\n\016transaction_id\030\001 \001(\t\">\n\rAbor" +
-      "tResponse\022-\n\005state\030\001 \001(\0162\036.scalardb.rpc." +
-      "TransactionState\"\212\t\n TwoPhaseCommitTrans" +
-      "actionRequest\022T\n\rstart_request\030\001 \001(\0132;.s" +
-      "calardb.rpc.TwoPhaseCommitTransactionReq" +
-      "uest.StartRequestH\000\022R\n\014join_request\030\002 \001(" +
-      "\0132:.scalardb.rpc.TwoPhaseCommitTransacti" +
-      "onRequest.JoinRequestH\000\022P\n\013get_request\030\003" +
-      " \001(\01329.scalardb.rpc.TwoPhaseCommitTransa" +
-      "ctionRequest.GetRequestH\000\022R\n\014scan_reques" +
-      "t\030\004 \001(\0132:.scalardb.rpc.TwoPhaseCommitTra" +
-      "nsactionRequest.ScanRequestH\000\022V\n\016mutate_" +
-      "request\030\005 \001(\0132<.scalardb.rpc.TwoPhaseCom" +
-      "mitTransactionRequest.MutateRequestH\000\022X\n" +
-      "\017prepare_request\030\006 \001(\0132=.scalardb.rpc.Tw" +
-      "oPhaseCommitTransactionRequest.PrepareRe" +
-      "questH\000\022Z\n\020validate_request\030\007 \001(\0132>.scal" +
-      "ardb.rpc.TwoPhaseCommitTransactionReques" +
-      "t.ValidateRequestH\000\022V\n\016commit_request\030\010 " +
-      "\001(\0132<.scalardb.rpc.TwoPhaseCommitTransac" +
-      "tionRequest.CommitRequestH\000\022Z\n\020rollback_" +
-      "request\030\t \001(\0132>.scalardb.rpc.TwoPhaseCom" +
-      "mitTransactionRequest.RollbackRequestH\000\032" +
-      ">\n\014StartRequest\022\033\n\016transaction_id\030\001 \001(\tH" +
-      "\000\210\001\001B\021\n\017_transaction_id\032%\n\013JoinRequest\022\026" +
-      "\n\016transaction_id\030\001 \001(\t\032,\n\nGetRequest\022\036\n\003" +
-      "get\030\002 \001(\0132\021.scalardb.rpc.Get\032/\n\013ScanRequ" +
-      "est\022 \n\004scan\030\002 \001(\0132\022.scalardb.rpc.Scan\032:\n" +
-      "\rMutateRequest\022)\n\tmutations\030\002 \003(\0132\026.scal" +
-      "ardb.rpc.Mutation\032\020\n\016PrepareRequest\032\021\n\017V" +
-      "alidateRequest\032\017\n\rCommitRequest\032\021\n\017Rollb" +
-      "ackRequestB\t\n\007request\"\351\005\n!TwoPhaseCommit" +
-      "TransactionResponse\022W\n\016start_response\030\001 " +
-      "\001(\0132=.scalardb.rpc.TwoPhaseCommitTransac" +
-      "tionResponse.StartResponseH\000\022S\n\014get_resp" +
-      "onse\030\002 \001(\0132;.scalardb.rpc.TwoPhaseCommit" +
-      "TransactionResponse.GetResponseH\000\022U\n\rsca" +
-      "n_response\030\003 \001(\0132<.scalardb.rpc.TwoPhase" +
-      "CommitTransactionResponse.ScanResponseH\000" +
-      "\022F\n\005error\030\004 \001(\01325.scalardb.rpc.TwoPhaseC" +
-      "ommitTransactionResponse.ErrorH\000\032\'\n\rStar" +
-      "tResponse\022\026\n\016transaction_id\030\001 \001(\t\0323\n\013Get" +
-      "Response\022$\n\006result\030\001 \001(\0132\024.scalardb.rpc." +
-      "Result\0325\n\014ScanResponse\022%\n\007results\030\001 \003(\0132" +
-      "\024.scalardb.rpc.Result\032\325\001\n\005Error\022S\n\nerror" +
-      "_code\030\001 \001(\0162?.scalardb.rpc.TwoPhaseCommi" +
-      "tTransactionResponse.Error.ErrorCode\022\017\n\007" +
-      "message\030\002 \001(\t\"f\n\tErrorCode\022\024\n\020INVALID_AR" +
-      "GUMENT\020\000\022\030\n\024TRANSACTION_CONFLICT\020\001\022\036\n\032UN" +
-      "KNOWN_TRANSACTION_STATUS\020\002\022\t\n\005OTHER\020\003B\n\n" +
-      "\010response\"\262\001\n\036CreateCoordinatorTablesReq" +
-      "uest\022J\n\007options\030\001 \003(\01329.scalardb.rpc.Cre" +
-      "ateCoordinatorTablesRequest.OptionsEntry" +
-      "\022\024\n\014if_not_exist\030\002 \001(\010\032.\n\014OptionsEntry\022\013" +
-      "\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"0\n\034DropCo" +
-      "ordinatorTablesRequest\022\020\n\010if_exist\030\001 \001(\010" +
-      "\"\"\n TruncateCoordinatorTablesRequest\"\037\n\035" +
-      "CoordinatorTablesExistRequest\"/\n\036Coordin" +
-      "atorTablesExistResponse\022\r\n\005exist\030\001 \001(\010\"\234" +
-      "\001\n\036RepairCoordinatorTablesRequest\022J\n\007opt" +
-      "ions\030\001 \003(\01329.scalardb.rpc.RepairCoordina" +
-      "torTablesRequest.OptionsEntry\032.\n\014Options" +
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001*a\n" +
-      "\013Consistency\022\032\n\026CONSISTENCY_SEQUENTIAL\020\000" +
-      "\022\030\n\024CONSISTENCY_EVENTUAL\020\001\022\034\n\030CONSISTENC" +
-      "Y_LINEARIZABLE\020\002*&\n\005Order\022\r\n\tORDER_ASC\020\000" +
-      "\022\016\n\nORDER_DESC\020\001*\235\001\n\010DataType\022\025\n\021DATA_TY" +
-      "PE_BOOLEAN\020\000\022\021\n\rDATA_TYPE_INT\020\001\022\024\n\020DATA_" +
-      "TYPE_BIGINT\020\002\022\023\n\017DATA_TYPE_FLOAT\020\003\022\024\n\020DA" +
-      "TA_TYPE_DOUBLE\020\004\022\022\n\016DATA_TYPE_TEXT\020\005\022\022\n\016" +
-      "DATA_TYPE_BLOB\020\006*q\n\020TransactionState\022\037\n\033" +
-      "TRANSACTION_STATE_COMMITTED\020\000\022\035\n\031TRANSAC" +
-      "TION_STATE_ABORTED\020\001\022\035\n\031TRANSACTION_STAT" +
-      "E_UNKNOWN\020\0022\330\001\n\022DistributedStorage\022<\n\003Ge" +
-      "t\022\030.scalardb.rpc.GetRequest\032\031.scalardb.r" +
-      "pc.GetResponse\"\000\022C\n\004Scan\022\031.scalardb.rpc." +
-      "ScanRequest\032\032.scalardb.rpc.ScanResponse\"" +
-      "\000(\0010\001\022?\n\006Mutate\022\033.scalardb.rpc.MutateReq" +
-      "uest\032\026.google.protobuf.Empty\"\0002\222\010\n\027Distr" +
-      "ibutedStorageAdmin\022Q\n\017CreateNamespace\022$." +
-      "scalardb.rpc.CreateNamespaceRequest\032\026.go" +
-      "ogle.protobuf.Empty\"\000\022M\n\rDropNamespace\022\"" +
-      ".scalardb.rpc.DropNamespaceRequest\032\026.goo" +
-      "gle.protobuf.Empty\"\000\022I\n\013CreateTable\022 .sc" +
-      "alardb.rpc.CreateTableRequest\032\026.google.p" +
-      "rotobuf.Empty\"\000\022E\n\tDropTable\022\036.scalardb." +
-      "rpc.DropTableRequest\032\026.google.protobuf.E" +
-      "mpty\"\000\022M\n\rTruncateTable\022\".scalardb.rpc.T" +
-      "runcateTableRequest\032\026.google.protobuf.Em" +
-      "pty\"\000\022I\n\013CreateIndex\022 .scalardb.rpc.Crea" +
-      "teIndexRequest\032\026.google.protobuf.Empty\"\000" +
-      "\022E\n\tDropIndex\022\036.scalardb.rpc.DropIndexRe" +
-      "quest\032\026.google.protobuf.Empty\"\000\022c\n\020GetTa" +
-      "bleMetadata\022%.scalardb.rpc.GetTableMetad" +
-      "ataRequest\032&.scalardb.rpc.GetTableMetada" +
-      "taResponse\"\000\022u\n\026GetNamespaceTableNames\022+" +
-      ".scalardb.rpc.GetNamespaceTableNamesRequ" +
-      "est\032,.scalardb.rpc.GetNamespaceTableName" +
-      "sResponse\"\000\022`\n\017NamespaceExists\022$.scalard" +
-      "b.rpc.NamespaceExistsRequest\032%.scalardb." +
-      "rpc.NamespaceExistsResponse\"\000\022I\n\013RepairT" +
-      "able\022 .scalardb.rpc.RepairTableRequest\032\026" +
-      ".google.protobuf.Empty\"\000\022Y\n\023AddNewColumn" +
-      "ToTable\022(.scalardb.rpc.AddNewColumnToTab" +
-      "leRequest\032\026.google.protobuf.Empty\"\0002\346\002\n\026" +
-      "DistributedTransaction\022X\n\013Transaction\022 ." +
-      "scalardb.rpc.TransactionRequest\032!.scalar" +
-      "db.rpc.TransactionResponse\"\000(\0010\001\022a\n\010GetS" +
-      "tate\022(.scalardb.rpc.GetTransactionStateR" +
-      "equest\032).scalardb.rpc.GetTransactionStat" +
-      "eResponse\"\000\022K\n\010Rollback\022\035.scalardb.rpc.R" +
-      "ollbackRequest\032\036.scalardb.rpc.RollbackRe" +
-      "sponse\"\000\022B\n\005Abort\022\032.scalardb.rpc.AbortRe" +
-      "quest\032\033.scalardb.rpc.AbortResponse\"\0002\307\002\n" +
-      "\031TwoPhaseCommitTransaction\022\202\001\n\031TwoPhaseC" +
-      "ommitTransaction\022..scalardb.rpc.TwoPhase" +
-      "CommitTransactionRequest\032/.scalardb.rpc." +
-      "TwoPhaseCommitTransactionResponse\"\000(\0010\001\022" +
-      "a\n\010GetState\022(.scalardb.rpc.GetTransactio" +
-      "nStateRequest\032).scalardb.rpc.GetTransact" +
-      "ionStateResponse\"\000\022B\n\005Abort\022\032.scalardb.r" +
-      "pc.AbortRequest\032\033.scalardb.rpc.AbortResp" +
-      "onse\"\0002\231\014\n\033DistributedTransactionAdmin\022Q" +
-      "\n\017CreateNamespace\022$.scalardb.rpc.CreateN" +
-      "amespaceRequest\032\026.google.protobuf.Empty\"" +
-      "\000\022M\n\rDropNamespace\022\".scalardb.rpc.DropNa" +
-      "mespaceRequest\032\026.google.protobuf.Empty\"\000" +
-      "\022I\n\013CreateTable\022 .scalardb.rpc.CreateTab" +
-      "leRequest\032\026.google.protobuf.Empty\"\000\022E\n\tD" +
-      "ropTable\022\036.scalardb.rpc.DropTableRequest" +
-      "\032\026.google.protobuf.Empty\"\000\022M\n\rTruncateTa" +
-      "ble\022\".scalardb.rpc.TruncateTableRequest\032" +
-      "\026.google.protobuf.Empty\"\000\022I\n\013CreateIndex" +
-      "\022 .scalardb.rpc.CreateIndexRequest\032\026.goo" +
-      "gle.protobuf.Empty\"\000\022E\n\tDropIndex\022\036.scal" +
-      "ardb.rpc.DropIndexRequest\032\026.google.proto" +
-      "buf.Empty\"\000\022c\n\020GetTableMetadata\022%.scalar" +
-      "db.rpc.GetTableMetadataRequest\032&.scalard" +
-      "b.rpc.GetTableMetadataResponse\"\000\022u\n\026GetN" +
-      "amespaceTableNames\022+.scalardb.rpc.GetNam" +
-      "espaceTableNamesRequest\032,.scalardb.rpc.G" +
-      "etNamespaceTableNamesResponse\"\000\022`\n\017Names" +
-      "paceExists\022$.scalardb.rpc.NamespaceExist" +
-      "sRequest\032%.scalardb.rpc.NamespaceExistsR" +
-      "esponse\"\000\022a\n\027CreateCoordinatorTables\022,.s" +
-      "calardb.rpc.CreateCoordinatorTablesReque" +
-      "st\032\026.google.protobuf.Empty\"\000\022]\n\025DropCoor" +
-      "dinatorTables\022*.scalardb.rpc.DropCoordin" +
-      "atorTablesRequest\032\026.google.protobuf.Empt" +
-      "y\"\000\022e\n\031TruncateCoordinatorTables\022..scala" +
-      "rdb.rpc.TruncateCoordinatorTablesRequest" +
-      "\032\026.google.protobuf.Empty\"\000\022u\n\026Coordinato" +
-      "rTablesExist\022+.scalardb.rpc.CoordinatorT" +
-      "ablesExistRequest\032,.scalardb.rpc.Coordin" +
-      "atorTablesExistResponse\"\000\022I\n\013RepairTable" +
-      "\022 .scalardb.rpc.RepairTableRequest\032\026.goo" +
-      "gle.protobuf.Empty\"\000\022a\n\027RepairCoordinato" +
-      "rTables\022,.scalardb.rpc.RepairCoordinator" +
+      "\t\022\023\n\013column_name\030\003 \001(\t\0225\n\007options\030\004 \003(\0132" +
+      "$.rpc.CreateIndexRequest.OptionsEntry\022\025\n" +
+      "\rif_not_exists\030\005 \001(\010\032.\n\014OptionsEntry\022\013\n\003" +
+      "key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\\\n\020DropInde" +
+      "xRequest\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 \001" +
+      "(\t\022\023\n\013column_name\030\003 \001(\t\022\021\n\tif_exists\030\004 \001" +
+      "(\010\";\n\027GetTableMetadataRequest\022\021\n\tnamespa" +
+      "ce\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\"F\n\030GetTableMetad" +
+      "ataResponse\022*\n\016table_metadata\030\001 \001(\0132\022.rp" +
+      "c.TableMetadata\"2\n\035GetNamespaceTableName" +
+      "sRequest\022\021\n\tnamespace\030\001 \001(\t\"5\n\036GetNamesp" +
+      "aceTableNamesResponse\022\023\n\013table_names\030\001 \003" +
+      "(\t\"+\n\026NamespaceExistsRequest\022\021\n\tnamespac" +
+      "e\030\001 \001(\t\")\n\027NamespaceExistsResponse\022\016\n\006ex" +
+      "ists\030\001 \001(\010\"\311\001\n\022RepairTableRequest\022\021\n\tnam" +
+      "espace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\022*\n\016table_met" +
+      "adata\030\003 \001(\0132\022.rpc.TableMetadata\0225\n\007optio" +
+      "ns\030\004 \003(\0132$.rpc.RepairTableRequest.Option" +
+      "sEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v" +
+      "alue\030\002 \001(\t:\0028\001\"w\n\032AddNewColumnToTableReq" +
+      "uest\022\021\n\tnamespace\030\001 \001(\t\022\r\n\005table\030\002 \001(\t\022\023" +
+      "\n\013column_name\030\003 \001(\t\022\"\n\013column_type\030\004 \001(\016" +
+      "2\r.rpc.DataType\"\317\006\n\022TransactionRequest\022=" +
+      "\n\rstart_request\030\001 \001(\0132$.rpc.TransactionR" +
+      "equest.StartRequestH\000\0229\n\013get_request\030\002 \001" +
+      "(\0132\".rpc.TransactionRequest.GetRequestH\000" +
+      "\022;\n\014scan_request\030\003 \001(\0132#.rpc.Transaction" +
+      "Request.ScanRequestH\000\022?\n\016mutate_request\030" +
+      "\004 \001(\0132%.rpc.TransactionRequest.MutateReq" +
+      "uestH\000\022?\n\016commit_request\030\005 \001(\0132%.rpc.Tra" +
+      "nsactionRequest.CommitRequestH\000\022=\n\rabort" +
+      "_request\030\006 \001(\0132$.rpc.TransactionRequest." +
+      "AbortRequestH\000\022=\n\rbegin_request\030\007 \001(\0132$." +
+      "rpc.TransactionRequest.BeginRequestH\000\022C\n" +
+      "\020rollback_request\030\010 \001(\0132\'.rpc.Transactio" +
+      "nRequest.RollbackRequestH\000\032>\n\014BeginReque" +
+      "st\022\033\n\016transaction_id\030\001 \001(\tH\000\210\001\001B\021\n\017_tran" +
+      "saction_id\032>\n\014StartRequest\022\033\n\016transactio" +
+      "n_id\030\001 \001(\tH\000\210\001\001B\021\n\017_transaction_id\032#\n\nGe" +
+      "tRequest\022\025\n\003get\030\002 \001(\0132\010.rpc.Get\032&\n\013ScanR" +
+      "equest\022\027\n\004scan\030\002 \001(\0132\t.rpc.Scan\0321\n\rMutat" +
+      "eRequest\022 \n\tmutations\030\002 \003(\0132\r.rpc.Mutati" +
+      "on\032\017\n\rCommitRequest\032\021\n\017RollbackRequest\032\016" +
+      "\n\014AbortRequestB\t\n\007request\"\301\005\n\023Transactio" +
+      "nResponse\022@\n\016start_response\030\001 \001(\0132&.rpc." +
+      "TransactionResponse.StartResponseH\000\022<\n\014g" +
+      "et_response\030\002 \001(\0132$.rpc.TransactionRespo" +
+      "nse.GetResponseH\000\022>\n\rscan_response\030\003 \001(\013" +
+      "2%.rpc.TransactionResponse.ScanResponseH" +
+      "\000\022/\n\005error\030\004 \001(\0132\036.rpc.TransactionRespon" +
+      "se.ErrorH\000\022@\n\016begin_response\030\005 \001(\0132&.rpc" +
+      ".TransactionResponse.BeginResponseH\000\032\'\n\r" +
+      "BeginResponse\022\026\n\016transaction_id\030\001 \001(\t\032\'\n" +
+      "\rStartResponse\022\026\n\016transaction_id\030\001 \001(\t\032*" +
+      "\n\013GetResponse\022\033\n\006result\030\001 \001(\0132\013.rpc.Resu" +
+      "lt\032,\n\014ScanResponse\022\034\n\007results\030\001 \003(\0132\013.rp" +
+      "c.Result\032\276\001\n\005Error\022<\n\nerror_code\030\001 \001(\0162(" +
+      ".rpc.TransactionResponse.Error.ErrorCode" +
+      "\022\017\n\007message\030\002 \001(\t\"f\n\tErrorCode\022\024\n\020INVALI" +
+      "D_ARGUMENT\020\000\022\030\n\024TRANSACTION_CONFLICT\020\001\022\036" +
+      "\n\032UNKNOWN_TRANSACTION_STATUS\020\002\022\t\n\005OTHER\020" +
+      "\003B\n\n\010response\"4\n\032GetTransactionStateRequ" +
+      "est\022\026\n\016transaction_id\030\001 \001(\t\"C\n\033GetTransa" +
+      "ctionStateResponse\022$\n\005state\030\001 \001(\0162\025.rpc." +
+      "TransactionState\")\n\017RollbackRequest\022\026\n\016t" +
+      "ransaction_id\030\001 \001(\t\"8\n\020RollbackResponse\022" +
+      "$\n\005state\030\001 \001(\0162\025.rpc.TransactionState\"&\n" +
+      "\014AbortRequest\022\026\n\016transaction_id\030\001 \001(\t\"5\n" +
+      "\rAbortResponse\022$\n\005state\030\001 \001(\0162\025.rpc.Tran" +
+      "sactionState\"\236\010\n TwoPhaseCommitTransacti" +
+      "onRequest\022K\n\rstart_request\030\001 \001(\01322.rpc.T" +
+      "woPhaseCommitTransactionRequest.StartReq" +
+      "uestH\000\022I\n\014join_request\030\002 \001(\01321.rpc.TwoPh" +
+      "aseCommitTransactionRequest.JoinRequestH" +
+      "\000\022G\n\013get_request\030\003 \001(\01320.rpc.TwoPhaseCom" +
+      "mitTransactionRequest.GetRequestH\000\022I\n\014sc" +
+      "an_request\030\004 \001(\01321.rpc.TwoPhaseCommitTra" +
+      "nsactionRequest.ScanRequestH\000\022M\n\016mutate_" +
+      "request\030\005 \001(\01323.rpc.TwoPhaseCommitTransa" +
+      "ctionRequest.MutateRequestH\000\022O\n\017prepare_" +
+      "request\030\006 \001(\01324.rpc.TwoPhaseCommitTransa" +
+      "ctionRequest.PrepareRequestH\000\022Q\n\020validat" +
+      "e_request\030\007 \001(\01325.rpc.TwoPhaseCommitTran" +
+      "sactionRequest.ValidateRequestH\000\022M\n\016comm" +
+      "it_request\030\010 \001(\01323.rpc.TwoPhaseCommitTra" +
+      "nsactionRequest.CommitRequestH\000\022Q\n\020rollb" +
+      "ack_request\030\t \001(\01325.rpc.TwoPhaseCommitTr" +
+      "ansactionRequest.RollbackRequestH\000\032>\n\014St" +
+      "artRequest\022\033\n\016transaction_id\030\001 \001(\tH\000\210\001\001B" +
+      "\021\n\017_transaction_id\032%\n\013JoinRequest\022\026\n\016tra" +
+      "nsaction_id\030\001 \001(\t\032#\n\nGetRequest\022\025\n\003get\030\002" +
+      " \001(\0132\010.rpc.Get\032&\n\013ScanRequest\022\027\n\004scan\030\002 " +
+      "\001(\0132\t.rpc.Scan\0321\n\rMutateRequest\022 \n\tmutat" +
+      "ions\030\002 \003(\0132\r.rpc.Mutation\032\020\n\016PrepareRequ" +
+      "est\032\021\n\017ValidateRequest\032\017\n\rCommitRequest\032" +
+      "\021\n\017RollbackRequestB\t\n\007request\"\252\005\n!TwoPha" +
+      "seCommitTransactionResponse\022N\n\016start_res" +
+      "ponse\030\001 \001(\01324.rpc.TwoPhaseCommitTransact" +
+      "ionResponse.StartResponseH\000\022J\n\014get_respo" +
+      "nse\030\002 \001(\01322.rpc.TwoPhaseCommitTransactio" +
+      "nResponse.GetResponseH\000\022L\n\rscan_response" +
+      "\030\003 \001(\01323.rpc.TwoPhaseCommitTransactionRe" +
+      "sponse.ScanResponseH\000\022=\n\005error\030\004 \001(\0132,.r" +
+      "pc.TwoPhaseCommitTransactionResponse.Err" +
+      "orH\000\032\'\n\rStartResponse\022\026\n\016transaction_id\030" +
+      "\001 \001(\t\032*\n\013GetResponse\022\033\n\006result\030\001 \001(\0132\013.r" +
+      "pc.Result\032,\n\014ScanResponse\022\034\n\007results\030\001 \003" +
+      "(\0132\013.rpc.Result\032\314\001\n\005Error\022J\n\nerror_code\030" +
+      "\001 \001(\01626.rpc.TwoPhaseCommitTransactionRes" +
+      "ponse.Error.ErrorCode\022\017\n\007message\030\002 \001(\t\"f" +
+      "\n\tErrorCode\022\024\n\020INVALID_ARGUMENT\020\000\022\030\n\024TRA" +
+      "NSACTION_CONFLICT\020\001\022\036\n\032UNKNOWN_TRANSACTI" +
+      "ON_STATUS\020\002\022\t\n\005OTHER\020\003B\n\n\010response\"\251\001\n\036C" +
+      "reateCoordinatorTablesRequest\022A\n\007options" +
+      "\030\001 \003(\01320.rpc.CreateCoordinatorTablesRequ" +
+      "est.OptionsEntry\022\024\n\014if_not_exist\030\002 \001(\010\032." +
+      "\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001" +
+      "(\t:\0028\001\"0\n\034DropCoordinatorTablesRequest\022\020" +
+      "\n\010if_exist\030\001 \001(\010\"\"\n TruncateCoordinatorT" +
+      "ablesRequest\"\037\n\035CoordinatorTablesExistRe" +
+      "quest\"/\n\036CoordinatorTablesExistResponse\022" +
+      "\r\n\005exist\030\001 \001(\010\"\223\001\n\036RepairCoordinatorTabl" +
+      "esRequest\022A\n\007options\030\001 \003(\01320.rpc.RepairC" +
+      "oordinatorTablesRequest.OptionsEntry\032.\n\014" +
+      "OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t" +
+      ":\0028\001*a\n\013Consistency\022\032\n\026CONSISTENCY_SEQUE" +
+      "NTIAL\020\000\022\030\n\024CONSISTENCY_EVENTUAL\020\001\022\034\n\030CON" +
+      "SISTENCY_LINEARIZABLE\020\002*&\n\005Order\022\r\n\tORDE" +
+      "R_ASC\020\000\022\016\n\nORDER_DESC\020\001*\235\001\n\010DataType\022\025\n\021" +
+      "DATA_TYPE_BOOLEAN\020\000\022\021\n\rDATA_TYPE_INT\020\001\022\024" +
+      "\n\020DATA_TYPE_BIGINT\020\002\022\023\n\017DATA_TYPE_FLOAT\020" +
+      "\003\022\024\n\020DATA_TYPE_DOUBLE\020\004\022\022\n\016DATA_TYPE_TEX" +
+      "T\020\005\022\022\n\016DATA_TYPE_BLOB\020\006*q\n\020TransactionSt" +
+      "ate\022\037\n\033TRANSACTION_STATE_COMMITTED\020\000\022\035\n\031" +
+      "TRANSACTION_STATE_ABORTED\020\001\022\035\n\031TRANSACTI" +
+      "ON_STATE_UNKNOWN\020\0022\253\001\n\022DistributedStorag" +
+      "e\022*\n\003Get\022\017.rpc.GetRequest\032\020.rpc.GetRespo" +
+      "nse\"\000\0221\n\004Scan\022\020.rpc.ScanRequest\032\021.rpc.Sc" +
+      "anResponse\"\000(\0010\001\0226\n\006Mutate\022\022.rpc.MutateR" +
+      "equest\032\026.google.protobuf.Empty\"\0002\213\007\n\027Dis" +
+      "tributedStorageAdmin\022H\n\017CreateNamespace\022" +
+      "\033.rpc.CreateNamespaceRequest\032\026.google.pr" +
+      "otobuf.Empty\"\000\022D\n\rDropNamespace\022\031.rpc.Dr" +
+      "opNamespaceRequest\032\026.google.protobuf.Emp" +
+      "ty\"\000\022@\n\013CreateTable\022\027.rpc.CreateTableReq" +
+      "uest\032\026.google.protobuf.Empty\"\000\022<\n\tDropTa" +
+      "ble\022\025.rpc.DropTableRequest\032\026.google.prot" +
+      "obuf.Empty\"\000\022D\n\rTruncateTable\022\031.rpc.Trun" +
+      "cateTableRequest\032\026.google.protobuf.Empty" +
+      "\"\000\022@\n\013CreateIndex\022\027.rpc.CreateIndexReque" +
+      "st\032\026.google.protobuf.Empty\"\000\022<\n\tDropInde" +
+      "x\022\025.rpc.DropIndexRequest\032\026.google.protob" +
+      "uf.Empty\"\000\022Q\n\020GetTableMetadata\022\034.rpc.Get" +
+      "TableMetadataRequest\032\035.rpc.GetTableMetad" +
+      "ataResponse\"\000\022c\n\026GetNamespaceTableNames\022" +
+      "\".rpc.GetNamespaceTableNamesRequest\032#.rp" +
+      "c.GetNamespaceTableNamesResponse\"\000\022N\n\017Na" +
+      "mespaceExists\022\033.rpc.NamespaceExistsReque" +
+      "st\032\034.rpc.NamespaceExistsResponse\"\000\022@\n\013Re" +
+      "pairTable\022\027.rpc.RepairTableRequest\032\026.goo" +
+      "gle.protobuf.Empty\"\000\022P\n\023AddNewColumnToTa" +
+      "ble\022\037.rpc.AddNewColumnToTableRequest\032\026.g" +
+      "oogle.protobuf.Empty\"\0002\236\002\n\026DistributedTr" +
+      "ansaction\022F\n\013Transaction\022\027.rpc.Transacti" +
+      "onRequest\032\030.rpc.TransactionResponse\"\000(\0010" +
+      "\001\022O\n\010GetState\022\037.rpc.GetTransactionStateR" +
+      "equest\032 .rpc.GetTransactionStateResponse" +
+      "\"\000\0229\n\010Rollback\022\024.rpc.RollbackRequest\032\025.r" +
+      "pc.RollbackResponse\"\000\0220\n\005Abort\022\021.rpc.Abo" +
+      "rtRequest\032\022.rpc.AbortResponse\"\0002\220\002\n\031TwoP" +
+      "haseCommitTransaction\022p\n\031TwoPhaseCommitT" +
+      "ransaction\022%.rpc.TwoPhaseCommitTransacti" +
+      "onRequest\032&.rpc.TwoPhaseCommitTransactio" +
+      "nResponse\"\000(\0010\001\022O\n\010GetState\022\037.rpc.GetTra" +
+      "nsactionStateRequest\032 .rpc.GetTransactio" +
+      "nStateResponse\"\000\0220\n\005Abort\022\021.rpc.AbortReq" +
+      "uest\032\022.rpc.AbortResponse\"\0002\334\n\n\033Distribut" +
+      "edTransactionAdmin\022H\n\017CreateNamespace\022\033." +
+      "rpc.CreateNamespaceRequest\032\026.google.prot" +
+      "obuf.Empty\"\000\022D\n\rDropNamespace\022\031.rpc.Drop" +
+      "NamespaceRequest\032\026.google.protobuf.Empty" +
+      "\"\000\022@\n\013CreateTable\022\027.rpc.CreateTableReque" +
+      "st\032\026.google.protobuf.Empty\"\000\022<\n\tDropTabl" +
+      "e\022\025.rpc.DropTableRequest\032\026.google.protob" +
+      "uf.Empty\"\000\022D\n\rTruncateTable\022\031.rpc.Trunca" +
+      "teTableRequest\032\026.google.protobuf.Empty\"\000" +
+      "\022@\n\013CreateIndex\022\027.rpc.CreateIndexRequest" +
+      "\032\026.google.protobuf.Empty\"\000\022<\n\tDropIndex\022" +
+      "\025.rpc.DropIndexRequest\032\026.google.protobuf" +
+      ".Empty\"\000\022Q\n\020GetTableMetadata\022\034.rpc.GetTa" +
+      "bleMetadataRequest\032\035.rpc.GetTableMetadat" +
+      "aResponse\"\000\022c\n\026GetNamespaceTableNames\022\"." +
+      "rpc.GetNamespaceTableNamesRequest\032#.rpc." +
+      "GetNamespaceTableNamesResponse\"\000\022N\n\017Name" +
+      "spaceExists\022\033.rpc.NamespaceExistsRequest" +
+      "\032\034.rpc.NamespaceExistsResponse\"\000\022X\n\027Crea" +
+      "teCoordinatorTables\022#.rpc.CreateCoordina" +
+      "torTablesRequest\032\026.google.protobuf.Empty" +
+      "\"\000\022T\n\025DropCoordinatorTables\022!.rpc.DropCo" +
+      "ordinatorTablesRequest\032\026.google.protobuf" +
+      ".Empty\"\000\022\\\n\031TruncateCoordinatorTables\022%." +
+      "rpc.TruncateCoordinatorTablesRequest\032\026.g" +
+      "oogle.protobuf.Empty\"\000\022c\n\026CoordinatorTab" +
+      "lesExist\022\".rpc.CoordinatorTablesExistReq" +
+      "uest\032#.rpc.CoordinatorTablesExistRespons" +
+      "e\"\000\022@\n\013RepairTable\022\027.rpc.RepairTableRequ" +
+      "est\032\026.google.protobuf.Empty\"\000\022X\n\027RepairC" +
+      "oordinatorTables\022#.rpc.RepairCoordinator" +
       "TablesRequest\032\026.google.protobuf.Empty\"\000\022" +
-      "Y\n\023AddNewColumnToTable\022(.scalardb.rpc.Ad" +
-      "dNewColumnToTableRequest\032\026.google.protob" +
-      "uf.Empty\"\000B$\n\021com.scalar.db.rpcB\rScalarD" +
-      "bProtoP\001b\006proto3"
+      "P\n\023AddNewColumnToTable\022\037.rpc.AddNewColum" +
+      "nToTableRequest\032\026.google.protobuf.Empty\"" +
+      "\000B$\n\021com.scalar.db.rpcB\rScalarDbProtoP\001b" +
+      "\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.EmptyProto.getDescriptor(),
         });
-    internal_static_scalardb_rpc_Value_descriptor =
+    internal_static_rpc_Value_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_scalardb_rpc_Value_fieldAccessorTable = new
+    internal_static_rpc_Value_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Value_descriptor,
+        internal_static_rpc_Value_descriptor,
         new java.lang.String[] { "Name", "BooleanValue", "IntValue", "BigintValue", "FloatValue", "DoubleValue", "TextValue", "BlobValue", "Value", });
-    internal_static_scalardb_rpc_Value_TextValue_descriptor =
-      internal_static_scalardb_rpc_Value_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_Value_TextValue_fieldAccessorTable = new
+    internal_static_rpc_Value_TextValue_descriptor =
+      internal_static_rpc_Value_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_Value_TextValue_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Value_TextValue_descriptor,
+        internal_static_rpc_Value_TextValue_descriptor,
         new java.lang.String[] { "Value", "Value", });
-    internal_static_scalardb_rpc_Value_BlobValue_descriptor =
-      internal_static_scalardb_rpc_Value_descriptor.getNestedTypes().get(1);
-    internal_static_scalardb_rpc_Value_BlobValue_fieldAccessorTable = new
+    internal_static_rpc_Value_BlobValue_descriptor =
+      internal_static_rpc_Value_descriptor.getNestedTypes().get(1);
+    internal_static_rpc_Value_BlobValue_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Value_BlobValue_descriptor,
+        internal_static_rpc_Value_BlobValue_descriptor,
         new java.lang.String[] { "Value", "Value", });
-    internal_static_scalardb_rpc_Column_descriptor =
+    internal_static_rpc_Column_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_scalardb_rpc_Column_fieldAccessorTable = new
+    internal_static_rpc_Column_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Column_descriptor,
+        internal_static_rpc_Column_descriptor,
         new java.lang.String[] { "Name", "BooleanValue", "IntValue", "BigintValue", "FloatValue", "DoubleValue", "TextValue", "BlobValue", "Value", });
-    internal_static_scalardb_rpc_Key_descriptor =
+    internal_static_rpc_Key_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_scalardb_rpc_Key_fieldAccessorTable = new
+    internal_static_rpc_Key_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Key_descriptor,
+        internal_static_rpc_Key_descriptor,
         new java.lang.String[] { "Value", "Columns", });
-    internal_static_scalardb_rpc_Get_descriptor =
+    internal_static_rpc_Get_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_scalardb_rpc_Get_fieldAccessorTable = new
+    internal_static_rpc_Get_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Get_descriptor,
+        internal_static_rpc_Get_descriptor,
         new java.lang.String[] { "Namespace", "Table", "PartitionKey", "ClusteringKey", "Consistency", "Projections", });
-    internal_static_scalardb_rpc_Ordering_descriptor =
+    internal_static_rpc_Ordering_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_scalardb_rpc_Ordering_fieldAccessorTable = new
+    internal_static_rpc_Ordering_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Ordering_descriptor,
+        internal_static_rpc_Ordering_descriptor,
         new java.lang.String[] { "Name", "Order", });
-    internal_static_scalardb_rpc_Scan_descriptor =
+    internal_static_rpc_Scan_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_scalardb_rpc_Scan_fieldAccessorTable = new
+    internal_static_rpc_Scan_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Scan_descriptor,
+        internal_static_rpc_Scan_descriptor,
         new java.lang.String[] { "Namespace", "Table", "PartitionKey", "Consistency", "Projections", "StartClusteringKey", "StartInclusive", "EndClusteringKey", "EndInclusive", "Orderings", "Limit", });
-    internal_static_scalardb_rpc_ConditionalExpression_descriptor =
+    internal_static_rpc_ConditionalExpression_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_scalardb_rpc_ConditionalExpression_fieldAccessorTable = new
+    internal_static_rpc_ConditionalExpression_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_ConditionalExpression_descriptor,
+        internal_static_rpc_ConditionalExpression_descriptor,
         new java.lang.String[] { "Name", "Value", "Operator", "Column", });
-    internal_static_scalardb_rpc_MutateCondition_descriptor =
+    internal_static_rpc_MutateCondition_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_scalardb_rpc_MutateCondition_fieldAccessorTable = new
+    internal_static_rpc_MutateCondition_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_MutateCondition_descriptor,
+        internal_static_rpc_MutateCondition_descriptor,
         new java.lang.String[] { "Type", "Expressions", });
-    internal_static_scalardb_rpc_Mutation_descriptor =
+    internal_static_rpc_Mutation_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_scalardb_rpc_Mutation_fieldAccessorTable = new
+    internal_static_rpc_Mutation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Mutation_descriptor,
+        internal_static_rpc_Mutation_descriptor,
         new java.lang.String[] { "Namespace", "Table", "PartitionKey", "ClusteringKey", "Consistency", "Condition", "Type", "Value", "Columns", });
-    internal_static_scalardb_rpc_Result_descriptor =
+    internal_static_rpc_Result_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_scalardb_rpc_Result_fieldAccessorTable = new
+    internal_static_rpc_Result_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_Result_descriptor,
+        internal_static_rpc_Result_descriptor,
         new java.lang.String[] { "Value", "Columns", });
-    internal_static_scalardb_rpc_GetRequest_descriptor =
+    internal_static_rpc_GetRequest_descriptor =
       getDescriptor().getMessageTypes().get(10);
-    internal_static_scalardb_rpc_GetRequest_fieldAccessorTable = new
+    internal_static_rpc_GetRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetRequest_descriptor,
+        internal_static_rpc_GetRequest_descriptor,
         new java.lang.String[] { "Get", });
-    internal_static_scalardb_rpc_GetResponse_descriptor =
+    internal_static_rpc_GetResponse_descriptor =
       getDescriptor().getMessageTypes().get(11);
-    internal_static_scalardb_rpc_GetResponse_fieldAccessorTable = new
+    internal_static_rpc_GetResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetResponse_descriptor,
+        internal_static_rpc_GetResponse_descriptor,
         new java.lang.String[] { "Result", });
-    internal_static_scalardb_rpc_ScanRequest_descriptor =
+    internal_static_rpc_ScanRequest_descriptor =
       getDescriptor().getMessageTypes().get(12);
-    internal_static_scalardb_rpc_ScanRequest_fieldAccessorTable = new
+    internal_static_rpc_ScanRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_ScanRequest_descriptor,
+        internal_static_rpc_ScanRequest_descriptor,
         new java.lang.String[] { "Scan", "FetchCount", "FetchCount", });
-    internal_static_scalardb_rpc_ScanResponse_descriptor =
+    internal_static_rpc_ScanResponse_descriptor =
       getDescriptor().getMessageTypes().get(13);
-    internal_static_scalardb_rpc_ScanResponse_fieldAccessorTable = new
+    internal_static_rpc_ScanResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_ScanResponse_descriptor,
+        internal_static_rpc_ScanResponse_descriptor,
         new java.lang.String[] { "Results", "HasMoreResults", });
-    internal_static_scalardb_rpc_MutateRequest_descriptor =
+    internal_static_rpc_MutateRequest_descriptor =
       getDescriptor().getMessageTypes().get(14);
-    internal_static_scalardb_rpc_MutateRequest_fieldAccessorTable = new
+    internal_static_rpc_MutateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_MutateRequest_descriptor,
+        internal_static_rpc_MutateRequest_descriptor,
         new java.lang.String[] { "Mutations", });
-    internal_static_scalardb_rpc_TableMetadata_descriptor =
+    internal_static_rpc_TableMetadata_descriptor =
       getDescriptor().getMessageTypes().get(15);
-    internal_static_scalardb_rpc_TableMetadata_fieldAccessorTable = new
+    internal_static_rpc_TableMetadata_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TableMetadata_descriptor,
+        internal_static_rpc_TableMetadata_descriptor,
         new java.lang.String[] { "Columns", "PartitionKeyNames", "ClusteringKeyNames", "ClusteringOrders", "SecondaryIndexNames", });
-    internal_static_scalardb_rpc_TableMetadata_ColumnsEntry_descriptor =
-      internal_static_scalardb_rpc_TableMetadata_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_TableMetadata_ColumnsEntry_fieldAccessorTable = new
+    internal_static_rpc_TableMetadata_ColumnsEntry_descriptor =
+      internal_static_rpc_TableMetadata_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_TableMetadata_ColumnsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TableMetadata_ColumnsEntry_descriptor,
+        internal_static_rpc_TableMetadata_ColumnsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_TableMetadata_ClusteringOrdersEntry_descriptor =
-      internal_static_scalardb_rpc_TableMetadata_descriptor.getNestedTypes().get(1);
-    internal_static_scalardb_rpc_TableMetadata_ClusteringOrdersEntry_fieldAccessorTable = new
+    internal_static_rpc_TableMetadata_ClusteringOrdersEntry_descriptor =
+      internal_static_rpc_TableMetadata_descriptor.getNestedTypes().get(1);
+    internal_static_rpc_TableMetadata_ClusteringOrdersEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TableMetadata_ClusteringOrdersEntry_descriptor,
+        internal_static_rpc_TableMetadata_ClusteringOrdersEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor =
+    internal_static_rpc_CreateNamespaceRequest_descriptor =
       getDescriptor().getMessageTypes().get(16);
-    internal_static_scalardb_rpc_CreateNamespaceRequest_fieldAccessorTable = new
+    internal_static_rpc_CreateNamespaceRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor,
+        internal_static_rpc_CreateNamespaceRequest_descriptor,
         new java.lang.String[] { "Namespace", "Options", "IfNotExists", });
-    internal_static_scalardb_rpc_CreateNamespaceRequest_OptionsEntry_descriptor =
-      internal_static_scalardb_rpc_CreateNamespaceRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_CreateNamespaceRequest_OptionsEntry_fieldAccessorTable = new
+    internal_static_rpc_CreateNamespaceRequest_OptionsEntry_descriptor =
+      internal_static_rpc_CreateNamespaceRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_CreateNamespaceRequest_OptionsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateNamespaceRequest_OptionsEntry_descriptor,
+        internal_static_rpc_CreateNamespaceRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_DropNamespaceRequest_descriptor =
+    internal_static_rpc_DropNamespaceRequest_descriptor =
       getDescriptor().getMessageTypes().get(17);
-    internal_static_scalardb_rpc_DropNamespaceRequest_fieldAccessorTable = new
+    internal_static_rpc_DropNamespaceRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_DropNamespaceRequest_descriptor,
+        internal_static_rpc_DropNamespaceRequest_descriptor,
         new java.lang.String[] { "Namespace", "IfExists", });
-    internal_static_scalardb_rpc_CreateTableRequest_descriptor =
+    internal_static_rpc_CreateTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(18);
-    internal_static_scalardb_rpc_CreateTableRequest_fieldAccessorTable = new
+    internal_static_rpc_CreateTableRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateTableRequest_descriptor,
+        internal_static_rpc_CreateTableRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", "TableMetadata", "Options", "IfNotExists", });
-    internal_static_scalardb_rpc_CreateTableRequest_OptionsEntry_descriptor =
-      internal_static_scalardb_rpc_CreateTableRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_CreateTableRequest_OptionsEntry_fieldAccessorTable = new
+    internal_static_rpc_CreateTableRequest_OptionsEntry_descriptor =
+      internal_static_rpc_CreateTableRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_CreateTableRequest_OptionsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateTableRequest_OptionsEntry_descriptor,
+        internal_static_rpc_CreateTableRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_DropTableRequest_descriptor =
+    internal_static_rpc_DropTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(19);
-    internal_static_scalardb_rpc_DropTableRequest_fieldAccessorTable = new
+    internal_static_rpc_DropTableRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_DropTableRequest_descriptor,
+        internal_static_rpc_DropTableRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", "IfExists", });
-    internal_static_scalardb_rpc_TruncateTableRequest_descriptor =
+    internal_static_rpc_TruncateTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(20);
-    internal_static_scalardb_rpc_TruncateTableRequest_fieldAccessorTable = new
+    internal_static_rpc_TruncateTableRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TruncateTableRequest_descriptor,
+        internal_static_rpc_TruncateTableRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", });
-    internal_static_scalardb_rpc_CreateIndexRequest_descriptor =
+    internal_static_rpc_CreateIndexRequest_descriptor =
       getDescriptor().getMessageTypes().get(21);
-    internal_static_scalardb_rpc_CreateIndexRequest_fieldAccessorTable = new
+    internal_static_rpc_CreateIndexRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateIndexRequest_descriptor,
+        internal_static_rpc_CreateIndexRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", "ColumnName", "Options", "IfNotExists", });
-    internal_static_scalardb_rpc_CreateIndexRequest_OptionsEntry_descriptor =
-      internal_static_scalardb_rpc_CreateIndexRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_CreateIndexRequest_OptionsEntry_fieldAccessorTable = new
+    internal_static_rpc_CreateIndexRequest_OptionsEntry_descriptor =
+      internal_static_rpc_CreateIndexRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_CreateIndexRequest_OptionsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateIndexRequest_OptionsEntry_descriptor,
+        internal_static_rpc_CreateIndexRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_DropIndexRequest_descriptor =
+    internal_static_rpc_DropIndexRequest_descriptor =
       getDescriptor().getMessageTypes().get(22);
-    internal_static_scalardb_rpc_DropIndexRequest_fieldAccessorTable = new
+    internal_static_rpc_DropIndexRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_DropIndexRequest_descriptor,
+        internal_static_rpc_DropIndexRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", "ColumnName", "IfExists", });
-    internal_static_scalardb_rpc_GetTableMetadataRequest_descriptor =
+    internal_static_rpc_GetTableMetadataRequest_descriptor =
       getDescriptor().getMessageTypes().get(23);
-    internal_static_scalardb_rpc_GetTableMetadataRequest_fieldAccessorTable = new
+    internal_static_rpc_GetTableMetadataRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetTableMetadataRequest_descriptor,
+        internal_static_rpc_GetTableMetadataRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", });
-    internal_static_scalardb_rpc_GetTableMetadataResponse_descriptor =
+    internal_static_rpc_GetTableMetadataResponse_descriptor =
       getDescriptor().getMessageTypes().get(24);
-    internal_static_scalardb_rpc_GetTableMetadataResponse_fieldAccessorTable = new
+    internal_static_rpc_GetTableMetadataResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetTableMetadataResponse_descriptor,
+        internal_static_rpc_GetTableMetadataResponse_descriptor,
         new java.lang.String[] { "TableMetadata", });
-    internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_descriptor =
+    internal_static_rpc_GetNamespaceTableNamesRequest_descriptor =
       getDescriptor().getMessageTypes().get(25);
-    internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable = new
+    internal_static_rpc_GetNamespaceTableNamesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetNamespaceTableNamesRequest_descriptor,
+        internal_static_rpc_GetNamespaceTableNamesRequest_descriptor,
         new java.lang.String[] { "Namespace", });
-    internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_descriptor =
+    internal_static_rpc_GetNamespaceTableNamesResponse_descriptor =
       getDescriptor().getMessageTypes().get(26);
-    internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable = new
+    internal_static_rpc_GetNamespaceTableNamesResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetNamespaceTableNamesResponse_descriptor,
+        internal_static_rpc_GetNamespaceTableNamesResponse_descriptor,
         new java.lang.String[] { "TableNames", });
-    internal_static_scalardb_rpc_NamespaceExistsRequest_descriptor =
+    internal_static_rpc_NamespaceExistsRequest_descriptor =
       getDescriptor().getMessageTypes().get(27);
-    internal_static_scalardb_rpc_NamespaceExistsRequest_fieldAccessorTable = new
+    internal_static_rpc_NamespaceExistsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_NamespaceExistsRequest_descriptor,
+        internal_static_rpc_NamespaceExistsRequest_descriptor,
         new java.lang.String[] { "Namespace", });
-    internal_static_scalardb_rpc_NamespaceExistsResponse_descriptor =
+    internal_static_rpc_NamespaceExistsResponse_descriptor =
       getDescriptor().getMessageTypes().get(28);
-    internal_static_scalardb_rpc_NamespaceExistsResponse_fieldAccessorTable = new
+    internal_static_rpc_NamespaceExistsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_NamespaceExistsResponse_descriptor,
+        internal_static_rpc_NamespaceExistsResponse_descriptor,
         new java.lang.String[] { "Exists", });
-    internal_static_scalardb_rpc_RepairTableRequest_descriptor =
+    internal_static_rpc_RepairTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(29);
-    internal_static_scalardb_rpc_RepairTableRequest_fieldAccessorTable = new
+    internal_static_rpc_RepairTableRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_RepairTableRequest_descriptor,
+        internal_static_rpc_RepairTableRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", "TableMetadata", "Options", });
-    internal_static_scalardb_rpc_RepairTableRequest_OptionsEntry_descriptor =
-      internal_static_scalardb_rpc_RepairTableRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_RepairTableRequest_OptionsEntry_fieldAccessorTable = new
+    internal_static_rpc_RepairTableRequest_OptionsEntry_descriptor =
+      internal_static_rpc_RepairTableRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_RepairTableRequest_OptionsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_RepairTableRequest_OptionsEntry_descriptor,
+        internal_static_rpc_RepairTableRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_AddNewColumnToTableRequest_descriptor =
+    internal_static_rpc_AddNewColumnToTableRequest_descriptor =
       getDescriptor().getMessageTypes().get(30);
-    internal_static_scalardb_rpc_AddNewColumnToTableRequest_fieldAccessorTable = new
+    internal_static_rpc_AddNewColumnToTableRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_AddNewColumnToTableRequest_descriptor,
+        internal_static_rpc_AddNewColumnToTableRequest_descriptor,
         new java.lang.String[] { "Namespace", "Table", "ColumnName", "ColumnType", });
-    internal_static_scalardb_rpc_TransactionRequest_descriptor =
+    internal_static_rpc_TransactionRequest_descriptor =
       getDescriptor().getMessageTypes().get(31);
-    internal_static_scalardb_rpc_TransactionRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_descriptor,
+        internal_static_rpc_TransactionRequest_descriptor,
         new java.lang.String[] { "StartRequest", "GetRequest", "ScanRequest", "MutateRequest", "CommitRequest", "AbortRequest", "BeginRequest", "RollbackRequest", "Request", });
-    internal_static_scalardb_rpc_TransactionRequest_BeginRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_TransactionRequest_BeginRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_BeginRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_TransactionRequest_BeginRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_BeginRequest_descriptor,
+        internal_static_rpc_TransactionRequest_BeginRequest_descriptor,
         new java.lang.String[] { "TransactionId", "TransactionId", });
-    internal_static_scalardb_rpc_TransactionRequest_StartRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(1);
-    internal_static_scalardb_rpc_TransactionRequest_StartRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_StartRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(1);
+    internal_static_rpc_TransactionRequest_StartRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_StartRequest_descriptor,
+        internal_static_rpc_TransactionRequest_StartRequest_descriptor,
         new java.lang.String[] { "TransactionId", "TransactionId", });
-    internal_static_scalardb_rpc_TransactionRequest_GetRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(2);
-    internal_static_scalardb_rpc_TransactionRequest_GetRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_GetRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(2);
+    internal_static_rpc_TransactionRequest_GetRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_GetRequest_descriptor,
+        internal_static_rpc_TransactionRequest_GetRequest_descriptor,
         new java.lang.String[] { "Get", });
-    internal_static_scalardb_rpc_TransactionRequest_ScanRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(3);
-    internal_static_scalardb_rpc_TransactionRequest_ScanRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_ScanRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(3);
+    internal_static_rpc_TransactionRequest_ScanRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_ScanRequest_descriptor,
+        internal_static_rpc_TransactionRequest_ScanRequest_descriptor,
         new java.lang.String[] { "Scan", });
-    internal_static_scalardb_rpc_TransactionRequest_MutateRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(4);
-    internal_static_scalardb_rpc_TransactionRequest_MutateRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_MutateRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(4);
+    internal_static_rpc_TransactionRequest_MutateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_MutateRequest_descriptor,
+        internal_static_rpc_TransactionRequest_MutateRequest_descriptor,
         new java.lang.String[] { "Mutations", });
-    internal_static_scalardb_rpc_TransactionRequest_CommitRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(5);
-    internal_static_scalardb_rpc_TransactionRequest_CommitRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_CommitRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(5);
+    internal_static_rpc_TransactionRequest_CommitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_CommitRequest_descriptor,
+        internal_static_rpc_TransactionRequest_CommitRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(6);
-    internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_RollbackRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(6);
+    internal_static_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_descriptor,
+        internal_static_rpc_TransactionRequest_RollbackRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TransactionRequest_AbortRequest_descriptor =
-      internal_static_scalardb_rpc_TransactionRequest_descriptor.getNestedTypes().get(7);
-    internal_static_scalardb_rpc_TransactionRequest_AbortRequest_fieldAccessorTable = new
+    internal_static_rpc_TransactionRequest_AbortRequest_descriptor =
+      internal_static_rpc_TransactionRequest_descriptor.getNestedTypes().get(7);
+    internal_static_rpc_TransactionRequest_AbortRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionRequest_AbortRequest_descriptor,
+        internal_static_rpc_TransactionRequest_AbortRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TransactionResponse_descriptor =
+    internal_static_rpc_TransactionResponse_descriptor =
       getDescriptor().getMessageTypes().get(32);
-    internal_static_scalardb_rpc_TransactionResponse_fieldAccessorTable = new
+    internal_static_rpc_TransactionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionResponse_descriptor,
+        internal_static_rpc_TransactionResponse_descriptor,
         new java.lang.String[] { "StartResponse", "GetResponse", "ScanResponse", "Error", "BeginResponse", "Response", });
-    internal_static_scalardb_rpc_TransactionResponse_BeginResponse_descriptor =
-      internal_static_scalardb_rpc_TransactionResponse_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_TransactionResponse_BeginResponse_fieldAccessorTable = new
+    internal_static_rpc_TransactionResponse_BeginResponse_descriptor =
+      internal_static_rpc_TransactionResponse_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_TransactionResponse_BeginResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionResponse_BeginResponse_descriptor,
+        internal_static_rpc_TransactionResponse_BeginResponse_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_TransactionResponse_StartResponse_descriptor =
-      internal_static_scalardb_rpc_TransactionResponse_descriptor.getNestedTypes().get(1);
-    internal_static_scalardb_rpc_TransactionResponse_StartResponse_fieldAccessorTable = new
+    internal_static_rpc_TransactionResponse_StartResponse_descriptor =
+      internal_static_rpc_TransactionResponse_descriptor.getNestedTypes().get(1);
+    internal_static_rpc_TransactionResponse_StartResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionResponse_StartResponse_descriptor,
+        internal_static_rpc_TransactionResponse_StartResponse_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_TransactionResponse_GetResponse_descriptor =
-      internal_static_scalardb_rpc_TransactionResponse_descriptor.getNestedTypes().get(2);
-    internal_static_scalardb_rpc_TransactionResponse_GetResponse_fieldAccessorTable = new
+    internal_static_rpc_TransactionResponse_GetResponse_descriptor =
+      internal_static_rpc_TransactionResponse_descriptor.getNestedTypes().get(2);
+    internal_static_rpc_TransactionResponse_GetResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionResponse_GetResponse_descriptor,
+        internal_static_rpc_TransactionResponse_GetResponse_descriptor,
         new java.lang.String[] { "Result", });
-    internal_static_scalardb_rpc_TransactionResponse_ScanResponse_descriptor =
-      internal_static_scalardb_rpc_TransactionResponse_descriptor.getNestedTypes().get(3);
-    internal_static_scalardb_rpc_TransactionResponse_ScanResponse_fieldAccessorTable = new
+    internal_static_rpc_TransactionResponse_ScanResponse_descriptor =
+      internal_static_rpc_TransactionResponse_descriptor.getNestedTypes().get(3);
+    internal_static_rpc_TransactionResponse_ScanResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionResponse_ScanResponse_descriptor,
+        internal_static_rpc_TransactionResponse_ScanResponse_descriptor,
         new java.lang.String[] { "Results", });
-    internal_static_scalardb_rpc_TransactionResponse_Error_descriptor =
-      internal_static_scalardb_rpc_TransactionResponse_descriptor.getNestedTypes().get(4);
-    internal_static_scalardb_rpc_TransactionResponse_Error_fieldAccessorTable = new
+    internal_static_rpc_TransactionResponse_Error_descriptor =
+      internal_static_rpc_TransactionResponse_descriptor.getNestedTypes().get(4);
+    internal_static_rpc_TransactionResponse_Error_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TransactionResponse_Error_descriptor,
+        internal_static_rpc_TransactionResponse_Error_descriptor,
         new java.lang.String[] { "ErrorCode", "Message", });
-    internal_static_scalardb_rpc_GetTransactionStateRequest_descriptor =
+    internal_static_rpc_GetTransactionStateRequest_descriptor =
       getDescriptor().getMessageTypes().get(33);
-    internal_static_scalardb_rpc_GetTransactionStateRequest_fieldAccessorTable = new
+    internal_static_rpc_GetTransactionStateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetTransactionStateRequest_descriptor,
+        internal_static_rpc_GetTransactionStateRequest_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_GetTransactionStateResponse_descriptor =
+    internal_static_rpc_GetTransactionStateResponse_descriptor =
       getDescriptor().getMessageTypes().get(34);
-    internal_static_scalardb_rpc_GetTransactionStateResponse_fieldAccessorTable = new
+    internal_static_rpc_GetTransactionStateResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_GetTransactionStateResponse_descriptor,
+        internal_static_rpc_GetTransactionStateResponse_descriptor,
         new java.lang.String[] { "State", });
-    internal_static_scalardb_rpc_RollbackRequest_descriptor =
+    internal_static_rpc_RollbackRequest_descriptor =
       getDescriptor().getMessageTypes().get(35);
-    internal_static_scalardb_rpc_RollbackRequest_fieldAccessorTable = new
+    internal_static_rpc_RollbackRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_RollbackRequest_descriptor,
+        internal_static_rpc_RollbackRequest_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_RollbackResponse_descriptor =
+    internal_static_rpc_RollbackResponse_descriptor =
       getDescriptor().getMessageTypes().get(36);
-    internal_static_scalardb_rpc_RollbackResponse_fieldAccessorTable = new
+    internal_static_rpc_RollbackResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_RollbackResponse_descriptor,
+        internal_static_rpc_RollbackResponse_descriptor,
         new java.lang.String[] { "State", });
-    internal_static_scalardb_rpc_AbortRequest_descriptor =
+    internal_static_rpc_AbortRequest_descriptor =
       getDescriptor().getMessageTypes().get(37);
-    internal_static_scalardb_rpc_AbortRequest_fieldAccessorTable = new
+    internal_static_rpc_AbortRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_AbortRequest_descriptor,
+        internal_static_rpc_AbortRequest_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_AbortResponse_descriptor =
+    internal_static_rpc_AbortResponse_descriptor =
       getDescriptor().getMessageTypes().get(38);
-    internal_static_scalardb_rpc_AbortResponse_fieldAccessorTable = new
+    internal_static_rpc_AbortResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_AbortResponse_descriptor,
+        internal_static_rpc_AbortResponse_descriptor,
         new java.lang.String[] { "State", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor =
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor =
       getDescriptor().getMessageTypes().get(39);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor,
         new java.lang.String[] { "StartRequest", "JoinRequest", "GetRequest", "ScanRequest", "MutateRequest", "PrepareRequest", "ValidateRequest", "CommitRequest", "RollbackRequest", "Request", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor,
         new java.lang.String[] { "TransactionId", "TransactionId", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(1);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(1);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(2);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(2);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor,
         new java.lang.String[] { "Get", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(3);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(3);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor,
         new java.lang.String[] { "Scan", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(4);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(4);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor,
         new java.lang.String[] { "Mutations", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(5);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(5);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(6);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(6);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(7);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(7);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(8);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor.getNestedTypes().get(8);
+    internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor =
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor =
       getDescriptor().getMessageTypes().get(40);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor,
         new java.lang.String[] { "StartResponse", "GetResponse", "ScanResponse", "Error", "Response", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor,
         new java.lang.String[] { "TransactionId", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(1);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(1);
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor,
         new java.lang.String[] { "Result", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(2);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(2);
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor,
         new java.lang.String[] { "Results", });
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor =
-      internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(3);
-    internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable = new
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor =
+      internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor.getNestedTypes().get(3);
+    internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor,
+        internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor,
         new java.lang.String[] { "ErrorCode", "Message", });
-    internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor =
+    internal_static_rpc_CreateCoordinatorTablesRequest_descriptor =
       getDescriptor().getMessageTypes().get(41);
-    internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable = new
+    internal_static_rpc_CreateCoordinatorTablesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor,
+        internal_static_rpc_CreateCoordinatorTablesRequest_descriptor,
         new java.lang.String[] { "Options", "IfNotExist", });
-    internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor =
-      internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable = new
+    internal_static_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor =
+      internal_static_rpc_CreateCoordinatorTablesRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_CreateCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor,
+        internal_static_rpc_CreateCoordinatorTablesRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
-    internal_static_scalardb_rpc_DropCoordinatorTablesRequest_descriptor =
+    internal_static_rpc_DropCoordinatorTablesRequest_descriptor =
       getDescriptor().getMessageTypes().get(42);
-    internal_static_scalardb_rpc_DropCoordinatorTablesRequest_fieldAccessorTable = new
+    internal_static_rpc_DropCoordinatorTablesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_DropCoordinatorTablesRequest_descriptor,
+        internal_static_rpc_DropCoordinatorTablesRequest_descriptor,
         new java.lang.String[] { "IfExist", });
-    internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_descriptor =
+    internal_static_rpc_TruncateCoordinatorTablesRequest_descriptor =
       getDescriptor().getMessageTypes().get(43);
-    internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable = new
+    internal_static_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_descriptor,
+        internal_static_rpc_TruncateCoordinatorTablesRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_CoordinatorTablesExistRequest_descriptor =
+    internal_static_rpc_CoordinatorTablesExistRequest_descriptor =
       getDescriptor().getMessageTypes().get(44);
-    internal_static_scalardb_rpc_CoordinatorTablesExistRequest_fieldAccessorTable = new
+    internal_static_rpc_CoordinatorTablesExistRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CoordinatorTablesExistRequest_descriptor,
+        internal_static_rpc_CoordinatorTablesExistRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_scalardb_rpc_CoordinatorTablesExistResponse_descriptor =
+    internal_static_rpc_CoordinatorTablesExistResponse_descriptor =
       getDescriptor().getMessageTypes().get(45);
-    internal_static_scalardb_rpc_CoordinatorTablesExistResponse_fieldAccessorTable = new
+    internal_static_rpc_CoordinatorTablesExistResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_CoordinatorTablesExistResponse_descriptor,
+        internal_static_rpc_CoordinatorTablesExistResponse_descriptor,
         new java.lang.String[] { "Exist", });
-    internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor =
+    internal_static_rpc_RepairCoordinatorTablesRequest_descriptor =
       getDescriptor().getMessageTypes().get(46);
-    internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable = new
+    internal_static_rpc_RepairCoordinatorTablesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor,
+        internal_static_rpc_RepairCoordinatorTablesRequest_descriptor,
         new java.lang.String[] { "Options", });
-    internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor =
-      internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_descriptor.getNestedTypes().get(0);
-    internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable = new
+    internal_static_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor =
+      internal_static_rpc_RepairCoordinatorTablesRequest_descriptor.getNestedTypes().get(0);
+    internal_static_rpc_RepairCoordinatorTablesRequest_OptionsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_scalardb_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor,
+        internal_static_rpc_RepairCoordinatorTablesRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     com.google.protobuf.EmptyProto.getDescriptor();
   }

--- a/rpc/src/main/java/com/scalar/db/rpc/Scan.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Scan.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.Scan}
+ * Protobuf type {@code rpc.Scan}
  */
 public final class Scan extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Scan)
+    // @@protoc_insertion_point(message_implements:rpc.Scan)
     ScanOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Scan.newBuilder() to construct.
@@ -173,13 +173,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Scan_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Scan_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Scan_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Scan_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Scan.class, com.scalar.db.rpc.Scan.Builder.class);
   }
@@ -263,7 +263,7 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_KEY_FIELD_NUMBER = 3;
   private com.scalar.db.rpc.Key partitionKey_;
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return Whether the partitionKey field is set.
    */
   @java.lang.Override
@@ -271,7 +271,7 @@ private static final long serialVersionUID = 0L;
     return partitionKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return The partitionKey.
    */
   @java.lang.Override
@@ -279,7 +279,7 @@ private static final long serialVersionUID = 0L;
     return partitionKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : partitionKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
@@ -289,14 +289,14 @@ private static final long serialVersionUID = 0L;
   public static final int CONSISTENCY_FIELD_NUMBER = 4;
   private int consistency_;
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+   * <code>.rpc.Consistency consistency = 4;</code>
    * @return The enum numeric value on the wire for consistency.
    */
   @java.lang.Override public int getConsistencyValue() {
     return consistency_;
   }
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+   * <code>.rpc.Consistency consistency = 4;</code>
    * @return The consistency.
    */
   @java.lang.Override public com.scalar.db.rpc.Consistency getConsistency() {
@@ -343,7 +343,7 @@ private static final long serialVersionUID = 0L;
   public static final int START_CLUSTERING_KEY_FIELD_NUMBER = 6;
   private com.scalar.db.rpc.Key startClusteringKey_;
   /**
-   * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+   * <code>.rpc.Key start_clustering_key = 6;</code>
    * @return Whether the startClusteringKey field is set.
    */
   @java.lang.Override
@@ -351,7 +351,7 @@ private static final long serialVersionUID = 0L;
     return startClusteringKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+   * <code>.rpc.Key start_clustering_key = 6;</code>
    * @return The startClusteringKey.
    */
   @java.lang.Override
@@ -359,7 +359,7 @@ private static final long serialVersionUID = 0L;
     return startClusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : startClusteringKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+   * <code>.rpc.Key start_clustering_key = 6;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getStartClusteringKeyOrBuilder() {
@@ -380,7 +380,7 @@ private static final long serialVersionUID = 0L;
   public static final int END_CLUSTERING_KEY_FIELD_NUMBER = 8;
   private com.scalar.db.rpc.Key endClusteringKey_;
   /**
-   * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+   * <code>.rpc.Key end_clustering_key = 8;</code>
    * @return Whether the endClusteringKey field is set.
    */
   @java.lang.Override
@@ -388,7 +388,7 @@ private static final long serialVersionUID = 0L;
     return endClusteringKey_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+   * <code>.rpc.Key end_clustering_key = 8;</code>
    * @return The endClusteringKey.
    */
   @java.lang.Override
@@ -396,7 +396,7 @@ private static final long serialVersionUID = 0L;
     return endClusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : endClusteringKey_;
   }
   /**
-   * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+   * <code>.rpc.Key end_clustering_key = 8;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getEndClusteringKeyOrBuilder() {
@@ -417,14 +417,14 @@ private static final long serialVersionUID = 0L;
   public static final int ORDERINGS_FIELD_NUMBER = 10;
   private java.util.List<com.scalar.db.rpc.Ordering> orderings_;
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.Ordering> getOrderingsList() {
     return orderings_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.OrderingOrBuilder> 
@@ -432,21 +432,21 @@ private static final long serialVersionUID = 0L;
     return orderings_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   @java.lang.Override
   public int getOrderingsCount() {
     return orderings_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Ordering getOrderings(int index) {
     return orderings_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.OrderingOrBuilder getOrderingsOrBuilder(
@@ -753,21 +753,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Scan}
+   * Protobuf type {@code rpc.Scan}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Scan)
+      // @@protoc_insertion_point(builder_implements:rpc.Scan)
       com.scalar.db.rpc.ScanOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Scan_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Scan_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Scan_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Scan_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Scan.class, com.scalar.db.rpc.Scan.Builder.class);
     }
@@ -835,7 +835,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Scan_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Scan_descriptor;
     }
 
     @java.lang.Override
@@ -1190,14 +1190,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> partitionKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      * @return Whether the partitionKey field is set.
      */
     public boolean hasPartitionKey() {
       return partitionKeyBuilder_ != null || partitionKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      * @return The partitionKey.
      */
     public com.scalar.db.rpc.Key getPartitionKey() {
@@ -1208,7 +1208,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder setPartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
@@ -1224,7 +1224,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder setPartitionKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -1238,7 +1238,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder mergePartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
@@ -1256,7 +1256,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder clearPartitionKey() {
       if (partitionKeyBuilder_ == null) {
@@ -1270,7 +1270,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.Key.Builder getPartitionKeyBuilder() {
       
@@ -1278,7 +1278,7 @@ private static final long serialVersionUID = 0L;
       return getPartitionKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
       if (partitionKeyBuilder_ != null) {
@@ -1289,7 +1289,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key partition_key = 3;</code>
+     * <code>.rpc.Key partition_key = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1307,14 +1307,14 @@ private static final long serialVersionUID = 0L;
 
     private int consistency_ = 0;
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+     * <code>.rpc.Consistency consistency = 4;</code>
      * @return The enum numeric value on the wire for consistency.
      */
     @java.lang.Override public int getConsistencyValue() {
       return consistency_;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+     * <code>.rpc.Consistency consistency = 4;</code>
      * @param value The enum numeric value on the wire for consistency to set.
      * @return This builder for chaining.
      */
@@ -1325,7 +1325,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+     * <code>.rpc.Consistency consistency = 4;</code>
      * @return The consistency.
      */
     @java.lang.Override
@@ -1335,7 +1335,7 @@ private static final long serialVersionUID = 0L;
       return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+     * <code>.rpc.Consistency consistency = 4;</code>
      * @param value The consistency to set.
      * @return This builder for chaining.
      */
@@ -1349,7 +1349,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+     * <code>.rpc.Consistency consistency = 4;</code>
      * @return This builder for chaining.
      */
     public Builder clearConsistency() {
@@ -1473,14 +1473,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> startClusteringKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      * @return Whether the startClusteringKey field is set.
      */
     public boolean hasStartClusteringKey() {
       return startClusteringKeyBuilder_ != null || startClusteringKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      * @return The startClusteringKey.
      */
     public com.scalar.db.rpc.Key getStartClusteringKey() {
@@ -1491,7 +1491,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public Builder setStartClusteringKey(com.scalar.db.rpc.Key value) {
       if (startClusteringKeyBuilder_ == null) {
@@ -1507,7 +1507,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public Builder setStartClusteringKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -1521,7 +1521,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public Builder mergeStartClusteringKey(com.scalar.db.rpc.Key value) {
       if (startClusteringKeyBuilder_ == null) {
@@ -1539,7 +1539,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public Builder clearStartClusteringKey() {
       if (startClusteringKeyBuilder_ == null) {
@@ -1553,7 +1553,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public com.scalar.db.rpc.Key.Builder getStartClusteringKeyBuilder() {
       
@@ -1561,7 +1561,7 @@ private static final long serialVersionUID = 0L;
       return getStartClusteringKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getStartClusteringKeyOrBuilder() {
       if (startClusteringKeyBuilder_ != null) {
@@ -1572,7 +1572,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+     * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1623,14 +1623,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> endClusteringKeyBuilder_;
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      * @return Whether the endClusteringKey field is set.
      */
     public boolean hasEndClusteringKey() {
       return endClusteringKeyBuilder_ != null || endClusteringKey_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      * @return The endClusteringKey.
      */
     public com.scalar.db.rpc.Key getEndClusteringKey() {
@@ -1641,7 +1641,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public Builder setEndClusteringKey(com.scalar.db.rpc.Key value) {
       if (endClusteringKeyBuilder_ == null) {
@@ -1657,7 +1657,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public Builder setEndClusteringKey(
         com.scalar.db.rpc.Key.Builder builderForValue) {
@@ -1671,7 +1671,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public Builder mergeEndClusteringKey(com.scalar.db.rpc.Key value) {
       if (endClusteringKeyBuilder_ == null) {
@@ -1689,7 +1689,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public Builder clearEndClusteringKey() {
       if (endClusteringKeyBuilder_ == null) {
@@ -1703,7 +1703,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public com.scalar.db.rpc.Key.Builder getEndClusteringKeyBuilder() {
       
@@ -1711,7 +1711,7 @@ private static final long serialVersionUID = 0L;
       return getEndClusteringKeyFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public com.scalar.db.rpc.KeyOrBuilder getEndClusteringKeyOrBuilder() {
       if (endClusteringKeyBuilder_ != null) {
@@ -1722,7 +1722,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+     * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Key, com.scalar.db.rpc.Key.Builder, com.scalar.db.rpc.KeyOrBuilder> 
@@ -1782,7 +1782,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Ordering, com.scalar.db.rpc.Ordering.Builder, com.scalar.db.rpc.OrderingOrBuilder> orderingsBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public java.util.List<com.scalar.db.rpc.Ordering> getOrderingsList() {
       if (orderingsBuilder_ == null) {
@@ -1792,7 +1792,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public int getOrderingsCount() {
       if (orderingsBuilder_ == null) {
@@ -1802,7 +1802,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public com.scalar.db.rpc.Ordering getOrderings(int index) {
       if (orderingsBuilder_ == null) {
@@ -1812,7 +1812,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder setOrderings(
         int index, com.scalar.db.rpc.Ordering value) {
@@ -1829,7 +1829,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder setOrderings(
         int index, com.scalar.db.rpc.Ordering.Builder builderForValue) {
@@ -1843,7 +1843,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder addOrderings(com.scalar.db.rpc.Ordering value) {
       if (orderingsBuilder_ == null) {
@@ -1859,7 +1859,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder addOrderings(
         int index, com.scalar.db.rpc.Ordering value) {
@@ -1876,7 +1876,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder addOrderings(
         com.scalar.db.rpc.Ordering.Builder builderForValue) {
@@ -1890,7 +1890,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder addOrderings(
         int index, com.scalar.db.rpc.Ordering.Builder builderForValue) {
@@ -1904,7 +1904,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder addAllOrderings(
         java.lang.Iterable<? extends com.scalar.db.rpc.Ordering> values) {
@@ -1919,7 +1919,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder clearOrderings() {
       if (orderingsBuilder_ == null) {
@@ -1932,7 +1932,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public Builder removeOrderings(int index) {
       if (orderingsBuilder_ == null) {
@@ -1945,14 +1945,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public com.scalar.db.rpc.Ordering.Builder getOrderingsBuilder(
         int index) {
       return getOrderingsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public com.scalar.db.rpc.OrderingOrBuilder getOrderingsOrBuilder(
         int index) {
@@ -1962,7 +1962,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.OrderingOrBuilder> 
          getOrderingsOrBuilderList() {
@@ -1973,14 +1973,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public com.scalar.db.rpc.Ordering.Builder addOrderingsBuilder() {
       return getOrderingsFieldBuilder().addBuilder(
           com.scalar.db.rpc.Ordering.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public com.scalar.db.rpc.Ordering.Builder addOrderingsBuilder(
         int index) {
@@ -1988,7 +1988,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Ordering.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+     * <code>repeated .rpc.Ordering orderings = 10;</code>
      */
     public java.util.List<com.scalar.db.rpc.Ordering.Builder> 
          getOrderingsBuilderList() {
@@ -2052,10 +2052,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Scan)
+    // @@protoc_insertion_point(builder_scope:rpc.Scan)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Scan)
+  // @@protoc_insertion_point(class_scope:rpc.Scan)
   private static final com.scalar.db.rpc.Scan DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Scan();

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface ScanOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Scan)
+    // @@protoc_insertion_point(interface_extends:rpc.Scan)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -32,27 +32,27 @@ public interface ScanOrBuilder extends
       getTableBytes();
 
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return Whether the partitionKey field is set.
    */
   boolean hasPartitionKey();
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    * @return The partitionKey.
    */
   com.scalar.db.rpc.Key getPartitionKey();
   /**
-   * <code>.scalardb.rpc.Key partition_key = 3;</code>
+   * <code>.rpc.Key partition_key = 3;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+   * <code>.rpc.Consistency consistency = 4;</code>
    * @return The enum numeric value on the wire for consistency.
    */
   int getConsistencyValue();
   /**
-   * <code>.scalardb.rpc.Consistency consistency = 4;</code>
+   * <code>.rpc.Consistency consistency = 4;</code>
    * @return The consistency.
    */
   com.scalar.db.rpc.Consistency getConsistency();
@@ -83,17 +83,17 @@ public interface ScanOrBuilder extends
       getProjectionsBytes(int index);
 
   /**
-   * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+   * <code>.rpc.Key start_clustering_key = 6;</code>
    * @return Whether the startClusteringKey field is set.
    */
   boolean hasStartClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+   * <code>.rpc.Key start_clustering_key = 6;</code>
    * @return The startClusteringKey.
    */
   com.scalar.db.rpc.Key getStartClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key start_clustering_key = 6;</code>
+   * <code>.rpc.Key start_clustering_key = 6;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getStartClusteringKeyOrBuilder();
 
@@ -104,17 +104,17 @@ public interface ScanOrBuilder extends
   boolean getStartInclusive();
 
   /**
-   * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+   * <code>.rpc.Key end_clustering_key = 8;</code>
    * @return Whether the endClusteringKey field is set.
    */
   boolean hasEndClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+   * <code>.rpc.Key end_clustering_key = 8;</code>
    * @return The endClusteringKey.
    */
   com.scalar.db.rpc.Key getEndClusteringKey();
   /**
-   * <code>.scalardb.rpc.Key end_clustering_key = 8;</code>
+   * <code>.rpc.Key end_clustering_key = 8;</code>
    */
   com.scalar.db.rpc.KeyOrBuilder getEndClusteringKeyOrBuilder();
 
@@ -125,25 +125,25 @@ public interface ScanOrBuilder extends
   boolean getEndInclusive();
 
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   java.util.List<com.scalar.db.rpc.Ordering> 
       getOrderingsList();
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   com.scalar.db.rpc.Ordering getOrderings(int index);
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   int getOrderingsCount();
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.OrderingOrBuilder> 
       getOrderingsOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Ordering orderings = 10;</code>
+   * <code>repeated .rpc.Ordering orderings = 10;</code>
    */
   com.scalar.db.rpc.OrderingOrBuilder getOrderingsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.ScanRequest}
+ * Protobuf type {@code rpc.ScanRequest}
  */
 public final class ScanRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.ScanRequest)
+    // @@protoc_insertion_point(message_implements:rpc.ScanRequest)
     ScanRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use ScanRequest.newBuilder() to construct.
@@ -90,13 +90,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.ScanRequest.class, com.scalar.db.rpc.ScanRequest.Builder.class);
   }
@@ -105,7 +105,7 @@ private static final long serialVersionUID = 0L;
   public static final int SCAN_FIELD_NUMBER = 1;
   private com.scalar.db.rpc.Scan scan_;
   /**
-   * <code>.scalardb.rpc.Scan scan = 1;</code>
+   * <code>.rpc.Scan scan = 1;</code>
    * @return Whether the scan field is set.
    */
   @java.lang.Override
@@ -113,7 +113,7 @@ private static final long serialVersionUID = 0L;
     return scan_ != null;
   }
   /**
-   * <code>.scalardb.rpc.Scan scan = 1;</code>
+   * <code>.rpc.Scan scan = 1;</code>
    * @return The scan.
    */
   @java.lang.Override
@@ -121,7 +121,7 @@ private static final long serialVersionUID = 0L;
     return scan_ == null ? com.scalar.db.rpc.Scan.getDefaultInstance() : scan_;
   }
   /**
-   * <code>.scalardb.rpc.Scan scan = 1;</code>
+   * <code>.rpc.Scan scan = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
@@ -324,21 +324,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.ScanRequest}
+   * Protobuf type {@code rpc.ScanRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.ScanRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.ScanRequest)
       com.scalar.db.rpc.ScanRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.ScanRequest.class, com.scalar.db.rpc.ScanRequest.Builder.class);
     }
@@ -375,7 +375,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanRequest_descriptor;
     }
 
     @java.lang.Override
@@ -495,14 +495,14 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Scan, com.scalar.db.rpc.Scan.Builder, com.scalar.db.rpc.ScanOrBuilder> scanBuilder_;
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      * @return Whether the scan field is set.
      */
     public boolean hasScan() {
       return scanBuilder_ != null || scan_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      * @return The scan.
      */
     public com.scalar.db.rpc.Scan getScan() {
@@ -513,7 +513,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     public Builder setScan(com.scalar.db.rpc.Scan value) {
       if (scanBuilder_ == null) {
@@ -529,7 +529,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     public Builder setScan(
         com.scalar.db.rpc.Scan.Builder builderForValue) {
@@ -543,7 +543,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     public Builder mergeScan(com.scalar.db.rpc.Scan value) {
       if (scanBuilder_ == null) {
@@ -561,7 +561,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     public Builder clearScan() {
       if (scanBuilder_ == null) {
@@ -575,7 +575,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     public com.scalar.db.rpc.Scan.Builder getScanBuilder() {
       
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
       return getScanFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
       if (scanBuilder_ != null) {
@@ -594,7 +594,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 1;</code>
+     * <code>.rpc.Scan scan = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Scan, com.scalar.db.rpc.Scan.Builder, com.scalar.db.rpc.ScanOrBuilder> 
@@ -661,10 +661,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.ScanRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.ScanRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.ScanRequest)
+  // @@protoc_insertion_point(class_scope:rpc.ScanRequest)
   private static final com.scalar.db.rpc.ScanRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.ScanRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanRequestOrBuilder.java
@@ -4,21 +4,21 @@
 package com.scalar.db.rpc;
 
 public interface ScanRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.ScanRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.ScanRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.Scan scan = 1;</code>
+   * <code>.rpc.Scan scan = 1;</code>
    * @return Whether the scan field is set.
    */
   boolean hasScan();
   /**
-   * <code>.scalardb.rpc.Scan scan = 1;</code>
+   * <code>.rpc.Scan scan = 1;</code>
    * @return The scan.
    */
   com.scalar.db.rpc.Scan getScan();
   /**
-   * <code>.scalardb.rpc.Scan scan = 1;</code>
+   * <code>.rpc.Scan scan = 1;</code>
    */
   com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.ScanResponse}
+ * Protobuf type {@code rpc.ScanResponse}
  */
 public final class ScanResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.ScanResponse)
+    // @@protoc_insertion_point(message_implements:rpc.ScanResponse)
     ScanResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use ScanResponse.newBuilder() to construct.
@@ -90,13 +90,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.ScanResponse.class, com.scalar.db.rpc.ScanResponse.Builder.class);
   }
@@ -104,14 +104,14 @@ private static final long serialVersionUID = 0L;
   public static final int RESULTS_FIELD_NUMBER = 2;
   private java.util.List<com.scalar.db.rpc.Result> results_;
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   @java.lang.Override
   public java.util.List<com.scalar.db.rpc.Result> getResultsList() {
     return results_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   @java.lang.Override
   public java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
@@ -119,21 +119,21 @@ private static final long serialVersionUID = 0L;
     return results_;
   }
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   @java.lang.Override
   public int getResultsCount() {
     return results_.size();
   }
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Result getResults(int index) {
     return results_.get(index);
   }
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
@@ -322,21 +322,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.ScanResponse}
+   * Protobuf type {@code rpc.ScanResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.ScanResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.ScanResponse)
       com.scalar.db.rpc.ScanResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.ScanResponse.class, com.scalar.db.rpc.ScanResponse.Builder.class);
     }
@@ -374,7 +374,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_ScanResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_ScanResponse_descriptor;
     }
 
     @java.lang.Override
@@ -525,7 +525,7 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> resultsBuilder_;
 
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.Result> getResultsList() {
       if (resultsBuilder_ == null) {
@@ -535,7 +535,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public int getResultsCount() {
       if (resultsBuilder_ == null) {
@@ -545,7 +545,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public com.scalar.db.rpc.Result getResults(int index) {
       if (resultsBuilder_ == null) {
@@ -555,7 +555,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder setResults(
         int index, com.scalar.db.rpc.Result value) {
@@ -572,7 +572,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder setResults(
         int index, com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -586,7 +586,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder addResults(com.scalar.db.rpc.Result value) {
       if (resultsBuilder_ == null) {
@@ -602,7 +602,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder addResults(
         int index, com.scalar.db.rpc.Result value) {
@@ -619,7 +619,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder addResults(
         com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -633,7 +633,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder addResults(
         int index, com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -647,7 +647,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder addAllResults(
         java.lang.Iterable<? extends com.scalar.db.rpc.Result> values) {
@@ -662,7 +662,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder clearResults() {
       if (resultsBuilder_ == null) {
@@ -675,7 +675,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public Builder removeResults(int index) {
       if (resultsBuilder_ == null) {
@@ -688,14 +688,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public com.scalar.db.rpc.Result.Builder getResultsBuilder(
         int index) {
       return getResultsFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
         int index) {
@@ -705,7 +705,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
          getResultsOrBuilderList() {
@@ -716,14 +716,14 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public com.scalar.db.rpc.Result.Builder addResultsBuilder() {
       return getResultsFieldBuilder().addBuilder(
           com.scalar.db.rpc.Result.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public com.scalar.db.rpc.Result.Builder addResultsBuilder(
         int index) {
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
           index, com.scalar.db.rpc.Result.getDefaultInstance());
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 2;</code>
+     * <code>repeated .rpc.Result results = 2;</code>
      */
     public java.util.List<com.scalar.db.rpc.Result.Builder> 
          getResultsBuilderList() {
@@ -795,10 +795,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.ScanResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.ScanResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.ScanResponse)
+  // @@protoc_insertion_point(class_scope:rpc.ScanResponse)
   private static final com.scalar.db.rpc.ScanResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.ScanResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanResponseOrBuilder.java
@@ -4,29 +4,29 @@
 package com.scalar.db.rpc;
 
 public interface ScanResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.ScanResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.ScanResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   java.util.List<com.scalar.db.rpc.Result> 
       getResultsList();
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   com.scalar.db.rpc.Result getResults(int index);
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   int getResultsCount();
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
       getResultsOrBuilderList();
   /**
-   * <code>repeated .scalardb.rpc.Result results = 2;</code>
+   * <code>repeated .rpc.Result results = 2;</code>
    */
   com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
       int index);

--- a/rpc/src/main/java/com/scalar/db/rpc/TableMetadata.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TableMetadata.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TableMetadata}
+ * Protobuf type {@code rpc.TableMetadata}
  */
 public final class TableMetadata extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TableMetadata)
+    // @@protoc_insertion_point(message_implements:rpc.TableMetadata)
     TableMetadataOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TableMetadata.newBuilder() to construct.
@@ -137,7 +137,7 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -157,7 +157,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TableMetadata.class, com.scalar.db.rpc.TableMetadata.Builder.class);
   }
@@ -168,7 +168,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, java.lang.Integer> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.Integer>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_ColumnsEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_ColumnsEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.ENUM,
@@ -202,7 +202,7 @@ private static final long serialVersionUID = 0L;
     return internalGetColumns().getMap().size();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
 
   @java.lang.Override
@@ -221,7 +221,7 @@ private static final long serialVersionUID = 0L;
     return getColumnsMap();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
 
@@ -230,7 +230,7 @@ private static final long serialVersionUID = 0L;
     return internalGetAdaptedColumnsMap(
         internalGetColumns().getMap());}
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
 
@@ -247,7 +247,7 @@ com.scalar.db.rpc.DataType defaultValue) {
            : defaultValue;
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
 
@@ -271,7 +271,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     return getColumnsValueMap();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
 
@@ -280,7 +280,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     return internalGetColumns().getMap();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
 
@@ -293,7 +293,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     return map.containsKey(key) ? map.get(key) : defaultValue;
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
 
@@ -384,7 +384,7 @@ com.scalar.db.rpc.DataType defaultValue) {
         java.lang.String, java.lang.Integer> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, java.lang.Integer>newDefaultInstance(
-                com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_ClusteringOrdersEntry_descriptor, 
+                com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_ClusteringOrdersEntry_descriptor, 
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.ENUM,
@@ -418,7 +418,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     return internalGetClusteringOrders().getMap().size();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
 
   @java.lang.Override
@@ -437,7 +437,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     return getClusteringOrdersMap();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
 
@@ -446,7 +446,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     return internalGetAdaptedClusteringOrdersMap(
         internalGetClusteringOrders().getMap());}
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
 
@@ -463,7 +463,7 @@ com.scalar.db.rpc.Order defaultValue) {
            : defaultValue;
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
 
@@ -487,7 +487,7 @@ com.scalar.db.rpc.Order defaultValue) {
     return getClusteringOrdersValueMap();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
 
@@ -496,7 +496,7 @@ com.scalar.db.rpc.Order defaultValue) {
     return internalGetClusteringOrders().getMap();
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
 
@@ -509,7 +509,7 @@ com.scalar.db.rpc.Order defaultValue) {
     return map.containsKey(key) ? map.get(key) : defaultValue;
   }
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
 
@@ -799,15 +799,15 @@ com.scalar.db.rpc.Order defaultValue) {
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TableMetadata}
+   * Protobuf type {@code rpc.TableMetadata}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TableMetadata)
+      // @@protoc_insertion_point(builder_implements:rpc.TableMetadata)
       com.scalar.db.rpc.TableMetadataOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
@@ -839,7 +839,7 @@ com.scalar.db.rpc.Order defaultValue) {
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TableMetadata.class, com.scalar.db.rpc.TableMetadata.Builder.class);
     }
@@ -876,7 +876,7 @@ com.scalar.db.rpc.Order defaultValue) {
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TableMetadata_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TableMetadata_descriptor;
     }
 
     @java.lang.Override
@@ -1055,7 +1055,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return internalGetColumns().getMap().size();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
 
     @java.lang.Override
@@ -1074,7 +1074,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return getColumnsMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
 
@@ -1083,7 +1083,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return internalGetAdaptedColumnsMap(
           internalGetColumns().getMap());}
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
 
@@ -1100,7 +1100,7 @@ com.scalar.db.rpc.DataType defaultValue) {
              : defaultValue;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
 
@@ -1124,7 +1124,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return getColumnsValueMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
 
@@ -1133,7 +1133,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return internalGetColumns().getMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
 
@@ -1146,7 +1146,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
 
@@ -1167,7 +1167,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return this;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
 
     public Builder removeColumns(
@@ -1187,7 +1187,7 @@ com.scalar.db.rpc.DataType defaultValue) {
            internalGetMutableColumns().getMutableMap());
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     public Builder putColumns(
         java.lang.String key,
@@ -1199,7 +1199,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return this;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     public Builder putAllColumns(
         java.util.Map<java.lang.String, com.scalar.db.rpc.DataType> values) {
@@ -1217,7 +1217,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return internalGetMutableColumns().getMutableMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     public Builder putColumnsValue(
         java.lang.String key,
@@ -1229,7 +1229,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return this;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+     * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     public Builder putAllColumnsValue(
         java.util.Map<java.lang.String, java.lang.Integer> values) {
@@ -1485,7 +1485,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return internalGetClusteringOrders().getMap().size();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
 
     @java.lang.Override
@@ -1504,7 +1504,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return getClusteringOrdersMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
 
@@ -1513,7 +1513,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return internalGetAdaptedClusteringOrdersMap(
           internalGetClusteringOrders().getMap());}
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
 
@@ -1530,7 +1530,7 @@ com.scalar.db.rpc.Order defaultValue) {
              : defaultValue;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
 
@@ -1554,7 +1554,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return getClusteringOrdersValueMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
 
@@ -1563,7 +1563,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return internalGetClusteringOrders().getMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
 
@@ -1576,7 +1576,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
 
@@ -1597,7 +1597,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return this;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
 
     public Builder removeClusteringOrders(
@@ -1617,7 +1617,7 @@ com.scalar.db.rpc.Order defaultValue) {
            internalGetMutableClusteringOrders().getMutableMap());
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     public Builder putClusteringOrders(
         java.lang.String key,
@@ -1629,7 +1629,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return this;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     public Builder putAllClusteringOrders(
         java.util.Map<java.lang.String, com.scalar.db.rpc.Order> values) {
@@ -1647,7 +1647,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return internalGetMutableClusteringOrders().getMutableMap();
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     public Builder putClusteringOrdersValue(
         java.lang.String key,
@@ -1659,7 +1659,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return this;
     }
     /**
-     * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+     * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     public Builder putAllClusteringOrdersValue(
         java.util.Map<java.lang.String, java.lang.Integer> values) {
@@ -1790,10 +1790,10 @@ com.scalar.db.rpc.Order defaultValue) {
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TableMetadata)
+    // @@protoc_insertion_point(builder_scope:rpc.TableMetadata)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TableMetadata)
+  // @@protoc_insertion_point(class_scope:rpc.TableMetadata)
   private static final com.scalar.db.rpc.TableMetadata DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TableMetadata();

--- a/rpc/src/main/java/com/scalar/db/rpc/TableMetadataOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TableMetadataOrBuilder.java
@@ -4,15 +4,15 @@
 package com.scalar.db.rpc;
 
 public interface TableMetadataOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TableMetadata)
+    // @@protoc_insertion_point(interface_extends:rpc.TableMetadata)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   int getColumnsCount();
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   boolean containsColumns(
       java.lang.String key);
@@ -23,12 +23,12 @@ public interface TableMetadataOrBuilder extends
   java.util.Map<java.lang.String, com.scalar.db.rpc.DataType>
   getColumns();
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   java.util.Map<java.lang.String, com.scalar.db.rpc.DataType>
   getColumnsMap();
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   /* nullable */
 com.scalar.db.rpc.DataType getColumnsOrDefault(
@@ -36,7 +36,7 @@ com.scalar.db.rpc.DataType getColumnsOrDefault(
       /* nullable */
 com.scalar.db.rpc.DataType         defaultValue);
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   com.scalar.db.rpc.DataType getColumnsOrThrow(
       java.lang.String key);
@@ -47,19 +47,19 @@ com.scalar.db.rpc.DataType         defaultValue);
   java.util.Map<java.lang.String, java.lang.Integer>
   getColumnsValue();
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   java.util.Map<java.lang.String, java.lang.Integer>
   getColumnsValueMap();
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
 
   int getColumnsValueOrDefault(
       java.lang.String key,
       int defaultValue);
   /**
-   * <code>map&lt;string, .scalardb.rpc.DataType&gt; columns = 1;</code>
+   * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
 
   int getColumnsValueOrThrow(
@@ -116,11 +116,11 @@ com.scalar.db.rpc.DataType         defaultValue);
       getClusteringKeyNamesBytes(int index);
 
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   int getClusteringOrdersCount();
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   boolean containsClusteringOrders(
       java.lang.String key);
@@ -131,12 +131,12 @@ com.scalar.db.rpc.DataType         defaultValue);
   java.util.Map<java.lang.String, com.scalar.db.rpc.Order>
   getClusteringOrders();
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   java.util.Map<java.lang.String, com.scalar.db.rpc.Order>
   getClusteringOrdersMap();
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   /* nullable */
 com.scalar.db.rpc.Order getClusteringOrdersOrDefault(
@@ -144,7 +144,7 @@ com.scalar.db.rpc.Order getClusteringOrdersOrDefault(
       /* nullable */
 com.scalar.db.rpc.Order         defaultValue);
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   com.scalar.db.rpc.Order getClusteringOrdersOrThrow(
       java.lang.String key);
@@ -155,19 +155,19 @@ com.scalar.db.rpc.Order         defaultValue);
   java.util.Map<java.lang.String, java.lang.Integer>
   getClusteringOrdersValue();
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   java.util.Map<java.lang.String, java.lang.Integer>
   getClusteringOrdersValueMap();
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
 
   int getClusteringOrdersValueOrDefault(
       java.lang.String key,
       int defaultValue);
   /**
-   * <code>map&lt;string, .scalardb.rpc.Order&gt; clustering_orders = 4;</code>
+   * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
 
   int getClusteringOrdersValueOrThrow(

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TransactionRequest}
+ * Protobuf type {@code rpc.TransactionRequest}
  */
 public final class TransactionRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest)
+    // @@protoc_insertion_point(message_implements:rpc.TransactionRequest)
     TransactionRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TransactionRequest.newBuilder() to construct.
@@ -183,19 +183,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TransactionRequest.class, com.scalar.db.rpc.TransactionRequest.Builder.class);
   }
 
   public interface BeginRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.BeginRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.BeginRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -216,11 +216,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.BeginRequest}
+   * Protobuf type {@code rpc.TransactionRequest.BeginRequest}
    */
   public static final class BeginRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.BeginRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.BeginRequest)
       BeginRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use BeginRequest.newBuilder() to construct.
@@ -291,13 +291,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_BeginRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_BeginRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_BeginRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_BeginRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.BeginRequest.class, com.scalar.db.rpc.TransactionRequest.BeginRequest.Builder.class);
     }
@@ -509,21 +509,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.BeginRequest}
+     * Protobuf type {@code rpc.TransactionRequest.BeginRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.BeginRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.BeginRequest)
         com.scalar.db.rpc.TransactionRequest.BeginRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_BeginRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_BeginRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_BeginRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_BeginRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.BeginRequest.class, com.scalar.db.rpc.TransactionRequest.BeginRequest.Builder.class);
       }
@@ -554,7 +554,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_BeginRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_BeginRequest_descriptor;
       }
 
       @java.lang.Override
@@ -759,10 +759,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.BeginRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.BeginRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.BeginRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.BeginRequest)
     private static final com.scalar.db.rpc.TransactionRequest.BeginRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.BeginRequest();
@@ -800,7 +800,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface StartRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.StartRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.StartRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -821,11 +821,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.StartRequest}
+   * Protobuf type {@code rpc.TransactionRequest.StartRequest}
    */
   public static final class StartRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.StartRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.StartRequest)
       StartRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StartRequest.newBuilder() to construct.
@@ -896,13 +896,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_StartRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_StartRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_StartRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_StartRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.StartRequest.class, com.scalar.db.rpc.TransactionRequest.StartRequest.Builder.class);
     }
@@ -1114,21 +1114,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.StartRequest}
+     * Protobuf type {@code rpc.TransactionRequest.StartRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.StartRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.StartRequest)
         com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_StartRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_StartRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_StartRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_StartRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.StartRequest.class, com.scalar.db.rpc.TransactionRequest.StartRequest.Builder.class);
       }
@@ -1159,7 +1159,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_StartRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_StartRequest_descriptor;
       }
 
       @java.lang.Override
@@ -1364,10 +1364,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.StartRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.StartRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.StartRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.StartRequest)
     private static final com.scalar.db.rpc.TransactionRequest.StartRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.StartRequest();
@@ -1405,30 +1405,30 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface GetRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.GetRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.GetRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return Whether the get field is set.
      */
     boolean hasGet();
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return The get.
      */
     com.scalar.db.rpc.Get getGet();
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      */
     com.scalar.db.rpc.GetOrBuilder getGetOrBuilder();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.GetRequest}
+   * Protobuf type {@code rpc.TransactionRequest.GetRequest}
    */
   public static final class GetRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.GetRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.GetRequest)
       GetRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use GetRequest.newBuilder() to construct.
@@ -1504,13 +1504,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_GetRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_GetRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_GetRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_GetRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.GetRequest.class, com.scalar.db.rpc.TransactionRequest.GetRequest.Builder.class);
     }
@@ -1518,7 +1518,7 @@ private static final long serialVersionUID = 0L;
     public static final int GET_FIELD_NUMBER = 2;
     private com.scalar.db.rpc.Get get_;
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return Whether the get field is set.
      */
     @java.lang.Override
@@ -1526,7 +1526,7 @@ private static final long serialVersionUID = 0L;
       return get_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return The get.
      */
     @java.lang.Override
@@ -1534,7 +1534,7 @@ private static final long serialVersionUID = 0L;
       return get_ == null ? com.scalar.db.rpc.Get.getDefaultInstance() : get_;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
@@ -1702,21 +1702,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.GetRequest}
+     * Protobuf type {@code rpc.TransactionRequest.GetRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.GetRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.GetRequest)
         com.scalar.db.rpc.TransactionRequest.GetRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_GetRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_GetRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_GetRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_GetRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.GetRequest.class, com.scalar.db.rpc.TransactionRequest.GetRequest.Builder.class);
       }
@@ -1751,7 +1751,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_GetRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_GetRequest_descriptor;
       }
 
       @java.lang.Override
@@ -1860,14 +1860,14 @@ private static final long serialVersionUID = 0L;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Get, com.scalar.db.rpc.Get.Builder, com.scalar.db.rpc.GetOrBuilder> getBuilder_;
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        * @return Whether the get field is set.
        */
       public boolean hasGet() {
         return getBuilder_ != null || get_ != null;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        * @return The get.
        */
       public com.scalar.db.rpc.Get getGet() {
@@ -1878,7 +1878,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder setGet(com.scalar.db.rpc.Get value) {
         if (getBuilder_ == null) {
@@ -1894,7 +1894,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder setGet(
           com.scalar.db.rpc.Get.Builder builderForValue) {
@@ -1908,7 +1908,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder mergeGet(com.scalar.db.rpc.Get value) {
         if (getBuilder_ == null) {
@@ -1926,7 +1926,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder clearGet() {
         if (getBuilder_ == null) {
@@ -1940,7 +1940,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public com.scalar.db.rpc.Get.Builder getGetBuilder() {
         
@@ -1948,7 +1948,7 @@ private static final long serialVersionUID = 0L;
         return getGetFieldBuilder().getBuilder();
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
         if (getBuilder_ != null) {
@@ -1959,7 +1959,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Get, com.scalar.db.rpc.Get.Builder, com.scalar.db.rpc.GetOrBuilder> 
@@ -1987,10 +1987,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.GetRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.GetRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.GetRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.GetRequest)
     private static final com.scalar.db.rpc.TransactionRequest.GetRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.GetRequest();
@@ -2028,30 +2028,30 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ScanRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.ScanRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.ScanRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return Whether the scan field is set.
      */
     boolean hasScan();
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return The scan.
      */
     com.scalar.db.rpc.Scan getScan();
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      */
     com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.ScanRequest}
+   * Protobuf type {@code rpc.TransactionRequest.ScanRequest}
    */
   public static final class ScanRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.ScanRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.ScanRequest)
       ScanRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ScanRequest.newBuilder() to construct.
@@ -2127,13 +2127,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_ScanRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_ScanRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_ScanRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_ScanRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.ScanRequest.class, com.scalar.db.rpc.TransactionRequest.ScanRequest.Builder.class);
     }
@@ -2141,7 +2141,7 @@ private static final long serialVersionUID = 0L;
     public static final int SCAN_FIELD_NUMBER = 2;
     private com.scalar.db.rpc.Scan scan_;
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return Whether the scan field is set.
      */
     @java.lang.Override
@@ -2149,7 +2149,7 @@ private static final long serialVersionUID = 0L;
       return scan_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return The scan.
      */
     @java.lang.Override
@@ -2157,7 +2157,7 @@ private static final long serialVersionUID = 0L;
       return scan_ == null ? com.scalar.db.rpc.Scan.getDefaultInstance() : scan_;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
@@ -2325,21 +2325,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.ScanRequest}
+     * Protobuf type {@code rpc.TransactionRequest.ScanRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.ScanRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.ScanRequest)
         com.scalar.db.rpc.TransactionRequest.ScanRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_ScanRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_ScanRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_ScanRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_ScanRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.ScanRequest.class, com.scalar.db.rpc.TransactionRequest.ScanRequest.Builder.class);
       }
@@ -2374,7 +2374,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_ScanRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_ScanRequest_descriptor;
       }
 
       @java.lang.Override
@@ -2483,14 +2483,14 @@ private static final long serialVersionUID = 0L;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Scan, com.scalar.db.rpc.Scan.Builder, com.scalar.db.rpc.ScanOrBuilder> scanBuilder_;
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        * @return Whether the scan field is set.
        */
       public boolean hasScan() {
         return scanBuilder_ != null || scan_ != null;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        * @return The scan.
        */
       public com.scalar.db.rpc.Scan getScan() {
@@ -2501,7 +2501,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder setScan(com.scalar.db.rpc.Scan value) {
         if (scanBuilder_ == null) {
@@ -2517,7 +2517,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder setScan(
           com.scalar.db.rpc.Scan.Builder builderForValue) {
@@ -2531,7 +2531,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder mergeScan(com.scalar.db.rpc.Scan value) {
         if (scanBuilder_ == null) {
@@ -2549,7 +2549,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder clearScan() {
         if (scanBuilder_ == null) {
@@ -2563,7 +2563,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public com.scalar.db.rpc.Scan.Builder getScanBuilder() {
         
@@ -2571,7 +2571,7 @@ private static final long serialVersionUID = 0L;
         return getScanFieldBuilder().getBuilder();
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
         if (scanBuilder_ != null) {
@@ -2582,7 +2582,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Scan, com.scalar.db.rpc.Scan.Builder, com.scalar.db.rpc.ScanOrBuilder> 
@@ -2610,10 +2610,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.ScanRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.ScanRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.ScanRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.ScanRequest)
     private static final com.scalar.db.rpc.TransactionRequest.ScanRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.ScanRequest();
@@ -2651,39 +2651,39 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface MutateRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.MutateRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.MutateRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     java.util.List<com.scalar.db.rpc.Mutation> 
         getMutationsList();
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     com.scalar.db.rpc.Mutation getMutations(int index);
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     int getMutationsCount();
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
         getMutationsOrBuilderList();
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
         int index);
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.MutateRequest}
+   * Protobuf type {@code rpc.TransactionRequest.MutateRequest}
    */
   public static final class MutateRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.MutateRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.MutateRequest)
       MutateRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use MutateRequest.newBuilder() to construct.
@@ -2760,13 +2760,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_MutateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_MutateRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_MutateRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_MutateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.MutateRequest.class, com.scalar.db.rpc.TransactionRequest.MutateRequest.Builder.class);
     }
@@ -2774,14 +2774,14 @@ private static final long serialVersionUID = 0L;
     public static final int MUTATIONS_FIELD_NUMBER = 2;
     private java.util.List<com.scalar.db.rpc.Mutation> mutations_;
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public java.util.List<com.scalar.db.rpc.Mutation> getMutationsList() {
       return mutations_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
@@ -2789,21 +2789,21 @@ private static final long serialVersionUID = 0L;
       return mutations_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public int getMutationsCount() {
       return mutations_.size();
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.Mutation getMutations(int index) {
       return mutations_.get(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
@@ -2969,21 +2969,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.MutateRequest}
+     * Protobuf type {@code rpc.TransactionRequest.MutateRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.MutateRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.MutateRequest)
         com.scalar.db.rpc.TransactionRequest.MutateRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_MutateRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_MutateRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_MutateRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_MutateRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.MutateRequest.class, com.scalar.db.rpc.TransactionRequest.MutateRequest.Builder.class);
       }
@@ -3019,7 +3019,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_MutateRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_MutateRequest_descriptor;
       }
 
       @java.lang.Override
@@ -3166,7 +3166,7 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Mutation, com.scalar.db.rpc.Mutation.Builder, com.scalar.db.rpc.MutationOrBuilder> mutationsBuilder_;
 
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public java.util.List<com.scalar.db.rpc.Mutation> getMutationsList() {
         if (mutationsBuilder_ == null) {
@@ -3176,7 +3176,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public int getMutationsCount() {
         if (mutationsBuilder_ == null) {
@@ -3186,7 +3186,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation getMutations(int index) {
         if (mutationsBuilder_ == null) {
@@ -3196,7 +3196,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder setMutations(
           int index, com.scalar.db.rpc.Mutation value) {
@@ -3213,7 +3213,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder setMutations(
           int index, com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -3227,7 +3227,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(com.scalar.db.rpc.Mutation value) {
         if (mutationsBuilder_ == null) {
@@ -3243,7 +3243,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(
           int index, com.scalar.db.rpc.Mutation value) {
@@ -3260,7 +3260,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(
           com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -3274,7 +3274,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(
           int index, com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -3288,7 +3288,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addAllMutations(
           java.lang.Iterable<? extends com.scalar.db.rpc.Mutation> values) {
@@ -3303,7 +3303,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder clearMutations() {
         if (mutationsBuilder_ == null) {
@@ -3316,7 +3316,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder removeMutations(int index) {
         if (mutationsBuilder_ == null) {
@@ -3329,14 +3329,14 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation.Builder getMutationsBuilder(
           int index) {
         return getMutationsFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
           int index) {
@@ -3346,7 +3346,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
            getMutationsOrBuilderList() {
@@ -3357,14 +3357,14 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation.Builder addMutationsBuilder() {
         return getMutationsFieldBuilder().addBuilder(
             com.scalar.db.rpc.Mutation.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation.Builder addMutationsBuilder(
           int index) {
@@ -3372,7 +3372,7 @@ private static final long serialVersionUID = 0L;
             index, com.scalar.db.rpc.Mutation.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public java.util.List<com.scalar.db.rpc.Mutation.Builder> 
            getMutationsBuilderList() {
@@ -3405,10 +3405,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.MutateRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.MutateRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.MutateRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.MutateRequest)
     private static final com.scalar.db.rpc.TransactionRequest.MutateRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.MutateRequest();
@@ -3446,15 +3446,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface CommitRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.CommitRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.CommitRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.CommitRequest}
+   * Protobuf type {@code rpc.TransactionRequest.CommitRequest}
    */
   public static final class CommitRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.CommitRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.CommitRequest)
       CommitRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use CommitRequest.newBuilder() to construct.
@@ -3517,13 +3517,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_CommitRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_CommitRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_CommitRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_CommitRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.CommitRequest.class, com.scalar.db.rpc.TransactionRequest.CommitRequest.Builder.class);
     }
@@ -3673,21 +3673,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.CommitRequest}
+     * Protobuf type {@code rpc.TransactionRequest.CommitRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.CommitRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.CommitRequest)
         com.scalar.db.rpc.TransactionRequest.CommitRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_CommitRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_CommitRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_CommitRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_CommitRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.CommitRequest.class, com.scalar.db.rpc.TransactionRequest.CommitRequest.Builder.class);
       }
@@ -3716,7 +3716,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_CommitRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_CommitRequest_descriptor;
       }
 
       @java.lang.Override
@@ -3825,10 +3825,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.CommitRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.CommitRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.CommitRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.CommitRequest)
     private static final com.scalar.db.rpc.TransactionRequest.CommitRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.CommitRequest();
@@ -3866,15 +3866,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface RollbackRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.RollbackRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.RollbackRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.RollbackRequest}
+   * Protobuf type {@code rpc.TransactionRequest.RollbackRequest}
    */
   public static final class RollbackRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.RollbackRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.RollbackRequest)
       RollbackRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use RollbackRequest.newBuilder() to construct.
@@ -3937,13 +3937,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_RollbackRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.RollbackRequest.class, com.scalar.db.rpc.TransactionRequest.RollbackRequest.Builder.class);
     }
@@ -4093,21 +4093,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.RollbackRequest}
+     * Protobuf type {@code rpc.TransactionRequest.RollbackRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.RollbackRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.RollbackRequest)
         com.scalar.db.rpc.TransactionRequest.RollbackRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_RollbackRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_RollbackRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.RollbackRequest.class, com.scalar.db.rpc.TransactionRequest.RollbackRequest.Builder.class);
       }
@@ -4136,7 +4136,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_RollbackRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_RollbackRequest_descriptor;
       }
 
       @java.lang.Override
@@ -4245,10 +4245,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.RollbackRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.RollbackRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.RollbackRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.RollbackRequest)
     private static final com.scalar.db.rpc.TransactionRequest.RollbackRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.RollbackRequest();
@@ -4286,15 +4286,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface AbortRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest.AbortRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest.AbortRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest.AbortRequest}
+   * Protobuf type {@code rpc.TransactionRequest.AbortRequest}
    */
   public static final class AbortRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionRequest.AbortRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionRequest.AbortRequest)
       AbortRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use AbortRequest.newBuilder() to construct.
@@ -4357,13 +4357,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_AbortRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_AbortRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_AbortRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_AbortRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.AbortRequest.class, com.scalar.db.rpc.TransactionRequest.AbortRequest.Builder.class);
     }
@@ -4513,21 +4513,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionRequest.AbortRequest}
+     * Protobuf type {@code rpc.TransactionRequest.AbortRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest.AbortRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest.AbortRequest)
         com.scalar.db.rpc.TransactionRequest.AbortRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_AbortRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_AbortRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_AbortRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_AbortRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionRequest.AbortRequest.class, com.scalar.db.rpc.TransactionRequest.AbortRequest.Builder.class);
       }
@@ -4556,7 +4556,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_AbortRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_AbortRequest_descriptor;
       }
 
       @java.lang.Override
@@ -4665,10 +4665,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest.AbortRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest.AbortRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest.AbortRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionRequest.AbortRequest)
     private static final com.scalar.db.rpc.TransactionRequest.AbortRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest.AbortRequest();
@@ -4760,7 +4760,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int START_REQUEST_FIELD_NUMBER = 1;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
    * @return Whether the startRequest field is set.
    */
   @java.lang.Override
@@ -4768,7 +4768,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 1;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
    * @return The startRequest.
    */
   @java.lang.Override
@@ -4779,7 +4779,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.StartRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder getStartRequestOrBuilder() {
@@ -4791,7 +4791,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int GET_REQUEST_FIELD_NUMBER = 2;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+   * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
    * @return Whether the getRequest field is set.
    */
   @java.lang.Override
@@ -4799,7 +4799,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 2;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+   * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
    * @return The getRequest.
    */
   @java.lang.Override
@@ -4810,7 +4810,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.GetRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+   * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.GetRequestOrBuilder getGetRequestOrBuilder() {
@@ -4822,7 +4822,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int SCAN_REQUEST_FIELD_NUMBER = 3;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+   * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
    * @return Whether the scanRequest field is set.
    */
   @java.lang.Override
@@ -4830,7 +4830,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 3;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+   * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
    * @return The scanRequest.
    */
   @java.lang.Override
@@ -4841,7 +4841,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.ScanRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+   * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.ScanRequestOrBuilder getScanRequestOrBuilder() {
@@ -4853,7 +4853,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int MUTATE_REQUEST_FIELD_NUMBER = 4;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+   * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
    * @return Whether the mutateRequest field is set.
    */
   @java.lang.Override
@@ -4861,7 +4861,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 4;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+   * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
    * @return The mutateRequest.
    */
   @java.lang.Override
@@ -4872,7 +4872,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.MutateRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+   * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.MutateRequestOrBuilder getMutateRequestOrBuilder() {
@@ -4884,7 +4884,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int COMMIT_REQUEST_FIELD_NUMBER = 5;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+   * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
    * @return Whether the commitRequest field is set.
    */
   @java.lang.Override
@@ -4892,7 +4892,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 5;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+   * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
    * @return The commitRequest.
    */
   @java.lang.Override
@@ -4903,7 +4903,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.CommitRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+   * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.CommitRequestOrBuilder getCommitRequestOrBuilder() {
@@ -4915,7 +4915,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int ABORT_REQUEST_FIELD_NUMBER = 6;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+   * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
    * @return Whether the abortRequest field is set.
    */
   @java.lang.Override
@@ -4923,7 +4923,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 6;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+   * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
    * @return The abortRequest.
    */
   @java.lang.Override
@@ -4934,7 +4934,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.AbortRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+   * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.AbortRequestOrBuilder getAbortRequestOrBuilder() {
@@ -4946,7 +4946,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int BEGIN_REQUEST_FIELD_NUMBER = 7;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+   * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
    * @return Whether the beginRequest field is set.
    */
   @java.lang.Override
@@ -4954,7 +4954,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 7;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+   * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
    * @return The beginRequest.
    */
   @java.lang.Override
@@ -4965,7 +4965,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.BeginRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+   * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.BeginRequestOrBuilder getBeginRequestOrBuilder() {
@@ -4977,7 +4977,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int ROLLBACK_REQUEST_FIELD_NUMBER = 8;
   /**
-   * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+   * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
    * @return Whether the rollbackRequest field is set.
    */
   @java.lang.Override
@@ -4985,7 +4985,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 8;
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+   * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
    * @return The rollbackRequest.
    */
   @java.lang.Override
@@ -4996,7 +4996,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionRequest.RollbackRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+   * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder() {
@@ -5280,21 +5280,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionRequest}
+   * Protobuf type {@code rpc.TransactionRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.TransactionRequest)
       com.scalar.db.rpc.TransactionRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionRequest.class, com.scalar.db.rpc.TransactionRequest.Builder.class);
     }
@@ -5325,7 +5325,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionRequest_descriptor;
     }
 
     @java.lang.Override
@@ -5534,7 +5534,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.StartRequest, com.scalar.db.rpc.TransactionRequest.StartRequest.Builder, com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder> startRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      * @return Whether the startRequest field is set.
      */
     @java.lang.Override
@@ -5542,7 +5542,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 1;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      * @return The startRequest.
      */
     @java.lang.Override
@@ -5560,7 +5560,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder setStartRequest(com.scalar.db.rpc.TransactionRequest.StartRequest value) {
       if (startRequestBuilder_ == null) {
@@ -5576,7 +5576,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder setStartRequest(
         com.scalar.db.rpc.TransactionRequest.StartRequest.Builder builderForValue) {
@@ -5590,7 +5590,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder mergeStartRequest(com.scalar.db.rpc.TransactionRequest.StartRequest value) {
       if (startRequestBuilder_ == null) {
@@ -5613,7 +5613,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder clearStartRequest() {
       if (startRequestBuilder_ == null) {
@@ -5632,13 +5632,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.StartRequest.Builder getStartRequestBuilder() {
       return getStartRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder getStartRequestOrBuilder() {
@@ -5652,7 +5652,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.StartRequest, com.scalar.db.rpc.TransactionRequest.StartRequest.Builder, com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder> 
@@ -5676,7 +5676,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.GetRequest, com.scalar.db.rpc.TransactionRequest.GetRequest.Builder, com.scalar.db.rpc.TransactionRequest.GetRequestOrBuilder> getRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      * @return Whether the getRequest field is set.
      */
     @java.lang.Override
@@ -5684,7 +5684,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 2;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      * @return The getRequest.
      */
     @java.lang.Override
@@ -5702,7 +5702,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     public Builder setGetRequest(com.scalar.db.rpc.TransactionRequest.GetRequest value) {
       if (getRequestBuilder_ == null) {
@@ -5718,7 +5718,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     public Builder setGetRequest(
         com.scalar.db.rpc.TransactionRequest.GetRequest.Builder builderForValue) {
@@ -5732,7 +5732,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     public Builder mergeGetRequest(com.scalar.db.rpc.TransactionRequest.GetRequest value) {
       if (getRequestBuilder_ == null) {
@@ -5755,7 +5755,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     public Builder clearGetRequest() {
       if (getRequestBuilder_ == null) {
@@ -5774,13 +5774,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.GetRequest.Builder getGetRequestBuilder() {
       return getGetRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.GetRequestOrBuilder getGetRequestOrBuilder() {
@@ -5794,7 +5794,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+     * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.GetRequest, com.scalar.db.rpc.TransactionRequest.GetRequest.Builder, com.scalar.db.rpc.TransactionRequest.GetRequestOrBuilder> 
@@ -5818,7 +5818,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.ScanRequest, com.scalar.db.rpc.TransactionRequest.ScanRequest.Builder, com.scalar.db.rpc.TransactionRequest.ScanRequestOrBuilder> scanRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      * @return Whether the scanRequest field is set.
      */
     @java.lang.Override
@@ -5826,7 +5826,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 3;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      * @return The scanRequest.
      */
     @java.lang.Override
@@ -5844,7 +5844,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     public Builder setScanRequest(com.scalar.db.rpc.TransactionRequest.ScanRequest value) {
       if (scanRequestBuilder_ == null) {
@@ -5860,7 +5860,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     public Builder setScanRequest(
         com.scalar.db.rpc.TransactionRequest.ScanRequest.Builder builderForValue) {
@@ -5874,7 +5874,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     public Builder mergeScanRequest(com.scalar.db.rpc.TransactionRequest.ScanRequest value) {
       if (scanRequestBuilder_ == null) {
@@ -5897,7 +5897,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     public Builder clearScanRequest() {
       if (scanRequestBuilder_ == null) {
@@ -5916,13 +5916,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.ScanRequest.Builder getScanRequestBuilder() {
       return getScanRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.ScanRequestOrBuilder getScanRequestOrBuilder() {
@@ -5936,7 +5936,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+     * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.ScanRequest, com.scalar.db.rpc.TransactionRequest.ScanRequest.Builder, com.scalar.db.rpc.TransactionRequest.ScanRequestOrBuilder> 
@@ -5960,7 +5960,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.MutateRequest, com.scalar.db.rpc.TransactionRequest.MutateRequest.Builder, com.scalar.db.rpc.TransactionRequest.MutateRequestOrBuilder> mutateRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      * @return Whether the mutateRequest field is set.
      */
     @java.lang.Override
@@ -5968,7 +5968,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 4;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      * @return The mutateRequest.
      */
     @java.lang.Override
@@ -5986,7 +5986,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     public Builder setMutateRequest(com.scalar.db.rpc.TransactionRequest.MutateRequest value) {
       if (mutateRequestBuilder_ == null) {
@@ -6002,7 +6002,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     public Builder setMutateRequest(
         com.scalar.db.rpc.TransactionRequest.MutateRequest.Builder builderForValue) {
@@ -6016,7 +6016,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     public Builder mergeMutateRequest(com.scalar.db.rpc.TransactionRequest.MutateRequest value) {
       if (mutateRequestBuilder_ == null) {
@@ -6039,7 +6039,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     public Builder clearMutateRequest() {
       if (mutateRequestBuilder_ == null) {
@@ -6058,13 +6058,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.MutateRequest.Builder getMutateRequestBuilder() {
       return getMutateRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.MutateRequestOrBuilder getMutateRequestOrBuilder() {
@@ -6078,7 +6078,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+     * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.MutateRequest, com.scalar.db.rpc.TransactionRequest.MutateRequest.Builder, com.scalar.db.rpc.TransactionRequest.MutateRequestOrBuilder> 
@@ -6102,7 +6102,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.CommitRequest, com.scalar.db.rpc.TransactionRequest.CommitRequest.Builder, com.scalar.db.rpc.TransactionRequest.CommitRequestOrBuilder> commitRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      * @return Whether the commitRequest field is set.
      */
     @java.lang.Override
@@ -6110,7 +6110,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 5;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      * @return The commitRequest.
      */
     @java.lang.Override
@@ -6128,7 +6128,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     public Builder setCommitRequest(com.scalar.db.rpc.TransactionRequest.CommitRequest value) {
       if (commitRequestBuilder_ == null) {
@@ -6144,7 +6144,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     public Builder setCommitRequest(
         com.scalar.db.rpc.TransactionRequest.CommitRequest.Builder builderForValue) {
@@ -6158,7 +6158,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     public Builder mergeCommitRequest(com.scalar.db.rpc.TransactionRequest.CommitRequest value) {
       if (commitRequestBuilder_ == null) {
@@ -6181,7 +6181,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     public Builder clearCommitRequest() {
       if (commitRequestBuilder_ == null) {
@@ -6200,13 +6200,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.CommitRequest.Builder getCommitRequestBuilder() {
       return getCommitRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.CommitRequestOrBuilder getCommitRequestOrBuilder() {
@@ -6220,7 +6220,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+     * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.CommitRequest, com.scalar.db.rpc.TransactionRequest.CommitRequest.Builder, com.scalar.db.rpc.TransactionRequest.CommitRequestOrBuilder> 
@@ -6244,7 +6244,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.AbortRequest, com.scalar.db.rpc.TransactionRequest.AbortRequest.Builder, com.scalar.db.rpc.TransactionRequest.AbortRequestOrBuilder> abortRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      * @return Whether the abortRequest field is set.
      */
     @java.lang.Override
@@ -6252,7 +6252,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 6;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      * @return The abortRequest.
      */
     @java.lang.Override
@@ -6270,7 +6270,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     public Builder setAbortRequest(com.scalar.db.rpc.TransactionRequest.AbortRequest value) {
       if (abortRequestBuilder_ == null) {
@@ -6286,7 +6286,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     public Builder setAbortRequest(
         com.scalar.db.rpc.TransactionRequest.AbortRequest.Builder builderForValue) {
@@ -6300,7 +6300,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     public Builder mergeAbortRequest(com.scalar.db.rpc.TransactionRequest.AbortRequest value) {
       if (abortRequestBuilder_ == null) {
@@ -6323,7 +6323,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     public Builder clearAbortRequest() {
       if (abortRequestBuilder_ == null) {
@@ -6342,13 +6342,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.AbortRequest.Builder getAbortRequestBuilder() {
       return getAbortRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.AbortRequestOrBuilder getAbortRequestOrBuilder() {
@@ -6362,7 +6362,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+     * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.AbortRequest, com.scalar.db.rpc.TransactionRequest.AbortRequest.Builder, com.scalar.db.rpc.TransactionRequest.AbortRequestOrBuilder> 
@@ -6386,7 +6386,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.BeginRequest, com.scalar.db.rpc.TransactionRequest.BeginRequest.Builder, com.scalar.db.rpc.TransactionRequest.BeginRequestOrBuilder> beginRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      * @return Whether the beginRequest field is set.
      */
     @java.lang.Override
@@ -6394,7 +6394,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 7;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      * @return The beginRequest.
      */
     @java.lang.Override
@@ -6412,7 +6412,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     public Builder setBeginRequest(com.scalar.db.rpc.TransactionRequest.BeginRequest value) {
       if (beginRequestBuilder_ == null) {
@@ -6428,7 +6428,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     public Builder setBeginRequest(
         com.scalar.db.rpc.TransactionRequest.BeginRequest.Builder builderForValue) {
@@ -6442,7 +6442,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     public Builder mergeBeginRequest(com.scalar.db.rpc.TransactionRequest.BeginRequest value) {
       if (beginRequestBuilder_ == null) {
@@ -6465,7 +6465,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     public Builder clearBeginRequest() {
       if (beginRequestBuilder_ == null) {
@@ -6484,13 +6484,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.BeginRequest.Builder getBeginRequestBuilder() {
       return getBeginRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.BeginRequestOrBuilder getBeginRequestOrBuilder() {
@@ -6504,7 +6504,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+     * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.BeginRequest, com.scalar.db.rpc.TransactionRequest.BeginRequest.Builder, com.scalar.db.rpc.TransactionRequest.BeginRequestOrBuilder> 
@@ -6528,7 +6528,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.RollbackRequest, com.scalar.db.rpc.TransactionRequest.RollbackRequest.Builder, com.scalar.db.rpc.TransactionRequest.RollbackRequestOrBuilder> rollbackRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      * @return Whether the rollbackRequest field is set.
      */
     @java.lang.Override
@@ -6536,7 +6536,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 8;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      * @return The rollbackRequest.
      */
     @java.lang.Override
@@ -6554,7 +6554,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     public Builder setRollbackRequest(com.scalar.db.rpc.TransactionRequest.RollbackRequest value) {
       if (rollbackRequestBuilder_ == null) {
@@ -6570,7 +6570,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     public Builder setRollbackRequest(
         com.scalar.db.rpc.TransactionRequest.RollbackRequest.Builder builderForValue) {
@@ -6584,7 +6584,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     public Builder mergeRollbackRequest(com.scalar.db.rpc.TransactionRequest.RollbackRequest value) {
       if (rollbackRequestBuilder_ == null) {
@@ -6607,7 +6607,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     public Builder clearRollbackRequest() {
       if (rollbackRequestBuilder_ == null) {
@@ -6626,13 +6626,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     public com.scalar.db.rpc.TransactionRequest.RollbackRequest.Builder getRollbackRequestBuilder() {
       return getRollbackRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder() {
@@ -6646,7 +6646,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+     * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.RollbackRequest, com.scalar.db.rpc.TransactionRequest.RollbackRequest.Builder, com.scalar.db.rpc.TransactionRequest.RollbackRequestOrBuilder> 
@@ -6679,10 +6679,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.TransactionRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionRequest)
+  // @@protoc_insertion_point(class_scope:rpc.TransactionRequest)
   private static final com.scalar.db.rpc.TransactionRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionRequestOrBuilder.java
@@ -4,126 +4,126 @@
 package com.scalar.db.rpc;
 
 public interface TransactionRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.TransactionRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
    * @return Whether the startRequest field is set.
    */
   boolean hasStartRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
    * @return The startRequest.
    */
   com.scalar.db.rpc.TransactionRequest.StartRequest getStartRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TransactionRequest.StartRequest start_request = 1;</code>
    */
   com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder getStartRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+   * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
    * @return Whether the getRequest field is set.
    */
   boolean hasGetRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+   * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
    * @return The getRequest.
    */
   com.scalar.db.rpc.TransactionRequest.GetRequest getGetRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.GetRequest get_request = 2;</code>
+   * <code>.rpc.TransactionRequest.GetRequest get_request = 2;</code>
    */
   com.scalar.db.rpc.TransactionRequest.GetRequestOrBuilder getGetRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+   * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
    * @return Whether the scanRequest field is set.
    */
   boolean hasScanRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+   * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
    * @return The scanRequest.
    */
   com.scalar.db.rpc.TransactionRequest.ScanRequest getScanRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
+   * <code>.rpc.TransactionRequest.ScanRequest scan_request = 3;</code>
    */
   com.scalar.db.rpc.TransactionRequest.ScanRequestOrBuilder getScanRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+   * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
    * @return Whether the mutateRequest field is set.
    */
   boolean hasMutateRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+   * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
    * @return The mutateRequest.
    */
   com.scalar.db.rpc.TransactionRequest.MutateRequest getMutateRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
+   * <code>.rpc.TransactionRequest.MutateRequest mutate_request = 4;</code>
    */
   com.scalar.db.rpc.TransactionRequest.MutateRequestOrBuilder getMutateRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+   * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
    * @return Whether the commitRequest field is set.
    */
   boolean hasCommitRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+   * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
    * @return The commitRequest.
    */
   com.scalar.db.rpc.TransactionRequest.CommitRequest getCommitRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
+   * <code>.rpc.TransactionRequest.CommitRequest commit_request = 5;</code>
    */
   com.scalar.db.rpc.TransactionRequest.CommitRequestOrBuilder getCommitRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+   * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
    * @return Whether the abortRequest field is set.
    */
   boolean hasAbortRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+   * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
    * @return The abortRequest.
    */
   com.scalar.db.rpc.TransactionRequest.AbortRequest getAbortRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
+   * <code>.rpc.TransactionRequest.AbortRequest abort_request = 6;</code>
    */
   com.scalar.db.rpc.TransactionRequest.AbortRequestOrBuilder getAbortRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+   * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
    * @return Whether the beginRequest field is set.
    */
   boolean hasBeginRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+   * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
    * @return The beginRequest.
    */
   com.scalar.db.rpc.TransactionRequest.BeginRequest getBeginRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
+   * <code>.rpc.TransactionRequest.BeginRequest begin_request = 7;</code>
    */
   com.scalar.db.rpc.TransactionRequest.BeginRequestOrBuilder getBeginRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+   * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
    * @return Whether the rollbackRequest field is set.
    */
   boolean hasRollbackRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+   * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
    * @return The rollbackRequest.
    */
   com.scalar.db.rpc.TransactionRequest.RollbackRequest getRollbackRequest();
   /**
-   * <code>.scalardb.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
+   * <code>.rpc.TransactionRequest.RollbackRequest rollback_request = 8;</code>
    */
   com.scalar.db.rpc.TransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TransactionResponse}
+ * Protobuf type {@code rpc.TransactionResponse}
  */
 public final class TransactionResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionResponse)
+    // @@protoc_insertion_point(message_implements:rpc.TransactionResponse)
     TransactionResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TransactionResponse.newBuilder() to construct.
@@ -141,19 +141,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TransactionResponse.class, com.scalar.db.rpc.TransactionResponse.Builder.class);
   }
 
   public interface BeginResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionResponse.BeginResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionResponse.BeginResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -169,11 +169,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionResponse.BeginResponse}
+   * Protobuf type {@code rpc.TransactionResponse.BeginResponse}
    */
   public static final class BeginResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionResponse.BeginResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionResponse.BeginResponse)
       BeginResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use BeginResponse.newBuilder() to construct.
@@ -243,13 +243,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_BeginResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_BeginResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_BeginResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_BeginResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionResponse.BeginResponse.class, com.scalar.db.rpc.TransactionResponse.BeginResponse.Builder.class);
     }
@@ -447,21 +447,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionResponse.BeginResponse}
+     * Protobuf type {@code rpc.TransactionResponse.BeginResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionResponse.BeginResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionResponse.BeginResponse)
         com.scalar.db.rpc.TransactionResponse.BeginResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_BeginResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_BeginResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_BeginResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_BeginResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionResponse.BeginResponse.class, com.scalar.db.rpc.TransactionResponse.BeginResponse.Builder.class);
       }
@@ -492,7 +492,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_BeginResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_BeginResponse_descriptor;
       }
 
       @java.lang.Override
@@ -682,10 +682,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionResponse.BeginResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionResponse.BeginResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionResponse.BeginResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionResponse.BeginResponse)
     private static final com.scalar.db.rpc.TransactionResponse.BeginResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionResponse.BeginResponse();
@@ -723,7 +723,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface StartResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionResponse.StartResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionResponse.StartResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -739,11 +739,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionResponse.StartResponse}
+   * Protobuf type {@code rpc.TransactionResponse.StartResponse}
    */
   public static final class StartResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionResponse.StartResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionResponse.StartResponse)
       StartResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StartResponse.newBuilder() to construct.
@@ -813,13 +813,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_StartResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_StartResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_StartResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_StartResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionResponse.StartResponse.class, com.scalar.db.rpc.TransactionResponse.StartResponse.Builder.class);
     }
@@ -1017,21 +1017,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionResponse.StartResponse}
+     * Protobuf type {@code rpc.TransactionResponse.StartResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionResponse.StartResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionResponse.StartResponse)
         com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_StartResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_StartResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_StartResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_StartResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionResponse.StartResponse.class, com.scalar.db.rpc.TransactionResponse.StartResponse.Builder.class);
       }
@@ -1062,7 +1062,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_StartResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_StartResponse_descriptor;
       }
 
       @java.lang.Override
@@ -1252,10 +1252,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionResponse.StartResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionResponse.StartResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionResponse.StartResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionResponse.StartResponse)
     private static final com.scalar.db.rpc.TransactionResponse.StartResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionResponse.StartResponse();
@@ -1293,30 +1293,30 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface GetResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionResponse.GetResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionResponse.GetResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return Whether the result field is set.
      */
     boolean hasResult();
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return The result.
      */
     com.scalar.db.rpc.Result getResult();
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionResponse.GetResponse}
+   * Protobuf type {@code rpc.TransactionResponse.GetResponse}
    */
   public static final class GetResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionResponse.GetResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionResponse.GetResponse)
       GetResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use GetResponse.newBuilder() to construct.
@@ -1392,13 +1392,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_GetResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_GetResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_GetResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_GetResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionResponse.GetResponse.class, com.scalar.db.rpc.TransactionResponse.GetResponse.Builder.class);
     }
@@ -1406,7 +1406,7 @@ private static final long serialVersionUID = 0L;
     public static final int RESULT_FIELD_NUMBER = 1;
     private com.scalar.db.rpc.Result result_;
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return Whether the result field is set.
      */
     @java.lang.Override
@@ -1414,7 +1414,7 @@ private static final long serialVersionUID = 0L;
       return result_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return The result.
      */
     @java.lang.Override
@@ -1422,7 +1422,7 @@ private static final long serialVersionUID = 0L;
       return result_ == null ? com.scalar.db.rpc.Result.getDefaultInstance() : result_;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
@@ -1590,21 +1590,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionResponse.GetResponse}
+     * Protobuf type {@code rpc.TransactionResponse.GetResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionResponse.GetResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionResponse.GetResponse)
         com.scalar.db.rpc.TransactionResponse.GetResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_GetResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_GetResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_GetResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_GetResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionResponse.GetResponse.class, com.scalar.db.rpc.TransactionResponse.GetResponse.Builder.class);
       }
@@ -1639,7 +1639,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_GetResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_GetResponse_descriptor;
       }
 
       @java.lang.Override
@@ -1748,14 +1748,14 @@ private static final long serialVersionUID = 0L;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> resultBuilder_;
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        * @return Whether the result field is set.
        */
       public boolean hasResult() {
         return resultBuilder_ != null || result_ != null;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        * @return The result.
        */
       public com.scalar.db.rpc.Result getResult() {
@@ -1766,7 +1766,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder setResult(com.scalar.db.rpc.Result value) {
         if (resultBuilder_ == null) {
@@ -1782,7 +1782,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder setResult(
           com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -1796,7 +1796,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder mergeResult(com.scalar.db.rpc.Result value) {
         if (resultBuilder_ == null) {
@@ -1814,7 +1814,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder clearResult() {
         if (resultBuilder_ == null) {
@@ -1828,7 +1828,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder getResultBuilder() {
         
@@ -1836,7 +1836,7 @@ private static final long serialVersionUID = 0L;
         return getResultFieldBuilder().getBuilder();
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
         if (resultBuilder_ != null) {
@@ -1847,7 +1847,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> 
@@ -1875,10 +1875,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionResponse.GetResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionResponse.GetResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionResponse.GetResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionResponse.GetResponse)
     private static final com.scalar.db.rpc.TransactionResponse.GetResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionResponse.GetResponse();
@@ -1916,39 +1916,39 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ScanResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionResponse.ScanResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionResponse.ScanResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     java.util.List<com.scalar.db.rpc.Result> 
         getResultsList();
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     com.scalar.db.rpc.Result getResults(int index);
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     int getResultsCount();
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
         getResultsOrBuilderList();
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
         int index);
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionResponse.ScanResponse}
+   * Protobuf type {@code rpc.TransactionResponse.ScanResponse}
    */
   public static final class ScanResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionResponse.ScanResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionResponse.ScanResponse)
       ScanResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ScanResponse.newBuilder() to construct.
@@ -2025,13 +2025,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_ScanResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_ScanResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_ScanResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_ScanResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionResponse.ScanResponse.class, com.scalar.db.rpc.TransactionResponse.ScanResponse.Builder.class);
     }
@@ -2039,14 +2039,14 @@ private static final long serialVersionUID = 0L;
     public static final int RESULTS_FIELD_NUMBER = 1;
     private java.util.List<com.scalar.db.rpc.Result> results_;
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public java.util.List<com.scalar.db.rpc.Result> getResultsList() {
       return results_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
@@ -2054,21 +2054,21 @@ private static final long serialVersionUID = 0L;
       return results_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public int getResultsCount() {
       return results_.size();
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.Result getResults(int index) {
       return results_.get(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
@@ -2234,21 +2234,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionResponse.ScanResponse}
+     * Protobuf type {@code rpc.TransactionResponse.ScanResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionResponse.ScanResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionResponse.ScanResponse)
         com.scalar.db.rpc.TransactionResponse.ScanResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_ScanResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_ScanResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_ScanResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_ScanResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionResponse.ScanResponse.class, com.scalar.db.rpc.TransactionResponse.ScanResponse.Builder.class);
       }
@@ -2284,7 +2284,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_ScanResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_ScanResponse_descriptor;
       }
 
       @java.lang.Override
@@ -2431,7 +2431,7 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> resultsBuilder_;
 
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public java.util.List<com.scalar.db.rpc.Result> getResultsList() {
         if (resultsBuilder_ == null) {
@@ -2441,7 +2441,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public int getResultsCount() {
         if (resultsBuilder_ == null) {
@@ -2451,7 +2451,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result getResults(int index) {
         if (resultsBuilder_ == null) {
@@ -2461,7 +2461,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder setResults(
           int index, com.scalar.db.rpc.Result value) {
@@ -2478,7 +2478,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder setResults(
           int index, com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -2492,7 +2492,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(com.scalar.db.rpc.Result value) {
         if (resultsBuilder_ == null) {
@@ -2508,7 +2508,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(
           int index, com.scalar.db.rpc.Result value) {
@@ -2525,7 +2525,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(
           com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -2539,7 +2539,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(
           int index, com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -2553,7 +2553,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addAllResults(
           java.lang.Iterable<? extends com.scalar.db.rpc.Result> values) {
@@ -2568,7 +2568,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder clearResults() {
         if (resultsBuilder_ == null) {
@@ -2581,7 +2581,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder removeResults(int index) {
         if (resultsBuilder_ == null) {
@@ -2594,14 +2594,14 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder getResultsBuilder(
           int index) {
         return getResultsFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
           int index) {
@@ -2611,7 +2611,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
            getResultsOrBuilderList() {
@@ -2622,14 +2622,14 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder addResultsBuilder() {
         return getResultsFieldBuilder().addBuilder(
             com.scalar.db.rpc.Result.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder addResultsBuilder(
           int index) {
@@ -2637,7 +2637,7 @@ private static final long serialVersionUID = 0L;
             index, com.scalar.db.rpc.Result.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public java.util.List<com.scalar.db.rpc.Result.Builder> 
            getResultsBuilderList() {
@@ -2670,10 +2670,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionResponse.ScanResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionResponse.ScanResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionResponse.ScanResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionResponse.ScanResponse)
     private static final com.scalar.db.rpc.TransactionResponse.ScanResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionResponse.ScanResponse();
@@ -2711,16 +2711,16 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ErrorOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionResponse.Error)
+      // @@protoc_insertion_point(interface_extends:rpc.TransactionResponse.Error)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The enum numeric value on the wire for errorCode.
      */
     int getErrorCodeValue();
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The errorCode.
      */
     com.scalar.db.rpc.TransactionResponse.Error.ErrorCode getErrorCode();
@@ -2738,11 +2738,11 @@ private static final long serialVersionUID = 0L;
         getMessageBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionResponse.Error}
+   * Protobuf type {@code rpc.TransactionResponse.Error}
    */
   public static final class Error extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TransactionResponse.Error)
+      // @@protoc_insertion_point(message_implements:rpc.TransactionResponse.Error)
       ErrorOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Error.newBuilder() to construct.
@@ -2819,19 +2819,19 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_Error_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_Error_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_Error_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_Error_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionResponse.Error.class, com.scalar.db.rpc.TransactionResponse.Error.Builder.class);
     }
 
     /**
-     * Protobuf enum {@code scalardb.rpc.TransactionResponse.Error.ErrorCode}
+     * Protobuf enum {@code rpc.TransactionResponse.Error.ErrorCode}
      */
     public enum ErrorCode
         implements com.google.protobuf.ProtocolMessageEnum {
@@ -2953,20 +2953,20 @@ private static final long serialVersionUID = 0L;
         this.value = value;
       }
 
-      // @@protoc_insertion_point(enum_scope:scalardb.rpc.TransactionResponse.Error.ErrorCode)
+      // @@protoc_insertion_point(enum_scope:rpc.TransactionResponse.Error.ErrorCode)
     }
 
     public static final int ERROR_CODE_FIELD_NUMBER = 1;
     private int errorCode_;
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The enum numeric value on the wire for errorCode.
      */
     @java.lang.Override public int getErrorCodeValue() {
       return errorCode_;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The errorCode.
      */
     @java.lang.Override public com.scalar.db.rpc.TransactionResponse.Error.ErrorCode getErrorCode() {
@@ -3178,21 +3178,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TransactionResponse.Error}
+     * Protobuf type {@code rpc.TransactionResponse.Error}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionResponse.Error)
+        // @@protoc_insertion_point(builder_implements:rpc.TransactionResponse.Error)
         com.scalar.db.rpc.TransactionResponse.ErrorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_Error_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_Error_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_Error_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_Error_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TransactionResponse.Error.class, com.scalar.db.rpc.TransactionResponse.Error.Builder.class);
       }
@@ -3225,7 +3225,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_Error_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_Error_descriptor;
       }
 
       @java.lang.Override
@@ -3333,14 +3333,14 @@ private static final long serialVersionUID = 0L;
 
       private int errorCode_ = 0;
       /**
-       * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @return The enum numeric value on the wire for errorCode.
        */
       @java.lang.Override public int getErrorCodeValue() {
         return errorCode_;
       }
       /**
-       * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @param value The enum numeric value on the wire for errorCode to set.
        * @return This builder for chaining.
        */
@@ -3351,7 +3351,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @return The errorCode.
        */
       @java.lang.Override
@@ -3361,7 +3361,7 @@ private static final long serialVersionUID = 0L;
         return result == null ? com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.UNRECOGNIZED : result;
       }
       /**
-       * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @param value The errorCode to set.
        * @return This builder for chaining.
        */
@@ -3375,7 +3375,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearErrorCode() {
@@ -3473,10 +3473,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionResponse.Error)
+      // @@protoc_insertion_point(builder_scope:rpc.TransactionResponse.Error)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionResponse.Error)
+    // @@protoc_insertion_point(class_scope:rpc.TransactionResponse.Error)
     private static final com.scalar.db.rpc.TransactionResponse.Error DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionResponse.Error();
@@ -3562,7 +3562,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int START_RESPONSE_FIELD_NUMBER = 1;
   /**
-   * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
    * @return Whether the startResponse field is set.
    */
   @java.lang.Override
@@ -3570,7 +3570,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 1;
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
    * @return The startResponse.
    */
   @java.lang.Override
@@ -3581,7 +3581,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionResponse.StartResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder getStartResponseOrBuilder() {
@@ -3593,7 +3593,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int GET_RESPONSE_FIELD_NUMBER = 2;
   /**
-   * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
    * @return Whether the getResponse field is set.
    */
   @java.lang.Override
@@ -3601,7 +3601,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 2;
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
    * @return The getResponse.
    */
   @java.lang.Override
@@ -3612,7 +3612,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionResponse.GetResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionResponse.GetResponseOrBuilder getGetResponseOrBuilder() {
@@ -3624,7 +3624,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int SCAN_RESPONSE_FIELD_NUMBER = 3;
   /**
-   * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
    * @return Whether the scanResponse field is set.
    */
   @java.lang.Override
@@ -3632,7 +3632,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 3;
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
    * @return The scanResponse.
    */
   @java.lang.Override
@@ -3643,7 +3643,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionResponse.ScanResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionResponse.ScanResponseOrBuilder getScanResponseOrBuilder() {
@@ -3655,7 +3655,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int ERROR_FIELD_NUMBER = 4;
   /**
-   * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TransactionResponse.Error error = 4;</code>
    * @return Whether the error field is set.
    */
   @java.lang.Override
@@ -3663,7 +3663,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 4;
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TransactionResponse.Error error = 4;</code>
    * @return The error.
    */
   @java.lang.Override
@@ -3674,7 +3674,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionResponse.Error.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TransactionResponse.Error error = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionResponse.ErrorOrBuilder getErrorOrBuilder() {
@@ -3686,7 +3686,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int BEGIN_RESPONSE_FIELD_NUMBER = 5;
   /**
-   * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+   * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
    * @return Whether the beginResponse field is set.
    */
   @java.lang.Override
@@ -3694,7 +3694,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 5;
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+   * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
    * @return The beginResponse.
    */
   @java.lang.Override
@@ -3705,7 +3705,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TransactionResponse.BeginResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+   * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TransactionResponse.BeginResponseOrBuilder getBeginResponseOrBuilder() {
@@ -3944,21 +3944,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TransactionResponse}
+   * Protobuf type {@code rpc.TransactionResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TransactionResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.TransactionResponse)
       com.scalar.db.rpc.TransactionResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TransactionResponse.class, com.scalar.db.rpc.TransactionResponse.Builder.class);
     }
@@ -3989,7 +3989,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TransactionResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TransactionResponse_descriptor;
     }
 
     @java.lang.Override
@@ -4165,7 +4165,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.StartResponse, com.scalar.db.rpc.TransactionResponse.StartResponse.Builder, com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder> startResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      * @return Whether the startResponse field is set.
      */
     @java.lang.Override
@@ -4173,7 +4173,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 1;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      * @return The startResponse.
      */
     @java.lang.Override
@@ -4191,7 +4191,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder setStartResponse(com.scalar.db.rpc.TransactionResponse.StartResponse value) {
       if (startResponseBuilder_ == null) {
@@ -4207,7 +4207,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder setStartResponse(
         com.scalar.db.rpc.TransactionResponse.StartResponse.Builder builderForValue) {
@@ -4221,7 +4221,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder mergeStartResponse(com.scalar.db.rpc.TransactionResponse.StartResponse value) {
       if (startResponseBuilder_ == null) {
@@ -4244,7 +4244,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder clearStartResponse() {
       if (startResponseBuilder_ == null) {
@@ -4263,13 +4263,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     public com.scalar.db.rpc.TransactionResponse.StartResponse.Builder getStartResponseBuilder() {
       return getStartResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder getStartResponseOrBuilder() {
@@ -4283,7 +4283,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.StartResponse, com.scalar.db.rpc.TransactionResponse.StartResponse.Builder, com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder> 
@@ -4307,7 +4307,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.GetResponse, com.scalar.db.rpc.TransactionResponse.GetResponse.Builder, com.scalar.db.rpc.TransactionResponse.GetResponseOrBuilder> getResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      * @return Whether the getResponse field is set.
      */
     @java.lang.Override
@@ -4315,7 +4315,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 2;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      * @return The getResponse.
      */
     @java.lang.Override
@@ -4333,7 +4333,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder setGetResponse(com.scalar.db.rpc.TransactionResponse.GetResponse value) {
       if (getResponseBuilder_ == null) {
@@ -4349,7 +4349,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder setGetResponse(
         com.scalar.db.rpc.TransactionResponse.GetResponse.Builder builderForValue) {
@@ -4363,7 +4363,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder mergeGetResponse(com.scalar.db.rpc.TransactionResponse.GetResponse value) {
       if (getResponseBuilder_ == null) {
@@ -4386,7 +4386,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder clearGetResponse() {
       if (getResponseBuilder_ == null) {
@@ -4405,13 +4405,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     public com.scalar.db.rpc.TransactionResponse.GetResponse.Builder getGetResponseBuilder() {
       return getGetResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionResponse.GetResponseOrBuilder getGetResponseOrBuilder() {
@@ -4425,7 +4425,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.GetResponse, com.scalar.db.rpc.TransactionResponse.GetResponse.Builder, com.scalar.db.rpc.TransactionResponse.GetResponseOrBuilder> 
@@ -4449,7 +4449,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.ScanResponse, com.scalar.db.rpc.TransactionResponse.ScanResponse.Builder, com.scalar.db.rpc.TransactionResponse.ScanResponseOrBuilder> scanResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      * @return Whether the scanResponse field is set.
      */
     @java.lang.Override
@@ -4457,7 +4457,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 3;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      * @return The scanResponse.
      */
     @java.lang.Override
@@ -4475,7 +4475,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder setScanResponse(com.scalar.db.rpc.TransactionResponse.ScanResponse value) {
       if (scanResponseBuilder_ == null) {
@@ -4491,7 +4491,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder setScanResponse(
         com.scalar.db.rpc.TransactionResponse.ScanResponse.Builder builderForValue) {
@@ -4505,7 +4505,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder mergeScanResponse(com.scalar.db.rpc.TransactionResponse.ScanResponse value) {
       if (scanResponseBuilder_ == null) {
@@ -4528,7 +4528,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder clearScanResponse() {
       if (scanResponseBuilder_ == null) {
@@ -4547,13 +4547,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public com.scalar.db.rpc.TransactionResponse.ScanResponse.Builder getScanResponseBuilder() {
       return getScanResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionResponse.ScanResponseOrBuilder getScanResponseOrBuilder() {
@@ -4567,7 +4567,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.ScanResponse, com.scalar.db.rpc.TransactionResponse.ScanResponse.Builder, com.scalar.db.rpc.TransactionResponse.ScanResponseOrBuilder> 
@@ -4591,7 +4591,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.Error, com.scalar.db.rpc.TransactionResponse.Error.Builder, com.scalar.db.rpc.TransactionResponse.ErrorOrBuilder> errorBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      * @return Whether the error field is set.
      */
     @java.lang.Override
@@ -4599,7 +4599,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 4;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      * @return The error.
      */
     @java.lang.Override
@@ -4617,7 +4617,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     public Builder setError(com.scalar.db.rpc.TransactionResponse.Error value) {
       if (errorBuilder_ == null) {
@@ -4633,7 +4633,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     public Builder setError(
         com.scalar.db.rpc.TransactionResponse.Error.Builder builderForValue) {
@@ -4647,7 +4647,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     public Builder mergeError(com.scalar.db.rpc.TransactionResponse.Error value) {
       if (errorBuilder_ == null) {
@@ -4670,7 +4670,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     public Builder clearError() {
       if (errorBuilder_ == null) {
@@ -4689,13 +4689,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     public com.scalar.db.rpc.TransactionResponse.Error.Builder getErrorBuilder() {
       return getErrorFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionResponse.ErrorOrBuilder getErrorOrBuilder() {
@@ -4709,7 +4709,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TransactionResponse.Error error = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.Error, com.scalar.db.rpc.TransactionResponse.Error.Builder, com.scalar.db.rpc.TransactionResponse.ErrorOrBuilder> 
@@ -4733,7 +4733,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.BeginResponse, com.scalar.db.rpc.TransactionResponse.BeginResponse.Builder, com.scalar.db.rpc.TransactionResponse.BeginResponseOrBuilder> beginResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      * @return Whether the beginResponse field is set.
      */
     @java.lang.Override
@@ -4741,7 +4741,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 5;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      * @return The beginResponse.
      */
     @java.lang.Override
@@ -4759,7 +4759,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     public Builder setBeginResponse(com.scalar.db.rpc.TransactionResponse.BeginResponse value) {
       if (beginResponseBuilder_ == null) {
@@ -4775,7 +4775,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     public Builder setBeginResponse(
         com.scalar.db.rpc.TransactionResponse.BeginResponse.Builder builderForValue) {
@@ -4789,7 +4789,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     public Builder mergeBeginResponse(com.scalar.db.rpc.TransactionResponse.BeginResponse value) {
       if (beginResponseBuilder_ == null) {
@@ -4812,7 +4812,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     public Builder clearBeginResponse() {
       if (beginResponseBuilder_ == null) {
@@ -4831,13 +4831,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     public com.scalar.db.rpc.TransactionResponse.BeginResponse.Builder getBeginResponseBuilder() {
       return getBeginResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionResponse.BeginResponseOrBuilder getBeginResponseOrBuilder() {
@@ -4851,7 +4851,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+     * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.BeginResponse, com.scalar.db.rpc.TransactionResponse.BeginResponse.Builder, com.scalar.db.rpc.TransactionResponse.BeginResponseOrBuilder> 
@@ -4884,10 +4884,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TransactionResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.TransactionResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TransactionResponse)
+  // @@protoc_insertion_point(class_scope:rpc.TransactionResponse)
   private static final com.scalar.db.rpc.TransactionResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TransactionResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionResponseOrBuilder.java
@@ -4,81 +4,81 @@
 package com.scalar.db.rpc;
 
 public interface TransactionResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TransactionResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.TransactionResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
    * @return Whether the startResponse field is set.
    */
   boolean hasStartResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
    * @return The startResponse.
    */
   com.scalar.db.rpc.TransactionResponse.StartResponse getStartResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TransactionResponse.StartResponse start_response = 1;</code>
    */
   com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder getStartResponseOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
    * @return Whether the getResponse field is set.
    */
   boolean hasGetResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
    * @return The getResponse.
    */
   com.scalar.db.rpc.TransactionResponse.GetResponse getGetResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TransactionResponse.GetResponse get_response = 2;</code>
    */
   com.scalar.db.rpc.TransactionResponse.GetResponseOrBuilder getGetResponseOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
    * @return Whether the scanResponse field is set.
    */
   boolean hasScanResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
    * @return The scanResponse.
    */
   com.scalar.db.rpc.TransactionResponse.ScanResponse getScanResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TransactionResponse.ScanResponse scan_response = 3;</code>
    */
   com.scalar.db.rpc.TransactionResponse.ScanResponseOrBuilder getScanResponseOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TransactionResponse.Error error = 4;</code>
    * @return Whether the error field is set.
    */
   boolean hasError();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TransactionResponse.Error error = 4;</code>
    * @return The error.
    */
   com.scalar.db.rpc.TransactionResponse.Error getError();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TransactionResponse.Error error = 4;</code>
    */
   com.scalar.db.rpc.TransactionResponse.ErrorOrBuilder getErrorOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+   * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
    * @return Whether the beginResponse field is set.
    */
   boolean hasBeginResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+   * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
    * @return The beginResponse.
    */
   com.scalar.db.rpc.TransactionResponse.BeginResponse getBeginResponse();
   /**
-   * <code>.scalardb.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
+   * <code>.rpc.TransactionResponse.BeginResponse begin_response = 5;</code>
    */
   com.scalar.db.rpc.TransactionResponse.BeginResponseOrBuilder getBeginResponseOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionState.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionState.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf enum {@code scalardb.rpc.TransactionState}
+ * Protobuf enum {@code rpc.TransactionState}
  */
 public enum TransactionState
     implements com.google.protobuf.ProtocolMessageEnum {
@@ -117,6 +117,6 @@ public enum TransactionState
     this.value = value;
   }
 
-  // @@protoc_insertion_point(enum_scope:scalardb.rpc.TransactionState)
+  // @@protoc_insertion_point(enum_scope:rpc.TransactionState)
 }
 

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateCoordinatorTablesRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TruncateCoordinatorTablesRequest}
+ * Protobuf type {@code rpc.TruncateCoordinatorTablesRequest}
  */
 public final class TruncateCoordinatorTablesRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TruncateCoordinatorTablesRequest)
+    // @@protoc_insertion_point(message_implements:rpc.TruncateCoordinatorTablesRequest)
     TruncateCoordinatorTablesRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TruncateCoordinatorTablesRequest.newBuilder() to construct.
@@ -71,13 +71,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateCoordinatorTablesRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TruncateCoordinatorTablesRequest.class, com.scalar.db.rpc.TruncateCoordinatorTablesRequest.Builder.class);
   }
@@ -227,21 +227,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TruncateCoordinatorTablesRequest}
+   * Protobuf type {@code rpc.TruncateCoordinatorTablesRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TruncateCoordinatorTablesRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.TruncateCoordinatorTablesRequest)
       com.scalar.db.rpc.TruncateCoordinatorTablesRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateCoordinatorTablesRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateCoordinatorTablesRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TruncateCoordinatorTablesRequest.class, com.scalar.db.rpc.TruncateCoordinatorTablesRequest.Builder.class);
     }
@@ -270,7 +270,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateCoordinatorTablesRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateCoordinatorTablesRequest_descriptor;
     }
 
     @java.lang.Override
@@ -379,10 +379,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TruncateCoordinatorTablesRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.TruncateCoordinatorTablesRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TruncateCoordinatorTablesRequest)
+  // @@protoc_insertion_point(class_scope:rpc.TruncateCoordinatorTablesRequest)
   private static final com.scalar.db.rpc.TruncateCoordinatorTablesRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TruncateCoordinatorTablesRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateCoordinatorTablesRequestOrBuilder.java
@@ -4,6 +4,6 @@
 package com.scalar.db.rpc;
 
 public interface TruncateCoordinatorTablesRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TruncateCoordinatorTablesRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.TruncateCoordinatorTablesRequest)
     com.google.protobuf.MessageOrBuilder {
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TruncateTableRequest}
+ * Protobuf type {@code rpc.TruncateTableRequest}
  */
 public final class TruncateTableRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TruncateTableRequest)
+    // @@protoc_insertion_point(message_implements:rpc.TruncateTableRequest)
     TruncateTableRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TruncateTableRequest.newBuilder() to construct.
@@ -85,13 +85,13 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateTableRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateTableRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateTableRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateTableRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TruncateTableRequest.class, com.scalar.db.rpc.TruncateTableRequest.Builder.class);
   }
@@ -337,21 +337,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TruncateTableRequest}
+   * Protobuf type {@code rpc.TruncateTableRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TruncateTableRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.TruncateTableRequest)
       com.scalar.db.rpc.TruncateTableRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateTableRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateTableRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateTableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TruncateTableRequest.class, com.scalar.db.rpc.TruncateTableRequest.Builder.class);
     }
@@ -384,7 +384,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TruncateTableRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TruncateTableRequest_descriptor;
     }
 
     @java.lang.Override
@@ -655,10 +655,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TruncateTableRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.TruncateTableRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TruncateTableRequest)
+  // @@protoc_insertion_point(class_scope:rpc.TruncateTableRequest)
   private static final com.scalar.db.rpc.TruncateTableRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TruncateTableRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 public interface TruncateTableRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TruncateTableRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.TruncateTableRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest}
+ * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest}
  */
 public final class TwoPhaseCommitTransactionRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest)
+    // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest)
     TwoPhaseCommitTransactionRequestOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TwoPhaseCommitTransactionRequest.newBuilder() to construct.
@@ -197,19 +197,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.Builder.class);
   }
 
   public interface StartRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.StartRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -230,11 +230,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.StartRequest}
    */
   public static final class StartRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.StartRequest)
       StartRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StartRequest.newBuilder() to construct.
@@ -305,13 +305,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder.class);
     }
@@ -523,21 +523,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.StartRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.StartRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder.class);
       }
@@ -568,7 +568,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_StartRequest_descriptor;
       }
 
       @java.lang.Override
@@ -773,10 +773,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.StartRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.StartRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest();
@@ -814,7 +814,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface JoinRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -830,11 +830,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.JoinRequest}
    */
   public static final class JoinRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
       JoinRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use JoinRequest.newBuilder() to construct.
@@ -904,13 +904,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.Builder.class);
     }
@@ -1108,21 +1108,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.JoinRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.Builder.class);
       }
@@ -1153,7 +1153,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_JoinRequest_descriptor;
       }
 
       @java.lang.Override
@@ -1343,10 +1343,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.JoinRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest();
@@ -1384,30 +1384,30 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface GetRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.GetRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return Whether the get field is set.
      */
     boolean hasGet();
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return The get.
      */
     com.scalar.db.rpc.Get getGet();
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      */
     com.scalar.db.rpc.GetOrBuilder getGetOrBuilder();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.GetRequest}
    */
   public static final class GetRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.GetRequest)
       GetRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use GetRequest.newBuilder() to construct.
@@ -1483,13 +1483,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.Builder.class);
     }
@@ -1497,7 +1497,7 @@ private static final long serialVersionUID = 0L;
     public static final int GET_FIELD_NUMBER = 2;
     private com.scalar.db.rpc.Get get_;
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return Whether the get field is set.
      */
     @java.lang.Override
@@ -1505,7 +1505,7 @@ private static final long serialVersionUID = 0L;
       return get_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      * @return The get.
      */
     @java.lang.Override
@@ -1513,7 +1513,7 @@ private static final long serialVersionUID = 0L;
       return get_ == null ? com.scalar.db.rpc.Get.getDefaultInstance() : get_;
     }
     /**
-     * <code>.scalardb.rpc.Get get = 2;</code>
+     * <code>.rpc.Get get = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
@@ -1681,21 +1681,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.GetRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.GetRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.Builder.class);
       }
@@ -1730,7 +1730,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_GetRequest_descriptor;
       }
 
       @java.lang.Override
@@ -1839,14 +1839,14 @@ private static final long serialVersionUID = 0L;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Get, com.scalar.db.rpc.Get.Builder, com.scalar.db.rpc.GetOrBuilder> getBuilder_;
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        * @return Whether the get field is set.
        */
       public boolean hasGet() {
         return getBuilder_ != null || get_ != null;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        * @return The get.
        */
       public com.scalar.db.rpc.Get getGet() {
@@ -1857,7 +1857,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder setGet(com.scalar.db.rpc.Get value) {
         if (getBuilder_ == null) {
@@ -1873,7 +1873,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder setGet(
           com.scalar.db.rpc.Get.Builder builderForValue) {
@@ -1887,7 +1887,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder mergeGet(com.scalar.db.rpc.Get value) {
         if (getBuilder_ == null) {
@@ -1905,7 +1905,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public Builder clearGet() {
         if (getBuilder_ == null) {
@@ -1919,7 +1919,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public com.scalar.db.rpc.Get.Builder getGetBuilder() {
         
@@ -1927,7 +1927,7 @@ private static final long serialVersionUID = 0L;
         return getGetFieldBuilder().getBuilder();
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
         if (getBuilder_ != null) {
@@ -1938,7 +1938,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Get get = 2;</code>
+       * <code>.rpc.Get get = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Get, com.scalar.db.rpc.Get.Builder, com.scalar.db.rpc.GetOrBuilder> 
@@ -1966,10 +1966,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.GetRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.GetRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest();
@@ -2007,30 +2007,30 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ScanRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return Whether the scan field is set.
      */
     boolean hasScan();
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return The scan.
      */
     com.scalar.db.rpc.Scan getScan();
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      */
     com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.ScanRequest}
    */
   public static final class ScanRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
       ScanRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ScanRequest.newBuilder() to construct.
@@ -2106,13 +2106,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.Builder.class);
     }
@@ -2120,7 +2120,7 @@ private static final long serialVersionUID = 0L;
     public static final int SCAN_FIELD_NUMBER = 2;
     private com.scalar.db.rpc.Scan scan_;
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return Whether the scan field is set.
      */
     @java.lang.Override
@@ -2128,7 +2128,7 @@ private static final long serialVersionUID = 0L;
       return scan_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      * @return The scan.
      */
     @java.lang.Override
@@ -2136,7 +2136,7 @@ private static final long serialVersionUID = 0L;
       return scan_ == null ? com.scalar.db.rpc.Scan.getDefaultInstance() : scan_;
     }
     /**
-     * <code>.scalardb.rpc.Scan scan = 2;</code>
+     * <code>.rpc.Scan scan = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
@@ -2304,21 +2304,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.ScanRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.Builder.class);
       }
@@ -2353,7 +2353,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ScanRequest_descriptor;
       }
 
       @java.lang.Override
@@ -2462,14 +2462,14 @@ private static final long serialVersionUID = 0L;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Scan, com.scalar.db.rpc.Scan.Builder, com.scalar.db.rpc.ScanOrBuilder> scanBuilder_;
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        * @return Whether the scan field is set.
        */
       public boolean hasScan() {
         return scanBuilder_ != null || scan_ != null;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        * @return The scan.
        */
       public com.scalar.db.rpc.Scan getScan() {
@@ -2480,7 +2480,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder setScan(com.scalar.db.rpc.Scan value) {
         if (scanBuilder_ == null) {
@@ -2496,7 +2496,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder setScan(
           com.scalar.db.rpc.Scan.Builder builderForValue) {
@@ -2510,7 +2510,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder mergeScan(com.scalar.db.rpc.Scan value) {
         if (scanBuilder_ == null) {
@@ -2528,7 +2528,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder clearScan() {
         if (scanBuilder_ == null) {
@@ -2542,7 +2542,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public com.scalar.db.rpc.Scan.Builder getScanBuilder() {
         
@@ -2550,7 +2550,7 @@ private static final long serialVersionUID = 0L;
         return getScanFieldBuilder().getBuilder();
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
         if (scanBuilder_ != null) {
@@ -2561,7 +2561,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Scan scan = 2;</code>
+       * <code>.rpc.Scan scan = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Scan, com.scalar.db.rpc.Scan.Builder, com.scalar.db.rpc.ScanOrBuilder> 
@@ -2589,10 +2589,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.ScanRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest();
@@ -2630,39 +2630,39 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface MutateRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     java.util.List<com.scalar.db.rpc.Mutation> 
         getMutationsList();
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     com.scalar.db.rpc.Mutation getMutations(int index);
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     int getMutationsCount();
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
         getMutationsOrBuilderList();
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
         int index);
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.MutateRequest}
    */
   public static final class MutateRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
       MutateRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use MutateRequest.newBuilder() to construct.
@@ -2739,13 +2739,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.Builder.class);
     }
@@ -2753,14 +2753,14 @@ private static final long serialVersionUID = 0L;
     public static final int MUTATIONS_FIELD_NUMBER = 2;
     private java.util.List<com.scalar.db.rpc.Mutation> mutations_;
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public java.util.List<com.scalar.db.rpc.Mutation> getMutationsList() {
       return mutations_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
@@ -2768,21 +2768,21 @@ private static final long serialVersionUID = 0L;
       return mutations_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public int getMutationsCount() {
       return mutations_.size();
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.Mutation getMutations(int index) {
       return mutations_.get(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+     * <code>repeated .rpc.Mutation mutations = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
@@ -2948,21 +2948,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.MutateRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.Builder.class);
       }
@@ -2998,7 +2998,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_MutateRequest_descriptor;
       }
 
       @java.lang.Override
@@ -3145,7 +3145,7 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Mutation, com.scalar.db.rpc.Mutation.Builder, com.scalar.db.rpc.MutationOrBuilder> mutationsBuilder_;
 
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public java.util.List<com.scalar.db.rpc.Mutation> getMutationsList() {
         if (mutationsBuilder_ == null) {
@@ -3155,7 +3155,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public int getMutationsCount() {
         if (mutationsBuilder_ == null) {
@@ -3165,7 +3165,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation getMutations(int index) {
         if (mutationsBuilder_ == null) {
@@ -3175,7 +3175,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder setMutations(
           int index, com.scalar.db.rpc.Mutation value) {
@@ -3192,7 +3192,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder setMutations(
           int index, com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -3206,7 +3206,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(com.scalar.db.rpc.Mutation value) {
         if (mutationsBuilder_ == null) {
@@ -3222,7 +3222,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(
           int index, com.scalar.db.rpc.Mutation value) {
@@ -3239,7 +3239,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(
           com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -3253,7 +3253,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addMutations(
           int index, com.scalar.db.rpc.Mutation.Builder builderForValue) {
@@ -3267,7 +3267,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder addAllMutations(
           java.lang.Iterable<? extends com.scalar.db.rpc.Mutation> values) {
@@ -3282,7 +3282,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder clearMutations() {
         if (mutationsBuilder_ == null) {
@@ -3295,7 +3295,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public Builder removeMutations(int index) {
         if (mutationsBuilder_ == null) {
@@ -3308,14 +3308,14 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation.Builder getMutationsBuilder(
           int index) {
         return getMutationsFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.MutationOrBuilder getMutationsOrBuilder(
           int index) {
@@ -3325,7 +3325,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public java.util.List<? extends com.scalar.db.rpc.MutationOrBuilder> 
            getMutationsOrBuilderList() {
@@ -3336,14 +3336,14 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation.Builder addMutationsBuilder() {
         return getMutationsFieldBuilder().addBuilder(
             com.scalar.db.rpc.Mutation.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public com.scalar.db.rpc.Mutation.Builder addMutationsBuilder(
           int index) {
@@ -3351,7 +3351,7 @@ private static final long serialVersionUID = 0L;
             index, com.scalar.db.rpc.Mutation.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Mutation mutations = 2;</code>
+       * <code>repeated .rpc.Mutation mutations = 2;</code>
        */
       public java.util.List<com.scalar.db.rpc.Mutation.Builder> 
            getMutationsBuilderList() {
@@ -3384,10 +3384,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.MutateRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest();
@@ -3425,15 +3425,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface PrepareRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.PrepareRequest}
    */
   public static final class PrepareRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
       PrepareRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use PrepareRequest.newBuilder() to construct.
@@ -3496,13 +3496,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.Builder.class);
     }
@@ -3652,21 +3652,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.PrepareRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.Builder.class);
       }
@@ -3695,7 +3695,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_PrepareRequest_descriptor;
       }
 
       @java.lang.Override
@@ -3804,10 +3804,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.PrepareRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest();
@@ -3845,15 +3845,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ValidateRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.ValidateRequest}
    */
   public static final class ValidateRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
       ValidateRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ValidateRequest.newBuilder() to construct.
@@ -3916,13 +3916,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.Builder.class);
     }
@@ -4072,21 +4072,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.ValidateRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.Builder.class);
       }
@@ -4115,7 +4115,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_ValidateRequest_descriptor;
       }
 
       @java.lang.Override
@@ -4224,10 +4224,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.ValidateRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest();
@@ -4265,15 +4265,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface CommitRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.CommitRequest}
    */
   public static final class CommitRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
       CommitRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use CommitRequest.newBuilder() to construct.
@@ -4336,13 +4336,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.Builder.class);
     }
@@ -4492,21 +4492,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.CommitRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.Builder.class);
       }
@@ -4535,7 +4535,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_CommitRequest_descriptor;
       }
 
       @java.lang.Override
@@ -4644,10 +4644,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.CommitRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest();
@@ -4685,15 +4685,15 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface RollbackRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.RollbackRequest}
    */
   public static final class RollbackRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
       RollbackRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use RollbackRequest.newBuilder() to construct.
@@ -4756,13 +4756,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.Builder.class);
     }
@@ -4912,21 +4912,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest.RollbackRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.Builder.class);
       }
@@ -4955,7 +4955,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_RollbackRequest_descriptor;
       }
 
       @java.lang.Override
@@ -5064,10 +5064,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest.RollbackRequest)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest();
@@ -5161,7 +5161,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int START_REQUEST_FIELD_NUMBER = 1;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
    * @return Whether the startRequest field is set.
    */
   @java.lang.Override
@@ -5169,7 +5169,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 1;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
    * @return The startRequest.
    */
   @java.lang.Override
@@ -5180,7 +5180,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder getStartRequestOrBuilder() {
@@ -5192,7 +5192,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int JOIN_REQUEST_FIELD_NUMBER = 2;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
    * @return Whether the joinRequest field is set.
    */
   @java.lang.Override
@@ -5200,7 +5200,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 2;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
    * @return The joinRequest.
    */
   @java.lang.Override
@@ -5211,7 +5211,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequestOrBuilder getJoinRequestOrBuilder() {
@@ -5223,7 +5223,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int GET_REQUEST_FIELD_NUMBER = 3;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
    * @return Whether the getRequest field is set.
    */
   @java.lang.Override
@@ -5231,7 +5231,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 3;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
    * @return The getRequest.
    */
   @java.lang.Override
@@ -5242,7 +5242,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequestOrBuilder getGetRequestOrBuilder() {
@@ -5254,7 +5254,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int SCAN_REQUEST_FIELD_NUMBER = 4;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
    * @return Whether the scanRequest field is set.
    */
   @java.lang.Override
@@ -5262,7 +5262,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 4;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
    * @return The scanRequest.
    */
   @java.lang.Override
@@ -5273,7 +5273,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequestOrBuilder getScanRequestOrBuilder() {
@@ -5285,7 +5285,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int MUTATE_REQUEST_FIELD_NUMBER = 5;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
    * @return Whether the mutateRequest field is set.
    */
   @java.lang.Override
@@ -5293,7 +5293,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 5;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
    * @return The mutateRequest.
    */
   @java.lang.Override
@@ -5304,7 +5304,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequestOrBuilder getMutateRequestOrBuilder() {
@@ -5316,7 +5316,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int PREPARE_REQUEST_FIELD_NUMBER = 6;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
    * @return Whether the prepareRequest field is set.
    */
   @java.lang.Override
@@ -5324,7 +5324,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 6;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
    * @return The prepareRequest.
    */
   @java.lang.Override
@@ -5335,7 +5335,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequestOrBuilder getPrepareRequestOrBuilder() {
@@ -5347,7 +5347,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int VALIDATE_REQUEST_FIELD_NUMBER = 7;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
    * @return Whether the validateRequest field is set.
    */
   @java.lang.Override
@@ -5355,7 +5355,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 7;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
    * @return The validateRequest.
    */
   @java.lang.Override
@@ -5366,7 +5366,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequestOrBuilder getValidateRequestOrBuilder() {
@@ -5378,7 +5378,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int COMMIT_REQUEST_FIELD_NUMBER = 8;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
    * @return Whether the commitRequest field is set.
    */
   @java.lang.Override
@@ -5386,7 +5386,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 8;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
    * @return The commitRequest.
    */
   @java.lang.Override
@@ -5397,7 +5397,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequestOrBuilder getCommitRequestOrBuilder() {
@@ -5409,7 +5409,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int ROLLBACK_REQUEST_FIELD_NUMBER = 9;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
    * @return Whether the rollbackRequest field is set.
    */
   @java.lang.Override
@@ -5417,7 +5417,7 @@ private static final long serialVersionUID = 0L;
     return requestCase_ == 9;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
    * @return The rollbackRequest.
    */
   @java.lang.Override
@@ -5428,7 +5428,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder() {
@@ -5727,21 +5727,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionRequest}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionRequest)
+      // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionRequest)
       com.scalar.db.rpc.TwoPhaseCommitTransactionRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.class, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.Builder.class);
     }
@@ -5772,7 +5772,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionRequest_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionRequest_descriptor;
     }
 
     @java.lang.Override
@@ -5992,7 +5992,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder> startRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      * @return Whether the startRequest field is set.
      */
     @java.lang.Override
@@ -6000,7 +6000,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 1;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      * @return The startRequest.
      */
     @java.lang.Override
@@ -6018,7 +6018,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder setStartRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest value) {
       if (startRequestBuilder_ == null) {
@@ -6034,7 +6034,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder setStartRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder builderForValue) {
@@ -6048,7 +6048,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder mergeStartRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest value) {
       if (startRequestBuilder_ == null) {
@@ -6071,7 +6071,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     public Builder clearStartRequest() {
       if (startRequestBuilder_ == null) {
@@ -6090,13 +6090,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder getStartRequestBuilder() {
       return getStartRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder getStartRequestOrBuilder() {
@@ -6110,7 +6110,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder> 
@@ -6134,7 +6134,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequestOrBuilder> joinRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      * @return Whether the joinRequest field is set.
      */
     @java.lang.Override
@@ -6142,7 +6142,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 2;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      * @return The joinRequest.
      */
     @java.lang.Override
@@ -6160,7 +6160,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     public Builder setJoinRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest value) {
       if (joinRequestBuilder_ == null) {
@@ -6176,7 +6176,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     public Builder setJoinRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.Builder builderForValue) {
@@ -6190,7 +6190,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     public Builder mergeJoinRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest value) {
       if (joinRequestBuilder_ == null) {
@@ -6213,7 +6213,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     public Builder clearJoinRequest() {
       if (joinRequestBuilder_ == null) {
@@ -6232,13 +6232,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.Builder getJoinRequestBuilder() {
       return getJoinRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequestOrBuilder getJoinRequestOrBuilder() {
@@ -6252,7 +6252,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequestOrBuilder> 
@@ -6276,7 +6276,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequestOrBuilder> getRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      * @return Whether the getRequest field is set.
      */
     @java.lang.Override
@@ -6284,7 +6284,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 3;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      * @return The getRequest.
      */
     @java.lang.Override
@@ -6302,7 +6302,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     public Builder setGetRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest value) {
       if (getRequestBuilder_ == null) {
@@ -6318,7 +6318,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     public Builder setGetRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.Builder builderForValue) {
@@ -6332,7 +6332,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     public Builder mergeGetRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest value) {
       if (getRequestBuilder_ == null) {
@@ -6355,7 +6355,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     public Builder clearGetRequest() {
       if (getRequestBuilder_ == null) {
@@ -6374,13 +6374,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.Builder getGetRequestBuilder() {
       return getGetRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequestOrBuilder getGetRequestOrBuilder() {
@@ -6394,7 +6394,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequestOrBuilder> 
@@ -6418,7 +6418,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequestOrBuilder> scanRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      * @return Whether the scanRequest field is set.
      */
     @java.lang.Override
@@ -6426,7 +6426,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 4;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      * @return The scanRequest.
      */
     @java.lang.Override
@@ -6444,7 +6444,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     public Builder setScanRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest value) {
       if (scanRequestBuilder_ == null) {
@@ -6460,7 +6460,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     public Builder setScanRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.Builder builderForValue) {
@@ -6474,7 +6474,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     public Builder mergeScanRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest value) {
       if (scanRequestBuilder_ == null) {
@@ -6497,7 +6497,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     public Builder clearScanRequest() {
       if (scanRequestBuilder_ == null) {
@@ -6516,13 +6516,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.Builder getScanRequestBuilder() {
       return getScanRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequestOrBuilder getScanRequestOrBuilder() {
@@ -6536,7 +6536,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequestOrBuilder> 
@@ -6560,7 +6560,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequestOrBuilder> mutateRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      * @return Whether the mutateRequest field is set.
      */
     @java.lang.Override
@@ -6568,7 +6568,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 5;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      * @return The mutateRequest.
      */
     @java.lang.Override
@@ -6586,7 +6586,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     public Builder setMutateRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest value) {
       if (mutateRequestBuilder_ == null) {
@@ -6602,7 +6602,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     public Builder setMutateRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.Builder builderForValue) {
@@ -6616,7 +6616,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     public Builder mergeMutateRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest value) {
       if (mutateRequestBuilder_ == null) {
@@ -6639,7 +6639,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     public Builder clearMutateRequest() {
       if (mutateRequestBuilder_ == null) {
@@ -6658,13 +6658,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.Builder getMutateRequestBuilder() {
       return getMutateRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequestOrBuilder getMutateRequestOrBuilder() {
@@ -6678,7 +6678,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequestOrBuilder> 
@@ -6702,7 +6702,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequestOrBuilder> prepareRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      * @return Whether the prepareRequest field is set.
      */
     @java.lang.Override
@@ -6710,7 +6710,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 6;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      * @return The prepareRequest.
      */
     @java.lang.Override
@@ -6728,7 +6728,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     public Builder setPrepareRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest value) {
       if (prepareRequestBuilder_ == null) {
@@ -6744,7 +6744,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     public Builder setPrepareRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.Builder builderForValue) {
@@ -6758,7 +6758,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     public Builder mergePrepareRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest value) {
       if (prepareRequestBuilder_ == null) {
@@ -6781,7 +6781,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     public Builder clearPrepareRequest() {
       if (prepareRequestBuilder_ == null) {
@@ -6800,13 +6800,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.Builder getPrepareRequestBuilder() {
       return getPrepareRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequestOrBuilder getPrepareRequestOrBuilder() {
@@ -6820,7 +6820,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequestOrBuilder> 
@@ -6844,7 +6844,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequestOrBuilder> validateRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      * @return Whether the validateRequest field is set.
      */
     @java.lang.Override
@@ -6852,7 +6852,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 7;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      * @return The validateRequest.
      */
     @java.lang.Override
@@ -6870,7 +6870,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     public Builder setValidateRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest value) {
       if (validateRequestBuilder_ == null) {
@@ -6886,7 +6886,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     public Builder setValidateRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.Builder builderForValue) {
@@ -6900,7 +6900,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     public Builder mergeValidateRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest value) {
       if (validateRequestBuilder_ == null) {
@@ -6923,7 +6923,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     public Builder clearValidateRequest() {
       if (validateRequestBuilder_ == null) {
@@ -6942,13 +6942,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.Builder getValidateRequestBuilder() {
       return getValidateRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequestOrBuilder getValidateRequestOrBuilder() {
@@ -6962,7 +6962,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequestOrBuilder> 
@@ -6986,7 +6986,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequestOrBuilder> commitRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      * @return Whether the commitRequest field is set.
      */
     @java.lang.Override
@@ -6994,7 +6994,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 8;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      * @return The commitRequest.
      */
     @java.lang.Override
@@ -7012,7 +7012,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     public Builder setCommitRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest value) {
       if (commitRequestBuilder_ == null) {
@@ -7028,7 +7028,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     public Builder setCommitRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.Builder builderForValue) {
@@ -7042,7 +7042,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     public Builder mergeCommitRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest value) {
       if (commitRequestBuilder_ == null) {
@@ -7065,7 +7065,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     public Builder clearCommitRequest() {
       if (commitRequestBuilder_ == null) {
@@ -7084,13 +7084,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.Builder getCommitRequestBuilder() {
       return getCommitRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequestOrBuilder getCommitRequestOrBuilder() {
@@ -7104,7 +7104,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequestOrBuilder> 
@@ -7128,7 +7128,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder> rollbackRequestBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      * @return Whether the rollbackRequest field is set.
      */
     @java.lang.Override
@@ -7136,7 +7136,7 @@ private static final long serialVersionUID = 0L;
       return requestCase_ == 9;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      * @return The rollbackRequest.
      */
     @java.lang.Override
@@ -7154,7 +7154,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     public Builder setRollbackRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest value) {
       if (rollbackRequestBuilder_ == null) {
@@ -7170,7 +7170,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     public Builder setRollbackRequest(
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.Builder builderForValue) {
@@ -7184,7 +7184,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     public Builder mergeRollbackRequest(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest value) {
       if (rollbackRequestBuilder_ == null) {
@@ -7207,7 +7207,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     public Builder clearRollbackRequest() {
       if (rollbackRequestBuilder_ == null) {
@@ -7226,13 +7226,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.Builder getRollbackRequestBuilder() {
       return getRollbackRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder() {
@@ -7246,7 +7246,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder> 
@@ -7279,10 +7279,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest)
+    // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionRequest)
+  // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionRequest)
   private static final com.scalar.db.rpc.TwoPhaseCommitTransactionRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest();

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequestOrBuilder.java
@@ -4,141 +4,141 @@
 package com.scalar.db.rpc;
 
 public interface TwoPhaseCommitTransactionRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionRequest)
+    // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
    * @return Whether the startRequest field is set.
    */
   boolean hasStartRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
    * @return The startRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest getStartRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.StartRequest start_request = 1;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder getStartRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
    * @return Whether the joinRequest field is set.
    */
   boolean hasJoinRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
    * @return The joinRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest getJoinRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.JoinRequest join_request = 2;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequestOrBuilder getJoinRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
    * @return Whether the getRequest field is set.
    */
   boolean hasGetRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
    * @return The getRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest getGetRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.GetRequest get_request = 3;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequestOrBuilder getGetRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
    * @return Whether the scanRequest field is set.
    */
   boolean hasScanRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
    * @return The scanRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest getScanRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ScanRequest scan_request = 4;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequestOrBuilder getScanRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
    * @return Whether the mutateRequest field is set.
    */
   boolean hasMutateRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
    * @return The mutateRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest getMutateRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.MutateRequest mutate_request = 5;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequestOrBuilder getMutateRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
    * @return Whether the prepareRequest field is set.
    */
   boolean hasPrepareRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
    * @return The prepareRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest getPrepareRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.PrepareRequest prepare_request = 6;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.PrepareRequestOrBuilder getPrepareRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
    * @return Whether the validateRequest field is set.
    */
   boolean hasValidateRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
    * @return The validateRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest getValidateRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.ValidateRequest validate_request = 7;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ValidateRequestOrBuilder getValidateRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
    * @return Whether the commitRequest field is set.
    */
   boolean hasCommitRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
    * @return The commitRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequest getCommitRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.CommitRequest commit_request = 8;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.CommitRequestOrBuilder getCommitRequestOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
    * @return Whether the rollbackRequest field is set.
    */
   boolean hasRollbackRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
    * @return The rollbackRequest.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest getRollbackRequest();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionRequest.RollbackRequest rollback_request = 9;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.RollbackRequestOrBuilder getRollbackRequestOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
@@ -4,11 +4,11 @@
 package com.scalar.db.rpc;
 
 /**
- * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse}
+ * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse}
  */
 public final class TwoPhaseCommitTransactionResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse)
+    // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionResponse)
     TwoPhaseCommitTransactionResponseOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use TwoPhaseCommitTransactionResponse.newBuilder() to construct.
@@ -127,19 +127,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Builder.class);
   }
 
   public interface StartResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionResponse.StartResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -155,11 +155,11 @@ private static final long serialVersionUID = 0L;
         getTransactionIdBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.StartResponse}
    */
   public static final class StartResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionResponse.StartResponse)
       StartResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StartResponse.newBuilder() to construct.
@@ -229,13 +229,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder.class);
     }
@@ -433,21 +433,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.StartResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionResponse.StartResponse)
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder.class);
       }
@@ -478,7 +478,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_StartResponse_descriptor;
       }
 
       @java.lang.Override
@@ -668,10 +668,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionResponse.StartResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionResponse.StartResponse)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse();
@@ -709,30 +709,30 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface GetResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionResponse.GetResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return Whether the result field is set.
      */
     boolean hasResult();
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return The result.
      */
     com.scalar.db.rpc.Result getResult();
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.GetResponse}
    */
   public static final class GetResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionResponse.GetResponse)
       GetResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use GetResponse.newBuilder() to construct.
@@ -808,13 +808,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.Builder.class);
     }
@@ -822,7 +822,7 @@ private static final long serialVersionUID = 0L;
     public static final int RESULT_FIELD_NUMBER = 1;
     private com.scalar.db.rpc.Result result_;
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return Whether the result field is set.
      */
     @java.lang.Override
@@ -830,7 +830,7 @@ private static final long serialVersionUID = 0L;
       return result_ != null;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      * @return The result.
      */
     @java.lang.Override
@@ -838,7 +838,7 @@ private static final long serialVersionUID = 0L;
       return result_ == null ? com.scalar.db.rpc.Result.getDefaultInstance() : result_;
     }
     /**
-     * <code>.scalardb.rpc.Result result = 1;</code>
+     * <code>.rpc.Result result = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
@@ -1006,21 +1006,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.GetResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionResponse.GetResponse)
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.Builder.class);
       }
@@ -1055,7 +1055,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_GetResponse_descriptor;
       }
 
       @java.lang.Override
@@ -1164,14 +1164,14 @@ private static final long serialVersionUID = 0L;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> resultBuilder_;
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        * @return Whether the result field is set.
        */
       public boolean hasResult() {
         return resultBuilder_ != null || result_ != null;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        * @return The result.
        */
       public com.scalar.db.rpc.Result getResult() {
@@ -1182,7 +1182,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder setResult(com.scalar.db.rpc.Result value) {
         if (resultBuilder_ == null) {
@@ -1198,7 +1198,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder setResult(
           com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -1212,7 +1212,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder mergeResult(com.scalar.db.rpc.Result value) {
         if (resultBuilder_ == null) {
@@ -1230,7 +1230,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public Builder clearResult() {
         if (resultBuilder_ == null) {
@@ -1244,7 +1244,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder getResultBuilder() {
         
@@ -1252,7 +1252,7 @@ private static final long serialVersionUID = 0L;
         return getResultFieldBuilder().getBuilder();
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
         if (resultBuilder_ != null) {
@@ -1263,7 +1263,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>.scalardb.rpc.Result result = 1;</code>
+       * <code>.rpc.Result result = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> 
@@ -1291,10 +1291,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionResponse.GetResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionResponse.GetResponse)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse();
@@ -1332,39 +1332,39 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ScanResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     java.util.List<com.scalar.db.rpc.Result> 
         getResultsList();
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     com.scalar.db.rpc.Result getResults(int index);
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     int getResultsCount();
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
         getResultsOrBuilderList();
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
         int index);
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.ScanResponse}
    */
   public static final class ScanResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
       ScanResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ScanResponse.newBuilder() to construct.
@@ -1441,13 +1441,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.Builder.class);
     }
@@ -1455,14 +1455,14 @@ private static final long serialVersionUID = 0L;
     public static final int RESULTS_FIELD_NUMBER = 1;
     private java.util.List<com.scalar.db.rpc.Result> results_;
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public java.util.List<com.scalar.db.rpc.Result> getResultsList() {
       return results_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
@@ -1470,21 +1470,21 @@ private static final long serialVersionUID = 0L;
       return results_;
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public int getResultsCount() {
       return results_.size();
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.Result getResults(int index) {
       return results_.get(index);
     }
     /**
-     * <code>repeated .scalardb.rpc.Result results = 1;</code>
+     * <code>repeated .rpc.Result results = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
@@ -1650,21 +1650,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.ScanResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.Builder.class);
       }
@@ -1700,7 +1700,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_ScanResponse_descriptor;
       }
 
       @java.lang.Override
@@ -1847,7 +1847,7 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Result, com.scalar.db.rpc.Result.Builder, com.scalar.db.rpc.ResultOrBuilder> resultsBuilder_;
 
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public java.util.List<com.scalar.db.rpc.Result> getResultsList() {
         if (resultsBuilder_ == null) {
@@ -1857,7 +1857,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public int getResultsCount() {
         if (resultsBuilder_ == null) {
@@ -1867,7 +1867,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result getResults(int index) {
         if (resultsBuilder_ == null) {
@@ -1877,7 +1877,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder setResults(
           int index, com.scalar.db.rpc.Result value) {
@@ -1894,7 +1894,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder setResults(
           int index, com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -1908,7 +1908,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(com.scalar.db.rpc.Result value) {
         if (resultsBuilder_ == null) {
@@ -1924,7 +1924,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(
           int index, com.scalar.db.rpc.Result value) {
@@ -1941,7 +1941,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(
           com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -1955,7 +1955,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addResults(
           int index, com.scalar.db.rpc.Result.Builder builderForValue) {
@@ -1969,7 +1969,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder addAllResults(
           java.lang.Iterable<? extends com.scalar.db.rpc.Result> values) {
@@ -1984,7 +1984,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder clearResults() {
         if (resultsBuilder_ == null) {
@@ -1997,7 +1997,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public Builder removeResults(int index) {
         if (resultsBuilder_ == null) {
@@ -2010,14 +2010,14 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder getResultsBuilder(
           int index) {
         return getResultsFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.ResultOrBuilder getResultsOrBuilder(
           int index) {
@@ -2027,7 +2027,7 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public java.util.List<? extends com.scalar.db.rpc.ResultOrBuilder> 
            getResultsOrBuilderList() {
@@ -2038,14 +2038,14 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder addResultsBuilder() {
         return getResultsFieldBuilder().addBuilder(
             com.scalar.db.rpc.Result.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder addResultsBuilder(
           int index) {
@@ -2053,7 +2053,7 @@ private static final long serialVersionUID = 0L;
             index, com.scalar.db.rpc.Result.getDefaultInstance());
       }
       /**
-       * <code>repeated .scalardb.rpc.Result results = 1;</code>
+       * <code>repeated .rpc.Result results = 1;</code>
        */
       public java.util.List<com.scalar.db.rpc.Result.Builder> 
            getResultsBuilderList() {
@@ -2086,10 +2086,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionResponse.ScanResponse)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse();
@@ -2127,16 +2127,16 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface ErrorOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionResponse.Error)
+      // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionResponse.Error)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The enum numeric value on the wire for errorCode.
      */
     int getErrorCodeValue();
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The errorCode.
      */
     com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode getErrorCode();
@@ -2154,11 +2154,11 @@ private static final long serialVersionUID = 0L;
         getMessageBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.Error}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.Error}
    */
   public static final class Error extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.Error)
+      // @@protoc_insertion_point(message_implements:rpc.TwoPhaseCommitTransactionResponse.Error)
       ErrorOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Error.newBuilder() to construct.
@@ -2235,19 +2235,19 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.Builder.class);
     }
 
     /**
-     * Protobuf enum {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode}
+     * Protobuf enum {@code rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode}
      */
     public enum ErrorCode
         implements com.google.protobuf.ProtocolMessageEnum {
@@ -2369,20 +2369,20 @@ private static final long serialVersionUID = 0L;
         this.value = value;
       }
 
-      // @@protoc_insertion_point(enum_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode)
+      // @@protoc_insertion_point(enum_scope:rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode)
     }
 
     public static final int ERROR_CODE_FIELD_NUMBER = 1;
     private int errorCode_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The enum numeric value on the wire for errorCode.
      */
     @java.lang.Override public int getErrorCodeValue() {
       return errorCode_;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The errorCode.
      */
     @java.lang.Override public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode getErrorCode() {
@@ -2594,21 +2594,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse.Error}
+     * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse.Error}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse.Error)
+        // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionResponse.Error)
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.Builder.class);
       }
@@ -2641,7 +2641,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_Error_descriptor;
       }
 
       @java.lang.Override
@@ -2749,14 +2749,14 @@ private static final long serialVersionUID = 0L;
 
       private int errorCode_ = 0;
       /**
-       * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @return The enum numeric value on the wire for errorCode.
        */
       @java.lang.Override public int getErrorCodeValue() {
         return errorCode_;
       }
       /**
-       * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @param value The enum numeric value on the wire for errorCode to set.
        * @return This builder for chaining.
        */
@@ -2767,7 +2767,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @return The errorCode.
        */
       @java.lang.Override
@@ -2777,7 +2777,7 @@ private static final long serialVersionUID = 0L;
         return result == null ? com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.UNRECOGNIZED : result;
       }
       /**
-       * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @param value The errorCode to set.
        * @return This builder for chaining.
        */
@@ -2791,7 +2791,7 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
-       * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
+       * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearErrorCode() {
@@ -2889,10 +2889,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.Error)
+      // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionResponse.Error)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse.Error)
+    // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionResponse.Error)
     private static final com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error();
@@ -2976,7 +2976,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int START_RESPONSE_FIELD_NUMBER = 1;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
    * @return Whether the startResponse field is set.
    */
   @java.lang.Override
@@ -2984,7 +2984,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 1;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
    * @return The startResponse.
    */
   @java.lang.Override
@@ -2995,7 +2995,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder getStartResponseOrBuilder() {
@@ -3007,7 +3007,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int GET_RESPONSE_FIELD_NUMBER = 2;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
    * @return Whether the getResponse field is set.
    */
   @java.lang.Override
@@ -3015,7 +3015,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 2;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
    * @return The getResponse.
    */
   @java.lang.Override
@@ -3026,7 +3026,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponseOrBuilder getGetResponseOrBuilder() {
@@ -3038,7 +3038,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int SCAN_RESPONSE_FIELD_NUMBER = 3;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
    * @return Whether the scanResponse field is set.
    */
   @java.lang.Override
@@ -3046,7 +3046,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 3;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
    * @return The scanResponse.
    */
   @java.lang.Override
@@ -3057,7 +3057,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponseOrBuilder getScanResponseOrBuilder() {
@@ -3069,7 +3069,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int ERROR_FIELD_NUMBER = 4;
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
    * @return Whether the error field is set.
    */
   @java.lang.Override
@@ -3077,7 +3077,7 @@ private static final long serialVersionUID = 0L;
     return responseCase_ == 4;
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
    * @return The error.
    */
   @java.lang.Override
@@ -3088,7 +3088,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder getErrorOrBuilder() {
@@ -3312,21 +3312,21 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * Protobuf type {@code scalardb.rpc.TwoPhaseCommitTransactionResponse}
+   * Protobuf type {@code rpc.TwoPhaseCommitTransactionResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.TwoPhaseCommitTransactionResponse)
+      // @@protoc_insertion_point(builder_implements:rpc.TwoPhaseCommitTransactionResponse)
       com.scalar.db.rpc.TwoPhaseCommitTransactionResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.class, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Builder.class);
     }
@@ -3357,7 +3357,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_TwoPhaseCommitTransactionResponse_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_TwoPhaseCommitTransactionResponse_descriptor;
     }
 
     @java.lang.Override
@@ -3522,7 +3522,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder> startResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      * @return Whether the startResponse field is set.
      */
     @java.lang.Override
@@ -3530,7 +3530,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 1;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      * @return The startResponse.
      */
     @java.lang.Override
@@ -3548,7 +3548,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder setStartResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse value) {
       if (startResponseBuilder_ == null) {
@@ -3564,7 +3564,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder setStartResponse(
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder builderForValue) {
@@ -3578,7 +3578,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder mergeStartResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse value) {
       if (startResponseBuilder_ == null) {
@@ -3601,7 +3601,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     public Builder clearStartResponse() {
       if (startResponseBuilder_ == null) {
@@ -3620,13 +3620,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder getStartResponseBuilder() {
       return getStartResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder getStartResponseOrBuilder() {
@@ -3640,7 +3640,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder> 
@@ -3664,7 +3664,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponseOrBuilder> getResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      * @return Whether the getResponse field is set.
      */
     @java.lang.Override
@@ -3672,7 +3672,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 2;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      * @return The getResponse.
      */
     @java.lang.Override
@@ -3690,7 +3690,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder setGetResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse value) {
       if (getResponseBuilder_ == null) {
@@ -3706,7 +3706,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder setGetResponse(
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.Builder builderForValue) {
@@ -3720,7 +3720,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder mergeGetResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse value) {
       if (getResponseBuilder_ == null) {
@@ -3743,7 +3743,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     public Builder clearGetResponse() {
       if (getResponseBuilder_ == null) {
@@ -3762,13 +3762,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.Builder getGetResponseBuilder() {
       return getGetResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponseOrBuilder getGetResponseOrBuilder() {
@@ -3782,7 +3782,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponseOrBuilder> 
@@ -3806,7 +3806,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponseOrBuilder> scanResponseBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      * @return Whether the scanResponse field is set.
      */
     @java.lang.Override
@@ -3814,7 +3814,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 3;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      * @return The scanResponse.
      */
     @java.lang.Override
@@ -3832,7 +3832,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder setScanResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse value) {
       if (scanResponseBuilder_ == null) {
@@ -3848,7 +3848,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder setScanResponse(
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.Builder builderForValue) {
@@ -3862,7 +3862,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder mergeScanResponse(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse value) {
       if (scanResponseBuilder_ == null) {
@@ -3885,7 +3885,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public Builder clearScanResponse() {
       if (scanResponseBuilder_ == null) {
@@ -3904,13 +3904,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.Builder getScanResponseBuilder() {
       return getScanResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponseOrBuilder getScanResponseOrBuilder() {
@@ -3924,7 +3924,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponseOrBuilder> 
@@ -3948,7 +3948,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder> errorBuilder_;
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      * @return Whether the error field is set.
      */
     @java.lang.Override
@@ -3956,7 +3956,7 @@ private static final long serialVersionUID = 0L;
       return responseCase_ == 4;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      * @return The error.
      */
     @java.lang.Override
@@ -3974,7 +3974,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     public Builder setError(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error value) {
       if (errorBuilder_ == null) {
@@ -3990,7 +3990,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     public Builder setError(
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.Builder builderForValue) {
@@ -4004,7 +4004,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     public Builder mergeError(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error value) {
       if (errorBuilder_ == null) {
@@ -4027,7 +4027,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     public Builder clearError() {
       if (errorBuilder_ == null) {
@@ -4046,13 +4046,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.Builder getErrorBuilder() {
       return getErrorFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder getErrorOrBuilder() {
@@ -4066,7 +4066,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+     * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder> 
@@ -4099,10 +4099,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse)
+    // @@protoc_insertion_point(builder_scope:rpc.TwoPhaseCommitTransactionResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.TwoPhaseCommitTransactionResponse)
+  // @@protoc_insertion_point(class_scope:rpc.TwoPhaseCommitTransactionResponse)
   private static final com.scalar.db.rpc.TwoPhaseCommitTransactionResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse();

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponseOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponseOrBuilder.java
@@ -4,66 +4,66 @@
 package com.scalar.db.rpc;
 
 public interface TwoPhaseCommitTransactionResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.TwoPhaseCommitTransactionResponse)
+    // @@protoc_insertion_point(interface_extends:rpc.TwoPhaseCommitTransactionResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
    * @return Whether the startResponse field is set.
    */
   boolean hasStartResponse();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
    * @return The startResponse.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse getStartResponse();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.StartResponse start_response = 1;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder getStartResponseOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
    * @return Whether the getResponse field is set.
    */
   boolean hasGetResponse();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
    * @return The getResponse.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse getGetResponse();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.GetResponse get_response = 2;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponseOrBuilder getGetResponseOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
    * @return Whether the scanResponse field is set.
    */
   boolean hasScanResponse();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
    * @return The scanResponse.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse getScanResponse();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.ScanResponse scan_response = 3;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponseOrBuilder getScanResponseOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
    * @return Whether the error field is set.
    */
   boolean hasError();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
    * @return The error.
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error getError();
   /**
-   * <code>.scalardb.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
+   * <code>.rpc.TwoPhaseCommitTransactionResponse.Error error = 4;</code>
    */
   com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ErrorOrBuilder getErrorOrBuilder();
 

--- a/rpc/src/main/java/com/scalar/db/rpc/Value.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Value.java
@@ -8,11 +8,11 @@ package com.scalar.db.rpc;
  * Value is deprecated as of release 3.6.0. Will be removed in release 5.0.0. Use Column, instead.
  * </pre>
  *
- * Protobuf type {@code scalardb.rpc.Value}
+ * Protobuf type {@code rpc.Value}
  */
 @java.lang.Deprecated public final class Value extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:scalardb.rpc.Value)
+    // @@protoc_insertion_point(message_implements:rpc.Value)
     ValueOrBuilder {
 private static final long serialVersionUID = 0L;
   // Use Value.newBuilder() to construct.
@@ -135,19 +135,19 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_descriptor;
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_fieldAccessorTable
+    return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             com.scalar.db.rpc.Value.class, com.scalar.db.rpc.Value.Builder.class);
   }
 
   public interface TextValueOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.Value.TextValue)
+      // @@protoc_insertion_point(interface_extends:rpc.Value.TextValue)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -168,11 +168,11 @@ private static final long serialVersionUID = 0L;
         getValueBytes();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Value.TextValue}
+   * Protobuf type {@code rpc.Value.TextValue}
    */
   public static final class TextValue extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.Value.TextValue)
+      // @@protoc_insertion_point(message_implements:rpc.Value.TextValue)
       TextValueOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use TextValue.newBuilder() to construct.
@@ -243,13 +243,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_TextValue_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_TextValue_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_TextValue_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_TextValue_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Value.TextValue.class, com.scalar.db.rpc.Value.TextValue.Builder.class);
     }
@@ -461,21 +461,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.Value.TextValue}
+     * Protobuf type {@code rpc.Value.TextValue}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.Value.TextValue)
+        // @@protoc_insertion_point(builder_implements:rpc.Value.TextValue)
         com.scalar.db.rpc.Value.TextValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_TextValue_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_TextValue_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_TextValue_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_TextValue_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.Value.TextValue.class, com.scalar.db.rpc.Value.TextValue.Builder.class);
       }
@@ -506,7 +506,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_TextValue_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_TextValue_descriptor;
       }
 
       @java.lang.Override
@@ -711,10 +711,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.Value.TextValue)
+      // @@protoc_insertion_point(builder_scope:rpc.Value.TextValue)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.Value.TextValue)
+    // @@protoc_insertion_point(class_scope:rpc.Value.TextValue)
     private static final com.scalar.db.rpc.Value.TextValue DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.Value.TextValue();
@@ -752,7 +752,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public interface BlobValueOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:scalardb.rpc.Value.BlobValue)
+      // @@protoc_insertion_point(interface_extends:rpc.Value.BlobValue)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -767,11 +767,11 @@ private static final long serialVersionUID = 0L;
     com.google.protobuf.ByteString getValue();
   }
   /**
-   * Protobuf type {@code scalardb.rpc.Value.BlobValue}
+   * Protobuf type {@code rpc.Value.BlobValue}
    */
   public static final class BlobValue extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:scalardb.rpc.Value.BlobValue)
+      // @@protoc_insertion_point(message_implements:rpc.Value.BlobValue)
       BlobValueOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use BlobValue.newBuilder() to construct.
@@ -841,13 +841,13 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_BlobValue_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_BlobValue_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_BlobValue_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_BlobValue_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Value.BlobValue.class, com.scalar.db.rpc.Value.BlobValue.Builder.class);
     }
@@ -1033,21 +1033,21 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
-     * Protobuf type {@code scalardb.rpc.Value.BlobValue}
+     * Protobuf type {@code rpc.Value.BlobValue}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:scalardb.rpc.Value.BlobValue)
+        // @@protoc_insertion_point(builder_implements:rpc.Value.BlobValue)
         com.scalar.db.rpc.Value.BlobValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_BlobValue_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_BlobValue_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_BlobValue_fieldAccessorTable
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_BlobValue_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.scalar.db.rpc.Value.BlobValue.class, com.scalar.db.rpc.Value.BlobValue.Builder.class);
       }
@@ -1078,7 +1078,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_BlobValue_descriptor;
+        return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_BlobValue_descriptor;
       }
 
       @java.lang.Override
@@ -1240,10 +1240,10 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:scalardb.rpc.Value.BlobValue)
+      // @@protoc_insertion_point(builder_scope:rpc.Value.BlobValue)
     }
 
-    // @@protoc_insertion_point(class_scope:scalardb.rpc.Value.BlobValue)
+    // @@protoc_insertion_point(class_scope:rpc.Value.BlobValue)
     private static final com.scalar.db.rpc.Value.BlobValue DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.scalar.db.rpc.Value.BlobValue();
@@ -1476,7 +1476,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int TEXT_VALUE_FIELD_NUMBER = 7;
   /**
-   * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+   * <code>.rpc.Value.TextValue text_value = 7;</code>
    * @return Whether the textValue field is set.
    */
   @java.lang.Override
@@ -1484,7 +1484,7 @@ private static final long serialVersionUID = 0L;
     return valueCase_ == 7;
   }
   /**
-   * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+   * <code>.rpc.Value.TextValue text_value = 7;</code>
    * @return The textValue.
    */
   @java.lang.Override
@@ -1495,7 +1495,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.Value.TextValue.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+   * <code>.rpc.Value.TextValue text_value = 7;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Value.TextValueOrBuilder getTextValueOrBuilder() {
@@ -1507,7 +1507,7 @@ private static final long serialVersionUID = 0L;
 
   public static final int BLOB_VALUE_FIELD_NUMBER = 8;
   /**
-   * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+   * <code>.rpc.Value.BlobValue blob_value = 8;</code>
    * @return Whether the blobValue field is set.
    */
   @java.lang.Override
@@ -1515,7 +1515,7 @@ private static final long serialVersionUID = 0L;
     return valueCase_ == 8;
   }
   /**
-   * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+   * <code>.rpc.Value.BlobValue blob_value = 8;</code>
    * @return The blobValue.
    */
   @java.lang.Override
@@ -1526,7 +1526,7 @@ private static final long serialVersionUID = 0L;
     return com.scalar.db.rpc.Value.BlobValue.getDefaultInstance();
   }
   /**
-   * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+   * <code>.rpc.Value.BlobValue blob_value = 8;</code>
    */
   @java.lang.Override
   public com.scalar.db.rpc.Value.BlobValueOrBuilder getBlobValueOrBuilder() {
@@ -1825,21 +1825,21 @@ private static final long serialVersionUID = 0L;
    * Value is deprecated as of release 3.6.0. Will be removed in release 5.0.0. Use Column, instead.
    * </pre>
    *
-   * Protobuf type {@code scalardb.rpc.Value}
+   * Protobuf type {@code rpc.Value}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:scalardb.rpc.Value)
+      // @@protoc_insertion_point(builder_implements:rpc.Value)
       com.scalar.db.rpc.ValueOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_fieldAccessorTable
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.scalar.db.rpc.Value.class, com.scalar.db.rpc.Value.Builder.class);
     }
@@ -1872,7 +1872,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return com.scalar.db.rpc.ScalarDbProto.internal_static_scalardb_rpc_Value_descriptor;
+      return com.scalar.db.rpc.ScalarDbProto.internal_static_rpc_Value_descriptor;
     }
 
     @java.lang.Override
@@ -2336,7 +2336,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Value.TextValue, com.scalar.db.rpc.Value.TextValue.Builder, com.scalar.db.rpc.Value.TextValueOrBuilder> textValueBuilder_;
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      * @return Whether the textValue field is set.
      */
     @java.lang.Override
@@ -2344,7 +2344,7 @@ private static final long serialVersionUID = 0L;
       return valueCase_ == 7;
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      * @return The textValue.
      */
     @java.lang.Override
@@ -2362,7 +2362,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     public Builder setTextValue(com.scalar.db.rpc.Value.TextValue value) {
       if (textValueBuilder_ == null) {
@@ -2378,7 +2378,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     public Builder setTextValue(
         com.scalar.db.rpc.Value.TextValue.Builder builderForValue) {
@@ -2392,7 +2392,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     public Builder mergeTextValue(com.scalar.db.rpc.Value.TextValue value) {
       if (textValueBuilder_ == null) {
@@ -2415,7 +2415,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     public Builder clearTextValue() {
       if (textValueBuilder_ == null) {
@@ -2434,13 +2434,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     public com.scalar.db.rpc.Value.TextValue.Builder getTextValueBuilder() {
       return getTextValueFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.Value.TextValueOrBuilder getTextValueOrBuilder() {
@@ -2454,7 +2454,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+     * <code>.rpc.Value.TextValue text_value = 7;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Value.TextValue, com.scalar.db.rpc.Value.TextValue.Builder, com.scalar.db.rpc.Value.TextValueOrBuilder> 
@@ -2478,7 +2478,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Value.BlobValue, com.scalar.db.rpc.Value.BlobValue.Builder, com.scalar.db.rpc.Value.BlobValueOrBuilder> blobValueBuilder_;
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      * @return Whether the blobValue field is set.
      */
     @java.lang.Override
@@ -2486,7 +2486,7 @@ private static final long serialVersionUID = 0L;
       return valueCase_ == 8;
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      * @return The blobValue.
      */
     @java.lang.Override
@@ -2504,7 +2504,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     public Builder setBlobValue(com.scalar.db.rpc.Value.BlobValue value) {
       if (blobValueBuilder_ == null) {
@@ -2520,7 +2520,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     public Builder setBlobValue(
         com.scalar.db.rpc.Value.BlobValue.Builder builderForValue) {
@@ -2534,7 +2534,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     public Builder mergeBlobValue(com.scalar.db.rpc.Value.BlobValue value) {
       if (blobValueBuilder_ == null) {
@@ -2557,7 +2557,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     public Builder clearBlobValue() {
       if (blobValueBuilder_ == null) {
@@ -2576,13 +2576,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     public com.scalar.db.rpc.Value.BlobValue.Builder getBlobValueBuilder() {
       return getBlobValueFieldBuilder().getBuilder();
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     @java.lang.Override
     public com.scalar.db.rpc.Value.BlobValueOrBuilder getBlobValueOrBuilder() {
@@ -2596,7 +2596,7 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
-     * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+     * <code>.rpc.Value.BlobValue blob_value = 8;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.Value.BlobValue, com.scalar.db.rpc.Value.BlobValue.Builder, com.scalar.db.rpc.Value.BlobValueOrBuilder> 
@@ -2629,10 +2629,10 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:scalardb.rpc.Value)
+    // @@protoc_insertion_point(builder_scope:rpc.Value)
   }
 
-  // @@protoc_insertion_point(class_scope:scalardb.rpc.Value)
+  // @@protoc_insertion_point(class_scope:rpc.Value)
   private static final com.scalar.db.rpc.Value DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new com.scalar.db.rpc.Value();

--- a/rpc/src/main/java/com/scalar/db/rpc/ValueOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ValueOrBuilder.java
@@ -4,7 +4,7 @@
 package com.scalar.db.rpc;
 
 @java.lang.Deprecated public interface ValueOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:scalardb.rpc.Value)
+    // @@protoc_insertion_point(interface_extends:rpc.Value)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -75,32 +75,32 @@ package com.scalar.db.rpc;
   double getDoubleValue();
 
   /**
-   * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+   * <code>.rpc.Value.TextValue text_value = 7;</code>
    * @return Whether the textValue field is set.
    */
   boolean hasTextValue();
   /**
-   * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+   * <code>.rpc.Value.TextValue text_value = 7;</code>
    * @return The textValue.
    */
   com.scalar.db.rpc.Value.TextValue getTextValue();
   /**
-   * <code>.scalardb.rpc.Value.TextValue text_value = 7;</code>
+   * <code>.rpc.Value.TextValue text_value = 7;</code>
    */
   com.scalar.db.rpc.Value.TextValueOrBuilder getTextValueOrBuilder();
 
   /**
-   * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+   * <code>.rpc.Value.BlobValue blob_value = 8;</code>
    * @return Whether the blobValue field is set.
    */
   boolean hasBlobValue();
   /**
-   * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+   * <code>.rpc.Value.BlobValue blob_value = 8;</code>
    * @return The blobValue.
    */
   com.scalar.db.rpc.Value.BlobValue getBlobValue();
   /**
-   * <code>.scalardb.rpc.Value.BlobValue blob_value = 8;</code>
+   * <code>.rpc.Value.BlobValue blob_value = 8;</code>
    */
   com.scalar.db.rpc.Value.BlobValueOrBuilder getBlobValueOrBuilder();
 

--- a/rpc/src/main/proto/scalardb.proto
+++ b/rpc/src/main/proto/scalardb.proto
@@ -4,7 +4,7 @@ option java_multiple_files = true;
 option java_package = "com.scalar.db.rpc";
 option java_outer_classname = "ScalarDbProto";
 
-package scalardb.rpc;
+package rpc;
 
 import "google/protobuf/empty.proto";
 


### PR DESCRIPTION
I found renaming the proto package name in #655 breaks backward compatibility. This PR reverts the package name. Please take a look!