### PR TITLE
Fix two unit tests of OperationChecker

### DIFF
--- a/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/common/checker/OperationCheckerTest.java
@@ -537,7 +537,7 @@ public class OperationCheckerTest {
     Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    int limit = -10;
+    int limit = 10;
     Scan scan =
         new Scan(partitionKey)
             .withStart(startClusteringKey)
@@ -562,7 +562,7 @@ public class OperationCheckerTest {
     Key startClusteringKey = new Key(CKEY1, 2, CKEY2, "val1");
     Key endClusteringKey = new Key(CKEY1, 2, CKEY2, "val9");
     List<String> projections = Arrays.asList(COL1, COL2, COL3);
-    int limit = -10;
+    int limit = 10;
     Scan scan =
         new Scan(partitionKey)
             .withStart(startClusteringKey)


### PR DESCRIPTION
I found by chance small errors in two unit tests of the `OperationChecker`, this PR fixes them. Please see the inline comments for more details.

NB: the "docker" CI is failing because of a CVE