### PR TITLE
Add transaction state management

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -115,7 +115,7 @@ public abstract class AbstractDistributedTransactionManager
 
   protected DistributedTransaction wrap(DistributedTransaction transaction)
       throws TransactionException {
-    return new ActiveTransaction(new TransactionStateManagement(transaction));
+    return new ActiveTransaction(new StateManagedTransaction(transaction));
   }
 
   private class ActiveTransaction extends AbstractDistributedTransaction
@@ -194,7 +194,7 @@ public abstract class AbstractDistributedTransactionManager
   }
 
   @VisibleForTesting
-  static class TransactionStateManagement extends AbstractDistributedTransaction
+  static class StateManagedTransaction extends AbstractDistributedTransaction
       implements WrappedDistributedTransaction {
 
     private enum Status {
@@ -208,7 +208,7 @@ public abstract class AbstractDistributedTransactionManager
     private Status status;
 
     @VisibleForTesting
-    TransactionStateManagement(DistributedTransaction transaction) {
+    StateManagedTransaction(DistributedTransaction transaction) {
       this.transaction = transaction;
       status = Status.ACTIVE;
     }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -17,8 +17,10 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.util.ActiveExpiringMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,13 +113,18 @@ public abstract class AbstractDistributedTransactionManager
                         + "It might have been expired"));
   }
 
-  @VisibleForTesting
-  public class ActiveTransaction extends AbstractDistributedTransaction {
+  protected DistributedTransaction wrap(DistributedTransaction transaction)
+      throws TransactionException {
+    return new ActiveTransaction(new TransactionStateManagement(transaction));
+  }
+
+  private class ActiveTransaction extends AbstractDistributedTransaction
+      implements WrappedDistributedTransaction {
 
     private final DistributedTransaction transaction;
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
+    private ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
       this.transaction = transaction;
       addActiveTransaction(this);
     }
@@ -177,8 +184,119 @@ public abstract class AbstractDistributedTransactionManager
       }
     }
 
+    @Override
+    public DistributedTransaction getOriginalTransaction() {
+      if (transaction instanceof WrappedDistributedTransaction) {
+        return ((WrappedDistributedTransaction) transaction).getOriginalTransaction();
+      }
+      return transaction;
+    }
+  }
+
+  @VisibleForTesting
+  static class TransactionStateManagement extends AbstractDistributedTransaction
+      implements WrappedDistributedTransaction {
+
+    private enum Status {
+      ACTIVE,
+      COMMITTED,
+      COMMIT_FAILED,
+      ROLLED_BACK
+    }
+
+    private final DistributedTransaction transaction;
+    private Status status;
+
     @VisibleForTesting
-    public DistributedTransaction getActualTransaction() {
+    TransactionStateManagement(DistributedTransaction transaction) {
+      this.transaction = transaction;
+      status = Status.ACTIVE;
+    }
+
+    @Override
+    public String getId() {
+      return transaction.getId();
+    }
+
+    @Override
+    public Optional<Result> get(Get get) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      return transaction.get(get);
+    }
+
+    @Override
+    public List<Result> scan(Scan scan) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      return transaction.scan(scan);
+    }
+
+    @Override
+    public void put(Put put) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.put(put);
+    }
+
+    @Override
+    public void put(List<Put> puts) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.put(puts);
+    }
+
+    @Override
+    public void delete(Delete delete) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.delete(delete);
+    }
+
+    @Override
+    public void delete(List<Delete> deletes) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.delete(deletes);
+    }
+
+    @Override
+    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.mutate(mutations);
+    }
+
+    @Override
+    public void commit() throws CommitException, UnknownTransactionStatusException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      try {
+        transaction.commit();
+        status = Status.COMMITTED;
+      } catch (Exception e) {
+        status = Status.COMMIT_FAILED;
+        throw e;
+      }
+    }
+
+    @Override
+    public void rollback() throws RollbackException {
+      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+        throw new IllegalStateException(
+            "The transaction has already been committed or rolled back");
+      }
+      try {
+        transaction.rollback();
+      } finally {
+        status = Status.ROLLED_BACK;
+      }
+    }
+
+    private void checkStatus(@Nullable String message, Status... expectedStatus) {
+      boolean expected = Arrays.stream(expectedStatus).anyMatch(s -> status == s);
+      if (!expected) {
+        throw new IllegalStateException(message);
+      }
+    }
+
+    @Override
+    public DistributedTransaction getOriginalTransaction() {
+      if (transaction instanceof WrappedDistributedTransaction) {
+        return ((WrappedDistributedTransaction) transaction).getOriginalTransaction();
+      }
       return transaction;
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -193,6 +193,11 @@ public abstract class AbstractDistributedTransactionManager
     }
   }
 
