### PR TITLE
Add upgrade() method to the Cosmos Admin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -6,8 +6,6 @@ import com.scalar.db.util.CosmosAdminTestUtils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithCosmos
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -46,10 +44,4 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }
-
-  @Disabled("Temporarily until admin.upgrade() is implemented")
-  @Test
-  @Override
-  public void
-      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -6,8 +6,6 @@ import com.scalar.db.util.CosmosAdminTestUtils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
@@ -45,10 +43,4 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }
-
-  @Disabled("Temporarily until admin.upgrade() is implemented")
-  @Test
-  @Override
-  public void
-      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminTestUtils.java
@@ -88,7 +88,7 @@ public class CosmosAdminTestUtils extends AdminTestUtils {
   }
 
   @Override
-  public void dropNamespacesTable() throws Exception {
-    throw new UnsupportedOperationException("Not yet implemented");
+  public void dropNamespacesTable() {
+    client.getDatabase(metadataDatabase).getContainer(CosmosAdmin.NAMESPACES_CONTAINER).delete();
   }
 }


### PR DESCRIPTION
This implement the `CosmosAdmin.upgrade()` method in relation to the namespace management feature as it was done for the `JdbcAdmin` (cf. https://github.com/scalar-labs/scalardb/pull/696). 
FYI, the target branch is [feat/namespaces_management](https://github.com/scalar-labs/scalardb/tree/feat/namespaces_management)
