### PR TITLE
Throw TransactionNotFoundException when resuming a transaction but it's not found

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -1,6 +1,7 @@
 package com.scalar.db.api;
 
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
 
 public interface DistributedTransactionManager {
@@ -182,9 +183,10 @@ public interface DistributedTransactionManager {
    *
    * @param txId the transaction ID
    * @return {@link DistributedTransaction}
-   * @throws TransactionException if resuming the transaction failed
+   * @throws TransactionNotFoundException if the transaction associated with the specified
+   *     transaction ID is not found
    */
-  DistributedTransaction resume(String txId) throws TransactionException;
+  DistributedTransaction resume(String txId) throws TransactionNotFoundException;
 
   /**
    * Returns the state of a given transaction.

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
@@ -1,6 +1,7 @@
 package com.scalar.db.api;
 
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
 
 /**
@@ -116,9 +117,10 @@ public interface TwoPhaseCommitTransactionManager {
    *
    * @param txId the transaction ID
    * @return {@link TwoPhaseCommitTransaction}
-   * @throws TransactionException if resuming the transaction failed
+   * @throws TransactionNotFoundException if the transaction associated with the specified
+   *     transaction ID is not found
    */
-  TwoPhaseCommitTransaction resume(String txId) throws TransactionException;
+  TwoPhaseCommitTransaction resume(String txId) throws TransactionNotFoundException;
 
   /**
    * Returns the state of a given transaction.

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTransactionManager.java
@@ -12,6 +12,7 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.util.ActiveExpiringMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -48,7 +49,7 @@ public abstract class ActiveTransactionManagedTransactionManager
   private void add(DistributedTransaction transaction) throws TransactionException {
     if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
       transaction.rollback();
-      throw new IllegalStateException(
+      throw new TransactionException(
           "The transaction already exists. transactionId: " + transaction.getId());
     }
   }
@@ -58,12 +59,12 @@ public abstract class ActiveTransactionManagedTransactionManager
   }
 
   @Override
-  public DistributedTransaction resume(String txId) {
+  public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     return activeTransactions
         .get(txId)
         .orElseThrow(
             () ->
-                new IllegalStateException(
+                new TransactionNotFoundException(
                     "A transaction associated with the specified transaction ID is not found. "
                         + "It might have been expired. transactionId: "
                         + txId));

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -13,6 +13,7 @@ import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
 import com.scalar.db.util.ActiveExpiringMap;
@@ -50,7 +51,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   private void add(ActiveTransaction transaction) throws TransactionException {
     if (activeTransactions.putIfAbsent(transaction.getId(), transaction) != null) {
       transaction.rollback();
-      throw new IllegalStateException(
+      throw new TransactionException(
           "The transaction already exists. transactionId: " + transaction.getId());
     }
   }
@@ -60,12 +61,12 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   }
 
   @Override
-  public TwoPhaseCommitTransaction resume(String txId) {
+  public TwoPhaseCommitTransaction resume(String txId) throws TransactionNotFoundException {
     return activeTransactions
         .get(txId)
         .orElseThrow(
             () ->
-                new IllegalStateException(
+                new TransactionNotFoundException(
                     "A transaction associated with the specified transaction ID is not found. "
                         + "It might have been expired. transactionId: "
                         + txId));

--- a/core/src/main/java/com/scalar/db/exception/transaction/TransactionNotFoundException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/TransactionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.scalar.db.exception.transaction;
+
+public class TransactionNotFoundException extends TransactionException {
+
+  public TransactionNotFoundException(String message) {
+    super(message);
+  }
+
+  public TransactionNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.Isolation;
 import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -123,7 +124,7 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
-  public DistributedTransaction resume(String txId) throws TransactionException {
+  public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
     return manager.resume(txId);
   }
 

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 
@@ -80,7 +81,7 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   }
 
   @Override
-  public TwoPhaseCommitTransaction resume(String txId) throws TransactionException {
+  public TwoPhaseCommitTransaction resume(String txId) throws TransactionNotFoundException {
     return manager.resume(txId);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -114,6 +114,16 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
+  public void begin_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.begin(ANY_TX_ID);
+    assertThatThrownBy(() -> manager.begin(ANY_TX_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void start_NoArgumentGiven_ReturnConsensusCommitWithSomeTxIdAndSnapshotIsolation()
       throws TransactionException {
     // Arrange
@@ -195,6 +205,16 @@ public class ConsensusCommitManagerTest {
     assertThat(transaction1.getRecoveryHandler())
         .isEqualTo(transaction2.getRecoveryHandler())
         .isEqualTo(recovery);
+  }
+
+  @Test
+  public void start_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.start(ANY_TX_ID);
+    assertThatThrownBy(() -> manager.start(ANY_TX_ID)).isInstanceOf(TransactionException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -15,6 +15,7 @@ import com.scalar.db.common.WrappedDistributedTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
@@ -209,22 +210,24 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void resume_CalledWithoutBegin_ThrowIllegalStateException() {
+  public void resume_CalledWithoutBegin_ThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndCommit_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.commit();
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
@@ -248,14 +251,15 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin(ANY_TX_ID);
     transaction.rollback();
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -117,6 +117,16 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
+  public void begin_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.begin(ANY_TX_ID);
+    assertThatThrownBy(() -> manager.begin(ANY_TX_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void start_NoArgumentGiven_ReturnWithSomeTxIdAndSnapshotIsolation()
       throws TransactionException {
     // Arrange
@@ -174,6 +184,16 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
+  public void start_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.start(ANY_TX_ID);
+    assertThatThrownBy(() -> manager.start(ANY_TX_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void join_TxIdGiven_ReturnWithSpecifiedTxIdAndSnapshotIsolation()
       throws TransactionException {
     // Arrange
@@ -187,6 +207,16 @@ public class TwoPhaseConsensusCommitManagerTest {
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
     assertThat(transaction.getCrudHandler().getSnapshot().getIsolation())
         .isEqualTo(Isolation.SNAPSHOT);
+  }
+
+  @Test
+  public void join_CalledAfterBeginWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.begin(ANY_TX_ID);
+    assertThatThrownBy(() -> manager.join(ANY_TX_ID)).isInstanceOf(TransactionException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -16,6 +16,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import java.util.Optional;
@@ -213,15 +214,16 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
-  public void resume_CalledWithoutBeginOrJoin_ThrowIllegalStateException() {
+  public void resume_CalledWithoutBeginOrJoin_ThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndCommit_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager.begin(ANY_TX_ID);
@@ -229,7 +231,8 @@ public class TwoPhaseConsensusCommitManagerTest {
     transaction.commit();
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
@@ -254,7 +257,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager.begin(ANY_TX_ID);
@@ -262,12 +265,14 @@ public class TwoPhaseConsensusCommitManagerTest {
     transaction.rollback();
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowIllegalStateException()
-      throws TransactionException {
+  public void
+      resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowTransactionNotFoundException()
+          throws TransactionException {
     // Arrange
     doThrow(UnknownTransactionStatusException.class).when(commit).abort(any());
 
@@ -279,7 +284,8 @@ public class TwoPhaseConsensusCommitManagerTest {
     }
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_TX_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -21,6 +21,7 @@ import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.Key;
 import com.scalar.db.storage.jdbc.JdbcService;
@@ -391,22 +392,24 @@ public class JdbcTransactionManagerTest {
   }
 
   @Test
-  public void resume_CalledWithoutBegin_ThrowIllegalStateException() {
+  public void resume_CalledWithoutBegin_ThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndCommit_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin(ANY_ID);
     transaction.commit();
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
@@ -430,19 +433,21 @@ public class JdbcTransactionManagerTest {
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin(ANY_ID);
     transaction.rollback();
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowIllegalStateException()
-      throws TransactionException, SQLException {
+  public void
+      resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowTransactionNotFoundException()
+          throws TransactionException, SQLException {
     // Arrange
     doThrow(SQLException.class).when(connection).rollback();
 
@@ -454,6 +459,7 @@ public class JdbcTransactionManagerTest {
     }
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -380,6 +380,26 @@ public class JdbcTransactionManagerTest {
   }
 
   @Test
+  public void begin_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.begin(ANY_ID);
+    assertThatThrownBy(() -> manager.begin(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void start_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+
+    // Act Assert
+    manager.start(ANY_ID);
+    assertThatThrownBy(() -> manager.start(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     DistributedTransaction transaction1 = manager.begin(ANY_ID);

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
@@ -18,6 +18,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.rpc.AbortRequest;
 import com.scalar.db.rpc.AbortResponse;
 import com.scalar.db.rpc.DistributedTransactionGrpc;
@@ -93,15 +94,16 @@ public class GrpcTransactionManagerTest {
   }
 
   @Test
-  public void resume_CalledWithoutBeginOrStart_ThrowIllegalStateException() {
+  public void resume_CalledWithoutBeginOrStart_ThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndCommit_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     GrpcTransactionManager spiedManager = spy(manager);
@@ -114,7 +116,8 @@ public class GrpcTransactionManagerTest {
     transaction.commit();
 
     // Act Assert
-    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
@@ -144,7 +147,7 @@ public class GrpcTransactionManagerTest {
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     GrpcTransactionManager spiedManager = spy(manager);
@@ -157,12 +160,14 @@ public class GrpcTransactionManagerTest {
     transaction.rollback();
 
     // Act Assert
-    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowIllegalStateException()
-      throws TransactionException {
+  public void
+      resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowTransactionNotFoundException()
+          throws TransactionException {
     // Arrange
     GrpcTransactionManager spiedManager = spy(manager);
     GrpcTransactionOnBidirectionalStream bidirectionalStream =
@@ -180,7 +185,8 @@ public class GrpcTransactionManagerTest {
     }
 
     // Act Assert
-    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionManagerTest.java
@@ -58,6 +58,36 @@ public class GrpcTransactionManagerTest {
   }
 
   @Test
+  public void begin_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    // Act Assert
+    spiedManager.begin(ANY_ID);
+    assertThatThrownBy(() -> spiedManager.begin(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void start_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTransactionManager spiedManager = spy(manager);
+    GrpcTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getStream();
+    when(bidirectionalStream.startTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    // Act Assert
+    spiedManager.start(ANY_ID);
+    assertThatThrownBy(() -> spiedManager.start(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     GrpcTransactionManager spiedManager = spy(manager);

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
@@ -18,6 +18,7 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.rpc.AbortRequest;
 import com.scalar.db.rpc.AbortResponse;
 import com.scalar.db.rpc.GetTransactionStateRequest;
@@ -110,15 +111,16 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
   }
 
   @Test
-  public void resume_CalledWithoutBeginOrStartOrJoin_ThrowIllegalStateException() {
+  public void resume_CalledWithoutBeginOrStartOrJoin_ThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndCommit_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndCommit_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     GrpcTwoPhaseCommitTransactionManager spiedManager = spy(manager);
@@ -132,7 +134,8 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
     transaction.commit();
 
     // Act Assert
-    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
@@ -163,7 +166,7 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_ThrowIllegalStateException()
+  public void resume_CalledWithBeginAndRollback_ThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     GrpcTwoPhaseCommitTransactionManager spiedManager = spy(manager);
@@ -177,12 +180,14 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
     transaction.rollback();
 
     // Act Assert
-    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowIllegalStateException()
-      throws TransactionException {
+  public void
+      resume_CalledWithBeginAndRollback_RollbackExceptionThrown_ThrowTransactionNotFoundException()
+          throws TransactionException {
     // Arrange
     GrpcTwoPhaseCommitTransactionManager spiedManager = spy(manager);
     GrpcTwoPhaseCommitTransactionOnBidirectionalStream bidirectionalStream =
@@ -200,7 +205,8 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
     }
 
     // Act Assert
-    assertThatThrownBy(() -> spiedManager.resume(ANY_ID)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> spiedManager.resume(ANY_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManagerTest.java
@@ -58,6 +58,36 @@ public class GrpcTwoPhaseCommitTransactionManagerTest {
   }
 
   @Test
+  public void begin_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTwoPhaseCommitTransactionManager spiedManager = spy(manager);
+    GrpcTwoPhaseCommitTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTwoPhaseCommitTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getStream();
+    when(bidirectionalStream.beginTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    // Act Assert
+    spiedManager.begin(ANY_ID);
+    assertThatThrownBy(() -> spiedManager.begin(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void start_CalledTwiceWithSameTxId_ThrowTransactionException()
+      throws TransactionException {
+    // Arrange
+    GrpcTwoPhaseCommitTransactionManager spiedManager = spy(manager);
+    GrpcTwoPhaseCommitTransactionOnBidirectionalStream bidirectionalStream =
+        mock(GrpcTwoPhaseCommitTransactionOnBidirectionalStream.class);
+    doReturn(bidirectionalStream).when(spiedManager).getStream();
+    when(bidirectionalStream.startTransaction(ANY_ID)).thenReturn(ANY_ID);
+
+    // Act Assert
+    spiedManager.start(ANY_ID);
+    assertThatThrownBy(() -> spiedManager.start(ANY_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void resume_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
     // Arrange
     GrpcTwoPhaseCommitTransactionManager spiedManager = spy(manager);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -11,6 +11,7 @@ import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.IntValue;
@@ -916,15 +917,16 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
-  public void resume_WithoutBeginningTransaction_ShouldThrowIllegalStateException() {
+  public void resume_WithoutBeginningTransaction_ShouldThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager.resume("txId")).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager.resume("txId"))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_WithBeginningAndCommittingTransaction_ShouldThrowIllegalStateException()
+  public void resume_WithBeginningAndCommittingTransaction_ShouldThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
@@ -932,19 +934,20 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(transaction.getId()))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_WithBeginningAndRollingBackTransaction_ShouldThrowIllegalStateException()
-      throws TransactionException {
+  public void
+      resume_WithBeginningAndRollingBackTransaction_ShouldThrowTransactionNotFoundException()
+          throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
     transaction.rollback();
 
     // Act Assert
     assertThatThrownBy(() -> manager.resume(transaction.getId()))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   private void populateRecords() throws TransactionException {

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -11,6 +11,7 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.IntValue;
@@ -1141,15 +1142,16 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   @Test
-  public void resume_WithoutBeginningTransaction_ShouldThrowIllegalStateException() {
+  public void resume_WithoutBeginningTransaction_ShouldThrowTransactionNotFoundException() {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> manager1.resume("txId")).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> manager1.resume("txId"))
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_WithBeginningAndCommittingTransaction_ShouldThrowIllegalStateException()
+  public void resume_WithBeginningAndCommittingTransaction_ShouldThrowTransactionNotFoundException()
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1158,19 +1160,20 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
     // Act Assert
     assertThatThrownBy(() -> manager1.resume(transaction.getId()))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   @Test
-  public void resume_WithBeginningAndRollingBackTransaction_ShouldThrowIllegalStateException()
-      throws TransactionException {
+  public void
+      resume_WithBeginningAndRollingBackTransaction_ShouldThrowTransactionNotFoundException()
+          throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.rollback();
 
     // Act Assert
     assertThatThrownBy(() -> manager1.resume(transaction.getId()))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(TransactionNotFoundException.class);
   }
 
   private void populateRecords(


### PR DESCRIPTION
This PR adds `TransactionNotFoundException` and throws it when resuming a transaction but it's not found. We need this because we need special handling for the transaction not found situation, so it is helpful that we can catch a dedicated exception for that situation. Please take a look!