### PR TITLE
Add upgrade() method to the Dynamo Admin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -4,8 +4,6 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegration
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithDynamo
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -29,10 +27,4 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
   }
-
-  @Disabled("Temporarily until admin.upgrade() is implemented")
-  @Test
-  @Override
-  public void
-      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -4,8 +4,6 @@ import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
@@ -28,10 +26,4 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
   }
-
-  @Disabled("Temporarily until admin.upgrade() is implemented")
-  @Test
-  @Override
-  public void
-      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminTestUtils.java
@@ -137,7 +137,13 @@ public class DynamoAdminTestUtils extends AdminTestUtils {
   }
 
   @Override
-  public void dropNamespacesTable() throws Exception {
-    throw new UnsupportedOperationException("Not yet implemented");
+  public void dropNamespacesTable() {
+    client.deleteTable(
+        DeleteTableRequest.builder()
+            .tableName(getFullTableName(metadataNamespace, DynamoAdmin.NAMESPACES_TABLE))
+            .build());
+    if (!waitForTableDeletion(metadataNamespace, DynamoAdmin.NAMESPACES_TABLE)) {
+      throw new RuntimeException("Deleting the namespaces table timed out");
+    }
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -64,6 +64,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 import software.amazon.awssdk.services.dynamodb.model.UpdateContinuousBackupsRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateTableRequest;
 
 /**
@@ -1508,6 +1509,117 @@ public abstract class DynamoAdminTestBase {
             ScanRequest.builder()
                 .tableName(getFullNamespaceTableName())
                 .exclusiveStartKey(null)
+                .build());
+  }
+
+  @Test
+  public void upgrade_WithExistingTables_ShouldUpsertNamespaceNames() throws ExecutionException {
+    // Arrange
+    when(client.describeTable(any(DescribeTableRequest.class)))
+        .thenReturn(mock(DescribeTableResponse.class))
+        .thenThrow(mock(ResourceNotFoundException.class))
+        .thenReturn(tableIsActiveResponse);
+
+    when(client.describeContinuousBackups(any(DescribeContinuousBackupsRequest.class)))
+        .thenReturn(backupIsEnabledResponse);
+    ScanResponse scanResponse = mock(ScanResponse.class);
+    when(client.scan(any(ScanRequest.class))).thenReturn(scanResponse);
+    Map<String, AttributeValue> lastEvaluatedKeyFirstIteration =
+        ImmutableMap.of("", AttributeValue.builder().build());
+    Map<String, AttributeValue> lastEvaluatedKeySecondIteration = ImmutableMap.of();
+    when(scanResponse.lastEvaluatedKey())
+        .thenReturn(lastEvaluatedKeyFirstIteration)
+        .thenReturn(lastEvaluatedKeySecondIteration);
+    when(scanResponse.items())
+        .thenReturn(
+            ImmutableList.of(
+                ImmutableMap.of(
+                    DynamoAdmin.METADATA_ATTR_TABLE,
+                    AttributeValue.builder().s("ns1.tbl1").build())))
+        .thenReturn(
+            ImmutableList.of(
+                ImmutableMap.of(
+                    DynamoAdmin.METADATA_ATTR_TABLE,
+                    AttributeValue.builder().s("ns1.tbl2").build()),
+                ImmutableMap.of(
+                    DynamoAdmin.METADATA_ATTR_TABLE,
+                    AttributeValue.builder().s("ns2.tbl3").build())));
+
+    // Act
+    admin.upgrade(Collections.emptyMap());
+
+    // Assert
+    verify(client)
+        .describeTable(
+            DescribeTableRequest.builder().tableName(getFullMetadataTableName()).build());
+    verify(client, times(2))
+        .describeTable(
+            DescribeTableRequest.builder().tableName(getFullNamespaceTableName()).build());
+    CreateTableRequest createNamespaceTableRequest =
+        CreateTableRequest.builder()
+            .attributeDefinitions(
+                ImmutableList.of(
+                    AttributeDefinition.builder()
+                        .attributeName(DynamoAdmin.NAMESPACES_ATTR_NAME)
+                        .attributeType(ScalarAttributeType.S)
+                        .build()))
+            .keySchema(
+                KeySchemaElement.builder()
+                    .attributeName(DynamoAdmin.NAMESPACES_ATTR_NAME)
+                    .keyType(KeyType.HASH)
+                    .build())
+            .provisionedThroughput(
+                ProvisionedThroughput.builder()
+                    .readCapacityUnits(DynamoAdmin.METADATA_TABLES_REQUEST_UNIT)
+                    .writeCapacityUnits(DynamoAdmin.METADATA_TABLES_REQUEST_UNIT)
+                    .build())
+            .tableName(getFullNamespaceTableName())
+            .build();
+    verify(client).createTable(createNamespaceTableRequest);
+    verify(client)
+        .describeContinuousBackups(
+            DescribeContinuousBackupsRequest.builder()
+                .tableName(getFullNamespaceTableName())
+                .build());
+    verify(client)
+        .updateContinuousBackups(
+            UpdateContinuousBackupsRequest.builder()
+                .tableName(getFullNamespaceTableName())
+                .pointInTimeRecoverySpecification(
+                    PointInTimeRecoverySpecification.builder()
+                        .pointInTimeRecoveryEnabled(true)
+                        .build())
+                .build());
+    verify(client)
+        .scan(
+            ScanRequest.builder()
+                .tableName(getFullMetadataTableName())
+                .exclusiveStartKey(null)
+                .build());
+    verify(client)
+        .scan(
+            ScanRequest.builder()
+                .tableName(getFullMetadataTableName())
+                .exclusiveStartKey(lastEvaluatedKeyFirstIteration)
+                .build());
+
+    verify(client)
+        .updateItem(
+            UpdateItemRequest.builder()
+                .tableName(getFullNamespaceTableName())
+                .key(
+                    ImmutableMap.of(
+                        DynamoAdmin.NAMESPACES_ATTR_NAME,
+                        AttributeValue.builder().s("ns1").build()))
+                .build());
+    verify(client)
+        .updateItem(
+            UpdateItemRequest.builder()
+                .tableName(getFullNamespaceTableName())
+                .key(
+                    ImmutableMap.of(
+                        DynamoAdmin.NAMESPACES_ATTR_NAME,
+                        AttributeValue.builder().s("ns2").build()))
                 .build());
   }
 }


### PR DESCRIPTION
This implement the `DynamoAdmin.upgrade()` method in relation to the namespace management feature as it was done for the `JdbcAdmin` (cf. https://github.com/scalar-labs/scalardb/pull/696). 
FYI, the target branch is [feat/namespaces_management](https://github.com/scalar-labs/scalardb/tree/feat/namespaces_management)
