### PR TITLE
Refactor ConsensusCommitAdmin unit test

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -5,7 +5,6 @@ import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.get
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.removeTransactionMetaColumns;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.TableMetadata;
@@ -24,14 +23,6 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   private final DistributedStorageAdmin admin;
   private final String coordinatorNamespace;
   private final boolean isIncludeMetadataEnabled;
-
-  @Inject
-  public ConsensusCommitAdmin(DistributedStorageAdmin admin, DatabaseConfig databaseConfig) {
-    this.admin = admin;
-    ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
-    coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
-    isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
-  }
 
   public ConsensusCommitAdmin(DatabaseConfig databaseConfig) {
     StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -5,6 +5,7 @@ import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.get
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.removeTransactionMetaColumns;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.TableMetadata;
@@ -23,6 +24,14 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   private final DistributedStorageAdmin admin;
   private final String coordinatorNamespace;
   private final boolean isIncludeMetadataEnabled;
+
+  @Inject
+  public ConsensusCommitAdmin(DistributedStorageAdmin admin, DatabaseConfig databaseConfig) {
+    this.admin = admin;
+    ConsensusCommitConfig config = new ConsensusCommitConfig(databaseConfig);
+    coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
+    isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+  }
 
   public ConsensusCommitAdmin(DatabaseConfig databaseConfig) {
     StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -21,7 +21,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-public class ConsensusCommitAdminTest {
+/**
+ * Abstraction that defines unit tests for the {@link ConsensusCommitAdmin}. The class purpose is to
+ * be able to run the {@link ConsensusCommitAdmin} unit tests with different values for the {@link
+ * ConsensusCommitConfig}, notably {@link ConsensusCommitConfig#COORDINATOR_NAMESPACE}.
+ */
+public abstract class ConsensusCommitAdminTestBase {
 
   private static final String NAMESPACE = "test_namespace";
   private static final String TABLE = "test_table";
@@ -29,35 +34,22 @@ public class ConsensusCommitAdminTest {
   @Mock private DistributedStorageAdmin distributedStorageAdmin;
   @Mock private ConsensusCommitConfig config;
   private ConsensusCommitAdmin admin;
+  private String coordinatorNamespaceName;
 
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
+    when(config.getCoordinatorNamespace()).thenReturn(getCoordinatorNamespaceConfig());
     admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+    coordinatorNamespaceName = getCoordinatorNamespaceConfig().orElse(Coordinator.NAMESPACE);
   }
+
+  protected abstract Optional<String> getCoordinatorNamespaceConfig();
 
   @Test
   public void createCoordinatorTables_shouldCreateCoordinatorTableProperly()
       throws ExecutionException {
-    createCoordinatorTables_shouldCreateCoordinatorTableProperly(Optional.empty());
-  }
-
-  @Test
-  public void
-      createCoordinatorTables_WithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
-          throws ExecutionException {
-    createCoordinatorTables_shouldCreateCoordinatorTableProperly(
-        Optional.of("changed_coordinator"));
-  }
-
-  private void createCoordinatorTables_shouldCreateCoordinatorTableProperly(
-      Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
-    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
-    if (coordinatorNamespace.isPresent()) {
-      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
-      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
-    }
 
     // Act
     admin.createCoordinatorTables();
@@ -76,26 +68,7 @@ public class ConsensusCommitAdminTest {
   @Test
   public void createCoordinatorTables_WithOptions_shouldCreateCoordinatorTableProperly()
       throws ExecutionException {
-    createCoordinatorTables_WithOptions_shouldCreateCoordinatorTableProperly(Optional.empty());
-  }
-
-  @Test
-  public void
-      createCoordinatorTables_WithOptionsWithCoordinatorNamespaceChanged_shouldCreateWithChangedNamespace()
-          throws ExecutionException {
-    createCoordinatorTables_WithOptions_shouldCreateCoordinatorTableProperly(
-        Optional.of("changed_coordinator"));
-  }
-
-  private void createCoordinatorTables_WithOptions_shouldCreateCoordinatorTableProperly(
-      Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
-    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
-    if (coordinatorNamespace.isPresent()) {
-      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
-      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
-    }
-
     Map<String, String> options = ImmutableMap.of("name", "value");
 
     // Act
@@ -111,25 +84,7 @@ public class ConsensusCommitAdminTest {
   @Test
   public void truncateCoordinatorTables_shouldTruncateCoordinatorTableProperly()
       throws ExecutionException {
-    truncateCoordinatorTables_shouldTruncateCoordinatorTableProperly(Optional.empty());
-  }
-
-  @Test
-  public void
-      truncateCoordinatorTables_WithCoordinatorNamespaceChanged_shouldTruncateCoordinatorTableProperly()
-          throws ExecutionException {
-    truncateCoordinatorTables_shouldTruncateCoordinatorTableProperly(
-        Optional.of("changed_coordinator"));
-  }
-
-  private void truncateCoordinatorTables_shouldTruncateCoordinatorTableProperly(
-      Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
-    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
-    if (coordinatorNamespace.isPresent()) {
-      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
-      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
-    }
 
     // Act
     admin.truncateCoordinatorTables();
@@ -140,24 +95,7 @@ public class ConsensusCommitAdminTest {
 
   @Test
   public void dropCoordinatorTables_shouldDropCoordinatorTableProperly() throws ExecutionException {
-    dropCoordinatorTables_shouldDropCoordinatorTableProperly(Optional.empty());
-  }
-
-  @Test
-  public void
-      dropCoordinatorTables_WithCoordinatorNamespaceChanged_shouldDropCoordinatorTableProperly()
-          throws ExecutionException {
-    dropCoordinatorTables_shouldDropCoordinatorTableProperly(Optional.of("changed_coordinator"));
-  }
-
-  private void dropCoordinatorTables_shouldDropCoordinatorTableProperly(
-      Optional<String> coordinatorNamespace) throws ExecutionException {
     // Arrange
-    String coordinatorNamespaceName = coordinatorNamespace.orElse(Coordinator.NAMESPACE);
-    if (coordinatorNamespace.isPresent()) {
-      when(config.getCoordinatorNamespace()).thenReturn(coordinatorNamespace);
-      admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
-    }
 
     // Act
     admin.dropCoordinatorTables();
@@ -171,14 +109,13 @@ public class ConsensusCommitAdminTest {
   public void coordinatorTablesExist_WhenCoordinatorTableNotExist_shouldReturnFalse()
       throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(Coordinator.NAMESPACE, Coordinator.TABLE))
-        .thenReturn(false);
+    when(distributedStorageAdmin.tableExists(any(), any())).thenReturn(false);
 
     // Act
     boolean actual = admin.coordinatorTablesExist();
 
     // Assert
-    verify(distributedStorageAdmin).tableExists(Coordinator.NAMESPACE, Coordinator.TABLE);
+    verify(distributedStorageAdmin).tableExists(coordinatorNamespaceName, Coordinator.TABLE);
     assertThat(actual).isFalse();
   }
 
@@ -186,14 +123,13 @@ public class ConsensusCommitAdminTest {
   public void coordinatorTablesExist_WhenCoordinatorTableExists_shouldReturnTrue()
       throws ExecutionException {
     // Arrange
-    when(distributedStorageAdmin.tableExists(Coordinator.NAMESPACE, Coordinator.TABLE))
-        .thenReturn(true);
+    when(distributedStorageAdmin.tableExists(any(), any())).thenReturn(true);
 
     // Act
     boolean actual = admin.coordinatorTablesExist();
 
     // Assert
-    verify(distributedStorageAdmin).tableExists(Coordinator.NAMESPACE, Coordinator.TABLE);
+    verify(distributedStorageAdmin).tableExists(coordinatorNamespaceName, Coordinator.TABLE);
     assertThat(actual).isTrue();
   }
 
@@ -575,8 +511,7 @@ public class ConsensusCommitAdminTest {
   }
 
   @Test
-  public void repairCoordinatorTables_WithDefaultCoordinatorNamespace_ShouldCallJdbcAdminProperly()
-      throws ExecutionException {
+  public void repairCoordinatorTables_ShouldCallJdbcAdminProperly() throws ExecutionException {
     // Arrange
     Map<String, String> options = ImmutableMap.of("foo", "bar");
 
@@ -585,24 +520,8 @@ public class ConsensusCommitAdminTest {
 
     // Assert
     verify(distributedStorageAdmin)
-        .repairTable(Coordinator.NAMESPACE, Coordinator.TABLE, Coordinator.TABLE_METADATA, options);
-  }
-
-  @Test
-  public void repairCoordinatorTables_WithCustomCoordinatorNamespace_ShouldCallJdbcAdminProperly()
-      throws ExecutionException {
-    // Arrange
-    Map<String, String> options = ImmutableMap.of("foo", "bar");
-    String customNamespace = "custom";
-    when(config.getCoordinatorNamespace()).thenReturn(Optional.of(customNamespace));
-    admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
-
-    // Act
-    admin.repairCoordinatorTables(options);
-
-    // Assert
-    verify(distributedStorageAdmin)
-        .repairTable(customNamespace, Coordinator.TABLE, Coordinator.TABLE_METADATA, options);
+        .repairTable(
+            coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, options);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithCoordinatorNamespaceConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithCoordinatorNamespaceConfigTest.java
@@ -1,0 +1,12 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import java.util.Optional;
+
+public class ConsensusCommitAdminWithCoordinatorNamespaceConfigTest
+    extends ConsensusCommitAdminTestBase {
+
+  @Override
+  protected Optional<String> getCoordinatorNamespaceConfig() {
+    return Optional.of("my_coordinator_ns");
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithDefaultConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminWithDefaultConfigTest.java
@@ -1,0 +1,11 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import java.util.Optional;
+
+public class ConsensusCommitAdminWithDefaultConfigTest extends ConsensusCommitAdminTestBase {
+
+  @Override
+  protected Optional<String> getCoordinatorNamespaceConfig() {
+    return Optional.empty();
+  }
+}


### PR DESCRIPTION
This PR refactor the `ConsensusCommitAdmin` unit test class to be able to write tests easily for different values of `ConsensusCommitConfig.COORDINATOR_NAMESPACE`. All the storage admin classes were refactored the same way, for example, the [JdbcAdmin](https://github.com/scalar-labs/scalardb/pull/670/files)