### PR TITLE
Add method to retrieve the namespace names for Cassandra Admin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
@@ -2,27 +2,10 @@ package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class CassandraAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
   @Override
   protected Properties getProperties() {
     return CassandraEnv.getProperties();
   }
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void dropNamespace_ForNonExistingNamespace_ShouldDropNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -2,8 +2,6 @@ package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithCassandra
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -11,19 +9,4 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
   protected Properties getProps() {
     return CassandraEnv.getProperties();
   }
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void dropNamespace_ForNonExistingNamespace_ShouldDropNamespaceProperly() {}
-
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
-  @Test
-  @Override
-  public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
@@ -15,7 +15,6 @@ import java.util.Properties;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -362,7 +361,6 @@ public class MultiStorageAdminIntegrationTest {
     assertThat(tableMetadata.getSecondaryIndexNames()).isEmpty();
   }
 
-  @Disabled("Temporarily until admin.getNamespacesNames() is implemented")
   @Test
   public void getNamespaceNames_ShouldReturnExistingNamespaces() throws ExecutionException {
     // Arrange

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -58,7 +58,8 @@ public class Cassandra extends AbstractDistributedStorage {
 
     metadataManager =
         new TableMetadataManager(
-            new CassandraAdmin(clusterManager), config.getMetadataCacheExpirationTimeSecs());
+            new CassandraAdmin(clusterManager, config),
+            config.getMetadataCacheExpirationTimeSecs());
     operationChecker = new OperationChecker(metadataManager);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -117,7 +117,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     String insertQuery =
         QueryBuilder.insertInto(
                 quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
-            .value(quoteIfNecessary(KEYSPACES_NAME_COL), keyspace)
+            .value(KEYSPACES_NAME_COL, quoteIfNecessary(keyspace))
             .toString();
     clusterManager.getSession().execute(insertQuery);
   }
@@ -156,7 +156,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     String deleteQuery =
         QueryBuilder.delete()
             .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
-            .where(QueryBuilder.eq(quoteIfNecessary(KEYSPACES_NAME_COL), keyspace))
+            .where(QueryBuilder.eq(KEYSPACES_NAME_COL, quoteIfNecessary(keyspace)))
             .toString();
     clusterManager.getSession().execute(deleteQuery);
   }
@@ -337,7 +337,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
       Set<String> keyspaceNames = new HashSet<>();
       String selectQuery =
