### PR TITLE
Add upgrade command to schema loader

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderIntegrationTest.java
@@ -19,7 +19,7 @@ public class CassandraSchemaLoaderIntegrationTest extends SchemaLoaderIntegratio
   }
 
   @Override
-  protected void waitForKeyspacesTableCreation() {
+  protected void waitForNamespacesTableCreation() {
     // After the keyspaces metadata table is created, since it is not readable right away using the
     // Cluster API of the Cassandra driver, we need to wait a bit.
     Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderIntegrationTest.java
@@ -1,8 +1,10 @@
 package com.scalar.db.storage.cassandra;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 public class CassandraSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTestBase {
 
@@ -14,5 +16,12 @@ public class CassandraSchemaLoaderIntegrationTest extends SchemaLoaderIntegratio
   @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CassandraAdminTestUtils(getProperties(testName));
+  }
+
+  @Override
+  protected void waitForKeyspacesTableCreation() {
+    // After the keyspaces metadata table is created, since it is not readable right away using the
+    // Cluster API of the Cassandra driver, we need to wait a bit.
+    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
@@ -37,4 +37,12 @@ public class DynamoSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTe
         .add("--no-backup")
         .build();
   }
+
+  @Override
+  protected List<String> getCommandArgsForUpgrade(Path configFilePath) {
+    return ImmutableList.<String>builder()
+        .addAll(super.getCommandArgsForUpgrade(configFilePath))
+        .add("--no-backup")
+        .build();
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.scalar.db.storage.multistorage;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTestBase {
   @Override
@@ -55,5 +57,13 @@ public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegra
     return new MultiStorageAdminTestUtils(
         MultiStorageEnv.getPropertiesForCassandra(testName),
         MultiStorageEnv.getPropertiesForJdbc(testName));
+  }
+
+  @Override
+  protected void waitForKeyspacesTableCreation() {
+    // For Cassandra
+    // After the keyspaces metadata table is created, since it is not readable right away using the
+    // Cluster API of the Cassandra driver, we need to wait a bit.
+    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
@@ -60,7 +60,7 @@ public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegra
   }
 
   @Override
-  protected void waitForKeyspacesTableCreation() {
+  protected void waitForNamespacesTableCreation() {
     // For Cassandra
     // After the keyspaces metadata table is created, since it is not readable right away using the
     // Cluster API of the Cassandra driver, we need to wait a bit.

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -76,6 +76,13 @@ Create/Delete schemas in the storage defined in the config file
                       The replication strategy, must be SimpleStrategy or
                         NetworkTopologyStrategy (supported in Cassandra)
       --ru=<ru>       Base resource unit (supported in DynamoDB, Cosmos DB)
+      --upgrade       Upgrades the Scalar DB environment to support the latest
+                        version of the Scalar DB API. Typically, you will be
+                        requested, as indicated on the release notes, to run
+                        this command after updating the Scalar DB version of
+                        your application environment.
+
+
 ```
 
 For Cosmos DB (Deprecated. Please use the command using a config file instead):
@@ -312,6 +319,15 @@ $ java -jar scalardb-schema-loader-<version>.jar --cassandra -h <CASSANDRA_IP> [
 $ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> -p <PASSWORD> -f schema.json --repair-all
 ```
 
+### Upgrade the Scalar DB environment
+This command will upgrade the Scalar DB environment to support the latest version of the Scalar DB API. Typically, you will be requested, as indicated on the release notes, to run
+this command after updating the Scalar DB version of your application environment.
+
+Running the command requires a Scalar DB config file (a sample config file can be found [here](https://github.com/scalar-labs/scalardb/blob/master/conf/database.properties))
+```console
+$ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> --upgrade
+```
+
 ### Sample schema file
 
 The sample schema is as follows (Sample schema file can be found [here](https://github.com/scalar-labs/scalardb/blob/master/schema-loader/sample/schema_sample.json)):
@@ -465,7 +481,7 @@ dependencies {
 }
 ```
 
-### Create, alter, repair and delete
+### Code sample
 
 You can create, alter, delete and repair tables that are defined in the schema using SchemaLoader by
 simply passing Scalar DB configuration file, schema, and additional options if needed as shown
@@ -499,6 +515,9 @@ public class SchemaLoaderSample {
     Map<String, String> tableReparationOptions = new HashMap<>();
     indexCreationOptions.put(DynamoAdmin.NO_BACKUP, "true");
 
+    Map<String, String> upgradeOptions = new HashMap<>();
+    upgradeOptions.put(DynamoAdmin.NO_BACKUP, "true");
+
     // Create tables
     SchemaLoader.load(configFilePath, schemaFilePath, tableCreationOptions, createCoordinatorTables);
 
@@ -507,7 +526,10 @@ public class SchemaLoaderSample {
 
     // Repair tables
     SchemaLoader.repairTables(configFilePath, schemaFilePath, tableReparationOptions, repairCoordinatorTables);
-
+    
+    // Upgrade the environment
+    SchemaLoader.upgrade(configFilePath, upgradeOptions);
+    
     // Delete tables
     SchemaLoader.unload(configFilePath, schemaFilePath, deleteCoordinatorTables);
 
@@ -542,6 +564,9 @@ SchemaLoader.alterTables(properties, serializedAlteredSchemaFilePath, indexCreat
 
 // Repair tables
 SchemaLoader.repairTables(properties, serializedSchemaJson, tableReparationOptions, repairCoordinatorTables);
+
+// Upgrade the environment
+SchemaLoader.upgrade(properties, upgradeOptions);
 
 // Delete tables
 SchemaLoader.unload(properties, serializedSchemaJson, deleteCoordinatorTables);

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -414,7 +414,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
 
     // Assert
     assertThat(exitCodeUpgrade).isZero();
-    waitForKeyspacesTableCreation();
+    waitForNamespacesTableCreation();
     assertThat(transactionAdmin.getNamespaceNames()).containsOnly(namespace1, namespace2);
   }
 
@@ -448,7 +448,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
     return SchemaLoader.mainInternal(args.toArray(new String[0]));
   }
 
-  protected void waitForKeyspacesTableCreation() {
+  protected void waitForNamespacesTableCreation() {
     // Do nothing
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -507,6 +507,39 @@ public class SchemaLoader {
       operator.alterTables(tableSchemaList, indexCreationOptions);
     }
   }
+  /**
+   * Upgrades the Scalar DB environment to support the latest version of the Scalar DB API.
+   * Typically, you will be requested, as indicated on the release notes, to run this method after
+   * updating the Scalar DB version of your application environment.
+   *
+   * @param configPath path to the Scalar DB config properties.
+   * @param options specific options for upgrading.
+   * @throws SchemaLoaderException thrown when upgrading failed.
+   */
+  public static void upgrade(Path configPath, Map<String, String> options)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Left<>(configPath);
+    upgrade(config, options);
+  }
+  /**
+   * Upgrades the Scalar DB environment to support the latest version of the Scalar DB API.
+   * Typically, you will be requested, as indicated on the release notes, to run this method after
+   * updating the Scalar DB version of your application environment.
+   *
+   * @param configProperties Scalar DB config properties.
+   * @param options specific options for upgrading.
+   * @throws SchemaLoaderException thrown when upgrading failed.
+   */
+  public static void upgrade(Properties configProperties, Map<String, String> options)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Right<>(configProperties);
+    upgrade(config, options);
+  }
+
+  private static void upgrade(Either<Path, Properties> config, Map<String, String> options)
+      throws SchemaLoaderException {
+    getSchemaOperator(config).upgrade(options);
+  }
 
   @VisibleForTesting
   static SchemaOperator getSchemaOperator(Either<Path, Properties> config)

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -256,6 +256,18 @@ public class SchemaOperator implements AutoCloseable {
     }
   }
 
+  public void upgrade(Map<String, String> options) throws SchemaLoaderException {
+    try {
+      // As of 4.0.0, upgrade() implementation is identical for the storage or transaction admin.
+      // This could change in the future but for now using either admin regardless of the schema is
+      // fine
+      transactionAdmin.upgrade(options);
+      logger.info("Upgrading the environment succeeded.");
+    } catch (ExecutionException e) {
+      throw new RuntimeException("Upgrading the environment failed", e);
+    }
+  }
+
   private TableMetadata getCurrentTableMetadata(
       String namespace, String table, boolean isTransactional) throws ExecutionException {
     if (isTransactional) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -90,6 +90,14 @@ public class SchemaLoaderCommand implements Callable<Integer> {
                 + "It compares the provided table schema to the existing schema to decide which columns need to be added and which indexes need to be created or deleted",
         defaultValue = "false")
     boolean alterTables;
+
+    @Option(
+        names = {"--upgrade"},
+        description =
+            "Upgrades the Scalar DB environment to support the latest version of the Scalar DB API. Typically, you will be requested, as indicated on the release notes, to run this command after"
+                + " updating the Scalar DB version of your application environment.",
+        defaultValue = "false")
+    boolean upgrade;
   }
 
   @Override
@@ -105,6 +113,8 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       repairTables();
     } else if (mode.alterTables) {
       alterTables();
+    } else if (mode.upgrade) {
+      upgrade();
     }
     return 0;
   }
@@ -155,5 +165,13 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       options.put(DynamoAdmin.NO_SCALING, noScaling.toString());
     }
     SchemaLoader.alterTables(configPath, schemaFile, options);
+  }
+
+  private void upgrade() throws SchemaLoaderException {
+    Map<String, String> options = new HashMap<>();
+    if (noBackup != null) {
+      options.put(DynamoAdmin.NO_BACKUP, noBackup.toString());
+    }
+    SchemaLoader.upgrade(configPath, options);
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
@@ -707,4 +707,26 @@ public class SchemaLoaderTest {
     verify(parser).parse();
     verify(operator).alterTables(anyList(), anyMap());
   }
+
+  @Test
+  public void upgrade_WithConfigProperties_ShouldCallOperatorProperly() throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.upgrade(configProperties, options);
+
+    // Assert
+    verify(operator).upgrade(options);
+  }
+
+  @Test
+  public void upgrade_WithConfigFilePath_ShouldCallOperatorProperly() throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.upgrade(configFilePath, options);
+
+    // Assert
+    verify(operator).upgrade(options);
+  }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -411,4 +411,16 @@ public class SchemaOperatorTest {
     verifyNoMoreInteractions(transactionAdmin);
     verifyNoMoreInteractions(storageAdmin);
   }
+
+  @Test
+  public void upgrade_ShouldCallTransactionAdminProperly() throws Exception {
+    // Arrange
+
+    // Act
+    operator.upgrade(options);
+
+    // Assert
+    verify(transactionAdmin).upgrade(options);
+    verifyNoInteractions(storageAdmin);
+  }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
@@ -349,4 +349,17 @@ public class SchemaLoaderCommandTest {
     Assertions.assertThat(exitCode).isEqualTo(1);
     schemaLoaderMockedStatic.verifyNoInteractions();
   }
+
+  @Test
+  public void call_WithProperArgumentsForUpgrading_ShouldCallUpgradeProperly() {
+    // Arrange
+    String configFile = "path_to_config_file";
+    Map<String, String> options = ImmutableMap.of(DynamoAdmin.NO_BACKUP, noBackup.toString());
+
+    // Act
+    commandLine.execute("--config", configFile, "--upgrade", "--no-backup");
+
+    // Assert
+    schemaLoaderMockedStatic.verify(() -> SchemaLoader.upgrade(Paths.get(configFile), options));
+  }
 }


### PR DESCRIPTION
**Context**
This PR is part of the namespace management feature and targets its feature branch [feat/namespaces_management](https://github.com/scalar-labs/scalardb/tree/feat/namespaces_management)

**Changes** 
This PR adds the `--upgrade` command to the schema loader which is identical to calling the [admin.upgrade(Map<String, String options)](https://github.com/scalar-labs/scalardb/blob/9fce0686aa0a2d2b07f6562a5ea17c5d6638ed6c/core/src/main/java/com/scalar/db/api/Admin.java#L392-L399) method. 
For a concrete explanation of what running this method does, please refer to this [PR](https://github.com/scalar-labs/scalardb/pull/696#issue-1367431598)
 