### PR TITLE
In the Cosmos DB job of the CI, add a step to clean up gradle daemon logs file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
 
       - name : Delete gradle daemon log files
         if: always()
-#       Delete all files created more than 3 days ago with the ".out.log" file extension located in the "/home/azureuser/.gradle/daemon"
+#       Delete all files modified more than 3 days ago with the ".out.log" file extension located in the "/home/azureuser/.gradle/daemon"
 #       folder hierarchy. These files accumulate over time and can end up using a lot of disk space
         run : find /home/azureuser/.gradle/daemon -name "*.out.log" -type f -mtime +3 -exec rm -vf {} +
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,9 +184,9 @@ jobs:
 
       - name : Delete gradle daemon log files
         if: always()
-#       Delete all files with the ".out.log" file extension in the "/home/azureuser/.gradle/daemon"
+#       Delete all files created more than 3 days ago with the ".out.log" file extension located in the "/home/azureuser/.gradle/daemon"
 #       folder hierarchy. These files accumulate over time and can end up using a lot of disk space
-        run : find /home/azureuser/.gradle/daemon -name "*.out.log" -type f -exec rm -vf {} +
+        run : find /home/azureuser/.gradle/daemon -name "*.out.log" -type f -mtime +3 -exec rm -vf {} +
 
       - name: Upload Gradle test reports
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,12 @@ jobs:
         with:
           arguments: integrationTestCosmos -Dscalardb.cosmos.uri=${{ secrets.COSMOS_URI }} -Dscalardb.cosmos.password=${{ secrets.COSMOS_PASSWORD }} -Dscalardb.cosmos.database_prefix=${{ env.db_prefix }}_
 
+      - name : Delete gradle daemon log files
+        if: always()
+#       Delete all files with the ".out.log" file extension in the "/home/azureuser/.gradle/daemon"
+#       folder hierarchy. These files accumulate over time and can end up using a lot of disk space
+        run : find /home/azureuser/.gradle/daemon -name "*.out.log" -type f -exec rm -vf {} +
+
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The Azure VM running the CI for the Cosmos integration test ended up running out of disk space.
One of the reasons was that Gradle daemon creates a lot of log files. In this case, 20GB of logs file were created in the span of 5 months. 
So we decided to add a step to the CI to delete these log files. Below is the output produced by the new step.

![image](https://user-images.githubusercontent.com/3835021/191189731-cd345cc8-8179-46e7-a0e2-8fcba3dca178.png)

