### PR TITLE
Remove unnecessary key definition from API guide

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -527,10 +527,6 @@ Instead of calling the `partitionKey()` method in the builder, you can call the 
 
 ```java
 // Create a Scan operation without a partition key
-Key partitionKey = Key.ofInt("c1", 10);
-Key startClusteringKey = Key.of("c2", "aaa", "c3", 100L);
-Key endClusteringKey = Key.of("c2", "aaa", "c3", 300L);
-
 Scan scan =
     Scan.newBuilder()
         .namespace("ns")


### PR DESCRIPTION
It seems that there are some key definitions in the sample of the `all()` method of the `Scan` API.
However, I think we don't need to set the partition key and clustering key if we use the `Scan.all()`.

So, this PR removes the above unnecessary key definitions in the sample of `Scan.all()`.
Please take a look!