### PR TITLE
Add upgrade() method to the Cassandra Admin

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
@@ -3,8 +3,6 @@ package com.scalar.db.storage.cassandra;
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class CassandraAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
   @Override
@@ -16,10 +14,4 @@ public class CassandraAdminIntegrationTest extends DistributedStorageAdminIntegr
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CassandraAdminTestUtils(getProperties(testName));
   }
-
-  @Disabled("Temporarily until admin.upgrade() is implemented")
-  @Test
-  @Override
-  public void
-      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -3,8 +3,6 @@ package com.scalar.db.storage.cassandra;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithCassandra
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -17,10 +15,4 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CassandraAdminTestUtils(getProperties(testName));
   }
-
-  @Disabled("Temporarily until admin.upgrade() is implemented")
-  @Test
-  @Override
-  public void
-      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminIntegrationTest.java
@@ -16,7 +16,6 @@ import java.util.Properties;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -356,7 +355,6 @@ public class MultiStorageAdminIntegrationTest {
     assertThat(namespaces).containsExactlyInAnyOrder(NAMESPACE1, NAMESPACE2);
   }
 
-  @Disabled("Temporarily until admin.upgrade() is implemented")
   @Test
   public void
       upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces()


### PR DESCRIPTION
This implement the `Cassandra.upgrade()` method in relation to the namespace management feature as it was done for the `JdbcAdmin` (cf. https://github.com/scalar-labs/scalardb/pull/696). 
FYI, the target branch is [feat/namespaces_management](https://github.com/scalar-labs/scalardb/tree/feat/namespaces_management)