+  /**
+   * This class is to unify the call sequence of the transaction object. It doesn't care about the
+   * potential inconsistency between the status field on JVM memory and the underlying persistent
+   * layer.
+   */
   @VisibleForTesting
   static class StateManagedTransaction extends AbstractDistributedTransaction
       implements WrappedDistributedTransaction {

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -113,7 +113,7 @@ public abstract class AbstractDistributedTransactionManager
                         + "It might have been expired"));
   }
 
-  protected DistributedTransaction wrap(DistributedTransaction transaction)
+  protected DistributedTransaction activate(DistributedTransaction transaction)
       throws TransactionException {
     return new ActiveTransaction(new StateManagedTransaction(transaction));
   }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -204,6 +204,11 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     }
   }
 
+  /**
+   * This class is to unify the call sequence of the transaction object. It doesn't care about the
+   * potential inconsistency between the status field on JVM memory and the underlying persistent
+   * layer.
+   */
   @VisibleForTesting
   static class StateManagedTransaction extends AbstractTwoPhaseCommitTransaction
       implements WrappedTwoPhaseCommitTransaction {

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -19,8 +19,10 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.util.ActiveExpiringMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,13 +114,18 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
                         + "It might have been expired"));
   }
 
-  @VisibleForTesting
-  public class ActiveTransaction extends AbstractTwoPhaseCommitTransaction {
+  protected TwoPhaseCommitTransaction wrap(TwoPhaseCommitTransaction transaction)
+      throws TransactionException {
+    return new ActiveTransaction(new TransactionStateManagement(transaction));
+  }
+
+  private class ActiveTransaction extends AbstractTwoPhaseCommitTransaction
+      implements WrappedTwoPhaseCommitTransaction {
 
     private final TwoPhaseCommitTransaction transaction;
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
+    private ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
       this.transaction = transaction;
       addActiveTransaction(this);
     }
@@ -188,8 +195,148 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
       }
     }
 
