### PR TITLE
Throw an exception when putting an empty value to a secondary index column in Dynamo DB

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoOperationChecker.java
@@ -26,9 +26,9 @@ public class DynamoOperationChecker extends OperationChecker {
         .filter(column -> metadata.getSecondaryIndexNames().contains(column.getName()))
         .forEach(
             column -> {
-              if (!new ColumnChecker(metadata, true, false, false, false).check(column)) {
+              if (!new ColumnChecker(metadata, true, false, true, false).check(column)) {
                 throw new IllegalArgumentException(
-                    "A secondary index column cannot be set to null in DynamoDB. Operation: "
+                    "A secondary index column cannot be set to null or an empty value (for Text and Blob) in DynamoDB. Operation: "
                         + put);
               }
             });


### PR DESCRIPTION
Since Dynamo DB doesn't allow putting an empty value to a secondary index column, we should throw an exception in that situation. Please take a look!