### PR TITLE
Add logging for UnknownTransactionStatusException in Scalar DB Server

### DIFF
--- a/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -473,6 +473,7 @@ public class DistributedTransactionService
                 .setMessage(e.getMessage())
                 .build());
       } catch (UnknownTransactionStatusException e) {
+        logger.error("the transaction status is unknown", e);
         responseBuilder.setError(
             TransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)

--- a/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -473,7 +473,10 @@ public class DistributedTransactionService
                 .setMessage(e.getMessage())
                 .build());
       } catch (UnknownTransactionStatusException e) {
-        logger.error("the transaction status is unknown", e);
+        logger.error(
+            "the transaction status is unknown. transaction ID: "
+                + e.getUnknownTransactionId().orElse("null"),
+            e);
         responseBuilder.setError(
             TransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)

--- a/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
@@ -534,7 +534,10 @@ public class TwoPhaseCommitTransactionService
                 .setMessage(e.getMessage())
                 .build());
       } catch (UnknownTransactionStatusException e) {
-        logger.error("the transaction status is unknown", e);
+        logger.error(
+            "the transaction status is unknown. transaction ID: "
+                + e.getUnknownTransactionId().orElse("null"),
+            e);
         responseBuilder.setError(
             TwoPhaseCommitTransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)

--- a/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
@@ -534,6 +534,7 @@ public class TwoPhaseCommitTransactionService
                 .setMessage(e.getMessage())
                 .build());
       } catch (UnknownTransactionStatusException e) {
+        logger.error("the transaction status is unknown", e);
         responseBuilder.setError(
             TwoPhaseCommitTransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)


### PR DESCRIPTION
We should log when UnknownTransactionStatusException is thrown for debugging in Scalar DB Server. This PR adds logging for it. Please take a look!