### PR TITLE
Remove usages of getPartitionKey() and getClusteringKey() of Result from integration tests

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1436,11 +1436,8 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     assertThat(results.size()).isEqualTo(234);
     for (int i = 0; i < 234; i++) {
-      assertThat(results.get(i).getPartitionKey().isPresent()).isTrue();
-      assertThat(results.get(i).getClusteringKey().isPresent()).isTrue();
-
-      assertThat(results.get(i).getPartitionKey().get().get().get(0).getAsInt()).isEqualTo(1);
-      assertThat(results.get(i).getClusteringKey().get().get().get(0).getAsInt()).isEqualTo(i);
+      assertThat(results.get(i).getInt(COL_NAME1)).isEqualTo(1);
+      assertThat(results.get(i).getInt(COL_NAME4)).isEqualTo(i);
     }
   }
 
@@ -1461,19 +1458,16 @@ public abstract class DistributedStorageIntegrationTestBase {
             i ->
                 IntStream.range(0, 3)
                     .forEach(
-                        j -> {
-                          ExpectedResultBuilder erBuilder =
-                              new ExpectedResultBuilder()
-                                  .partitionKey(Key.ofInt(COL_NAME1, i))
-                                  .clusteringKey(Key.ofInt(COL_NAME4, j))
-                                  .nonKeyColumns(
-                                      ImmutableList.of(
-                                          TextColumn.of(COL_NAME2, Integer.toString(i + j)),
-                                          IntColumn.of(COL_NAME3, i + j),
-                                          BooleanColumn.of(COL_NAME5, j % 2 == 0),
-                                          BlobColumn.ofNull(COL_NAME6)));
-                          expectedResults.add(erBuilder.build());
-                        }));
+                        j ->
+                            expectedResults.add(
+                                new ExpectedResultBuilder()
+                                    .column(IntColumn.of(COL_NAME1, i))
+                                    .column(IntColumn.of(COL_NAME4, j))
+                                    .column(TextColumn.of(COL_NAME2, Integer.toString(i + j)))
+                                    .column(IntColumn.of(COL_NAME3, i + j))
+                                    .column(BooleanColumn.of(COL_NAME5, j % 2 == 0))
+                                    .column(BlobColumn.ofNull(COL_NAME6))
+                                    .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
@@ -1498,44 +1492,36 @@ public abstract class DistributedStorageIntegrationTestBase {
         results,
         ImmutableList.of(
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(COL_NAME1, 1))
-                .clusteringKey(Key.ofInt(COL_NAME4, 1))
-                .nonKeyColumns(
-                    Arrays.asList(
-                        TextColumn.ofNull(COL_NAME2),
-                        IntColumn.ofNull(COL_NAME3),
-                        BooleanColumn.ofNull(COL_NAME5),
-                        BlobColumn.ofNull(COL_NAME6)))
+                .column(IntColumn.of(COL_NAME1, 1))
+                .column(IntColumn.of(COL_NAME4, 1))
+                .column(TextColumn.ofNull(COL_NAME2))
+                .column(IntColumn.ofNull(COL_NAME3))
+                .column(BooleanColumn.ofNull(COL_NAME5))
+                .column(BlobColumn.ofNull(COL_NAME6))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(COL_NAME1, 1))
-                .clusteringKey(Key.ofInt(COL_NAME4, 2))
-                .nonKeyColumns(
-                    Arrays.asList(
-                        TextColumn.ofNull(COL_NAME2),
-                        IntColumn.ofNull(COL_NAME3),
-                        BooleanColumn.ofNull(COL_NAME5),
-                        BlobColumn.ofNull(COL_NAME6)))
+                .column(IntColumn.of(COL_NAME1, 1))
+                .column(IntColumn.of(COL_NAME4, 2))
+                .column(TextColumn.ofNull(COL_NAME2))
+                .column(IntColumn.ofNull(COL_NAME3))
+                .column(BooleanColumn.ofNull(COL_NAME5))
+                .column(BlobColumn.ofNull(COL_NAME6))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(COL_NAME1, 2))
-                .clusteringKey(Key.ofInt(COL_NAME4, 1))
-                .nonKeyColumns(
-                    Arrays.asList(
-                        TextColumn.ofNull(COL_NAME2),
-                        IntColumn.ofNull(COL_NAME3),
-                        BooleanColumn.ofNull(COL_NAME5),
-                        BlobColumn.ofNull(COL_NAME6)))
+                .column(IntColumn.of(COL_NAME1, 2))
+                .column(IntColumn.of(COL_NAME4, 1))
+                .column(TextColumn.ofNull(COL_NAME2))
+                .column(IntColumn.ofNull(COL_NAME3))
+                .column(BooleanColumn.ofNull(COL_NAME5))
+                .column(BlobColumn.ofNull(COL_NAME6))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(COL_NAME1, 3))
-                .clusteringKey(Key.ofInt(COL_NAME4, 0))
-                .nonKeyColumns(
-                    Arrays.asList(
-                        TextColumn.ofNull(COL_NAME2),
-                        IntColumn.ofNull(COL_NAME3),
-                        BooleanColumn.ofNull(COL_NAME5),
-                        BlobColumn.ofNull(COL_NAME6)))
+                .column(IntColumn.of(COL_NAME1, 3))
+                .column(IntColumn.of(COL_NAME4, 0))
+                .column(TextColumn.ofNull(COL_NAME2))
+                .column(IntColumn.ofNull(COL_NAME3))
+                .column(BooleanColumn.ofNull(COL_NAME5))
+                .column(BlobColumn.ofNull(COL_NAME6))
                 .build()));
     assertThat(results).hasSize(2);
   }