+    @Override
+    public TwoPhaseCommitTransaction getOriginalTransaction() {
+      if (transaction instanceof WrappedTwoPhaseCommitTransaction) {
+        return ((WrappedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
+      }
+      return transaction;
+    }
+  }
+
+  @VisibleForTesting
+  static class TransactionStateManagement extends AbstractTwoPhaseCommitTransaction
+      implements WrappedTwoPhaseCommitTransaction {
+
+    private enum Status {
+      ACTIVE,
+      PREPARED,
+      PREPARE_FAILED,
+      VALIDATED,
+      VALIDATION_FAILED,
+      COMMITTED,
+      COMMIT_FAILED,
+      ROLLED_BACK
+    }
+
+    private final TwoPhaseCommitTransaction transaction;
+    private Status status;
+
     @VisibleForTesting
-    public TwoPhaseCommitTransaction getActualTransaction() {
+    TransactionStateManagement(TwoPhaseCommitTransaction transaction) {
+      this.transaction = transaction;
+      status = Status.ACTIVE;
+    }
+
+    @Override
+    public String getId() {
+      return transaction.getId();
+    }
+
+    @Override
+    public Optional<Result> get(Get get) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      return transaction.get(get);
+    }
+
+    @Override
+    public List<Result> scan(Scan scan) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      return transaction.scan(scan);
+    }
+
+    @Override
+    public void put(Put put) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.put(put);
+    }
+
+    @Override
+    public void put(List<Put> puts) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.put(puts);
+    }
+
+    @Override
+    public void delete(Delete delete) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.delete(delete);
+    }
+
+    @Override
+    public void delete(List<Delete> deletes) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.delete(deletes);
+    }
+
+    @Override
+    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      transaction.mutate(mutations);
+    }
+
+    @Override
+    public void prepare() throws PreparationException {
+      checkStatus("The transaction is not active", Status.ACTIVE);
+      try {
+        transaction.prepare();
+        status = Status.PREPARED;
+      } catch (Exception e) {
+        status = Status.PREPARE_FAILED;
+        throw e;
+      }
+    }
+
+    @Override
+    public void validate() throws ValidationException {
+      checkStatus("The transaction is not prepared", Status.PREPARED);
+      try {
+        transaction.validate();
+        status = Status.VALIDATED;
+      } catch (Exception e) {
+        status = Status.VALIDATION_FAILED;
+        throw e;
+      }
+    }
+
+    @Override
+    public void commit() throws CommitException, UnknownTransactionStatusException {
+      checkStatus(
+          "The transaction is not prepared or validated.", Status.PREPARED, Status.VALIDATED);
+      try {
+        transaction.commit();
+        status = Status.COMMITTED;
+      } catch (Exception e) {
+        status = Status.COMMIT_FAILED;
+        throw e;
+      }
+    }
+
+    @Override
+    public void rollback() throws RollbackException {
+      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+        throw new IllegalStateException(
+            "The transaction has already been committed or rolled back");
+      }
+      try {
+        transaction.rollback();
+      } finally {
+        status = Status.ROLLED_BACK;
+      }
+    }
+
+    private void checkStatus(@Nullable String message, Status... expectedStatus) {
+      boolean expected = Arrays.stream(expectedStatus).anyMatch(s -> status == s);
+      if (!expected) {
+        throw new IllegalStateException(message);
+      }
+    }
+
+    @Override
+    public TwoPhaseCommitTransaction getOriginalTransaction() {
+      if (transaction instanceof WrappedTwoPhaseCommitTransaction) {
+        return ((WrappedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
+      }
       return transaction;
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -116,7 +116,7 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
 
   protected TwoPhaseCommitTransaction wrap(TwoPhaseCommitTransaction transaction)
       throws TransactionException {
-    return new ActiveTransaction(new TransactionStateManagement(transaction));
+    return new ActiveTransaction(new StateManagedTransaction(transaction));
   }
 
   private class ActiveTransaction extends AbstractTwoPhaseCommitTransaction
@@ -205,7 +205,7 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
   }
 
   @VisibleForTesting
-  static class TransactionStateManagement extends AbstractTwoPhaseCommitTransaction
+  static class StateManagedTransaction extends AbstractTwoPhaseCommitTransaction
       implements WrappedTwoPhaseCommitTransaction {
 
     private enum Status {
@@ -223,7 +223,7 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     private Status status;
 
     @VisibleForTesting
-    TransactionStateManagement(TwoPhaseCommitTransaction transaction) {
+    StateManagedTransaction(TwoPhaseCommitTransaction transaction) {
       this.transaction = transaction;
       status = Status.ACTIVE;
     }

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -114,7 +114,7 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
                         + "It might have been expired"));
   }
 
-  protected TwoPhaseCommitTransaction wrap(TwoPhaseCommitTransaction transaction)
+  protected TwoPhaseCommitTransaction activate(TwoPhaseCommitTransaction transaction)
       throws TransactionException {
     return new ActiveTransaction(new StateManagedTransaction(transaction));
   }

--- a/core/src/main/java/com/scalar/db/transaction/common/WrappedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/WrappedDistributedTransaction.java
@@ -1,0 +1,7 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.DistributedTransaction;
+
+public interface WrappedDistributedTransaction {
+  DistributedTransaction getOriginalTransaction();
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/WrappedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/WrappedTwoPhaseCommitTransaction.java
@@ -1,0 +1,7 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+
+public interface WrappedTwoPhaseCommitTransaction {
+  TwoPhaseCommitTransaction getOriginalTransaction();
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -183,7 +183,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
     getNamespace().ifPresent(consensus::withNamespace);
     getTable().ifPresent(consensus::withTable);
-    return wrap(consensus);
+    return activate(consensus);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -183,7 +183,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
     getNamespace().ifPresent(consensus::withNamespace);
     getTable().ifPresent(consensus::withTable);
-    return new ActiveTransaction(consensus);
+    return wrap(consensus);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -142,7 +142,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     getNamespace().ifPresent(transaction::withNamespace);
     getTable().ifPresent(transaction::withTable);
-    return wrap(transaction);
+    return activate(transaction);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -142,7 +142,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     getNamespace().ifPresent(transaction::withNamespace);
     getTable().ifPresent(transaction::withTable);
-    return new ActiveTransaction(transaction);
+    return wrap(transaction);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -79,7 +79,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
           new JdbcTransaction(txId, jdbcService, dataSource.getConnection(), rdbEngine);
       getNamespace().ifPresent(transaction::withNamespace);
       getTable().ifPresent(transaction::withTable);
-      return wrap(transaction);
+      return activate(transaction);
     } catch (SQLException e) {
       throw new TransactionException("failed to start the transaction", e);
     }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -79,7 +79,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
           new JdbcTransaction(txId, jdbcService, dataSource.getConnection(), rdbEngine);
       getNamespace().ifPresent(transaction::withNamespace);
       getTable().ifPresent(transaction::withTable);
-      return new ActiveTransaction(transaction);
+      return wrap(transaction);
     } catch (SQLException e) {
       throw new TransactionException("failed to start the transaction", e);
     }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
@@ -103,7 +103,7 @@ public class GrpcTransactionManager extends AbstractDistributedTransactionManage
           GrpcTransaction transaction = new GrpcTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return new ActiveTransaction(transaction);
+          return wrap(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -126,7 +126,7 @@ public class GrpcTransactionManager extends AbstractDistributedTransactionManage
           GrpcTransaction transaction = new GrpcTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return new ActiveTransaction(transaction);
+          return wrap(transaction);
         },
         EXCEPTION_FACTORY);
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
@@ -103,7 +103,7 @@ public class GrpcTransactionManager extends AbstractDistributedTransactionManage
           GrpcTransaction transaction = new GrpcTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return wrap(transaction);
+          return activate(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -126,7 +126,7 @@ public class GrpcTransactionManager extends AbstractDistributedTransactionManage
           GrpcTransaction transaction = new GrpcTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return wrap(transaction);
+          return activate(transaction);
         },
         EXCEPTION_FACTORY);
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
@@ -89,7 +89,7 @@ public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommit
               new GrpcTwoPhaseCommitTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return wrap(transaction);
