### PR TITLE
Update the Scalar DB supported database matrix with Scalar DB 3.7

### DIFF
--- a/docs/scalardb-supported-databases.md
+++ b/docs/scalardb-supported-databases.md
@@ -15,6 +15,7 @@ Scalar DB supports the following databases and the databases that are compatible
 
 | Scalar DB Version | Cassandra 3.11 | Cassandra 3.0    | Cassandra 2.2   | Cosmos DB | DynamoDB  | MySQL 8.0  | MySQL 5.7  | PostgreSQL 14 | PostgreSQL 13 | PostgreSQL 12 | Oracle 21.3.0-xe   | Oracle 18.4.0-xe | SQL Server 2022 | SQL Server 2019 | SQL Server 2017 | AWS Aurora MySQL 3 (MySQL 8) | AWS Aurora MySQL 2 (MySQL 5.7) |  AWS Aurora PostgreSQL 14 |  AWS Aurora PostgreSQL 13 | AWS Aurora PostgreSQL 12 |
 |:------------------|:---------------|:-----------------|:----------------|:----------|:----------|:-----------|:-----------|:--------------|:--------------|:--------------|:-------------------|:-----------------|:----------------|:----------------|:----------------|:-----------------------------|:-------------------------------|:--------------------------|:--------------------------|:-------------------------|
+| Scalar DB 3.7 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Scalar DB 3.6 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Scalar DB 3.5 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Scalar DB 3.4 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |


### PR DESCRIPTION
I got an exception while connecting  the Scalar DB version `3.x` to AWS Aurora Mysql 5.7
```
Caused by: com.mysql.cj.exceptions.CJCommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
...

Caused by: javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
	at sun.security.ssl.HandshakeContext.<init>(HandshakeContext.java:171)
	at sun.security.ssl.ClientHandshakeContext.<init>(ClientHandshakeContext.java:103)
```
But it is working fine after adding `enabledTLSProtocols=TLSv1.2`  with the connection string
```
docker run --rm ghcr.io/scalar-labs/scalardl-schema-loader:3.5.0 --jdbc -j jdbc:mysql://xxxxxxx.xxxxxxx.us-west-2.rds.amazonaws.com:3306?enabledTLSProtocols=TLSv1.2 -u admin -p *******
```
