### PR TITLE
Fix dependency and spotbugs issues for >JDK 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ subprojects {
         sqlserverDriverVersion = '8.4.1.jre8'
         grpcVersion = '1.46.0'
         protobufVersion = '3.20.1'
+        annotationVersion = '1.3.2'
         picocliVersion = '4.1.4'
         scalarAdminVersion = '1.2.0'
         dropwizardMetricsVersion = '4.2.2'

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -5,6 +5,8 @@
       <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
       <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
       <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+      <!-- Temporarily excluded. See https://github.com/spotbugs/spotbugs/issues/1694 -->
+      <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
     </Or>
   </Match>
 

--- a/rpc/build.gradle
+++ b/rpc/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     api "io.grpc:grpc-protobuf:${grpcVersion}"
     api "io.grpc:grpc-stub:${grpcVersion}"
     api "io.grpc:grpc-services:${grpcVersion}"
+    implementation "javax.annotation:javax.annotation-api:${annotationVersion}"
 }
 
 javadoc {


### PR DESCRIPTION
A similar change to https://github.com/scalar-labs/scalardb-sql/pull/74. PTAL~

> I noticed we can't build this project with JDK 9 or later, but JDK 8 isn't actively supported. So I tried supporting JDK 9 or later by fixing build dependency and spotbugs issues while I tested it only with JDK 11.
> The package of this project is built on CI using JDK 8, so I don't think this change affects the Maven package artifacts.

~"spotlessApply" gradle task changed the Javadoc comments this time, though.~ 
Hmm. ~This~ `spotlessCheck` error happened only on my laptop. Reverted the changes.