-          QueryBuilder.select(quoteIfNecessary(KEYSPACES_NAME_COL))
+          QueryBuilder.select(KEYSPACES_NAME_COL)
               .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
               .getQueryString();
       for (Row row : clusterManager.getSession().execute(selectQuery).all()) {
@@ -362,7 +362,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
   private void dropKeyspacesTableIfEmpty() {
     String selectQuery =
-        QueryBuilder.select(quoteIfNecessary(KEYSPACES_NAME_COL))
+        QueryBuilder.select(KEYSPACES_NAME_COL)
             .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
             .limit(1)
             .getQueryString();

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -6,6 +6,7 @@ import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import com.datastax.driver.core.ClusteringOrder;
 import com.datastax.driver.core.ColumnMetadata;
 import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.Create;
 import com.datastax.driver.core.schemabuilder.CreateKeyspace;
@@ -23,6 +24,8 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -36,17 +39,24 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   public static final String REPLICATION_STRATEGY = "replication-strategy";
   public static final String COMPACTION_STRATEGY = "compaction-strategy";
   public static final String REPLICATION_FACTOR = "replication-factor";
+  public static final String METADATA_KEYSPACE = "scalardb";
+  public static final String KEYSPACES_TABLE = "keyspaces";
+  public static final String KEYSPACES_NAME_COL = "name";
   @VisibleForTesting static final String INDEX_NAME_PREFIX = "index";
-
   private final ClusterManager clusterManager;
+  private final String metadataKeyspace;
 
   @Inject
   public CassandraAdmin(DatabaseConfig config) {
     clusterManager = new ClusterManager(config);
+    CassandraConfig cassandraConfig = new CassandraConfig(config);
+    metadataKeyspace = cassandraConfig.getMetadataKeyspace().orElse(METADATA_KEYSPACE);
   }
 
-  CassandraAdmin(ClusterManager clusterManager) {
+  CassandraAdmin(ClusterManager clusterManager, DatabaseConfig config) {
     this.clusterManager = clusterManager;
+    CassandraConfig cassandraConfig = new CassandraConfig(config);
+    metadataKeyspace = cassandraConfig.getMetadataKeyspace().orElse(METADATA_KEYSPACE);
   }
 
   @Override
@@ -60,7 +70,20 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   @Override
   public void createNamespace(String namespace, Map<String, String> options)
       throws ExecutionException {
-    CreateKeyspace query = SchemaBuilder.createKeyspace(quoteIfNecessary(namespace));
+    try {
+      createKeyspace(namespace, options);
+      createMetadataKeyspaceIfNotExists();
+      createKeyspacesTableIfNotExists();
+      insertIntoKeyspacesTable(namespace);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ExecutionException(String.format("creating the keyspace %s failed", namespace), e);
+    }
+  }
+
+  private void createKeyspace(String keyspace, Map<String, String> options) {
+    CreateKeyspace query = SchemaBuilder.createKeyspace(quoteIfNecessary(keyspace));
     String replicationFactor = options.getOrDefault(REPLICATION_FACTOR, "1");
     ReplicationStrategy replicationStrategy =
         options.containsKey(REPLICATION_STRATEGY)
@@ -74,13 +97,29 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       replicationOptions.put("class", ReplicationStrategy.NETWORK_TOPOLOGY_STRATEGY.toString());
       replicationOptions.put("dc1", replicationFactor);
     }
-    try {
-      clusterManager
-          .getSession()
-          .execute(query.with().replication(replicationOptions).getQueryString());
-    } catch (RuntimeException e) {
-      throw new ExecutionException(String.format("creating the keyspace %s failed", namespace), e);
-    }
+    String queryString = query.with().replication(replicationOptions).getQueryString();
+
+    clusterManager.getSession().execute(queryString);
+  }
+
+  private void createMetadataKeyspaceIfNotExists() {
+    CreateKeyspace query =
+        SchemaBuilder.createKeyspace(quoteIfNecessary(metadataKeyspace)).ifNotExists();
+    Map<String, Object> replicationOptions = new HashMap<>();
+    replicationOptions.put("class", ReplicationStrategy.SIMPLE_STRATEGY.toString());
+    replicationOptions.put("replication_factor", "1");
+    String queryString = query.with().replication(replicationOptions).getQueryString();
+
+    clusterManager.getSession().execute(queryString);
+  }
+
+  private void insertIntoKeyspacesTable(String keyspace) {
+    String insertQuery =
+        QueryBuilder.insertInto(
+                quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
+            .value(quoteIfNecessary(KEYSPACES_NAME_COL), keyspace)
+            .toString();
+    clusterManager.getSession().execute(insertQuery);
   }
 
   @Override
@@ -98,12 +137,28 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
   @Override
   public void dropNamespace(String namespace) throws ExecutionException {
-    String dropKeyspace = SchemaBuilder.dropKeyspace(quoteIfNecessary(namespace)).getQueryString();
     try {
-      clusterManager.getSession().execute(dropKeyspace);
+      dropKeyspace(namespace);
+      deleteFromKeyspacesTable(namespace);
+      dropKeyspacesTableIfEmpty();
     } catch (RuntimeException e) {
       throw new ExecutionException(String.format("dropping the %s keyspace failed", namespace), e);
     }
+  }
+
+  private void dropKeyspace(String keyspace) {
+    String dropKeyspaceQuery =
+        SchemaBuilder.dropKeyspace(quoteIfNecessary(keyspace)).getQueryString();
+    clusterManager.getSession().execute(dropKeyspaceQuery);
+  }
+
+  private void deleteFromKeyspacesTable(String keyspace) {
+    String deleteQuery =
+        QueryBuilder.delete()
+            .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
+            .where(QueryBuilder.eq(quoteIfNecessary(KEYSPACES_NAME_COL), keyspace))
+            .toString();
+    clusterManager.getSession().execute(deleteQuery);
   }
 
   @Override
@@ -273,6 +328,50 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     }
   }
 
+  @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    try {
+      if (clusterManager.getMetadata(metadataKeyspace, KEYSPACES_TABLE) == null) {
+        return Collections.emptySet();
+      }
+
+      Set<String> keyspaceNames = new HashSet<>();
+      String selectQuery =
+          QueryBuilder.select(quoteIfNecessary(KEYSPACES_NAME_COL))
+              .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
+              .getQueryString();
+      for (Row row : clusterManager.getSession().execute(selectQuery).all()) {
+        keyspaceNames.add(row.getString(KEYSPACES_NAME_COL));
+      }
+
+      return keyspaceNames;
+    } catch (RuntimeException e) {
+      throw new ExecutionException("Retrieving the existing namespace names failed", e);
+    }
+  }
+
+  private void createKeyspacesTableIfNotExists() {
+    String createTableQuery =
+        SchemaBuilder.createTable(
+                quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
+            .ifNotExists()
+            .addPartitionKey(KEYSPACES_NAME_COL, com.datastax.driver.core.DataType.text())
+            .getQueryString();
+    clusterManager.getSession().execute(createTableQuery);
+  }
+
+  private void dropKeyspacesTableIfEmpty() {
+    String selectQuery =
+        QueryBuilder.select(quoteIfNecessary(KEYSPACES_NAME_COL))
+            .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(KEYSPACES_TABLE))
+            .limit(1)
+            .getQueryString();
+    boolean isKeyspacesTableEmpty = clusterManager.getSession().execute(selectQuery).one() == null;
+    if (isKeyspacesTableEmpty) {
+      dropKeyspace(metadataKeyspace);
+    }
+  }
+
   @VisibleForTesting
   void createTableInternal(
       String keyspace, String table, TableMetadata metadata, Map<String, String> options)
