### PR TITLE
Fix CVE-2022-32149

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.32 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.13
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.14
 ENV DOCKERIZE_VERSION v0.6.1
 
 # Install grpc_health_probe for kubernetes.


### PR DESCRIPTION
This PR fixes CVE-2022-32149 by upgrading [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe).