### PR TITLE
Move vuln check to a separate daily workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,47 +87,6 @@ jobs:
         with:
           arguments: :schema-loader:dockerfileLint
 
-      - name: Login to GitHub Container Registry
-        if: always()
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Docker build
-        if: always()
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: docker
-
-      - name: Set version
-        if: always()
-        id: version
-        run: |
-          VERSION=$(gradle :core:properties -q | grep "version:" | awk '{print $2}')
-          echo ::set-output name=version::${VERSION}
-
-      - name: Run Trivy vulnerability scanner for Scalar DB Server
-        if: always()
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-
-      - name: Run Trivy vulnerability scanner for Scalar DB Schema Loader
-        if: always()
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-
   integration-test-for-cassandra:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -1,0 +1,63 @@
+name: Vulnerability Check
+
+on:
+  schedule:
+    # UTC
+    - cron: '0 20 * * *'
+
+env:
+  TERM: dumb
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Login to GitHub Container Registry
+        if: always()
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Docker build
+        if: always()
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: docker
+
+      - name: Set version
+        if: always()
+        id: version
+        run: |
+          VERSION=$(gradle :core:properties -q | grep "version:" | awk '{print $2}')
+          echo ::set-output name=version::${VERSION}
+
+      - name: Run Trivy vulnerability scanner for Scalar DB Server
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - name: Run Trivy vulnerability scanner for Scalar DB Schema Loader
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+


### PR DESCRIPTION
Current main CI workflow contains vulnerability check tasks and they sometimes results in CI failure due to third party security issue that we can't always handle on our side. This PR moves the check to a separate daily scheduled workflow not to block our PR flows.

We'll take care of vuln check for some released versions as a different PR.