### PR TITLE
Deprecate getPartitionKey() and getClusteringKey() of Result

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Result.java
+++ b/core/src/main/java/com/scalar/db/api/Result.java
@@ -20,14 +20,18 @@ public interface Result {
    * Returns the partition {@link Key}
    *
    * @return an {@code Optional} with the partition {@code Key}
+   * @deprecated As of release 3.8.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   Optional<Key> getPartitionKey();
 
   /**
    * Returns the clustering {@link Key}
    *
    * @return an {@code Optional} with the clustering {@code Key}
+   * @deprecated As of release 3.8.0. Will be removed in release 5.0.0
    */
+  @Deprecated
   Optional<Key> getClusteringKey();
 
   /**

--- a/core/src/main/java/com/scalar/db/common/ResultImpl.java
+++ b/core/src/main/java/com/scalar/db/common/ResultImpl.java
@@ -27,11 +27,15 @@ public class ResultImpl extends AbstractResult {
     this.metadata = Objects.requireNonNull(metadata);
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
     return getKey(metadata.getPartitionKeyNames());
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {
     return getKey(metadata.getClusteringKeyNames());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/FilteredResult.java
@@ -49,11 +49,15 @@ public class FilteredResult extends AbstractResult {
     containedColumnNames = builder.build();
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
     return getKey(original.getPartitionKey());
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {
     return getKey(original.getClusteringKey());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
@@ -41,11 +41,15 @@ public class MergedResult extends AbstractResult {
     this.metadata = metadata;
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<com.scalar.db.io.Key> getPartitionKey() {
     return Optional.of(put.getPartitionKey());
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<com.scalar.db.io.Key> getClusteringKey() {
     return put.getClusteringKey();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
@@ -23,11 +23,15 @@ public class TransactionResult extends AbstractResult {
     this.result = checkNotNull(result);
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<Key> getPartitionKey() {
     return result.getPartitionKey();
   }
 
+  /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
+  @Deprecated
   @Override
   public Optional<Key> getClusteringKey() {
     return result.getClusteringKey();


### PR DESCRIPTION
This PR deprecates the `getPartitionKey()` and `getClusteringKey()` methods of the `Result` class. This is because those methods are more like utility ones, so we should separate them into another utility class. I will add that utility class in another PR, and this PR just deprecates the methods. Please take a look!