### PR TITLE
Fix CVE-2021-3999, CVE-2022-1586 and CVE-2022-1587

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.7
+FROM ghcr.io/scalar-labs/jre8:1.1.8
 
 COPY scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM ghcr.io/scalar-labs/jre8:1.1.7
+FROM ghcr.io/scalar-labs/jre8:1.1.8
 
 COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/


### PR DESCRIPTION
This fixes several CVEs by updating the internal JRE used in docker images.

The CI is failing because of another CVE targeting the `grpc_health_probe` package, which will be addressed in another PR as there is no fix available as of now.