### PR TITLE
Separate active transaction management from AbstractDistributedTransactionManager and AbstractTwoPhaseCommitTransactionManager

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractDistributedTransactionManager.java
@@ -9,49 +9,25 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
-import com.scalar.db.util.ActiveExpiringMap;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class AbstractDistributedTransactionManager
     implements DistributedTransactionManager {
 
-  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(AbstractDistributedTransactionManager.class);
-
   private Optional<String> namespace;
   private Optional<String> tableName;
 
-  private final ActiveExpiringMap<String, DistributedTransaction> activeTransactions;
-
-  public AbstractDistributedTransactionManager(DatabaseConfig config) {
+  public AbstractDistributedTransactionManager() {
     namespace = Optional.empty();
     tableName = Optional.empty();
-    activeTransactions =
-        new ActiveExpiringMap<>(
-            config.getActiveTransactionManagementExpirationTimeMillis(),
-            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
-            t -> {
-              logger.warn("the transaction is expired. transactionId: {}", t.getId());
-              try {
-                t.rollback();
-              } catch (RollbackException e) {
-                logger.warn("rollback failed", e);
-              }
-            });
   }
 
   /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
@@ -90,109 +66,9 @@ public abstract class AbstractDistributedTransactionManager
     return tableName;
   }
 
-  private void addActiveTransaction(DistributedTransaction transaction)
-      throws TransactionException {
-    if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
-      transaction.rollback();
-      throw new IllegalStateException(
-          "The transaction already exists. transactionId: " + transaction.getId());
-    }
-  }
-
-  private void removeActiveTransaction(String transactionId) {
-    activeTransactions.remove(transactionId);
-  }
-
-  @Override
-  public DistributedTransaction resume(String txId) {
-    return activeTransactions
-        .get(txId)
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    "A transaction associated with the specified transaction ID is not found. "
-                        + "It might have been expired. transactionId: "
-                        + txId));
-  }
-
   protected DistributedTransaction activate(DistributedTransaction transaction)
       throws TransactionException {
-    return new ActiveTransaction(new StateManagedTransaction(transaction));
-  }
-
-  private class ActiveTransaction extends AbstractDistributedTransaction
-      implements WrappedDistributedTransaction {
-
-    private final DistributedTransaction transaction;
-
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
-    private ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
-      this.transaction = transaction;
-      addActiveTransaction(this);
-    }
-
-    @Override
-    public String getId() {
-      return transaction.getId();
-    }
-
-    @Override
-    public Optional<Result> get(Get get) throws CrudException {
-      return transaction.get(get);
-    }
-
-    @Override
-    public List<Result> scan(Scan scan) throws CrudException {
-      return transaction.scan(scan);
-    }
-
-    @Override
-    public void put(Put put) throws CrudException {
-      transaction.put(put);
-    }
-
-    @Override
-    public void put(List<Put> puts) throws CrudException {
-      transaction.put(puts);
-    }
-
-    @Override
-    public void delete(Delete delete) throws CrudException {
-      transaction.delete(delete);
-    }
-
-    @Override
-    public void delete(List<Delete> deletes) throws CrudException {
-      transaction.delete(deletes);
-    }
-
-    @Override
-    public void mutate(List<? extends Mutation> mutations) throws CrudException {
-      transaction.mutate(mutations);
-    }
-
-    @Override
-    public void commit() throws CommitException, UnknownTransactionStatusException {
-      transaction.commit();
-      removeActiveTransaction(getId());
-    }
-
-    @Override
-    public void rollback() throws RollbackException {
-      try {
-        transaction.rollback();
-      } finally {
-        removeActiveTransaction(getId());
-      }
-    }
-
-    @Override
-    public DistributedTransaction getOriginalTransaction() {
-      if (transaction instanceof WrappedDistributedTransaction) {
-        return ((WrappedDistributedTransaction) transaction).getOriginalTransaction();
-      }
-      return transaction;
-    }
+    return new StateManagedTransaction(transaction);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -9,7 +9,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
-import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
@@ -17,43 +16,20 @@ import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
-import com.scalar.db.util.ActiveExpiringMap;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class AbstractTwoPhaseCommitTransactionManager
     implements TwoPhaseCommitTransactionManager {
 
-  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(AbstractTwoPhaseCommitTransactionManager.class);
-
   private Optional<String> namespace;
   private Optional<String> tableName;
 
-  private final ActiveExpiringMap<String, TwoPhaseCommitTransaction> activeTransactions;
-
-  public AbstractTwoPhaseCommitTransactionManager(DatabaseConfig config) {
+  public AbstractTwoPhaseCommitTransactionManager() {
     namespace = Optional.empty();
     tableName = Optional.empty();
-    activeTransactions =
-        new ActiveExpiringMap<>(
-            config.getActiveTransactionManagementExpirationTimeMillis(),
-            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
-            t -> {
-              logger.warn("the transaction is expired. transactionId: {}", t.getId());
-              try {
-                t.rollback();
-              } catch (RollbackException e) {
-                logger.warn("rollback failed", e);
-              }
-            });
   }
 
   /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
@@ -92,118 +68,9 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     return tableName;
   }
 
-  private void addActiveTransaction(ActiveTransaction transaction) throws TransactionException {
-    if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
-      transaction.rollback();
-      throw new IllegalStateException(
-          "The transaction already exists. transactionId: " + transaction.getId());
-    }
-  }
-
-  private void removeActiveTransaction(String transactionId) {
-    activeTransactions.remove(transactionId);
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction resume(String txId) {
-    return activeTransactions
-        .get(txId)
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    "A transaction associated with the specified transaction ID is not found. "
-                        + "It might have been expired. transactionId: "
-                        + txId));
-  }
-
   protected TwoPhaseCommitTransaction activate(TwoPhaseCommitTransaction transaction)
       throws TransactionException {
-    return new ActiveTransaction(new StateManagedTransaction(transaction));
-  }
-
-  private class ActiveTransaction extends AbstractTwoPhaseCommitTransaction
-      implements WrappedTwoPhaseCommitTransaction {
-
-    private final TwoPhaseCommitTransaction transaction;
-
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
-    private ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
-      this.transaction = transaction;
-      addActiveTransaction(this);
-    }
-
-    @Override
-    public String getId() {
-      return transaction.getId();
-    }
-
-    @Override
-    public Optional<Result> get(Get get) throws CrudException {
-      return transaction.get(get);
-    }
-
-    @Override
-    public List<Result> scan(Scan scan) throws CrudException {
-      return transaction.scan(scan);
-    }
-
-    @Override
-    public void put(Put put) throws CrudException {
-      transaction.put(put);
-    }
-
-    @Override
-    public void put(List<Put> puts) throws CrudException {
-      transaction.put(puts);
-    }
-
-    @Override
-    public void delete(Delete delete) throws CrudException {
-      transaction.delete(delete);
-    }
-
-    @Override
-    public void delete(List<Delete> deletes) throws CrudException {
-      transaction.delete(deletes);
-    }
-
-    @Override
-    public void mutate(List<? extends Mutation> mutations) throws CrudException {
-      transaction.mutate(mutations);
-    }
-
-    @Override
-    public void prepare() throws PreparationException {
-      transaction.prepare();
-    }
-
-    @Override
-    public void validate() throws ValidationException {
-      transaction.validate();
-    }
-
-    @Override
-    public void commit() throws CommitException, UnknownTransactionStatusException {
-      transaction.commit();
-      removeActiveTransaction(getId());
-    }
-
-    @Override
-    public void rollback() throws RollbackException {
-      try {
-        transaction.rollback();
-      } finally {
-        removeActiveTransaction(getId());
-      }
-    }
-
-    @Override
-    public TwoPhaseCommitTransaction getOriginalTransaction() {
-      if (transaction instanceof WrappedTwoPhaseCommitTransaction) {
-        return ((WrappedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
-      }
-      return transaction;
-    }
+    return new StateManagedTransaction(transaction);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTransactionManager.java
@@ -45,8 +45,7 @@ public abstract class ActiveTransactionManagedTransactionManager
             });
   }
 
