### PR TITLE
Update JdbcAdmin.namespaceExists() 

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -720,8 +720,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       }
     } catch (SQLException e) {
       // An exception will be thrown if the namespaces table does not exist when executing the
-      // select
-      // query
+      // select query
       if ((rdbEngine == RdbEngine.MYSQL && (e.getErrorCode() == 1049 || e.getErrorCode() == 1146))
           || (rdbEngine == RdbEngine.POSTGRESQL && "42P01".equals(e.getSQLState()))
           || (rdbEngine == RdbEngine.ORACLE && e.getErrorCode() == 942)

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -1152,7 +1152,8 @@ public abstract class JdbcAdminTestBase {
   @Test
   public void namespaceExists_forMysqlWithExistingNamespace_shouldReturnTrue() throws Exception {
     namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
-        RdbEngine.MYSQL, "SELECT 1 FROM `information_schema`.`schemata` WHERE `schema_name` = ?");
+        RdbEngine.MYSQL,
+        "SELECT 1 FROM `" + metadataSchemaName + "`.`namespaces` WHERE `namespace_name` = ?");
   }
 
   @Test
@@ -1160,20 +1161,22 @@ public abstract class JdbcAdminTestBase {
       throws Exception {
     namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
         RdbEngine.POSTGRESQL,
-        "SELECT 1 FROM \"information_schema\".\"schemata\" WHERE \"schema_name\" = ?");
+        "SELECT 1 FROM \"" + metadataSchemaName + "\".\"namespaces\" WHERE \"namespace_name\" = ?");
   }
 
   @Test
   public void namespaceExists_forSqlServerWithExistingNamespace_shouldReturnTrue()
       throws Exception {
     namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
-        RdbEngine.SQL_SERVER, "SELECT 1 FROM [sys].[schemas] WHERE [name] = ?");
+        RdbEngine.SQL_SERVER,
+        "SELECT 1 FROM [" + metadataSchemaName + "].[namespaces] WHERE [namespace_name] = ?");
   }
 
   @Test
   public void namespaceExists_forOracleWithExistingNamespace_shouldReturnTrue() throws Exception {
     namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
-        RdbEngine.ORACLE, "SELECT 1 FROM \"ALL_USERS\" WHERE \"USERNAME\" = ?");
+        RdbEngine.ORACLE,
+        "SELECT 1 FROM \"" + metadataSchemaName + "\".\"namespaces\" WHERE \"namespace_name\" = ?");
   }
 
   private void namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(


### PR DESCRIPTION
This PR updates the `JdbcAdmin.namespaceExists()` method to only return true if the namespace was created through Scalar DB.