### PR TITLE
Make ParallelExecutor workers daemon thread

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ParallelExecutor.java
@@ -38,7 +38,14 @@ public class ParallelExecutor {
       parallelExecutorService =
           Executors.newFixedThreadPool(
               config.getParallelExecutorCount(),
-              new ThreadFactoryBuilder().setNameFormat("parallel-executor-%d").build());
+              // Make this thread factory create daemon threads not to block JVM termination. JVM
+              // shutdown hook is executed before terminating daemon threads. So, daemon threads
+              // created by this thread factory will be properly terminated after pre-termination
+              // operations are done if the operations are set in JVM shutdown hook.
+              new ThreadFactoryBuilder()
+                  .setNameFormat("parallel-executor-%d")
+                  .setDaemon(true)
+                  .build());
     } else {
       parallelExecutorService = null;
     }


### PR DESCRIPTION
In current implementation, `scalar.db.consensus_commit.parallel_commit.enabled` is true by default. As a result, JVM process won't finish without explicitly calling `ParallelExecutor#close`, `System.exit` or receiving signals. This might block some kinds of applications or components which don't have chance to call `ParallelExecutor#close` for some reasons.

In this PR, we've changed ParallelExecutor workers to daemon threads not to block JVM process termination. Even if a user don't have chance to call `ParallelExecutor#close` for some reasons, `java.lang.Runtime#addShutdownHook` can be used to call the method as it's guaranteed that daemon threads will continue to run during the shutdown sequence https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.html#addShutdownHook(java.lang.Thread)