@@ -1558,16 +1544,14 @@ public abstract class DistributedStorageIntegrationTestBase {
             i ->
                 IntStream.range(0, 3)
                     .forEach(
-                        j -> {
-                          ExpectedResultBuilder erBuilder =
-                              new ExpectedResultBuilder().partitionKey(Key.ofInt(COL_NAME1, i));
-                          erBuilder.nonKeyColumns(
-                              ImmutableList.of(
-                                  TextColumn.of(COL_NAME2, Integer.toString(i + j)),
-                                  IntColumn.of(COL_NAME3, i + j),
-                                  BlobColumn.ofNull(COL_NAME6)));
-                          expectedResults.add(erBuilder.build());
-                        }));
+                        j ->
+                            expectedResults.add(
+                                new ExpectedResultBuilder()
+                                    .column(IntColumn.of(COL_NAME1, i))
+                                    .column(TextColumn.of(COL_NAME2, Integer.toString(i + j)))
+                                    .column(IntColumn.of(COL_NAME3, i + j))
+                                    .column(BlobColumn.ofNull(COL_NAME6))
+                                    .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(actualResults, expectedResults);
     actualResults.forEach(
         actualResult ->
@@ -1594,18 +1578,14 @@ public abstract class DistributedStorageIntegrationTestBase {
     // Assert
     List<ExpectedResult> expectedResults = new ArrayList<>();
     for (int i = 0; i < 345; i++) {
-      Key partitionKey = new Key(COL_NAME1, i % 4);
-      Key clusteringKey = new Key(COL_NAME4, i);
       expectedResults.add(
           new ExpectedResultBuilder()
-              .partitionKey(partitionKey)
-              .clusteringKey(clusteringKey)
-              .nonKeyColumns(
-                  Arrays.asList(
-                      TextColumn.ofNull(COL_NAME2),
-                      IntColumn.ofNull(COL_NAME3),
-                      BooleanColumn.ofNull(COL_NAME5),
-                      BlobColumn.of(COL_NAME6, new byte[getLargeDataSizeInBytes()])))
+              .column(IntColumn.of(COL_NAME1, i % 4))
+              .column(IntColumn.of(COL_NAME4, i))
+              .column(TextColumn.ofNull(COL_NAME2))
+              .column(IntColumn.ofNull(COL_NAME3))
+              .column(BooleanColumn.ofNull(COL_NAME5))
+              .column(BlobColumn.of(COL_NAME6, new byte[getLargeDataSizeInBytes()]))
               .build());
     }
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -371,19 +371,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     List<ExpectedResult> expectedResults = new ArrayList<>();
     expectedResults.add(
         new ExpectedResultBuilder()
-            .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
-            .nonKeyColumns(
-                ImmutableList.of(
-                    IntColumn.of(BALANCE, INITIAL_BALANCE), IntColumn.of(SOME_COLUMN, 2)))
+            .column(IntColumn.of(ACCOUNT_ID, 1))
+            .column(IntColumn.of(ACCOUNT_TYPE, 2))
+            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .column(IntColumn.of(SOME_COLUMN, 2))
             .build());
     expectedResults.add(
         new ExpectedResultBuilder()
-            .partitionKey(Key.ofInt(ACCOUNT_ID, 2))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
-            .nonKeyColumns(
-                ImmutableList.of(
-                    IntColumn.of(BALANCE, INITIAL_BALANCE), IntColumn.of(SOME_COLUMN, 2)))
+            .column(IntColumn.of(ACCOUNT_ID, 2))
+            .column(IntColumn.of(ACCOUNT_TYPE, 1))
+            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .column(IntColumn.of(SOME_COLUMN, 2))
             .build());
 
     // Act
@@ -415,17 +413,14 @@ public abstract class DistributedTransactionIntegrationTestBase {
             i ->
                 IntStream.range(0, NUM_TYPES)
                     .forEach(
-                        j -> {
-                          ExpectedResultBuilder erBuilder =
-                              new ExpectedResultBuilder()
-                                  .partitionKey(Key.ofInt(ACCOUNT_ID, i))
-                                  .clusteringKey(Key.ofInt(ACCOUNT_TYPE, j))
-                                  .nonKeyColumns(
-                                      ImmutableList.of(
-                                          IntColumn.of(BALANCE, INITIAL_BALANCE),
-                                          IntColumn.of(SOME_COLUMN, i * j)));
-                          expectedResults.add(erBuilder.build());
-                        }));
+                        j ->
+                            expectedResults.add(
+                                new ExpectedResultBuilder()
+                                    .column(IntColumn.of(ACCOUNT_ID, i))
+                                    .column(IntColumn.of(ACCOUNT_TYPE, j))
+                                    .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+                                    .column(IntColumn.of(SOME_COLUMN, i * j))
+                                    .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
@@ -462,28 +457,28 @@ public abstract class DistributedTransactionIntegrationTestBase {
         results,
         ImmutableList.of(
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 1))
+                .column(IntColumn.of(ACCOUNT_TYPE, 1))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 1))
+                .column(IntColumn.of(ACCOUNT_TYPE, 2))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 2))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 2))
+                .column(IntColumn.of(ACCOUNT_TYPE, 1))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 3))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 3))
+                .column(IntColumn.of(ACCOUNT_TYPE, 0))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build()));
     assertThat(results).hasSize(2);
   }
