### PR TITLE
Make JDK11+ use the same google java format version as JDK8 uses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ subprojects {
         protobufPluginVersion = '0.8.17'
         shadowPluginVersion = '7.1.2'
         dockerPluginVersion = '0.25.0'
+        // Make JDK11+ use the same version as JDK8 uses
+        googleJavaFormatVersion = '1.7'
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -184,7 +184,7 @@ spotless {
         target 'src/*/java/**/*.java'
         importOrder()
         removeUnusedImports()
-        googleJavaFormat()
+        googleJavaFormat(googleJavaFormatVersion)
     }
 }
 

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -34,7 +34,7 @@ spotless {
         target 'src/*/java/**/*.java'
         importOrder()
         removeUnusedImports()
-        googleJavaFormat()
+        googleJavaFormat(googleJavaFormatVersion)
     }
 }
 

--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -57,7 +57,7 @@ spotless {
         target 'src/*/java/**/*.java'
         importOrder()
         removeUnusedImports()
-        googleJavaFormat()
+        googleJavaFormat(googleJavaFormatVersion)
     }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -98,7 +98,7 @@ spotless {
         target 'src/*/java/**/*.java'
         importOrder()
         removeUnusedImports()
-        googleJavaFormat()
+        googleJavaFormat(googleJavaFormatVersion)
     }
 }
 


### PR DESCRIPTION
I noticed there were sometimes differences between the spotlessCheck results on my laptop (JDK11) and CI (JDK8.) It seems different versions of https://github.com/google/google-java-format are internally used via the spotless plugin. This PR specifies the google-java-format version to make JDK11+ use the same version as JDK8 uses.