### PR TITLE
Automatically terminate idle parallel execution threads not to block JVM shutdown

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -29,6 +29,7 @@ public class ConsensusCommitConfig {
 
   public static final String ASYNC_COMMIT_ENABLED = PREFIX + "async_commit.enabled";
   public static final String ASYNC_ROLLBACK_ENABLED = PREFIX + "async_rollback.enabled";
+  public static final String IDLE_THREAD_AUTO_TERMINATION_ENABLED = PREFIX + "idle_thread_auto_termination.enabled";
 
   public static final int DEFAULT_PARALLEL_EXECUTOR_COUNT = 128;
 
@@ -45,6 +46,7 @@ public class ConsensusCommitConfig {
   private final boolean parallelRollbackEnabled;
   private final boolean asyncCommitEnabled;
   private final boolean asyncRollbackEnabled;
+  private final boolean idleThreadAutoTerminationEnabled;
 
   private final boolean isIncludeMetadataEnabled;
 
@@ -104,6 +106,8 @@ public class ConsensusCommitConfig {
     asyncCommitEnabled = getBoolean(databaseConfig.getProperties(), ASYNC_COMMIT_ENABLED, true);
     asyncRollbackEnabled =
         getBoolean(databaseConfig.getProperties(), ASYNC_ROLLBACK_ENABLED, asyncCommitEnabled);
+    idleThreadAutoTerminationEnabled =
+        getBoolean(databaseConfig.getProperties(), IDLE_THREAD_AUTO_TERMINATION_ENABLED, false);
     isIncludeMetadataEnabled =
         getBoolean(databaseConfig.getProperties(), INCLUDE_METADATA_ENABLED, false);
   }
@@ -146,6 +150,10 @@ public class ConsensusCommitConfig {
 
   public boolean isAsyncRollbackEnabled() {
     return asyncRollbackEnabled;
+  }
+
+  public boolean isIdleThreadAutoTerminationEnabled() {
+    return idleThreadAutoTerminationEnabled;
   }
 
   public boolean isIncludeMetadataEnabled() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
@@ -44,13 +44,13 @@ public class ParallelExecutor {
       return;
     }
     Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setDaemon(true).setNameFormat("idle-thread-auto-terminator-%d").build())
-        .schedule(() -> {
+        .scheduleAtFixedRate(() -> {
+          // TODO: Make the timeout and interval configurable
           Instant thresholdOfIdleTimeout = Instant.now().minusSeconds(30);
           if (lastParallelTaskTime.get().isBefore(thresholdOfIdleTimeout)) {
-            logger.info("Detected idle parallel-execution thread (last timestamp: {}). Stopping it", lastParallelTaskTime.get());
             teardownParallelExecutionService();
           }
-        }, 10, TimeUnit.SECONDS);
+        }, 10, 10, TimeUnit.SECONDS);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
In current implementation, `scalar.db.consensus_commit.parallel_commit.enabled` is true by default. As a result, JVM process won't finish without explicitly calling `System.exit()` or receiving signals. This might block some kinds of applications or components.

In this PR, I'm introducing a background monitor task to terminate `ParallelExecutor#parallelExecutorService` when it's idle. The terminated `parallelExecutorService` will be re-setup when it's needed. This won't cause any error.