### PR TITLE
Add method to retrieve the namespace names for Cosmos Admin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -4,8 +4,6 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegration
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithCosmos
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -39,19 +37,4 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void dropNamespace_ForNonExistingNamespace_ShouldDropNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -4,8 +4,6 @@ import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
@@ -38,19 +36,4 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void dropNamespace_ForNonExistingNamespace_ShouldDropNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/util/CosmosAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/util/CosmosAdminTestUtils.java
@@ -6,7 +6,6 @@ import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.CosmosStoredProcedure;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
@@ -36,21 +35,14 @@ public class CosmosAdminTestUtils extends AdminTestUtils {
             .buildClient();
     metadataNamespace =
         new CosmosConfig(new DatabaseConfig(properties))
-            .getTableMetadataDatabase()
+            .getMetadataDatabase()
             .orElse(CosmosAdmin.METADATA_DATABASE);
-    metadataTable = CosmosAdmin.METADATA_CONTAINER;
+    metadataTable = CosmosAdmin.TABLE_METADATA_CONTAINER;
   }
 
   @Override
   public void dropMetadataTable() {
-    client.getDatabase(metadataNamespace).delete();
-    try {
-      client.getDatabase(metadataNamespace).read();
-    } catch (CosmosException e) {
-      if (e.getStatusCode() != 404) {
-        throw new RuntimeException("Dropping the metadata table failed", e);
-      }
-    }
+    client.getDatabase(metadataNamespace).getContainer(metadataTable).delete();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -493,7 +493,17 @@ public class CosmosAdmin implements DistributedStorageAdmin {
 
   @Override
   public boolean namespaceExists(String namespace) throws ExecutionException {
-    return databaseExists(namespace);
+    try {
+      getNamespacesContainer()
+          .readItem(namespace, new PartitionKey(namespace), CosmosNamespace.class);
+      return true;
+    } catch (RuntimeException e) {
+      if (e instanceof CosmosException
+          && ((CosmosException) e).getStatusCode() == CosmosErrorCode.NOT_FOUND.get()) {
+        return false;
+      }
+      throw new ExecutionException("checking if the namespace exists failed", e);
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -53,7 +53,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   public static final String DEFAULT_NO_SCALING = "false";
 
   public static final String METADATA_DATABASE = "scalardb";
-  public static final String METADATA_CONTAINER = "metadata";
+  public static final String TABLE_METADATA_CONTAINER = "metadata";
+  public static final String NAMESPACES_CONTAINER = "namespaces";
   private static final String ID = "id";
   private static final String CONCATENATED_PARTITION_KEY = "concatenatedPartitionKey";
   private static final String PARTITION_KEY_PATH = "/" + CONCATENATED_PARTITION_KEY;
@@ -77,12 +78,12 @@ public class CosmosAdmin implements DistributedStorageAdmin {
             .directMode()
             .consistencyLevel(ConsistencyLevel.STRONG)
             .buildClient();
-    metadataDatabase = config.getTableMetadataDatabase().orElse(METADATA_DATABASE);
+    metadataDatabase = config.getMetadataDatabase().orElse(METADATA_DATABASE);
   }
 
   CosmosAdmin(CosmosClient client, CosmosConfig config) {
     this.client = client;
-    metadataDatabase = config.getTableMetadataDatabase().orElse(METADATA_DATABASE);
+    metadataDatabase = config.getMetadataDatabase().orElse(METADATA_DATABASE);
   }
 
   @Override
@@ -139,7 +140,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
           .read();
       return true;
     } catch (CosmosException e) {
-      if (e.getStatusCode() == 404) {
+      if (e.getStatusCode() == CosmosErrorCode.NOT_FOUND.get()) {
         return false;
       }
       throw e;
@@ -221,27 +222,27 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   private void putTableMetadata(String namespace, String table, TableMetadata metadata)
       throws ExecutionException {
     try {
-      createMetadataDatabaseAndContainerIfNotExists();
+      createMetadataDatabaseAndTableMetadataContainerIfNotExists();
 
       CosmosTableMetadata cosmosTableMetadata =
           convertToCosmosTableMetadata(getFullTableName(namespace, table), metadata);
-      getMetadataContainer().upsertItem(cosmosTableMetadata);
+      getTableMetadataContainer().upsertItem(cosmosTableMetadata);
     } catch (RuntimeException e) {
       throw new ExecutionException("putting the table metadata failed", e);
     }
   }
 
-  private void createMetadataDatabaseAndContainerIfNotExists() {
+  private void createMetadataDatabaseAndTableMetadataContainerIfNotExists() {
     ThroughputProperties manualThroughput =
         ThroughputProperties.createManualThroughput(Integer.parseInt(DEFAULT_REQUEST_UNIT));
     client.createDatabaseIfNotExists(metadataDatabase, manualThroughput);
     CosmosContainerProperties containerProperties =
-        new CosmosContainerProperties(METADATA_CONTAINER, "/id");
+        new CosmosContainerProperties(TABLE_METADATA_CONTAINER, "/id");
     client.getDatabase(metadataDatabase).createContainerIfNotExists(containerProperties);
   }
 
-  private CosmosContainer getMetadataContainer() {
-    return client.getDatabase(metadataDatabase).getContainer(METADATA_CONTAINER);
+  private CosmosContainer getTableMetadataContainer() {
+    return client.getDatabase(metadataDatabase).getContainer(TABLE_METADATA_CONTAINER);
   }
 
   private CosmosTableMetadata convertToCosmosTableMetadata(
@@ -271,6 +272,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       throws ExecutionException {
     try {
       client.createDatabase(namespace, calculateThroughput(options));
+      createMetadataDatabaseAndNamespaceContainerIfNotExists();
+      getNamespacesContainer().createItem(new CosmosNamespace(namespace));
     } catch (RuntimeException e) {
       throw new ExecutionException("creating the database failed", e);
     }
@@ -281,13 +284,12 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     if (!databaseExists(namespace)) {
       throw new ExecutionException("the database does not exist");
     }
-    CosmosDatabase database = client.getDatabase(namespace);
-    if (!containerExists(database, table)) {
+    if (!containerExists(namespace, table)) {
       throw new ExecutionException("the container does not exist");
     }
 
     try {
-      database.getContainer(table).delete();
+      client.getDatabase(namespace).getContainer(table).delete();
       deleteTableMetadata(namespace, table);
     } catch (RuntimeException e) {
       throw new ExecutionException("deleting the container failed", e);
@@ -297,20 +299,19 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   private void deleteTableMetadata(String namespace, String table) throws ExecutionException {
     String fullTableName = getFullTableName(namespace, table);
     try {
-      getMetadataContainer()
+      getTableMetadataContainer()
           .deleteItem(
               fullTableName, new PartitionKey(fullTableName), new CosmosItemRequestOptions());
-      // Delete the metadata container and table if there is no more metadata stored
-      if (!getMetadataContainer()
+      // Delete the table metadata container if there is no more metadata stored
+      if (!getTableMetadataContainer()
           .queryItems(
-              "SELECT 1 FROM " + METADATA_CONTAINER + " OFFSET 0 LIMIT 1",
+              "SELECT 1 FROM " + TABLE_METADATA_CONTAINER + " OFFSET 0 LIMIT 1",
               new CosmosQueryRequestOptions(),
               Object.class)
           .stream()
           .findFirst()
           .isPresent()) {
-        getMetadataContainer().delete();
-        client.getDatabase(metadataDatabase).delete();
+        getTableMetadataContainer().delete();
       }
     } catch (RuntimeException e) {
       throw new ExecutionException("deleting the table metadata failed", e);
@@ -319,12 +320,24 @@ public class CosmosAdmin implements DistributedStorageAdmin {
 
   @Override
   public void dropNamespace(String namespace) throws ExecutionException {
-    if (!databaseExists(namespace)) {
-      throw new ExecutionException("the database does not exist");
-    }
-
     try {
       client.getDatabase(namespace).delete();
+      CosmosContainer namespacesContainer = getNamespacesContainer();
+      namespacesContainer.deleteItem(
+          new CosmosNamespace(namespace), new CosmosItemRequestOptions());
+
+      // Delete the namespaces container and metadata database if there is no more existing
+      // namespaces
+      if (!namespacesContainer
+          .queryItems(
+              "SELECT 1 FROM container OFFSET 0 LIMIT 1",
+              new CosmosQueryRequestOptions(),
+              Object.class)
+          .stream()
+          .findFirst()
+          .isPresent()) {
+        client.getDatabase(metadataDatabase).delete();
+      }
     } catch (RuntimeException e) {
       throw new ExecutionException("deleting the database failed", e);
     }
@@ -403,7 +416,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   public TableMetadata getTableMetadata(String namespace, String table) throws ExecutionException {
     try {
       String fullName = getFullTableName(namespace, table);
-      CosmosTableMetadata cosmosTableMetadata = readMetadata(fullName);
+      CosmosTableMetadata cosmosTableMetadata = readTableMetadata(fullName);
       if (cosmosTableMetadata == null) {
         return null;
       }
@@ -413,9 +426,9 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private CosmosTableMetadata readMetadata(String fullName) {
+  private CosmosTableMetadata readTableMetadata(String fullName) {
     try {
-      return getMetadataContainer()
+      return getTableMetadataContainer()
           .readItem(fullName, new PartitionKey(fullName), CosmosTableMetadata.class)
           .getItem();
     } catch (NotFoundException e) {
@@ -488,17 +501,11 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
     try {
-      try {
-        // Since the metadata table may be missing, we cannot use CosmosAdmin.tableExists() as it
-        // queries the metadata table to verify if the given table exists
-        client.getDatabase(namespace).getContainer(table).read();
-      } catch (CosmosException e) {
-        if (e.getStatusCode() == 404) {
-          throw new IllegalArgumentException(
-              "The table " + getFullTableName(namespace, table) + "  does not exist");
-        }
+      if (!containerExists(namespace, table)) {
+        throw new IllegalArgumentException(
+            "The table " + getFullTableName(namespace, table) + "  does not exist");
       }
-      createMetadataDatabaseAndContainerIfNotExists();
+      createMetadataDatabaseAndTableMetadataContainerIfNotExists();
       putTableMetadata(namespace, table, metadata);
       if (!storedProcedureExists(namespace, table)) {
         addStoredProcedure(namespace, table);
@@ -525,18 +532,18 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   @Override
   public Set<String> getNamespaceTableNames(String namespace) throws ExecutionException {
     try {
-      if (!metadataContainerExists()) {
+      if (!tableMetadataContainerExists()) {
         return Collections.emptySet();
       }
       String selectAllDatabaseContainer =
           "SELECT * FROM "
-              + METADATA_CONTAINER
+              + TABLE_METADATA_CONTAINER
               + " WHERE "
-              + METADATA_CONTAINER
+              + TABLE_METADATA_CONTAINER
               + ".id LIKE '"
               + namespace
               + ".%'";
-      return getMetadataContainer()
+      return getTableMetadataContainer()
           .queryItems(
               selectAllDatabaseContainer,
               new CosmosQueryRequestOptions(),
@@ -574,33 +581,54 @@ public class CosmosAdmin implements DistributedStorageAdmin {
 
   @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
-    throw new UnsupportedOperationException("Not yet implemented");
+    try {
+      if (!namespacesContainerExists()) {
+        return Collections.emptySet();
+      }
+
+      CosmosPagedIterable<CosmosNamespace> allNamespaces =
+          getNamespacesContainer()
+              .queryItems(
+                  "SELECT * FROM container",
+                  new CosmosQueryRequestOptions(),
+                  CosmosNamespace.class);
+
+      return allNamespaces.stream().map(CosmosNamespace::getId).collect(Collectors.toSet());
+    } catch (RuntimeException e) {
+      throw new ExecutionException("retrieving the namespaces names failed", e);
+    }
   }
 
-  private boolean metadataContainerExists() {
+  private void createMetadataDatabaseAndNamespaceContainerIfNotExists() {
+    ThroughputProperties manualThroughput =
+        ThroughputProperties.createManualThroughput(Integer.parseInt(DEFAULT_REQUEST_UNIT));
+    client.createDatabaseIfNotExists(metadataDatabase, manualThroughput);
+    CosmosContainerProperties containerProperties =
+        new CosmosContainerProperties(NAMESPACES_CONTAINER, "/id");
+    client.getDatabase(metadataDatabase).createContainerIfNotExists(containerProperties);
+  }
+
+  private CosmosContainer getNamespacesContainer() {
+    return client.getDatabase(metadataDatabase).getContainer(NAMESPACES_CONTAINER);
+  }
+
+  private boolean tableMetadataContainerExists() throws RuntimeException {
+    return containerExists(metadataDatabase, TABLE_METADATA_CONTAINER);
+  }
+
+  private boolean namespacesContainerExists() throws RuntimeException {
+    return containerExists(metadataDatabase, NAMESPACES_CONTAINER);
+  }
+
+  private boolean containerExists(String databaseId, String containerId) throws CosmosException {
     try {
-      client.getDatabase(metadataDatabase).getContainer(METADATA_CONTAINER).read();
+      client.getDatabase(databaseId).getContainer(containerId).read();
     } catch (RuntimeException e) {
       if (e instanceof CosmosException
           && ((CosmosException) e).getStatusCode() == CosmosErrorCode.NOT_FOUND.get()) {
         return false;
       }
       throw e;
-    }
-    return true;
-  }
-
-  private boolean containerExists(CosmosDatabase database, String containerId)
-      throws ExecutionException {
-    try {
-      database.getContainer(containerId).read();
-    } catch (RuntimeException e) {
-      if (e instanceof CosmosException
-          && ((CosmosException) e).getStatusCode() == CosmosErrorCode.NOT_FOUND.get()) {
-        return false;
-      }
-      throw new ExecutionException(
-          String.format("reading the container %s failed", containerId), e);
     }
     return true;
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
@@ -6,27 +6,47 @@ import com.scalar.db.config.DatabaseConfig;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Immutable
 public class CosmosConfig {
-
+  private static final Logger logger = LoggerFactory.getLogger(CosmosConfig.class);
   public static final String PREFIX = DatabaseConfig.PREFIX + "cosmos.";
+  /** @deprecated As of 5.0, will be removed. Use {@link #METADATA_DATABASE} instead. */
+  @Deprecated
   public static final String TABLE_METADATA_DATABASE = PREFIX + "table_metadata.database";
 
+  public static final String METADATA_DATABASE = PREFIX + "metadata.database";
   private final String endpoint;
   private final String key;
-  @Nullable private final String tableMetadataDatabase;
+  @Nullable private final String metadataDatabase;
 
   public CosmosConfig(DatabaseConfig databaseConfig) {
-    String storage = databaseConfig.getStorage();
-    if (!storage.equals("cosmos")) {
+    String storage = databaseConfig.getProperties().getProperty(DatabaseConfig.STORAGE);
+    if (storage == null || !storage.equals("cosmos")) {
       throw new IllegalArgumentException(DatabaseConfig.STORAGE + " should be 'cosmos'");
     }
 
     endpoint = databaseConfig.getContactPoints().get(0);
     key = databaseConfig.getPassword().orElse(null);
-    tableMetadataDatabase =
-        getString(databaseConfig.getProperties(), TABLE_METADATA_DATABASE, null);
+
+    if (databaseConfig.getProperties().containsKey(METADATA_DATABASE)
+        && databaseConfig.getProperties().containsKey(TABLE_METADATA_DATABASE)) {
+      throw new IllegalArgumentException(
+          "Use either " + METADATA_DATABASE + " or " + TABLE_METADATA_DATABASE + " but not both");
+    }
+    if (databaseConfig.getProperties().containsKey(TABLE_METADATA_DATABASE)) {
+      logger.warn(
+          "The configuration property \""
+              + TABLE_METADATA_DATABASE
+              + "\" is deprecated and will be removed in 5.0.0. Please use \""
+              + METADATA_DATABASE
+              + "\" instead.");
+      metadataDatabase = getString(databaseConfig.getProperties(), TABLE_METADATA_DATABASE, null);
+    } else {
+      metadataDatabase = getString(databaseConfig.getProperties(), METADATA_DATABASE, null);
+    }
   }
 
   public String getEndpoint() {
@@ -37,7 +57,7 @@ public class CosmosConfig {
     return key;
   }
 
-  public Optional<String> getTableMetadataDatabase() {
-    return Optional.ofNullable(tableMetadataDatabase);
+  public Optional<String> getMetadataDatabase() {
+    return Optional.ofNullable(metadataDatabase);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosNamespace.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosNamespace.java
@@ -1,0 +1,45 @@
+package com.scalar.db.storage.cosmos;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+
+public class CosmosNamespace {
+  private String id;
+
+  public CosmosNamespace() {}
+
+  public CosmosNamespace(String id) {
+    this.id = id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CosmosNamespace)) {
+      return false;
+    }
+    CosmosNamespace that = (CosmosNamespace) o;
+
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("id", id).toString();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -64,6 +64,7 @@ public abstract class CosmosAdminTestBase {
   @Mock private CosmosConfig config;
   @Mock private CosmosDatabase database;
   @Mock private CosmosContainer container;
+  @Mock private CosmosException notFoundException;
   private CosmosAdmin admin;
   private String metadataDatabaseName;
 
@@ -72,10 +73,11 @@ public abstract class CosmosAdminTestBase {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    when(config.getTableMetadataDatabase()).thenReturn(getTableMetadataDatabaseConfig());
+    when(config.getMetadataDatabase()).thenReturn(getTableMetadataDatabaseConfig());
     admin = new CosmosAdmin(client, config);
 
     metadataDatabaseName = getTableMetadataDatabaseConfig().orElse("scalardb");
+    when(notFoundException.getStatusCode()).thenReturn(CosmosErrorCode.NOT_FOUND.get());
   }
 
   /**
@@ -97,7 +99,7 @@ public abstract class CosmosAdminTestBase {
     CosmosItemResponse<CosmosTableMetadata> response = mock(CosmosItemResponse.class);
 
     when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
-    when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
+    when(database.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER)).thenReturn(container);
     when(container.readItem(
             anyString(),
             any(PartitionKey.class),
@@ -126,7 +128,7 @@ public abstract class CosmosAdminTestBase {
                 .build());
 
     verify(client).getDatabase(metadataDatabaseName);
-    verify(database).getContainer(CosmosAdmin.METADATA_CONTAINER);
+    verify(database).getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER);
     verify(container).readItem(fullName, new PartitionKey(fullName), CosmosTableMetadata.class);
     verify(response).getItem();
   }
@@ -137,6 +139,10 @@ public abstract class CosmosAdminTestBase {
     // Arrange
     String namespace = "ns";
     String throughput = "2000";
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer namespacesContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(anyString())).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(anyString())).thenReturn(namespacesContainer);
 
     // Act
     admin.createNamespace(
@@ -147,6 +153,21 @@ public abstract class CosmosAdminTestBase {
         .createDatabase(
             eq(namespace),
             refEq(ThroughputProperties.createManualThroughput(Integer.parseInt(throughput))));
+    verify(client)
+        .createDatabaseIfNotExists(
+            eq(metadataDatabaseName),
+            refEq(
+                ThroughputProperties.createManualThroughput(
+                    Integer.parseInt(CosmosAdmin.DEFAULT_REQUEST_UNIT))));
+    verify(client, times(2)).getDatabase(metadataDatabaseName);
+    ArgumentCaptor<CosmosContainerProperties> containerPropertiesCaptor =
+        ArgumentCaptor.forClass(CosmosContainerProperties.class);
+    verify(metadataDatabase).createContainerIfNotExists(containerPropertiesCaptor.capture());
+    CosmosContainerProperties namespaceContainerProperties = containerPropertiesCaptor.getValue();
+    assertThat(namespaceContainerProperties.getId()).isEqualTo(CosmosAdmin.NAMESPACES_CONTAINER);
+    assertThat(namespaceContainerProperties.getPartitionKeyDefinition().getPaths())
+        .containsExactly("/id");
+    verify(namespacesContainer).createItem(new CosmosNamespace(namespace));
   }
 
   @Test
@@ -155,6 +176,10 @@ public abstract class CosmosAdminTestBase {
     // Arrange
     String namespace = "ns";
     String throughput = "4000";
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer namespacesContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(anyString())).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(anyString())).thenReturn(namespacesContainer);
 
     // Act
     admin.createNamespace(
@@ -165,6 +190,21 @@ public abstract class CosmosAdminTestBase {
         .createDatabase(
             eq(namespace),
             refEq(ThroughputProperties.createAutoscaledThroughput(Integer.parseInt(throughput))));
+    verify(client)
+        .createDatabaseIfNotExists(
+            eq(metadataDatabaseName),
+            refEq(
+                ThroughputProperties.createManualThroughput(
+                    Integer.parseInt(CosmosAdmin.DEFAULT_REQUEST_UNIT))));
+    verify(client, times(2)).getDatabase(metadataDatabaseName);
+    ArgumentCaptor<CosmosContainerProperties> containerPropertiesCaptor =
+        ArgumentCaptor.forClass(CosmosContainerProperties.class);
+    verify(metadataDatabase).createContainerIfNotExists(containerPropertiesCaptor.capture());
+    CosmosContainerProperties namespaceContainerProperties = containerPropertiesCaptor.getValue();
+    assertThat(namespaceContainerProperties.getId()).isEqualTo(CosmosAdmin.NAMESPACES_CONTAINER);
+    assertThat(namespaceContainerProperties.getPartitionKeyDefinition().getPaths())
+        .containsExactly("/id");
+    verify(namespacesContainer).createItem(new CosmosNamespace(namespace));
   }
 
   @Test
@@ -175,6 +215,10 @@ public abstract class CosmosAdminTestBase {
     String namespace = "ns";
     String throughput = "4000";
     String noScaling = "true";
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer namespacesContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(anyString())).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(anyString())).thenReturn(namespacesContainer);
 
     // Act
     admin.createNamespace(
@@ -186,6 +230,21 @@ public abstract class CosmosAdminTestBase {
         .createDatabase(
             eq(namespace),
             refEq(ThroughputProperties.createManualThroughput(Integer.parseInt(throughput))));
+    verify(client)
+        .createDatabaseIfNotExists(
+            eq(metadataDatabaseName),
+            refEq(
+                ThroughputProperties.createManualThroughput(
+                    Integer.parseInt(CosmosAdmin.DEFAULT_REQUEST_UNIT))));
+    verify(client, times(2)).getDatabase(metadataDatabaseName);
+    ArgumentCaptor<CosmosContainerProperties> containerPropertiesCaptor =
+        ArgumentCaptor.forClass(CosmosContainerProperties.class);
+    verify(metadataDatabase).createContainerIfNotExists(containerPropertiesCaptor.capture());
+    CosmosContainerProperties namespaceContainerProperties = containerPropertiesCaptor.getValue();
+    assertThat(namespaceContainerProperties.getId()).isEqualTo(CosmosAdmin.NAMESPACES_CONTAINER);
+    assertThat(namespaceContainerProperties.getPartitionKeyDefinition().getPaths())
+        .containsExactly("/id");
+    verify(namespacesContainer).createItem(new CosmosNamespace(namespace));
   }
 
   @Test
@@ -217,7 +276,7 @@ public abstract class CosmosAdminTestBase {
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
 
     // Act
@@ -260,7 +319,7 @@ public abstract class CosmosAdminTestBase {
             refEq(ThroughputProperties.createManualThroughput(Integer.parseInt("400"))));
     verify(metadataDatabase).createContainerIfNotExists(containerPropertiesCaptor.capture());
     assertThat(containerPropertiesCaptor.getValue().getId())
-        .isEqualTo(CosmosAdmin.METADATA_CONTAINER);
+        .isEqualTo(CosmosAdmin.TABLE_METADATA_CONTAINER);
     assertThat(containerPropertiesCaptor.getValue().getPartitionKeyDefinition().getPaths())
         .containsExactly("/id");
     CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
@@ -310,7 +369,7 @@ public abstract class CosmosAdminTestBase {
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
 
     // Act
@@ -342,7 +401,7 @@ public abstract class CosmosAdminTestBase {
             refEq(ThroughputProperties.createManualThroughput(Integer.parseInt("400"))));
     verify(metadataDatabase).createContainerIfNotExists(containerPropertiesCaptor.capture());
     assertThat(containerPropertiesCaptor.getValue().getId())
-        .isEqualTo(CosmosAdmin.METADATA_CONTAINER);
+        .isEqualTo(CosmosAdmin.TABLE_METADATA_CONTAINER);
     assertThat(containerPropertiesCaptor.getValue().getPartitionKeyDefinition().getPaths())
         .containsExactly("/id");
     CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
@@ -384,7 +443,7 @@ public abstract class CosmosAdminTestBase {
   }
 
   @Test
-  public void dropTable_WithNoMetadataLeft_ShouldDropContainerAndDeleteMetadataAndDatabase()
+  public void dropTable_WithNoMetadataLeft_ShouldDropContainerAndDeleteTableMetadataContainer()
       throws ExecutionException {
     // Arrange
     String namespace = "ns";
@@ -397,7 +456,7 @@ public abstract class CosmosAdminTestBase {
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
     @SuppressWarnings("unchecked")
     CosmosPagedIterable<Object> queryResults = mock(CosmosPagedIterable.class);
@@ -413,13 +472,12 @@ public abstract class CosmosAdminTestBase {
 
     // for metadata table
     verify(client, atLeastOnce()).getDatabase(metadataDatabaseName);
-    verify(metadataDatabase, atLeastOnce()).getContainer(CosmosAdmin.METADATA_CONTAINER);
+    verify(metadataDatabase, atLeastOnce()).getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER);
     String fullTable = getFullTableName(namespace, table);
     verify(metadataContainer)
         .deleteItem(
             eq(fullTable), eq(new PartitionKey(fullTable)), refEq(new CosmosItemRequestOptions()));
     verify(metadataContainer).delete();
-    verify(metadataDatabase).delete();
   }
 
   public void dropTable_WithMetadataLeft_ShouldDropContainerAndOnlyDeleteMetadata()
@@ -435,7 +493,7 @@ public abstract class CosmosAdminTestBase {
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
     @SuppressWarnings("unchecked")
     CosmosPagedIterable<Object> queryResults = mock(CosmosPagedIterable.class);
@@ -451,7 +509,7 @@ public abstract class CosmosAdminTestBase {
 
     // for metadata table
     verify(client, atLeastOnce()).getDatabase(metadataDatabaseName);
-    verify(metadataDatabase, atLeastOnce()).getContainer(CosmosAdmin.METADATA_CONTAINER);
+    verify(metadataDatabase, atLeastOnce()).getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER);
     String fullTable = getFullTableName(namespace, table);
     verify(metadataContainer)
         .deleteItem(
@@ -461,16 +519,57 @@ public abstract class CosmosAdminTestBase {
   }
 
   @Test
-  public void dropNamespace_WithExistingDatabase_ShouldDropDatabase() throws ExecutionException {
+  public void
+      dropNamespace_WithExistingDatabaseAndNoMoreNamespaceLeft_ShouldDropDatabaseAndMetadataNamespace()
+          throws ExecutionException {
     // Arrange
     String namespace = "ns";
-    when(client.getDatabase(any())).thenReturn(database);
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    when(client.getDatabase(any())).thenReturn(database, metadataDatabase);
+    CosmosContainer namespacesContainer = mock(CosmosContainer.class);
+    when(metadataDatabase.getContainer(anyString())).thenReturn(namespacesContainer);
+
+    CosmosPagedIterable<Object> pagedIterable = mock(CosmosPagedIterable.class);
+    when(namespacesContainer.queryItems(anyString(), any(), any())).thenReturn(pagedIterable);
+    when(pagedIterable.stream()).thenReturn(Stream.empty());
 
     // Act
     admin.dropNamespace(namespace);
 
     // Assert
+    verify(client).getDatabase(namespace);
     verify(database).delete();
+    verify(client, times(2)).getDatabase(metadataDatabaseName);
+    verify(metadataDatabase).getContainer(CosmosAdmin.NAMESPACES_CONTAINER);
+    verify(namespacesContainer)
+        .deleteItem(eq(new CosmosNamespace(namespace)), refEq(new CosmosItemRequestOptions()));
+    verify(metadataDatabase).delete();
+  }
+
+  @Test
+  public void dropNamespace_WithExistingDatabaseAndSomeNamespacesLeft_ShouldDropDatabase()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    when(client.getDatabase(any())).thenReturn(database, metadataDatabase);
+    CosmosContainer namespacesContainer = mock(CosmosContainer.class);
+    when(metadataDatabase.getContainer(anyString())).thenReturn(namespacesContainer);
+
+    CosmosPagedIterable<Object> pagedIterable = mock(CosmosPagedIterable.class);
+    when(namespacesContainer.queryItems(anyString(), any(), any())).thenReturn(pagedIterable);
+    when(pagedIterable.stream()).thenReturn(Stream.of(mock(Object.class)));
+
+    // Act
+    admin.dropNamespace(namespace);
+
+    // Assert
+    verify(client).getDatabase(namespace);
+    verify(database).delete();
+    verify(client).getDatabase(metadataDatabaseName);
+    verify(metadataDatabase).getContainer(CosmosAdmin.NAMESPACES_CONTAINER);
+    verify(namespacesContainer)
+        .deleteItem(eq(new CosmosNamespace(namespace)), refEq(new CosmosItemRequestOptions()));
   }
 
   @Test
@@ -524,7 +623,7 @@ public abstract class CosmosAdminTestBase {
     t2.setId(getFullTableName(namespace, "t2"));
 
     when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
-    when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
+    when(database.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER)).thenReturn(container);
     @SuppressWarnings("unchecked")
     CosmosPagedIterable<CosmosTableMetadata> queryResults = mock(CosmosPagedIterable.class);
     when(container.queryItems(anyString(), any(), eq(CosmosTableMetadata.class)))
@@ -537,7 +636,7 @@ public abstract class CosmosAdminTestBase {
     // Assert
     assertThat(actualTableNames).containsExactly("t1", "t2");
     verify(client, atLeastOnce()).getDatabase(metadataDatabaseName);
-    verify(database, atLeastOnce()).getContainer(CosmosAdmin.METADATA_CONTAINER);
+    verify(database, atLeastOnce()).getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER);
     verify(container)
         .queryItems(
             eq("SELECT * FROM metadata WHERE metadata.id LIKE 'ns.%'"),
@@ -563,7 +662,7 @@ public abstract class CosmosAdminTestBase {
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
     @SuppressWarnings("unchecked")
     CosmosItemResponse<CosmosTableMetadata> itemResponse = mock(CosmosItemResponse.class);
@@ -632,7 +731,7 @@ public abstract class CosmosAdminTestBase {
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
     @SuppressWarnings("unchecked")
     CosmosItemResponse<CosmosTableMetadata> itemResponse = mock(CosmosItemResponse.class);
@@ -726,7 +825,7 @@ public abstract class CosmosAdminTestBase {
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
 
     CosmosScripts scripts = mock(CosmosScripts.class);
@@ -776,7 +875,7 @@ public abstract class CosmosAdminTestBase {
     CosmosContainer metadataContainer = mock(CosmosContainer.class);
     CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
     when(client.getDatabase(metadataDatabaseName)).thenReturn(metadataDatabase);
-    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+    when(metadataDatabase.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER))
         .thenReturn(metadataContainer);
 
     // Missing stored procedure
@@ -813,7 +912,7 @@ public abstract class CosmosAdminTestBase {
     CosmosItemResponse<CosmosTableMetadata> response = mock(CosmosItemResponse.class);
 
     when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
-    when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
+    when(database.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER)).thenReturn(container);
     when(container.readItem(
             anyString(),
             any(PartitionKey.class),
@@ -848,7 +947,7 @@ public abstract class CosmosAdminTestBase {
     CosmosItemResponse<CosmosTableMetadata> response = mock(CosmosItemResponse.class);
 
     when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
-    when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
+    when(database.getContainer(CosmosAdmin.TABLE_METADATA_CONTAINER)).thenReturn(container);
     when(container.readItem(
             anyString(),
             any(PartitionKey.class),
@@ -880,5 +979,47 @@ public abstract class CosmosAdminTestBase {
         ImmutableMap.of(currentColumn, "text", newColumn, "int"));
 
     verify(container).upsertItem(expectedCosmosTableMetadata);
+  }
+
+  @Test
+  public void getNamespaceNames_NonExistingNamespacesContainer_ShouldReturnEmptySet()
+      throws ExecutionException {
+    // Arrange
+    when(client.getDatabase(anyString())).thenThrow(notFoundException);
+
+    // Act
+    Set<String> actualNamespaces = admin.getNamespaceNames();
+
+    // Assert
+    assertThat(actualNamespaces).isEmpty();
+    verify(client).getDatabase(metadataDatabaseName);
+  }
+
+  @Test
+  public void getNamespaceNames_ShouldWorkProperly() throws ExecutionException {
+    // Arrange
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer namespacesContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(anyString())).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.NAMESPACES_CONTAINER))
+        .thenReturn(namespacesContainer);
+    CosmosPagedIterable<CosmosNamespace> pagedIterable = mock(CosmosPagedIterable.class);
+    when(namespacesContainer.queryItems(anyString(), any(), eq(CosmosNamespace.class)))
+        .thenReturn(pagedIterable);
+    when(pagedIterable.stream())
+        .thenReturn(Stream.of(new CosmosNamespace("ns1"), new CosmosNamespace("ns2")));
+
+    // Act
+    Set<String> actualNamespaces = admin.getNamespaceNames();
+
+    // Assert
+    verify(client, times(2)).getDatabase(metadataDatabaseName);
+    verify(metadataDatabase, times(2)).getContainer(CosmosAdmin.NAMESPACES_CONTAINER);
+    verify(namespacesContainer)
+        .queryItems(
+            eq("SELECT * FROM container"),
+            refEq(new CosmosQueryRequestOptions()),
+            eq(CosmosNamespace.class));
+    assertThat(actualNamespaces).containsOnly("ns1", "ns2");
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminWithMetadataDatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminWithMetadataDatabaseConfigTest.java
@@ -2,7 +2,7 @@ package com.scalar.db.storage.cosmos;
 
 import java.util.Optional;
 
-public class CosmosAdminTableMetadataDatabaseConfigTest extends CosmosAdminTestBase {
+public class CosmosAdminWithMetadataDatabaseConfigTest extends CosmosAdminTestBase {
   @Override
   Optional<String> getTableMetadataDatabaseConfig() {
     return Optional.of("my_meta_ns");

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
@@ -21,7 +21,7 @@ public class CosmosConfigTest {
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
     props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
     props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
-    props.setProperty(CosmosConfig.TABLE_METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+    props.setProperty(CosmosConfig.METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
 
     // Act
     CosmosConfig config = new CosmosConfig(new DatabaseConfig(props));
@@ -29,8 +29,8 @@ public class CosmosConfigTest {
     // Assert
     assertThat(config.getEndpoint()).isEqualTo(ANY_ENDPOINT);
     assertThat(config.getKey()).isEqualTo(ANY_KEY);
-    assertThat(config.getTableMetadataDatabase()).isPresent();
-    assertThat(config.getTableMetadataDatabase().get()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
+    assertThat(config.getMetadataDatabase()).isPresent();
+    assertThat(config.getMetadataDatabase().get()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
   }
 
   @Test
@@ -39,7 +39,7 @@ public class CosmosConfigTest {
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
     props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
-    props.setProperty(CosmosConfig.TABLE_METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+    props.setProperty(CosmosConfig.METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
 
     // Act Assert
     assertThatThrownBy(() -> new CosmosConfig(new DatabaseConfig(props)))
@@ -60,6 +60,41 @@ public class CosmosConfigTest {
     // Assert
     assertThat(config.getEndpoint()).isEqualTo(ANY_ENDPOINT);
     assertThat(config.getKey()).isEqualTo(ANY_KEY);
-    assertThat(config.getTableMetadataDatabase()).isNotPresent();
+    assertThat(config.getMetadataDatabase()).isNotPresent();
+  }
+
+  @Test
+  public void
+      constructor_WithTableMetadataDatabaseAndMetadataDatabaseGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
+    props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
+    props.setProperty(CosmosConfig.METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+    props.setProperty(CosmosConfig.TABLE_METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+
+    // Act Assert
+    assertThatThrownBy(() -> new CosmosConfig(new DatabaseConfig(props)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_WithTableMetadataDatabaseGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
+    props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
+    props.setProperty(CosmosConfig.TABLE_METADATA_DATABASE, ANY_TABLE_METADATA_DATABASE);
+
+    // Act
+    CosmosConfig config = new CosmosConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getEndpoint()).isEqualTo(ANY_ENDPOINT);
+    assertThat(config.getKey()).isEqualTo(ANY_KEY);
+    assertThat(config.getMetadataDatabase()).isPresent();
+    assertThat(config.getMetadataDatabase().get()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
   }
 }


### PR DESCRIPTION
This implement the `admin.getNamespaceNames()` for the CosmosAdmin .