-  private void addActiveTransaction(DistributedTransaction transaction)
-      throws TransactionException {
+  private void add(DistributedTransaction transaction) throws TransactionException {
     if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
       transaction.rollback();
       throw new IllegalStateException(
@@ -54,7 +53,7 @@ public abstract class ActiveTransactionManagedTransactionManager
     }
   }
 
-  private void removeActiveTransaction(String transactionId) {
+  private void remove(String transactionId) {
     activeTransactions.remove(transactionId);
   }
 
@@ -84,7 +83,7 @@ public abstract class ActiveTransactionManagedTransactionManager
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
       this.transaction = transaction;
-      addActiveTransaction(this);
+      add(this);
     }
 
     @Override
@@ -130,7 +129,7 @@ public abstract class ActiveTransactionManagedTransactionManager
     @Override
     public void commit() throws CommitException, UnknownTransactionStatusException {
       transaction.commit();
-      removeActiveTransaction(getId());
+      remove(getId());
     }
 
     @Override
@@ -138,7 +137,7 @@ public abstract class ActiveTransactionManagedTransactionManager
       try {
         transaction.rollback();
       } finally {
-        removeActiveTransaction(getId());
+        remove(getId());
       }
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTransactionManager.java
@@ -1,0 +1,153 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.util.ActiveExpiringMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ActiveTransactionManagedTransactionManager
+    extends AbstractDistributedTransactionManager {
+
+  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(ActiveTransactionManagedTransactionManager.class);
+
+  private final ActiveExpiringMap<String, DistributedTransaction> activeTransactions;
+
+  public ActiveTransactionManagedTransactionManager(DatabaseConfig config) {
+    activeTransactions =
+        new ActiveExpiringMap<>(
+            config.getActiveTransactionManagementExpirationTimeMillis(),
+            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
+            t -> {
+              logger.warn("the transaction is expired. transactionId: {}", t.getId());
+              try {
+                t.rollback();
+              } catch (RollbackException e) {
+                logger.warn("rollback failed", e);
+              }
+            });
+  }
+
+  private void addActiveTransaction(DistributedTransaction transaction)
+      throws TransactionException {
+    if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
+      transaction.rollback();
+      throw new IllegalStateException(
+          "The transaction already exists. transactionId: " + transaction.getId());
+    }
+  }
+
+  private void removeActiveTransaction(String transactionId) {
+    activeTransactions.remove(transactionId);
+  }
+
+  @Override
+  public DistributedTransaction resume(String txId) {
+    return activeTransactions
+        .get(txId)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "A transaction associated with the specified transaction ID is not found. "
+                        + "It might have been expired. transactionId: "
+                        + txId));
+  }
+
+  @Override
+  protected DistributedTransaction activate(DistributedTransaction transaction)
+      throws TransactionException {
+    return new ActiveTransaction(super.activate(transaction));
+  }
+
+  private class ActiveTransaction extends AbstractDistributedTransaction
+      implements WrappedDistributedTransaction {
+
+    private final DistributedTransaction transaction;
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    private ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
+      this.transaction = transaction;
+      addActiveTransaction(this);
+    }
+
+    @Override
+    public String getId() {
+      return transaction.getId();
+    }
+
+    @Override
+    public Optional<Result> get(Get get) throws CrudException {
+      return transaction.get(get);
+    }
+
+    @Override
+    public List<Result> scan(Scan scan) throws CrudException {
+      return transaction.scan(scan);
+    }
+
+    @Override
+    public void put(Put put) throws CrudException {
+      transaction.put(put);
+    }
+
+    @Override
+    public void put(List<Put> puts) throws CrudException {
+      transaction.put(puts);
+    }
+
+    @Override
+    public void delete(Delete delete) throws CrudException {
+      transaction.delete(delete);
+    }
+
+    @Override
+    public void delete(List<Delete> deletes) throws CrudException {
+      transaction.delete(deletes);
+    }
+
+    @Override
+    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+      transaction.mutate(mutations);
+    }
+
+    @Override
+    public void commit() throws CommitException, UnknownTransactionStatusException {
+      transaction.commit();
+      removeActiveTransaction(getId());
+    }
+
+    @Override
+    public void rollback() throws RollbackException {
+      try {
+        transaction.rollback();
+      } finally {
+        removeActiveTransaction(getId());
+      }
+    }
+
+    @Override
+    public DistributedTransaction getOriginalTransaction() {
+      if (transaction instanceof WrappedDistributedTransaction) {
+        return ((WrappedDistributedTransaction) transaction).getOriginalTransaction();
+      }
+      return transaction;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -47,7 +47,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
             });
   }
 