@@ -507,14 +502,12 @@ public abstract class DistributedTransactionIntegrationTestBase {
             i ->
                 IntStream.range(0, NUM_TYPES)
                     .forEach(
-                        j -> {
-                          ExpectedResultBuilder erBuilder =
-                              new ExpectedResultBuilder()
-                                  .clusteringKey(Key.ofInt(ACCOUNT_TYPE, j))
-                                  .nonKeyColumns(
-                                      ImmutableList.of(IntColumn.of(BALANCE, INITIAL_BALANCE)));
-                          expectedResults.add(erBuilder.build());
-                        }));
+                        j ->
+                            expectedResults.add(
+                                new ExpectedResultBuilder()
+                                    .column(IntColumn.of(ACCOUNT_TYPE, j))
+                                    .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+                                    .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
@@ -893,9 +886,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Assert
     ExpectedResult expectedResult =
         new ExpectedResultBuilder()
-            .nonKeyColumns(
-                ImmutableList.of(
-                    IntColumn.of(BALANCE, INITIAL_BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .column(IntColumn.ofNull(SOME_COLUMN))
             .build();
     TestUtils.assertResultsContainsExactlyInAnyOrder(
         results, Collections.singletonList(expectedResult));

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -409,19 +409,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     List<ExpectedResult> expectedResults = new ArrayList<>();
     expectedResults.add(
         new ExpectedResultBuilder()
-            .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
-            .nonKeyColumns(
-                ImmutableList.of(
-                    IntColumn.of(BALANCE, INITIAL_BALANCE), IntColumn.of(SOME_COLUMN, 2)))
+            .column(IntColumn.of(ACCOUNT_ID, 1))
+            .column(IntColumn.of(ACCOUNT_TYPE, 2))
+            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .column(IntColumn.of(SOME_COLUMN, 2))
             .build());
     expectedResults.add(
         new ExpectedResultBuilder()
-            .partitionKey(Key.ofInt(ACCOUNT_ID, 2))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
-            .nonKeyColumns(
-                ImmutableList.of(
-                    IntColumn.of(BALANCE, INITIAL_BALANCE), IntColumn.of(SOME_COLUMN, 2)))
+            .column(IntColumn.of(ACCOUNT_ID, 2))
+            .column(IntColumn.of(ACCOUNT_TYPE, 1))
+            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .column(IntColumn.of(SOME_COLUMN, 2))
             .build());
 
     // Act
@@ -918,17 +916,14 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             i ->
                 IntStream.range(0, NUM_TYPES)
                     .forEach(
-                        j -> {
-                          ExpectedResultBuilder erBuilder =
-                              new ExpectedResultBuilder()
-                                  .partitionKey(Key.ofInt(ACCOUNT_ID, i))
-                                  .clusteringKey(Key.ofInt(ACCOUNT_TYPE, j))
-                                  .nonKeyColumns(
-                                      ImmutableList.of(
-                                          IntColumn.of(BALANCE, INITIAL_BALANCE),
-                                          IntColumn.of(SOME_COLUMN, i * j)));
-                          expectedResults.add(erBuilder.build());
-                        }));
+                        j ->
+                            expectedResults.add(
+                                new ExpectedResultBuilder()
+                                    .column(IntColumn.of(ACCOUNT_ID, i))
+                                    .column(IntColumn.of(ACCOUNT_TYPE, j))
+                                    .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+                                    .column(IntColumn.of(SOME_COLUMN, i * j))
+                                    .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
@@ -969,28 +964,28 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         results,
         ImmutableList.of(
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 1))
+                .column(IntColumn.of(ACCOUNT_TYPE, 1))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 1))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 1))
+                .column(IntColumn.of(ACCOUNT_TYPE, 2))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 2))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 2))
+                .column(IntColumn.of(ACCOUNT_TYPE, 1))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build(),
             new ExpectedResultBuilder()