+          return activate(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -114,7 +114,7 @@ public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommit
               new GrpcTwoPhaseCommitTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return wrap(transaction);
+          return activate(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -129,7 +129,7 @@ public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommit
               new GrpcTwoPhaseCommitTransaction(txId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return wrap(transaction);
+          return activate(transaction);
         },
         EXCEPTION_FACTORY);
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
@@ -89,7 +89,7 @@ public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommit
               new GrpcTwoPhaseCommitTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return new ActiveTransaction(transaction);
+          return wrap(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -114,7 +114,7 @@ public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommit
               new GrpcTwoPhaseCommitTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return new ActiveTransaction(transaction);
+          return wrap(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -129,7 +129,7 @@ public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommit
               new GrpcTwoPhaseCommitTransaction(txId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return new ActiveTransaction(transaction);
+          return wrap(transaction);
         },
         EXCEPTION_FACTORY);
   }

--- a/core/src/test/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManagerTest.java
@@ -1,0 +1,194 @@
+package com.scalar.db.transaction.common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AbstractDistributedTransactionManagerTest {
+
+  @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
+  @SuppressWarnings("ClassCanBeStatic")
+  @Nested
+  public class TransactionStateManagementTest {
+
+    @Mock private DistributedTransaction distributedTransaction;
+
+    private AbstractDistributedTransactionManager.TransactionStateManagement transaction;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+      MockitoAnnotations.openMocks(this).close();
+
+      // Arrange
+      transaction =
+          new AbstractDistributedTransactionManager.TransactionStateManagement(
+              distributedTransaction);
+    }
+
+    @Test
+    public void crud_ShouldNotThrowAnyException() {
+      // Arrange
+      Get get = mock(Get.class);
+      Scan scan = mock(Scan.class);
+      Put put = mock(Put.class);
+      @SuppressWarnings("unchecked")
+      List<Put> puts = (List<Put>) mock(List.class);
+      Delete delete = mock(Delete.class);
+      @SuppressWarnings("unchecked")
+      List<Delete> deletes = (List<Delete>) mock(List.class);
+      @SuppressWarnings("unchecked")
+      List<Mutation> mutations = (List<Mutation>) mock(List.class);
+
+      // Act Assert
+      assertThatCode(() -> transaction.get(get)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.scan(scan)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.put(put)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.put(puts)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.delete(delete)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.delete(deletes)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.mutate(mutations)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void crud_AfterCommit_ShouldThrowIllegalStateException()
+        throws CommitException, UnknownTransactionStatusException {
+      // Arrange
+      Get get = mock(Get.class);
+      Scan scan = mock(Scan.class);
+      Put put = mock(Put.class);
+      @SuppressWarnings("unchecked")
+      List<Put> puts = (List<Put>) mock(List.class);
+      Delete delete = mock(Delete.class);
+      @SuppressWarnings("unchecked")
+      List<Delete> deletes = (List<Delete>) mock(List.class);
+      @SuppressWarnings("unchecked")
+      List<Mutation> mutations = (List<Mutation>) mock(List.class);
+
+      transaction.commit();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.scan(scan)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(put)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(puts)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(delete))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.mutate(mutations))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void crud_AfterRollback_ShouldThrowIllegalStateException() throws RollbackException {
+      // Arrange
+      Get get = mock(Get.class);
+      Scan scan = mock(Scan.class);
+      Put put = mock(Put.class);
+      @SuppressWarnings("unchecked")
+      List<Put> puts = (List<Put>) mock(List.class);
+      Delete delete = mock(Delete.class);
+      @SuppressWarnings("unchecked")
+      List<Delete> deletes = (List<Delete>) mock(List.class);
+      @SuppressWarnings("unchecked")
+      List<Mutation> mutations = (List<Mutation>) mock(List.class);
+
+      transaction.rollback();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.scan(scan)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(put)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(puts)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(delete))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.mutate(mutations))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void commit_ShouldNotThrowAnyException() {
+      // Arrange
+
+      // Act Assert
+      assertThatCode(() -> transaction.commit()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void commit_Twice_ShouldThrowIllegalStateException()
+        throws CommitException, UnknownTransactionStatusException {
+      // Arrange
+      transaction.commit();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void commit_AfterRollback_ShouldThrowIllegalStateException() throws RollbackException {
+      // Arrange
+      transaction.rollback();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void rollback_ShouldNotThrowAnyException() {
+      // Arrange
+
+      // Act Assert
+      assertThatCode(() -> transaction.rollback()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rollback_AfterCommitFailed_ShouldNotThrowAnyException()
+        throws CommitException, UnknownTransactionStatusException {
+      // Arrange
+      doThrow(CommitException.class).when(distributedTransaction).commit();
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(CommitException.class);
+
+      // Act Assert
+      assertThatCode(() -> transaction.rollback()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rollback_AfterCommit_ShouldThrowIllegalStateException()
+        throws CommitException, UnknownTransactionStatusException {
+      // Arrange
+      transaction.commit();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.rollback()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void rollback_Twice_ShouldThrowIllegalStateException() throws RollbackException {
+      // Arrange
+      transaction.rollback();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.rollback()).isInstanceOf(IllegalStateException.class);
+    }
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManagerTest.java
@@ -27,11 +27,11 @@ public class AbstractDistributedTransactionManagerTest {
   @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
   @SuppressWarnings("ClassCanBeStatic")
   @Nested
-  public class TransactionStateManagementTest {
+  public class StateManagedTransactionTest {
 
-    @Mock private DistributedTransaction distributedTransaction;
+    @Mock private DistributedTransaction wrappedTransaction;
 
-    private AbstractDistributedTransactionManager.TransactionStateManagement transaction;
+    private AbstractDistributedTransactionManager.StateManagedTransaction transaction;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -39,8 +39,7 @@ public class AbstractDistributedTransactionManagerTest {
 
       // Arrange
       transaction =
-          new AbstractDistributedTransactionManager.TransactionStateManagement(
-              distributedTransaction);
+          new AbstractDistributedTransactionManager.StateManagedTransaction(wrappedTransaction);
     }
 
     @Test
@@ -165,7 +164,7 @@ public class AbstractDistributedTransactionManagerTest {
     public void rollback_AfterCommitFailed_ShouldNotThrowAnyException()
         throws CommitException, UnknownTransactionStatusException {
       // Arrange
-      doThrow(CommitException.class).when(distributedTransaction).commit();
+      doThrow(CommitException.class).when(wrappedTransaction).commit();
       assertThatThrownBy(() -> transaction.commit()).isInstanceOf(CommitException.class);
 
       // Act Assert

--- a/core/src/test/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManagerTest.java
@@ -1,0 +1,315 @@
+package com.scalar.db.transaction.common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AbstractTwoPhaseCommitTransactionManagerTest {
+
+  @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
+  @SuppressWarnings("ClassCanBeStatic")
+  @Nested
+  public class TransactionStateManagementTest {
+
+    @Mock private TwoPhaseCommitTransaction twoPhaseCommitTransaction;
+
+    private AbstractTwoPhaseCommitTransactionManager.TransactionStateManagement transaction;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+      MockitoAnnotations.openMocks(this).close();
+
+      // Arrange
+      transaction =
+          new AbstractTwoPhaseCommitTransactionManager.TransactionStateManagement(
+              twoPhaseCommitTransaction);
+    }
+
+    @Test
+    public void crud_ShouldNotThrowAnyException() {
+      // Arrange
+      Get get = mock(Get.class);
+      Scan scan = mock(Scan.class);
+      Put put = mock(Put.class);
+      @SuppressWarnings("unchecked")
+      List<Put> puts = (List<Put>) mock(List.class);
+      Delete delete = mock(Delete.class);
+      @SuppressWarnings("unchecked")
+      List<Delete> deletes = (List<Delete>) mock(List.class);
+      @SuppressWarnings("unchecked")
+      List<Mutation> mutations = (List<Mutation>) mock(List.class);
+
+      // Act Assert
+      assertThatCode(() -> transaction.get(get)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.scan(scan)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.put(put)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.put(puts)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.delete(delete)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.delete(deletes)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.mutate(mutations)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void crud_AfterPrepare_ShouldThrowIllegalStateException() throws PreparationException {
+      // Arrange
+      Get get = mock(Get.class);
+      Scan scan = mock(Scan.class);
+      Put put = mock(Put.class);
+      @SuppressWarnings("unchecked")
+      List<Put> puts = (List<Put>) mock(List.class);
+      Delete delete = mock(Delete.class);
+      @SuppressWarnings("unchecked")
+      List<Delete> deletes = (List<Delete>) mock(List.class);
+      @SuppressWarnings("unchecked")
+      List<Mutation> mutations = (List<Mutation>) mock(List.class);
+
+      transaction.prepare();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.scan(scan)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(put)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(puts)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(delete))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.mutate(mutations))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void crud_AfterRollback_ShouldThrowIllegalStateException() throws RollbackException {
+      // Arrange
+      Get get = mock(Get.class);
+      Scan scan = mock(Scan.class);
+      Put put = mock(Put.class);
+      @SuppressWarnings("unchecked")
+      List<Put> puts = (List<Put>) mock(List.class);
+      Delete delete = mock(Delete.class);
+      @SuppressWarnings("unchecked")
+      List<Delete> deletes = (List<Delete>) mock(List.class);
+      @SuppressWarnings("unchecked")
+      List<Mutation> mutations = (List<Mutation>) mock(List.class);
+
+      transaction.rollback();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.scan(scan)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(put)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.put(puts)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(delete))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.mutate(mutations))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void prepare_ShouldNotThrowAnyException() {
+      // Arrange
+
+      // Act Assert
+      assertThatCode(() -> transaction.prepare()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void prepare_Twice_ShouldThrowIllegalStateException() throws PreparationException {
+      // Arrange
+      transaction.prepare();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void validate_AfterPrepare_ShouldNotThrowAnyException() throws PreparationException {
+      // Arrange
+      transaction.prepare();
+
+      // Act Assert
+      assertThatCode(() -> transaction.validate()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void validate_Twice_ShouldThrowIllegalStateException()
+        throws PreparationException, ValidationException {
+      // Arrange
+      transaction.prepare();
+      transaction.validate();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.validate()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void validate_BeforePrepare_ShouldThrowIllegalStateException() {
+      // Arrange
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.validate()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void validate_AfterPrepareFailed_ShouldThrowIllegalStateException()
+        throws PreparationException {
+      // Arrange
+      doThrow(PreparationException.class).when(twoPhaseCommitTransaction).prepare();
+      assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.validate()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void commit_AfterPrepare_ShouldNotThrowAnyException() throws PreparationException {
+      // Arrange
+      transaction.prepare();
+
+      // Act Assert
+      assertThatCode(() -> transaction.commit()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void commit_AfterValidate_ShouldNotThrowAnyException()
+        throws PreparationException, ValidationException {
+      // Arrange
+      transaction.prepare();
+      transaction.validate();
+
+      // Act Assert
+      assertThatCode(() -> transaction.commit()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void commit_Twice_ShouldThrowIllegalStateException()
+        throws PreparationException, CommitException, UnknownTransactionStatusException {
+      // Arrange
+      transaction.prepare();
+      transaction.commit();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void commit_AfterPrepareFailed_ShouldThrowIllegalStateException()
+        throws PreparationException {
+      // Arrange
+      doThrow(PreparationException.class).when(twoPhaseCommitTransaction).prepare();
+      assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void commit_AfterValidateFailed_ShouldThrowIllegalStateException()
+        throws PreparationException, ValidationException {
+      // Arrange
+      doThrow(ValidationException.class).when(twoPhaseCommitTransaction).validate();
+
+      transaction.prepare();
+      assertThatThrownBy(() -> transaction.validate()).isInstanceOf(ValidationException.class);
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void commit_AfterRollback_ShouldThrowIllegalStateException() throws RollbackException {
+      // Arrange
+      transaction.rollback();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void rollback_ShouldNotThrowAnyException() {
+      // Arrange
+
+      // Act Assert
+      assertThatCode(() -> transaction.rollback()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rollback_AfterCommitFailed_ShouldNotThrowAnyException()
+        throws PreparationException, CommitException, UnknownTransactionStatusException {
+      // Arrange
+      doThrow(CommitException.class).when(twoPhaseCommitTransaction).commit();
+
+      transaction.prepare();
+      assertThatThrownBy(() -> transaction.commit()).isInstanceOf(CommitException.class);
+
+      // Act Assert
+      assertThatCode(() -> transaction.rollback()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rollback_AfterPrepareFailed_ShouldNotThrowAnyException()
+        throws PreparationException {
+      // Arrange
+      doThrow(PreparationException.class).when(twoPhaseCommitTransaction).prepare();
+      assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
+
+      // Act Assert
+      assertThatCode(() -> transaction.rollback()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rollback_AfterValidateFailed_ShouldNotThrowAnyException()
+        throws PreparationException, ValidationException {
+      // Arrange
+      doThrow(ValidationException.class).when(twoPhaseCommitTransaction).validate();
+
+      transaction.prepare();
+      assertThatThrownBy(() -> transaction.validate()).isInstanceOf(ValidationException.class);
+
+      // Act Assert
+      assertThatCode(() -> transaction.rollback()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rollback_AfterCommit_ShouldThrowIllegalStateException()
+        throws PreparationException, CommitException, UnknownTransactionStatusException {
+      // Arrange
+      transaction.prepare();
+      transaction.commit();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.rollback()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void rollback_Twice_ShouldThrowIllegalStateException() throws RollbackException {
+      // Arrange
+      transaction.rollback();
+
+      // Act Assert
+      assertThatThrownBy(() -> transaction.rollback()).isInstanceOf(IllegalStateException.class);
+    }
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManagerTest.java
@@ -29,11 +29,11 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
   @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
   @SuppressWarnings("ClassCanBeStatic")
   @Nested
-  public class TransactionStateManagementTest {
+  public class StateManagedTransactionTest {
 
-    @Mock private TwoPhaseCommitTransaction twoPhaseCommitTransaction;
+    @Mock private TwoPhaseCommitTransaction wrappedTransaction;
 
-    private AbstractTwoPhaseCommitTransactionManager.TransactionStateManagement transaction;
+    private AbstractTwoPhaseCommitTransactionManager.StateManagedTransaction transaction;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -41,8 +41,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
 
       // Arrange
       transaction =
-          new AbstractTwoPhaseCommitTransactionManager.TransactionStateManagement(
-              twoPhaseCommitTransaction);
+          new AbstractTwoPhaseCommitTransactionManager.StateManagedTransaction(wrappedTransaction);
     }
 
     @Test
@@ -176,7 +175,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
     public void validate_AfterPrepareFailed_ShouldThrowIllegalStateException()
         throws PreparationException {
       // Arrange
-      doThrow(PreparationException.class).when(twoPhaseCommitTransaction).prepare();
+      doThrow(PreparationException.class).when(wrappedTransaction).prepare();
       assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
 
       // Act Assert
@@ -218,7 +217,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
     public void commit_AfterPrepareFailed_ShouldThrowIllegalStateException()
         throws PreparationException {
       // Arrange
-      doThrow(PreparationException.class).when(twoPhaseCommitTransaction).prepare();
+      doThrow(PreparationException.class).when(wrappedTransaction).prepare();
       assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
 
       // Act Assert
@@ -229,7 +228,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
     public void commit_AfterValidateFailed_ShouldThrowIllegalStateException()
         throws PreparationException, ValidationException {
       // Arrange
-      doThrow(ValidationException.class).when(twoPhaseCommitTransaction).validate();
+      doThrow(ValidationException.class).when(wrappedTransaction).validate();
 
       transaction.prepare();
       assertThatThrownBy(() -> transaction.validate()).isInstanceOf(ValidationException.class);
@@ -259,7 +258,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
     public void rollback_AfterCommitFailed_ShouldNotThrowAnyException()
         throws PreparationException, CommitException, UnknownTransactionStatusException {
       // Arrange
-      doThrow(CommitException.class).when(twoPhaseCommitTransaction).commit();
+      doThrow(CommitException.class).when(wrappedTransaction).commit();
 
       transaction.prepare();
       assertThatThrownBy(() -> transaction.commit()).isInstanceOf(CommitException.class);
@@ -272,7 +271,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
     public void rollback_AfterPrepareFailed_ShouldNotThrowAnyException()
         throws PreparationException {
       // Arrange
-      doThrow(PreparationException.class).when(twoPhaseCommitTransaction).prepare();
+      doThrow(PreparationException.class).when(wrappedTransaction).prepare();
       assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
 
       // Act Assert
@@ -283,7 +282,7 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
     public void rollback_AfterValidateFailed_ShouldNotThrowAnyException()
         throws PreparationException, ValidationException {
       // Arrange
-      doThrow(ValidationException.class).when(twoPhaseCommitTransaction).validate();
+      doThrow(ValidationException.class).when(wrappedTransaction).validate();
 
       transaction.prepare();
       assertThatThrownBy(() -> transaction.validate()).isInstanceOf(ValidationException.class);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -15,7 +15,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
+import com.scalar.db.transaction.common.WrappedDistributedTransaction;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,8 +63,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -80,8 +79,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin(ANY_TX_ID))
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -97,12 +95,10 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction1 =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
     ConsensusCommit transaction2 =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -124,8 +120,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -141,8 +136,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start(ANY_TX_ID))
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.start(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -158,9 +152,9 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction)
+            ((WrappedDistributedTransaction)
                     manager.start(com.scalar.db.api.Isolation.SERIALIZABLE))
-                .getActualTransaction();
+                .getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -185,12 +179,10 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction1 =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.start()).getOriginalTransaction();
     ConsensusCommit transaction2 =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.start())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -16,7 +16,7 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransactionManager;
+import com.scalar.db.transaction.common.WrappedTwoPhaseCommitTransaction;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,8 +66,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -83,8 +82,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.begin(ANY_TX_ID))
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.begin(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -100,12 +98,10 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction1 =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
     TwoPhaseConsensusCommit transaction2 =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -127,8 +123,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.start())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -144,8 +139,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.start(ANY_TX_ID))
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.start(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -161,13 +155,10 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction1 =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.start())
-                .getActualTransaction();
-
+            ((WrappedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
     TwoPhaseConsensusCommit transaction2 =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.start())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -189,8 +180,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager.join(ANY_TX_ID))
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager.join(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -35,7 +35,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
+import com.scalar.db.transaction.common.WrappedDistributedTransaction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -522,8 +522,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -600,8 +599,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -892,8 +890,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -961,8 +958,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((AbstractDistributedTransactionManager.ActiveTransaction) manager.begin())
-                .getActualTransaction();
+            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -28,7 +28,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransactionManager;
+import com.scalar.db.transaction.common.WrappedTwoPhaseCommitTransaction;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Collections;
 import java.util.List;
@@ -498,8 +498,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager1.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -578,8 +577,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager1.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -880,8 +878,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager1.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -954,8 +951,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((AbstractTwoPhaseCommitTransactionManager.ActiveTransaction) manager1.begin())
-                .getActualTransaction();
+            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->


### PR DESCRIPTION
This PR adds transaction state management to improve usability. The purpose of this state management is to unify the call sequence of the transaction object (e.g. CRUD -> prepare -> validate -> commit or CRUD -> prepare (failed) -> rollback, etc.). I'll add inline comments for the details. Please take a look!