### PR TITLE
Add resume() to DistributedTransactionManager

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -178,6 +178,15 @@ public interface DistributedTransactionManager {
       throws TransactionException;
 
   /**
+   * Resumes an ongoing transaction associated with the specified transaction ID.
+   *
+   * @param txId the transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionException if resuming the transaction failed
+   */
+  DistributedTransaction resume(String txId) throws TransactionException;
+
+  /**
    * Returns the state of a given transaction.
    *
    * @param txId a transaction ID

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -123,6 +123,11 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
+  public DistributedTransaction resume(String txId) throws TransactionException {
+    return manager.resume(txId);
+  }
+
+  @Override
   public TransactionState getState(String txId) throws TransactionException {
     return manager.getState(txId);
   }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -1,17 +1,55 @@
 package com.scalar.db.transaction.common;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.util.ActiveExpiringMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractDistributedTransactionManager
     implements DistributedTransactionManager {
 
+  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(AbstractDistributedTransactionManager.class);
+
   private Optional<String> namespace;
   private Optional<String> tableName;
 
-  public AbstractDistributedTransactionManager() {
+  private final ActiveExpiringMap<String, DistributedTransaction> activeTransactions;
+
+  public AbstractDistributedTransactionManager(DatabaseConfig config) {
     namespace = Optional.empty();
     tableName = Optional.empty();
+    activeTransactions =
+        new ActiveExpiringMap<>(
+            config.getActiveTransactionManagementExpirationTimeMillis(),
+            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
+            t -> {
+              logger.warn("the transaction is expired. transactionId: {}", t.getId());
+              try {
+                t.rollback();
+              } catch (RollbackException e) {
+                logger.warn("rollback failed", e);
+              }
+            });
   }
 
   /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
@@ -48,5 +86,100 @@ public abstract class AbstractDistributedTransactionManager
   @Override
   public Optional<String> getTable() {
     return tableName;
+  }
+
+  private void addActiveTransaction(DistributedTransaction transaction)
+      throws TransactionException {
+    if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
+      transaction.rollback();
+      throw new TransactionException("The transaction already exists");
+    }
+  }
+
+  private void removeActiveTransaction(String transactionId) {
+    activeTransactions.remove(transactionId);
+  }
+
+  @Override
+  public DistributedTransaction resume(String txId) throws TransactionException {
+    return activeTransactions
+        .get(txId)
+        .orElseThrow(
+            () ->
+                new TransactionException(
+                    "A transaction associated with the specified transaction ID is not found. "
+                        + "It might have been expired"));
+  }
+
+  @VisibleForTesting
+  public class ActiveTransaction extends AbstractDistributedTransaction {
+
+    private final DistributedTransaction transaction;
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
+      this.transaction = transaction;
+      addActiveTransaction(this);
+    }
+
+    @Override
+    public String getId() {
+      return transaction.getId();
+    }
+
+    @Override
+    public Optional<Result> get(Get get) throws CrudException {
+      return transaction.get(get);
+    }
+
+    @Override
+    public List<Result> scan(Scan scan) throws CrudException {
+      return transaction.scan(scan);
+    }
+
+    @Override
+    public void put(Put put) throws CrudException {
+      transaction.put(put);
+    }
+
+    @Override
+    public void put(List<Put> puts) throws CrudException {
+      transaction.put(puts);
+    }
+
+    @Override
+    public void delete(Delete delete) throws CrudException {
+      transaction.delete(delete);
+    }
+
+    @Override
+    public void delete(List<Delete> deletes) throws CrudException {
+      transaction.delete(deletes);
+    }
+
+    @Override
+    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+      transaction.mutate(mutations);
+    }
+
+    @Override
+    public void commit() throws CommitException, UnknownTransactionStatusException {
+      transaction.commit();
+      removeActiveTransaction(getId());
+    }
+
+    @Override
+    public void rollback() throws RollbackException {
+      try {
+        transaction.rollback();
+      } finally {
+        removeActiveTransaction(getId());
+      }
+    }
+
+    @VisibleForTesting
+    public DistributedTransaction getActualTransaction() {
+      return transaction;
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -2,6 +2,7 @@ package com.scalar.db.transaction.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Isolation;
 import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
@@ -34,6 +35,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
 
   @Inject
   public JdbcTransactionManager(DatabaseConfig databaseConfig) {
+    super(databaseConfig);
     JdbcConfig config = new JdbcConfig(databaseConfig);
 
     dataSource = JdbcUtils.initDataSource(config, true);
@@ -52,10 +54,12 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
 
   @VisibleForTesting
   JdbcTransactionManager(
+      DatabaseConfig databaseConfig,
       BasicDataSource dataSource,
       BasicDataSource tableMetadataDataSource,
       RdbEngine rdbEngine,
       JdbcService jdbcService) {
+    super(databaseConfig);
     this.dataSource = dataSource;
     this.tableMetadataDataSource = tableMetadataDataSource;
     this.rdbEngine = rdbEngine;
@@ -63,39 +67,29 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
   }
 
   @Override
-  public JdbcTransaction begin() throws TransactionException {
+  public DistributedTransaction begin() throws TransactionException {
     String txId = UUID.randomUUID().toString();
     return begin(txId);
   }
 
   @Override
-  public JdbcTransaction begin(String txId) throws TransactionException {
+  public DistributedTransaction begin(String txId) throws TransactionException {
     try {
       JdbcTransaction transaction =
           new JdbcTransaction(txId, jdbcService, dataSource.getConnection(), rdbEngine);
       getNamespace().ifPresent(transaction::withNamespace);
       getTable().ifPresent(transaction::withTable);
-      return transaction;
+      return new ActiveTransaction(transaction);
     } catch (SQLException e) {
       throw new TransactionException("failed to start the transaction", e);
     }
   }
 
-  @Override
-  public JdbcTransaction start() throws TransactionException {
-    return (JdbcTransaction) super.start();
-  }
-
-  @Override
-  public JdbcTransaction start(String txId) throws TransactionException {
-    return (JdbcTransaction) super.start(txId);
-  }
-
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
-  public JdbcTransaction start(Isolation isolation) throws TransactionException {
+  public DistributedTransaction start(Isolation isolation) throws TransactionException {
     return begin();
   }
 
@@ -103,32 +97,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
-  public JdbcTransaction start(String txId, Isolation isolation) throws TransactionException {
-    return begin(txId);
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @SuppressWarnings("InlineMeSuggester")
-  @Deprecated
-  @Override
-  public JdbcTransaction start(Isolation isolation, SerializableStrategy strategy)
-      throws TransactionException {
-    return begin();
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @SuppressWarnings("InlineMeSuggester")
-  @Deprecated
-  @Override
-  public JdbcTransaction start(SerializableStrategy strategy) throws TransactionException {
-    return begin();
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @SuppressWarnings("InlineMeSuggester")
-  @Deprecated
-  @Override
-  public JdbcTransaction start(String txId, SerializableStrategy strategy)
+  public DistributedTransaction start(String txId, Isolation isolation)
       throws TransactionException {
     return begin(txId);
   }
@@ -137,8 +106,34 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated
   @Override
-  public JdbcTransaction start(String txId, Isolation isolation, SerializableStrategy strategy)
+  public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
       throws TransactionException {
+    return begin();
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
+    return begin();
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(String txId, SerializableStrategy strategy)
+      throws TransactionException {
+    return begin(txId);
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(
+      String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
     return begin(txId);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -1,16 +1,21 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,11 +56,15 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void begin_NoArgumentGiven_ReturnConsensusCommitWithSomeTxIdAndSnapshotIsolation() {
+  public void begin_NoArgumentGiven_ReturnConsensusCommitWithSomeTxIdAndSnapshotIsolation()
+      throws TransactionException {
     // Arrange
 
     // Act
-    ConsensusCommit transaction = manager.begin();
+    ConsensusCommit transaction =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -64,11 +73,15 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void begin_TxIdGiven_ReturnWithSpecifiedTxIdAndSnapshotIsolation() {
+  public void begin_TxIdGiven_ReturnWithSpecifiedTxIdAndSnapshotIsolation()
+      throws TransactionException {
     // Arrange
 
     // Act
-    ConsensusCommit transaction = manager.begin(ANY_TX_ID);
+    ConsensusCommit transaction =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin(ANY_TX_ID))
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -77,12 +90,19 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void begin_CalledTwice_ReturnRespectiveConsensusCommitWithSharedCommitAndRecovery() {
+  public void begin_CalledTwice_ReturnRespectiveConsensusCommitWithSharedCommitAndRecovery()
+      throws TransactionException {
     // Arrange
 
     // Act
-    ConsensusCommit transaction1 = manager.begin();
-    ConsensusCommit transaction2 = manager.begin();
+    ConsensusCommit transaction1 =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
+                .getActualTransaction();
+    ConsensusCommit transaction2 =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -102,7 +122,10 @@ public class ConsensusCommitManagerTest {
     // Arrange
 
     // Act
-    ConsensusCommit transaction = manager.start();
+    ConsensusCommit transaction =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start())
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -116,7 +139,10 @@ public class ConsensusCommitManagerTest {
     // Arrange
 
     // Act
-    ConsensusCommit transaction = manager.start(ANY_TX_ID);
+    ConsensusCommit transaction =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start(ANY_TX_ID))
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -125,11 +151,16 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void start_SerializableGiven_ReturnConsensusCommitWithSomeTxIdAndSerializable() {
+  public void start_SerializableGiven_ReturnConsensusCommitWithSomeTxIdAndSerializable()
+      throws TransactionException {
     // Arrange
 
     // Act
-    ConsensusCommit transaction = manager.start(com.scalar.db.api.Isolation.SERIALIZABLE);
+    ConsensusCommit transaction =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction)
+                    manager.start(com.scalar.db.api.Isolation.SERIALIZABLE))
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -152,8 +183,14 @@ public class ConsensusCommitManagerTest {
     // Arrange
 
     // Act
-    ConsensusCommit transaction1 = manager.start();
-    ConsensusCommit transaction2 = manager.start();
+    ConsensusCommit transaction1 =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start())
+                .getActualTransaction();
+    ConsensusCommit transaction2 =
+        (ConsensusCommit)
+            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start())
+                .getActualTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -165,6 +202,68 @@ public class ConsensusCommitManagerTest {
     assertThat(transaction1.getRecoveryHandler())
         .isEqualTo(transaction2.getRecoveryHandler())
         .isEqualTo(recovery);
+  }
+
+  @Test
+  public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction1 = manager.begin(ANY_TX_ID);
+
+    // Act
+    DistributedTransaction transaction2 = manager.resume(ANY_TX_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithoutBegin_ThrowTransactionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID);
+    transaction.commit();
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndCommit_CommitExceptionThrown_ReturnSameTransactionObject()
+      throws TransactionException {
+    // Arrange
+    doThrow(CommitException.class).when(commit).commit(any());
+
+    DistributedTransaction transaction1 = manager.begin(ANY_TX_ID);
+    try {
+      transaction1.commit();
+    } catch (CommitException ignored) {
+      // expected
+    }
+
+    // Act
+    DistributedTransaction transaction2 = manager.resume(ANY_TX_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID);
+    transaction.rollback();
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(TransactionException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -43,6 +43,11 @@ public class ConsensusCommitTest {
   @Mock private CrudHandler crud;
   @Mock private CommitHandler commit;
   @Mock private RecoveryHandler recovery;
+
+  @SuppressWarnings("unused")
+  @Mock
+  private ConsensusCommitManager manager;
+
   @InjectMocks private ConsensusCommit consensus;
 
   @BeforeEach

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -8,15 +9,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
 import com.scalar.db.storage.jdbc.JdbcService;
@@ -35,7 +39,9 @@ public class JdbcTransactionManagerTest {
 
   private static final String NAMESPACE = "ns";
   private static final String TABLE = "tbl";
+  private static final String ANY_ID = "id";
 
+  @Mock private DatabaseConfig databaseConfig;
   @Mock private BasicDataSource dataSource;
   @Mock private BasicDataSource tableMetadataDataSource;
   @Mock private JdbcService jdbcService;
@@ -52,7 +58,7 @@ public class JdbcTransactionManagerTest {
     when(dataSource.getConnection()).thenReturn(connection);
     manager =
         new JdbcTransactionManager(
-            dataSource, tableMetadataDataSource, RdbEngine.MYSQL, jdbcService);
+            databaseConfig, dataSource, tableMetadataDataSource, RdbEngine.MYSQL, jdbcService);
   }
 
   @Test
@@ -63,7 +69,7 @@ public class JdbcTransactionManagerTest {
     when(jdbcService.delete(any(), any())).thenReturn(true);
 
     // Act
-    JdbcTransaction transaction = manager.begin();
+    DistributedTransaction transaction = manager.begin();
     Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
     transaction.get(get);
     Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
@@ -97,7 +103,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
             })
@@ -114,7 +120,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
             })
@@ -130,7 +136,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.scan(scan);
             })
@@ -147,7 +153,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.scan(scan);
             })
@@ -163,7 +169,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Put put =
                   new Put(new Key("p1", "val1"))
                       .withValue("v1", "val2")
@@ -184,7 +190,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Put put =
                   new Put(new Key("p1", "val1"))
                       .withValue("v1", "val2")
@@ -205,7 +211,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Delete delete =
                   new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.delete(delete);
@@ -223,7 +229,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Delete delete =
                   new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.delete(delete);
@@ -241,7 +247,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Put put =
                   new Put(new Key("p1", "val1"))
                       .withValue("v1", "val2")
@@ -264,7 +270,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Put put =
                   new Put(new Key("p1", "val1"))
                       .withValue("v1", "val2")
@@ -285,7 +291,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
@@ -309,7 +315,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
@@ -332,7 +338,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.begin();
+              DistributedTransaction transaction = manager.begin();
               Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
@@ -357,7 +363,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(
             () -> {
-              JdbcTransaction transaction = manager.start();
+              DistributedTransaction transaction = manager.start();
               Get get = new Get(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               transaction.get(get);
               Put put =
@@ -370,5 +376,84 @@ public class JdbcTransactionManagerTest {
             })
         .isInstanceOf(UnknownTransactionStatusException.class);
     verify(connection).close();
+  }
+
+  @Test
+  public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction1 = manager.begin(ANY_ID);
+
+    // Act
+    DistributedTransaction transaction2 = manager.resume(ANY_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithoutBegin_ThrowTransactionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin(ANY_ID);
+    transaction.commit();
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndCommit_CommitExceptionThrown_ReturnSameTransactionObject()
+      throws TransactionException, SQLException {
+    // Arrange
+    doThrow(SQLException.class).when(connection).commit();
+
+    DistributedTransaction transaction1 = manager.begin(ANY_ID);
+    try {
+      transaction1.commit();
+    } catch (CommitException ignored) {
+      // expected
+    }
+
+    // Act
+    DistributedTransaction transaction2 = manager.resume(ANY_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin(ANY_ID);
+    transaction.rollback();
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowTransactionException()
+      throws TransactionException, SQLException {
+    // Arrange
+    doThrow(SQLException.class).when(connection).rollback();
+
+    DistributedTransaction transaction1 = manager.begin(ANY_ID);
+    try {
+      transaction1.rollback();
+    } catch (RollbackException ignored) {
+      // expected
+    }
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
@@ -4,12 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.TableMetadataManager;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.rpc.AbortRequest;
 import com.scalar.db.rpc.AbortResponse;
@@ -29,6 +36,7 @@ public class GrpcTransactionManagerTest {
 
   private static final String ANY_ID = "id";
 
+  @Mock private DatabaseConfig databaseConfig;
   @Mock private GrpcConfig config;
   @Mock private DistributedTransactionGrpc.DistributedTransactionStub stub;
   @Mock private DistributedTransactionGrpc.DistributedTransactionBlockingStub blockingStub;
@@ -41,10 +49,138 @@ public class GrpcTransactionManagerTest {
     MockitoAnnotations.openMocks(this).close();
 
     // Arrange
-    manager = new GrpcTransactionManager(config, stub, blockingStub, metadataManager);
+    manager =
+        new GrpcTransactionManager(databaseConfig, config, stub, blockingStub, metadataManager);
     manager.with("namespace", "table");
     when(config.getDeadlineDurationMillis()).thenReturn(60000L);
     when(blockingStub.withDeadlineAfter(anyLong(), any())).thenReturn(blockingStub);
+  }
+
+  @Test
+  public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getBidirectionalStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    DistributedTransaction transaction1 = spiedManager.begin(ANY_ID);
+
+    // Act
+    DistributedTransaction transaction2 = spiedManager.resume(ANY_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithStart_ReturnSameTransactionObject() throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getBidirectionalStream();
+    when(bidirectionalStream.startTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    DistributedTransaction transaction1 = spiedManager.start(ANY_ID);
+
+    // Act
+    DistributedTransaction transaction2 = spiedManager.resume(ANY_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithoutBeginOrStart_ThrowTransactionException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getBidirectionalStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    DistributedTransaction transaction = spiedManager.begin(ANY_ID);
+    transaction.commit();
+
+    // Act Assert
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndCommit_CommitExceptionThrown_ReturnSameTransactionObject()
+      throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getBidirectionalStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    doThrow(CommitException.class).when(bidirectionalStream).commit();
+
+    DistributedTransaction transaction1 = spiedManager.begin(ANY_ID);
+    try {
+      transaction1.commit();
+    } catch (CommitException ignored) {
+      // expected
+    }
+
+    // Act
+    DistributedTransaction transaction2 = spiedManager.resume(ANY_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getBidirectionalStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    DistributedTransaction transaction = spiedManager.begin(ANY_ID);
+    transaction.rollback();
+
+    // Act Assert
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getBidirectionalStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    doThrow(RollbackException.class).when(bidirectionalStream).rollback();
+
+    DistributedTransaction transaction1 = spiedManager.begin(ANY_ID);
+    try {
+      transaction1.rollback();
+    } catch (RollbackException ignored) {
+      // expected
+    }
+
+    // Act Assert
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(TransactionException.class);
   }
 
   @Test

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -305,6 +305,19 @@ DistributedTransaction transaction = manager.start("<transaction ID>");
 
 Note that you must guarantee uniqueness of the transaction ID in this case.
 
+### Resume a transaction
+
+You can resume a transaction you have already begun with specifying a transaction ID as follows:
+
+```java
+// Resume a transaction
+DistributedTransaction transaction = manager.resume("<transaction ID>");
+```
+
+It is helpful in a stateful application where a transaction spans multiple client requests.
+In that case, the application can begin a transaction in the first client request.
+And in the following client requests, it can resume the transaction with the `resume()` method.
+
 ### CRUD operations
 
 #### Key construction


### PR DESCRIPTION
This PR add a method `resume()` to `DistributedTransactionManager`. And it also makes `DistributedTransactionManager` hold the ongoing transactions, and we will be able to get these transactions with the `resume()` method. Please take a look!