### PR TITLE
Add external Scalar DB property file support to getting-started application

### DIFF
--- a/docs/getting-started/src/main/java/sample/ElectronicMoney.java
+++ b/docs/getting-started/src/main/java/sample/ElectronicMoney.java
@@ -8,14 +8,11 @@ import com.scalar.db.api.Result;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.TransactionFactory;
-import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 
 public class ElectronicMoney {
 
-  private static final String SCALARDB_PROPERTIES =
-      System.getProperty("user.dir") + File.separator + "scalardb.properties";
   private static final String NAMESPACE = "emoney";
   private static final String TABLENAME = "account";
   private static final String ID = "id";
@@ -23,8 +20,8 @@ public class ElectronicMoney {
 
   private final DistributedTransactionManager manager;
 
-  public ElectronicMoney() throws IOException {
-    TransactionFactory factory = TransactionFactory.create(SCALARDB_PROPERTIES);
+  public ElectronicMoney(String scalarDBProperties) throws IOException {
+    TransactionFactory factory = TransactionFactory.create(scalarDBProperties);
     manager = factory.getTransactionManager();
   }
 

--- a/docs/getting-started/src/main/java/sample/ElectronicMoneyMain.java
+++ b/docs/getting-started/src/main/java/sample/ElectronicMoneyMain.java
@@ -1,5 +1,7 @@
 package sample;
 
+import java.io.File;
+
 public class ElectronicMoneyMain {
 
   public static void main(String[] args) throws Exception {
@@ -8,6 +10,7 @@ public class ElectronicMoneyMain {
     String to = null;
     String from = null;
     String id = null;
+    String scalarDBProperties = null;
 
     for (int i = 0; i < args.length; ++i) {
       if ("-action".equals(args[i])) {
@@ -20,6 +23,8 @@ public class ElectronicMoneyMain {
         from = args[++i];
       } else if ("-id".equals(args[i])) {
         id = args[++i];
+      } else if ("-config".equals(args[i])) {
+        scalarDBProperties = args[++i];
       } else if ("-help".equals(args[i])) {
         printUsageAndExit();
         return;
@@ -31,7 +36,13 @@ public class ElectronicMoneyMain {
       return;
     }
 
-    ElectronicMoney eMoney = new ElectronicMoney();
+    ElectronicMoney eMoney;
+    if (scalarDBProperties != null) {
+      eMoney = new ElectronicMoney(scalarDBProperties);
+    } else {
+      scalarDBProperties = System.getProperty("user.dir") + File.separator + "scalardb.properties";
+      eMoney = new ElectronicMoney(scalarDBProperties);
+    }
 
     if (action.equalsIgnoreCase("charge")) {
       if (to == null || amount < 0) {


### PR DESCRIPTION
Add external Scalar DB property file support to getting-started application for compatibility tests and other external use.

Now we can run getting-started application with/without external property file
```
./gradlew run --args="-action charge -amount 1000 -to user1"
```
or
```
./gradlew run --args="-config <Scalar DB property file path> -action charge -amount 1000 -to user1"
```

The CI failed because of some other vulnerabilities.

Ref: https://github.com/scalar-labs/scalar-qa/pull/5#discussion_r969213496