### PR TITLE
Add description of limitations of data types

### DIFF
--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -446,9 +446,9 @@ However, the following types in JDBC databases are converted differently when th
 | TEXT     | VARCHAR(64)   | VARCHAR(10485760) | VARCHAR2(64) |
 | BLOB     | VARBINARY(64) |                   | RAW(64)      |
 
-If this data type mapping doesn't match your application, please alter the tables to change the data types after creating them with this tool.
+Also, `BIGINT` of Scalar DB supports a value from -2^53 to 2^53 even if you use any databases.
 
-Also, the data types of Scalar DB have some limitations. For example, BIGINT has a limitation of range. Please refer to the [javadoc](https://javadoc.io/doc/com.scalar-labs/scalardb/latest/index.html) (`com.scalar.db.io` package) for more details of the data types of Scalar DB.
+If this data type mapping doesn't match your application, please alter the tables to change the data types after creating them with this tool.
 
 ## Internal metadata for Consensus Commit
 

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -446,7 +446,7 @@ However, the following types in JDBC databases are converted differently when th
 | TEXT     | VARCHAR(64)   | VARCHAR(10485760) | VARCHAR2(64) |
 | BLOB     | VARBINARY(64) |                   | RAW(64)      |
 
-Also, `BIGINT` of Scalar DB supports a value from -2^53 to 2^53 even if you use any databases.
+The value range of `BIGINT` in Scalar DB is from -2^53 to 2^53 regardless of the underlying database.
 
 If this data type mapping doesn't match your application, please alter the tables to change the data types after creating them with this tool.
 

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -448,6 +448,8 @@ However, the following types in JDBC databases are converted differently when th
 
 If this data type mapping doesn't match your application, please alter the tables to change the data types after creating them with this tool.
 
+Also, the data types of Scalar DB have some limitations. For example, BIGINT has a limitation of range. Please refer to the [javadoc](https://javadoc.io/doc/com.scalar-labs/scalardb/latest/index.html) (`com.scalar.db.io` package) for more details of the data types of Scalar DB.
+
 ## Internal metadata for Consensus Commit
 
 The Consensus Commit transaction manager manages metadata (e.g., transaction ID, record version, transaction status) stored along with the actual records to handle transactions properly.


### PR DESCRIPTION
This PR adds the description of limitations of data types in the docs of the schema. For example, the range of `BIGINT` is described in the javadoc only. So, I added the link of javadoc to see the details of data types.

Please take a look!