@@ -433,10 +532,5 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     public String toString() {
       return strategyName;
     }
-  }
-
-  @Override
-  public Set<String> getNamespaceNames() throws ExecutionException {
-    throw new UnsupportedOperationException("Not yet implemented");
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
@@ -1,0 +1,25 @@
+package com.scalar.db.storage.cassandra;
+
+import static com.scalar.db.config.ConfigUtils.getString;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class CassandraConfig {
+  public static final String PREFIX = DatabaseConfig.PREFIX + "cassandra.";
+  public static final String METADATA_KEYSPACE = PREFIX + "metadata.keyspace";
+  @Nullable private final String metadataKeyspace;
+
+  public CassandraConfig(DatabaseConfig databaseConfig) {
+    String storage = databaseConfig.getStorage();
+    if (!storage.equals("cassandra")) {
+      throw new IllegalArgumentException(DatabaseConfig.STORAGE + " should be 'cassandra'");
+    }
+    metadataKeyspace = getString(databaseConfig.getProperties(), METADATA_KEYSPACE, null);
+  }
+
+  public Optional<String> getMetadataKeyspace() {
+    return Optional.ofNullable(metadataKeyspace);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTestBase.java
@@ -623,7 +623,8 @@ public abstract class CassandraAdminTestBase {
   }
 
   @Test
-  public void namespaceExists_WithNonExistingNamespace_ShouldReturnFalse() throws ExecutionException {
+  public void namespaceExists_WithNonExistingNamespace_ShouldReturnFalse()
+      throws ExecutionException {
     // Arrange
     String namespace = "sample_ns";
     when(clusterManager.getMetadata(anyString(), anyString()))
@@ -648,11 +649,11 @@ public abstract class CassandraAdminTestBase {
   }
 
   @Test
-  public void namespaceExists_WithNonExistingKeyspacesTable_ShouldReturnFalse() throws ExecutionException {
+  public void namespaceExists_WithNonExistingKeyspacesTable_ShouldReturnFalse()
+      throws ExecutionException {
     // Arrange
     String namespace = "sample_ns";
-    when(clusterManager.getMetadata(anyString(), anyString()))
-        .thenReturn(null);
+    when(clusterManager.getMetadata(anyString(), anyString())).thenReturn(null);
 
     // Act
     // Assert

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTestBase.java
@@ -1,10 +1,12 @@
 package com.scalar.db.storage.cassandra;
 
 import static com.datastax.driver.core.Metadata.quote;
+import static com.datastax.driver.core.Metadata.quoteIfNecessary;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,9 +15,12 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ColumnMetadata;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.Create.Options;
+import com.datastax.driver.core.schemabuilder.CreateKeyspace;
 import com.datastax.driver.core.schemabuilder.KeyspaceOptions;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder.Direction;
@@ -25,16 +30,20 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.cassandra.CassandraAdmin.CompactionStrategy;
 import com.scalar.db.storage.cassandra.CassandraAdmin.ReplicationStrategy;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,20 +52,42 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class CassandraAdminTest {
+/**
+ * Abstraction that defines unit tests for the {@link CassandraAdmin}. The class purpose is to be
+ * able to run the {@link CassandraAdmin} unit tests with different values for the {@link
+ * CassandraAdmin}, notably {@link CassandraAdmin#METADATA_KEYSPACE}.
+ */
+public abstract class CassandraAdminTestBase {
 
   private CassandraAdmin cassandraAdmin;
+  private String metadataKeyspaceName;
   @Mock private ClusterManager clusterManager;
   @Mock private Session cassandraSession;
   @Mock private Cluster cluster;
   @Mock private Metadata metadata;
   @Mock private KeyspaceMetadata keyspaceMetadata;
 
+  /**
+   * This sets the {@link CassandraConfig#METADATA_KEYSPACE} value that will be used to run the
+   * tests.
+   *
+   * @return {@link CassandraConfig#METADATA_KEYSPACE} value
+   */
+  abstract Optional<String> getMetadataKeyspaceConfig();
+
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     when(clusterManager.getSession()).thenReturn(cassandraSession);
-    cassandraAdmin = new CassandraAdmin(clusterManager);
+    Properties cassandraConfigProperties = new Properties();
+    getMetadataKeyspaceConfig()
+        .ifPresent(
+            metadataKeyspace ->
+                cassandraConfigProperties.setProperty(
+                    CassandraConfig.METADATA_KEYSPACE, metadataKeyspace));
+    cassandraAdmin =
+        new CassandraAdmin(clusterManager, new DatabaseConfig(cassandraConfigProperties));
+    metadataKeyspaceName = getMetadataKeyspaceConfig().orElse(CassandraAdmin.METADATA_KEYSPACE);
   }
 
   @Test
@@ -105,6 +136,9 @@ public class CassandraAdminTest {
     KeyspaceOptions query =
         SchemaBuilder.createKeyspace(namespace).with().replication(replicationOptions);
     verify(cassandraSession).execute(query.getQueryString());
+    verifyCreateMetadataKeyspaceQuery();
+    verifyCreateKeyspacesTableQuery();
+    verifyInsertIntoKeyspacesTableQuery(namespace);
   }
 
   @Test
@@ -128,6 +162,9 @@ public class CassandraAdminTest {
     KeyspaceOptions query =
         SchemaBuilder.createKeyspace(namespace).with().replication(replicationOptions);
     verify(cassandraSession).execute(query.getQueryString());
+    verifyCreateMetadataKeyspaceQuery();
+    verifyCreateKeyspacesTableQuery();
+    verifyInsertIntoKeyspacesTableQuery(namespace);
   }
 
   @Test
@@ -147,8 +184,10 @@ public class CassandraAdminTest {
     replicationOptions.put("replication_factor", "1");
     KeyspaceOptions query =
         SchemaBuilder.createKeyspace(namespace).with().replication(replicationOptions);
-
     verify(cassandraSession).execute(query.getQueryString());
+    verifyCreateMetadataKeyspaceQuery();
+    verifyCreateKeyspacesTableQuery();
+    verifyInsertIntoKeyspacesTableQuery(namespace);
   }
 
   @Test
@@ -169,6 +208,41 @@ public class CassandraAdminTest {
         SchemaBuilder.createKeyspace(quote(namespace)).with().replication(replicationOptions);
 
     verify(cassandraSession).execute(query.getQueryString());
+    verifyCreateMetadataKeyspaceQuery();
+    verifyCreateKeyspacesTableQuery();
+    verifyInsertIntoKeyspacesTableQuery(namespace);
+  }
+
+  private void verifyCreateMetadataKeyspaceQuery() {
+    CreateKeyspace query =
+        SchemaBuilder.createKeyspace(quoteIfNecessary(metadataKeyspaceName)).ifNotExists();
+    Map<String, Object> replicationOptions = new HashMap<>();
+    replicationOptions.put("class", "SimpleStrategy");
+    replicationOptions.put("replication_factor", "1");
+    String queryString = query.with().replication(replicationOptions).getQueryString();
+    verify(cassandraSession).execute(queryString);
+  }
+
+  private void verifyCreateKeyspacesTableQuery() {
+    String query =
+        SchemaBuilder.createTable(
+                quoteIfNecessary(metadataKeyspaceName),
+                quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
+            .ifNotExists()
+            .addPartitionKey(
+                CassandraAdmin.KEYSPACES_NAME_COL, com.datastax.driver.core.DataType.text())
+            .getQueryString();
+    verify(cassandraSession).execute(query);
+  }
+
+  private void verifyInsertIntoKeyspacesTableQuery(String keyspace) {
+    String query =
+        QueryBuilder.insertInto(
+                quoteIfNecessary(metadataKeyspaceName),
+                quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
+            .value(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL), keyspace)
+            .toString();
+    verify(cassandraSession).execute(query);
   }
 
   @Test
@@ -380,9 +454,14 @@ public class CassandraAdminTest {
   }
 
   @Test
-  public void dropNamespace_WithCorrectParameters_ShouldDropKeyspace() throws ExecutionException {
+  public void
+      dropNamespace_WithCorrectParametersWithNoMoreKeyspacesLeft_ShouldDropKeyspaceAndMetadataKeyspace()
+          throws ExecutionException {
     // Arrange
     String namespace = "sample_ns";
+    ResultSet selectQueryResult = mock(ResultSet.class);
+    when(selectQueryResult.one()).thenReturn(null);
+    when(cassandraSession.execute(anyString())).thenReturn(null, null, selectQueryResult, null);
 
     // Act
     cassandraAdmin.dropNamespace(namespace);
@@ -390,6 +469,28 @@ public class CassandraAdminTest {
     // Assert
     String dropKeyspaceStatement = SchemaBuilder.dropKeyspace(namespace).getQueryString();
     verify(cassandraSession).execute(dropKeyspaceStatement);
+    verifyDeleteFromKeyspacesTableQuery(namespace);
+    verifySelectOneFromKeyspacesTableQuery();
+    verifyDropMetadataKeyspaceQuery();
+  }
+
+  @Test
+  public void dropNamespace_WithCorrectParametersWithSomeKeyspacesLeft_ShouldOnlyDropKeyspace()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "sample_ns";
+    ResultSet selectQueryResult = mock(ResultSet.class);
+    when(selectQueryResult.one()).thenReturn(mock(Row.class));
+    when(cassandraSession.execute(anyString())).thenReturn(null, null, selectQueryResult, null);
+
+    // Act
+    cassandraAdmin.dropNamespace(namespace);
+
+    // Assert
+    String dropKeyspaceStatement = SchemaBuilder.dropKeyspace(namespace).getQueryString();
+    verify(cassandraSession).execute(dropKeyspaceStatement);
+    verifyDeleteFromKeyspacesTableQuery(namespace);
+    verifySelectOneFromKeyspacesTableQuery();
   }
 
   @Test
@@ -397,6 +498,9 @@ public class CassandraAdminTest {
       throws ExecutionException {
     // Arrange
     String namespace = "keyspace";
+    ResultSet selectQueryResult = mock(ResultSet.class);
+    when(selectQueryResult.one()).thenReturn(null);
+    when(cassandraSession.execute(anyString())).thenReturn(null, null, selectQueryResult, null);
 
     // Act
     cassandraAdmin.dropNamespace(namespace);
@@ -404,6 +508,37 @@ public class CassandraAdminTest {
     // Assert
     String dropKeyspaceStatement = SchemaBuilder.dropKeyspace(quote(namespace)).getQueryString();
     verify(cassandraSession).execute(dropKeyspaceStatement);
+    verifyDeleteFromKeyspacesTableQuery(namespace);
+    verifySelectOneFromKeyspacesTableQuery();
+    verifyDropMetadataKeyspaceQuery();
+  }
+
+  private void verifyDeleteFromKeyspacesTableQuery(String keyspace) {
+    String query =
+        QueryBuilder.delete()
+            .from(
+                quoteIfNecessary(metadataKeyspaceName),
+                quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
+            .where(QueryBuilder.eq(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL), keyspace))
+            .toString();
+    verify(cassandraSession).execute(query);
+  }
+
+  private void verifySelectOneFromKeyspacesTableQuery() {
+    String query =
+        QueryBuilder.select(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL))
+            .from(
+                quoteIfNecessary(metadataKeyspaceName),
+                quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
+            .limit(1)
+            .getQueryString();
+    verify(cassandraSession).execute(query);
+  }
+
+  private void verifyDropMetadataKeyspaceQuery() {
+    String query =
+        SchemaBuilder.dropKeyspace(quoteIfNecessary(metadataKeyspaceName)).getQueryString();
+    verify(cassandraSession).execute(query);
   }
 
   @Test
@@ -616,5 +751,48 @@ public class CassandraAdminTest {
             .type(com.datastax.driver.core.DataType.text())
             .getQueryString();
     verify(cassandraSession).execute(alterTableQuery);
+  }
+
+  @Test
+  public void getNamespacesNames_WithNonExistingKeyspaces_ShouldReturnEmptySet()
+      throws ExecutionException {
+    // Arrange
+    when(clusterManager.getMetadata(anyString(), anyString())).thenReturn(null);
+
+    // Act
+    Set<String> actualKeyspaceNames = cassandraAdmin.getNamespaceNames();
+
+    // Assert
+    assertThat(actualKeyspaceNames).isEmpty();
+    verify(clusterManager).getMetadata(metadataKeyspaceName, CassandraAdmin.KEYSPACES_TABLE);
+  }
+
+  @Test
+  public void getNamespacesNames_WithExistingKeyspaces_ShouldReturnKeyspacesNames()
+      throws ExecutionException {
+    // Arrange
+    when(clusterManager.getMetadata(anyString(), anyString()))
+        .thenReturn(mock(com.datastax.driver.core.TableMetadata.class));
+    ResultSet resultSet = mock(ResultSet.class);
+    Row row1 = mock(Row.class);
+    Row row2 = mock(Row.class);
+    when(row1.getString(CassandraAdmin.KEYSPACES_NAME_COL)).thenReturn("ns1");
+    when(row2.getString(CassandraAdmin.KEYSPACES_NAME_COL)).thenReturn("ns2");
+    when(resultSet.all()).thenReturn(Arrays.asList(row1, row2));
+    when(cassandraSession.execute(anyString())).thenReturn(resultSet);
+
+    // Act
+    Set<String> actualKeyspaceNames = cassandraAdmin.getNamespaceNames();
+
+    // Assert
+    assertThat(actualKeyspaceNames).containsOnly("ns1", "ns2");
+    verify(clusterManager).getMetadata(metadataKeyspaceName, CassandraAdmin.KEYSPACES_TABLE);
+    String selectQuery =
+        QueryBuilder.select(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL))
+            .from(
+                quoteIfNecessary(metadataKeyspaceName),
+                quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
+            .getQueryString();
+    verify(cassandraSession).execute(selectQuery);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTestBase.java
@@ -240,7 +240,7 @@ public abstract class CassandraAdminTestBase {
         QueryBuilder.insertInto(
                 quoteIfNecessary(metadataKeyspaceName),
                 quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
-            .value(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL), keyspace)
+            .value(CassandraAdmin.KEYSPACES_NAME_COL,quoteIfNecessary( keyspace))
             .toString();
     verify(cassandraSession).execute(query);
   }
@@ -519,14 +519,14 @@ public abstract class CassandraAdminTestBase {
             .from(
                 quoteIfNecessary(metadataKeyspaceName),
                 quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
-            .where(QueryBuilder.eq(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL), keyspace))
+            .where(QueryBuilder.eq(CassandraAdmin.KEYSPACES_NAME_COL, quoteIfNecessary(keyspace)))
             .toString();
     verify(cassandraSession).execute(query);
   }
 
   private void verifySelectOneFromKeyspacesTableQuery() {
     String query =
-        QueryBuilder.select(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL))
+        QueryBuilder.select(CassandraAdmin.KEYSPACES_NAME_COL)
             .from(
                 quoteIfNecessary(metadataKeyspaceName),
                 quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))
@@ -788,7 +788,7 @@ public abstract class CassandraAdminTestBase {
     assertThat(actualKeyspaceNames).containsOnly("ns1", "ns2");
     verify(clusterManager).getMetadata(metadataKeyspaceName, CassandraAdmin.KEYSPACES_TABLE);
     String selectQuery =
-        QueryBuilder.select(quoteIfNecessary(CassandraAdmin.KEYSPACES_NAME_COL))
+        QueryBuilder.select(CassandraAdmin.KEYSPACES_NAME_COL)
             .from(
                 quoteIfNecessary(metadataKeyspaceName),
                 quoteIfNecessary(CassandraAdmin.KEYSPACES_TABLE))

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminWithDefaultConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminWithDefaultConfigTest.java
@@ -1,0 +1,11 @@
+package com.scalar.db.storage.cassandra;
+
+import java.util.Optional;
+
+public class CassandraAdminWithDefaultConfigTest extends CassandraAdminTestBase {
+
+  @Override
+  Optional<String> getMetadataKeyspaceConfig() {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminWithMetadataKeyspaceConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminWithMetadataKeyspaceConfigTest.java
@@ -1,0 +1,11 @@
+package com.scalar.db.storage.cassandra;
+
+import java.util.Optional;
+
+public class CassandraAdminWithMetadataKeyspaceConfigTest extends CassandraAdminTestBase {
+
+  @Override
+  Optional<String> getMetadataKeyspaceConfig() {
+    return Optional.of("my_ks");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraConfigTest.java
@@ -1,0 +1,44 @@
+package com.scalar.db.storage.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+public class CassandraConfigTest {
+  private static final String ANY_METADATA_NAMESPACE = "any_namespace";
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void constructor_MetadataNamespaceGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(CassandraConfig.METADATA_KEYSPACE, ANY_METADATA_NAMESPACE);
+
+    // Act
+    CassandraConfig config = new CassandraConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getMetadataKeyspace()).isPresent();
+    assertThat(config.getMetadataKeyspace().get()).isEqualTo(ANY_METADATA_NAMESPACE);
+  }
+
+  @Test
+  public void constructor_WithNoPropertiesGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+
+    // Act
+    CassandraConfig config = new CassandraConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getMetadataKeyspace()).isEmpty();
+  }
+}


### PR DESCRIPTION
This implements the `admin.getNamespaceNames()` for the Cassandra admin.