-  private void addActiveTransaction(ActiveTransaction transaction) throws TransactionException {
+  private void add(ActiveTransaction transaction) throws TransactionException {
     if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
       transaction.rollback();
       throw new IllegalStateException(
@@ -55,7 +55,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     }
   }
 
-  private void removeActiveTransaction(String transactionId) {
+  private void remove(String transactionId) {
     activeTransactions.remove(transactionId);
   }
 
@@ -85,7 +85,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
       this.transaction = transaction;
-      addActiveTransaction(this);
+      add(this);
     }
 
     @Override
@@ -141,7 +141,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @Override
     public void commit() throws CommitException, UnknownTransactionStatusException {
       transaction.commit();
-      removeActiveTransaction(getId());
+      remove(getId());
     }
 
     @Override
@@ -149,7 +149,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       try {
         transaction.rollback();
       } finally {
-        removeActiveTransaction(getId());
+        remove(getId());
       }
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -1,0 +1,164 @@
+package com.scalar.db.transaction.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.util.ActiveExpiringMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
+    extends AbstractTwoPhaseCommitTransactionManager {
+
+  private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(AbstractTwoPhaseCommitTransactionManager.class);
+
+  private final ActiveExpiringMap<String, TwoPhaseCommitTransaction> activeTransactions;
+
+  public ActiveTransactionManagedTwoPhaseCommitTransactionManager(DatabaseConfig config) {
+    activeTransactions =
+        new ActiveExpiringMap<>(
+            config.getActiveTransactionManagementExpirationTimeMillis(),
+            TRANSACTION_EXPIRATION_INTERVAL_MILLIS,
+            t -> {
+              logger.warn("the transaction is expired. transactionId: {}", t.getId());
+              try {
+                t.rollback();
+              } catch (RollbackException e) {
+                logger.warn("rollback failed", e);
+              }
+            });
+  }
+
+  private void addActiveTransaction(ActiveTransaction transaction) throws TransactionException {
+    if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
+      transaction.rollback();
+      throw new IllegalStateException(
+          "The transaction already exists. transactionId: " + transaction.getId());
+    }
+  }
+
+  private void removeActiveTransaction(String transactionId) {
+    activeTransactions.remove(transactionId);
+  }
+
+  @Override
+  public TwoPhaseCommitTransaction resume(String txId) {
+    return activeTransactions
+        .get(txId)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "A transaction associated with the specified transaction ID is not found. "
+                        + "It might have been expired. transactionId: "
+                        + txId));
+  }
+
+  @Override
+  protected TwoPhaseCommitTransaction activate(TwoPhaseCommitTransaction transaction)
+      throws TransactionException {
+    return new ActiveTransaction(super.activate(transaction));
+  }
+
+  private class ActiveTransaction extends AbstractTwoPhaseCommitTransaction
+      implements WrappedTwoPhaseCommitTransaction {
+
+    private final TwoPhaseCommitTransaction transaction;
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    private ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
+      this.transaction = transaction;
+      addActiveTransaction(this);
+    }
+
+    @Override
+    public String getId() {
+      return transaction.getId();
+    }
+
+    @Override
+    public Optional<Result> get(Get get) throws CrudException {
+      return transaction.get(get);
+    }
+
+    @Override
+    public List<Result> scan(Scan scan) throws CrudException {
+      return transaction.scan(scan);
+    }
+
+    @Override
+    public void put(Put put) throws CrudException {
+      transaction.put(put);
+    }
+
+    @Override
+    public void put(List<Put> puts) throws CrudException {
+      transaction.put(puts);
+    }
+
+    @Override
+    public void delete(Delete delete) throws CrudException {
+      transaction.delete(delete);
+    }
+
+    @Override
+    public void delete(List<Delete> deletes) throws CrudException {
+      transaction.delete(deletes);
+    }
+
+    @Override
+    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+      transaction.mutate(mutations);
+    }
+
+    @Override
+    public void prepare() throws PreparationException {
+      transaction.prepare();
+    }
+
+    @Override
+    public void validate() throws ValidationException {
+      transaction.validate();
+    }
+
+    @Override
+    public void commit() throws CommitException, UnknownTransactionStatusException {
+      transaction.commit();
+      removeActiveTransaction(getId());
+    }
+
+    @Override
+    public void rollback() throws RollbackException {
+      try {
+        transaction.rollback();
+      } finally {
+        removeActiveTransaction(getId());
+      }
+    }
+
+    @Override
+    public TwoPhaseCommitTransaction getOriginalTransaction() {
+      if (transaction instanceof WrappedTwoPhaseCommitTransaction) {
+        return ((WrappedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
+      }
+      return transaction;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -14,7 +14,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
+import com.scalar.db.transaction.common.ActiveTransactionManagedTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class ConsensusCommitManager extends AbstractDistributedTransactionManager {
+public class ConsensusCommitManager extends ActiveTransactionManagedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(ConsensusCommitManager.class);
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -12,7 +12,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransactionManager;
+import com.scalar.db.transaction.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
@@ -21,7 +21,8 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 @ThreadSafe
-public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransactionManager {
+public class TwoPhaseConsensusCommitManager
+    extends ActiveTransactionManagedTwoPhaseCommitTransactionManager {
 
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -16,7 +16,7 @@ import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.db.storage.jdbc.query.QueryBuilder;
-import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
+import com.scalar.db.transaction.common.ActiveTransactionManagedTransactionManager;
 import java.sql.SQLException;
 import java.util.UUID;
 import javax.annotation.concurrent.ThreadSafe;
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class JdbcTransactionManager extends AbstractDistributedTransactionManager {
+public class JdbcTransactionManager extends ActiveTransactionManagedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(JdbcTransactionManager.class);
 
   private final BasicDataSource dataSource;

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
@@ -20,7 +20,7 @@ import com.scalar.db.rpc.RollbackRequest;
 import com.scalar.db.rpc.RollbackResponse;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcConfig;
-import com.scalar.db.transaction.common.AbstractDistributedTransactionManager;
+import com.scalar.db.transaction.common.ActiveTransactionManagedTransactionManager;
 import com.scalar.db.util.ProtoUtils;
 import com.scalar.db.util.ThrowableSupplier;
 import com.scalar.db.util.retry.Retry;
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class GrpcTransactionManager extends AbstractDistributedTransactionManager {
+public class GrpcTransactionManager extends ActiveTransactionManagedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(GrpcTransactionManager.class);
 
   static final Retry.ExceptionFactory<TransactionException> EXCEPTION_FACTORY =

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
@@ -20,7 +20,7 @@ import com.scalar.db.rpc.RollbackResponse;
 import com.scalar.db.rpc.TwoPhaseCommitTransactionGrpc;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcConfig;
-import com.scalar.db.transaction.common.AbstractTwoPhaseCommitTransactionManager;
+import com.scalar.db.transaction.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager;
 import com.scalar.db.util.ProtoUtils;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NettyChannelBuilder;
@@ -31,7 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class GrpcTwoPhaseCommitTransactionManager extends AbstractTwoPhaseCommitTransactionManager {
+public class GrpcTwoPhaseCommitTransactionManager
+    extends ActiveTransactionManagedTwoPhaseCommitTransactionManager {
   private static final Logger logger =
       LoggerFactory.getLogger(GrpcTwoPhaseCommitTransactionManager.class);
 


### PR DESCRIPTION
This is a refactoring thing. This PR separate the active transaction management from `AbstractDistributedTransactionManager` and `AbstractTwoPhaseCommitTransactionManager`, and it adds `ActiveTransactionManagedTransactionManager` and `ActiveTransactionManagedTransactionManager` to manage active transactions.