### PR TITLE
Delete setDriver() for BasicDataSource in JDBC

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -1,10 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
-import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.SQLException;
-import oracle.jdbc.OracleDriver;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
@@ -30,16 +27,7 @@ public final class JdbcUtils {
 
   public static BasicDataSource initDataSource(JdbcConfig config, boolean transactional) {
     BasicDataSource dataSource = new BasicDataSource();
-
-    /*
-     * We need to set the driver class of an underlying database to the dataSource in order
-     * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
-     * work (e.g., when we dynamically load a driver class from a fatJar).
-     */
-    dataSource.setDriver(getDriverClass(config.getJdbcUrl()));
-
     dataSource.setUrl(config.getJdbcUrl());
-
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
 
@@ -78,71 +66,29 @@ public final class JdbcUtils {
     dataSource.setMaxTotal(config.getConnectionPoolMaxTotal());
     dataSource.setPoolPreparedStatements(config.isPreparedStatementsPoolEnabled());
     dataSource.setMaxOpenPreparedStatements(config.getPreparedStatementsPoolMaxOpen());
-
     return dataSource;
   }
 
   public static BasicDataSource initDataSourceForTableMetadata(JdbcConfig config) {
     BasicDataSource dataSource = new BasicDataSource();
-
-    /*
-     * We need to set the driver class of an underlying database to the dataSource in order
-     * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
-     * work (e.g., when we dynamically load a driver class from a fatJar).
-     */
-    dataSource.setDriver(getDriverClass(config.getJdbcUrl()));
-
     dataSource.setUrl(config.getJdbcUrl());
-
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
-
     dataSource.setMinIdle(config.getTableMetadataConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getTableMetadataConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getTableMetadataConnectionPoolMaxTotal());
-
     return dataSource;
   }
 
   public static BasicDataSource initDataSourceForAdmin(JdbcConfig config) {
     BasicDataSource dataSource = new BasicDataSource();
-
-    /*
-     * We need to set the driver class of an underlying database to the dataSource in order
-     * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
-     * work (e.g., when we dynamically load a driver class from a fatJar).
-     */
-    dataSource.setDriver(getDriverClass(config.getJdbcUrl()));
-
     dataSource.setUrl(config.getJdbcUrl());
-
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
-
     dataSource.setMinIdle(config.getAdminConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getAdminConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getAdminConnectionPoolMaxTotal());
-
     return dataSource;
-  }
-
-  private static Driver getDriverClass(String jdbcUrl) {
-    switch (getRdbEngine(jdbcUrl)) {
-      case MYSQL:
-        try {
-          return new com.mysql.cj.jdbc.Driver();
-        } catch (SQLException e) {
-          throw new RuntimeException(e);
-        }
-      case POSTGRESQL:
-        return new org.postgresql.Driver();
-      case ORACLE:
-        return new OracleDriver();
-      case SQL_SERVER:
-        return new SQLServerDriver();
-      default:
-        throw new AssertionError();
-    }
   }
 
   public static boolean isConflictError(SQLException e, RdbEngine rdbEngine) {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -33,7 +33,6 @@ public class JdbcUtilsTest {
 
     // Assert
     assertThat(dataSource.getUrl()).isEqualTo("jdbc:mysql://localhost:3306/");
-    assertThat(dataSource.getDriver().getClass().getName()).isEqualTo("com.mysql.cj.jdbc.Driver");
     assertThat(dataSource.getUsername()).isEqualTo("root");
     assertThat(dataSource.getPassword()).isEqualTo("mysql");
 
@@ -73,7 +72,6 @@ public class JdbcUtilsTest {
 
     // Assert
     assertThat(dataSource.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/");
-    assertThat(dataSource.getDriver().getClass().getName()).isEqualTo("org.postgresql.Driver");
     assertThat(dataSource.getUsername()).isEqualTo("user");
     assertThat(dataSource.getPassword()).isEqualTo("postgres");
 
@@ -112,8 +110,6 @@ public class JdbcUtilsTest {
     // Assert
     assertThat(tableMetadataDataSource.getUrl())
         .isEqualTo("jdbc:oracle:thin:@localhost:1521/XEPDB1");
-    assertThat(tableMetadataDataSource.getDriver().getClass().getName())
-        .isEqualTo("oracle.jdbc.OracleDriver");
     assertThat(tableMetadataDataSource.getUsername()).isEqualTo("user");
     assertThat(tableMetadataDataSource.getPassword()).isEqualTo("oracle");
 
@@ -143,8 +139,6 @@ public class JdbcUtilsTest {
 
     // Assert
     assertThat(adminDataSource.getUrl()).isEqualTo("jdbc:sqlserver://localhost:1433");
-    assertThat(adminDataSource.getDriver().getClass().getName())
-        .isEqualTo("com.microsoft.sqlserver.jdbc.SQLServerDriver");
     assertThat(adminDataSource.getUsername()).isEqualTo("user");
     assertThat(adminDataSource.getPassword()).isEqualTo("sqlserver");
 


### PR DESCRIPTION
As we have found how to avoid the "No suitable driver" error in https://github.com/scalar-labs/kelpie/pull/28, we no longer need to call `setDriver()` for `BasicDataSource`.

Please take a look!