-                .partitionKey(Key.ofInt(ACCOUNT_ID, 3))
-                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-                .nonKeyColumns(
-                    Arrays.asList(IntColumn.ofNull(BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+                .column(IntColumn.of(ACCOUNT_ID, 3))
+                .column(IntColumn.of(ACCOUNT_TYPE, 0))
+                .column(IntColumn.ofNull(BALANCE))
+                .column(IntColumn.ofNull(SOME_COLUMN))
                 .build()));
     assertThat(results).hasSize(2);
   }
@@ -1017,14 +1012,12 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             i ->
                 IntStream.range(0, NUM_TYPES)
                     .forEach(
-                        j -> {
-                          ExpectedResultBuilder erBuilder =
-                              new ExpectedResultBuilder()
-                                  .clusteringKey(Key.ofInt(ACCOUNT_TYPE, j))
-                                  .nonKeyColumns(
-                                      ImmutableList.of(IntColumn.of(BALANCE, INITIAL_BALANCE)));
-                          expectedResults.add(erBuilder.build());
-                        }));
+                        j ->
+                            expectedResults.add(
+                                new ExpectedResultBuilder()
+                                    .column(IntColumn.of(ACCOUNT_TYPE, j))
+                                    .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+                                    .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
     results.forEach(
         result -> {
@@ -1117,9 +1110,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Assert
     ExpectedResult expectedResult =
         new ExpectedResultBuilder()
-            .nonKeyColumns(
-                ImmutableList.of(
-                    IntColumn.of(BALANCE, INITIAL_BALANCE), IntColumn.ofNull(SOME_COLUMN)))
+            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .column(IntColumn.ofNull(SOME_COLUMN))
             .build();
     TestUtils.assertResultsContainsExactlyInAnyOrder(
         results, Collections.singletonList(expectedResult));


### PR DESCRIPTION
As the `getPartitionKey()` and `getClusteringKey()` methods of the `Result` class are deprecated in #750, this PR removes the usages from the integration tests. Please take a look!