### PR TITLE
Make ConsensusCommitAdmin.getNamespaceNames() to not return the coordinator namespace name

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -19,17 +19,7 @@ public class JdbcTransactionAdminIntegrationTest
   }
 
   @Override
-  protected boolean hasCoordinatorTables() {
-    return false;
-  }
-
-  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new JdbcAdminTestUtils(JdbcEnv.getProperties(testName));
-  }
-
-  @Override
-  protected String getCoordinatorNamespace(String testName) {
-    throw new UnsupportedOperationException();
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -16,6 +16,7 @@ import com.scalar.db.service.StorageFactory;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -173,7 +174,9 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
 
   @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
-    return admin.getNamespaceNames();
+    return admin.getNamespaceNames().stream()
+        .filter(namespace -> !namespace.equals(coordinatorNamespace))
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -546,7 +546,7 @@ public abstract class ConsensusCommitAdminTestBase {
   @Test
   public void getNamespacesNames_ShouldCallJdbcAdminProperly() throws ExecutionException {
     // Arrange
-    Set<String> namespaces = ImmutableSet.of("n1", "n2");
+    Set<String> namespaces = ImmutableSet.of("n1", "n2", coordinatorNamespaceName);
     when(distributedStorageAdmin.getNamespaceNames()).thenReturn(namespaces);
 
     // Act

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -103,8 +103,6 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     return NAMESPACE3;
   }
 
-  protected abstract String getCoordinatorNamespace(String testName);
-
   private void createTables() throws ExecutionException {
     Map<String, String> options = getCreationOptions();
     for (String namespace : Arrays.asList(namespace1, namespace2)) {
@@ -626,12 +624,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     Set<String> namespaces = admin.getNamespaceNames();
 
     // Assert
-    if (hasCoordinatorTables()) {
-      assertThat(namespaces)
-          .containsOnly(namespace1, namespace2, getCoordinatorNamespace(TEST_NAME));
-    } else {
-      assertThat(namespaces).containsOnly(namespace1, namespace2);
-    }
+    assertThat(namespaces).containsOnly(namespace1, namespace2);
   }
 
   @Test
@@ -645,19 +638,10 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     admin.upgrade(getCreationOptions());
 
     // Assert
-    if (hasCoordinatorTables()) {
-      assertThat(admin.getNamespaceNames())
-          .containsOnly(namespace1, namespace2, getCoordinatorNamespace(TEST_NAME));
-    } else {
-      assertThat(admin.getNamespaceNames()).containsOnly(namespace1, namespace2);
-    }
+    assertThat(admin.getNamespaceNames()).containsOnly(namespace1, namespace2);
   }
 
   protected boolean isIndexOnBooleanColumnSupported() {
-    return true;
-  }
-
-  protected boolean hasCoordinatorTables() {
     return true;
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
@@ -61,13 +61,6 @@ public abstract class ConsensusCommitAdminIntegrationTestBase
     return properties;
   }
 
-  @Override
-  protected String getCoordinatorNamespace(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
-        .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
-  }
-
   @Test
   public void
       getTableMetadata_WhenIncludeMetadataIsEnabled_ShouldReturnCorrectMetadataWithTransactionMetadataColumns()

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService.java
@@ -64,14 +64,6 @@ public class ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminS
   }
 
   @Override
-  protected String getCoordinatorNamespace(String testName) {
-    String coordinatorNamespace =
-        ServerEnv.getServerProperties1(testName)
-            .getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
-    return coordinatorNamespace + "_" + testName;
-  }
-
-  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     Properties properties = ServerEnv.getServerProperties1(testName);
 


### PR DESCRIPTION
**Background**
This PR is part of the namespace management feature and targets its feature branch [feat/namespaces_management](https://github.com/scalar-labs/scalardb/tree/feat/namespaces_management)

**Changes** 
We decided that the `ConsensusCommitAdmin` methods should not expose the coordinator namespace and table (implemented by https://github.com/scalar-labs/scalardb/pull/702).  
To stay consistent, this updates the `ConsensusCommitAdmin.getNamespaceNames()` to not return the coordinator namespace name.