### PR TITLE
Validate contact points size in XxxxConfig to avoid "java.lang.ArrayIndexOutOfBoundsException: 0"

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
@@ -23,6 +23,9 @@ public class CosmosConfig {
       throw new IllegalArgumentException(DatabaseConfig.STORAGE + " should be 'cosmos'");
     }
 
+    if (databaseConfig.getContactPoints().isEmpty()) {
+      throw new IllegalArgumentException(DatabaseConfig.CONTACT_POINTS + " is empty");
+    }
     endpoint = databaseConfig.getContactPoints().get(0);
     key = databaseConfig.getPassword().orElse(null);
     tableMetadataDatabase =

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
@@ -31,6 +31,9 @@ public class DynamoConfig {
       throw new IllegalArgumentException(DatabaseConfig.STORAGE + " should be 'dynamo'");
     }
 
+    if (databaseConfig.getContactPoints().isEmpty()) {
+      throw new IllegalArgumentException(DatabaseConfig.CONTACT_POINTS + " is empty");
+    }
     region = databaseConfig.getContactPoints().get(0);
     accessKeyId = databaseConfig.getUsername().orElse(null);
     secretAccessKey = databaseConfig.getPassword().orElse(null);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -84,6 +84,9 @@ public class JdbcConfig {
               + " should be 'jdbc'");
     }
 
+    if (databaseConfig.getContactPoints().isEmpty()) {
+      throw new IllegalArgumentException(DatabaseConfig.CONTACT_POINTS + " is empty");
+    }
     jdbcUrl = databaseConfig.getContactPoints().get(0);
     username = databaseConfig.getUsername().orElse(null);
     password = databaseConfig.getPassword().orElse(null);

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
@@ -30,6 +30,9 @@ public class GrpcConfig {
               + " should be 'grpc'");
     }
 
+    if (databaseConfig.getContactPoints().isEmpty()) {
+      throw new IllegalArgumentException(DatabaseConfig.CONTACT_POINTS + " is empty");
+    }
     host = databaseConfig.getContactPoints().get(0);
     port =
         databaseConfig.getContactPort() == 0

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
@@ -62,4 +62,17 @@ public class CosmosConfigTest {
     assertThat(config.getKey()).isEqualTo(ANY_KEY);
     assertThat(config.getTableMetadataDatabase()).isNotPresent();
   }
+
+  @Test
+  public void
+      constructor_PropertiesWithEmptyContactPointsGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
+    props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
+
+    // Act
+    assertThatThrownBy(() -> new CosmosConfig(new DatabaseConfig(props)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoConfigTest.java
@@ -138,4 +138,19 @@ public class DynamoConfigTest {
     assertThat(config.getSecretAccessKey()).isEqualTo(ANY_SECRET_ACCESS_ID);
     assertThat(config.getNamespacePrefix()).isEmpty();
   }
+
+  @Test
+  public void
+      constructor_PropertiesWithEmptyContactPointsGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.USERNAME, ANY_ACCESS_KEY_ID);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_SECRET_ACCESS_ID);
+    props.setProperty(DatabaseConfig.STORAGE, DYNAMO_STORAGE);
+    props.setProperty(DynamoConfig.TABLE_METADATA_NAMESPACE, ANY_TABLE_METADATA_NAMESPACE);
+
+    // Act Assert
+    assertThatThrownBy(() -> new DynamoConfig(new DatabaseConfig(props)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -204,4 +204,18 @@ public class JdbcConfigTest {
     assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props)))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void
+      constructor_PropertiesWithEmptyContactPointsGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
+    props.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+    props.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
+
+    // Act Assert
+    assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
@@ -76,4 +76,16 @@ public class GrpcConfigTest {
     assertThatThrownBy(() -> new GrpcConfig(new DatabaseConfig(props)))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void
+      constructor_PropertiesWithEmptyContactPointsGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
+
+    // Act
+    assertThatThrownBy(() -> new GrpcConfig(new DatabaseConfig(props)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }


### PR DESCRIPTION
When I forgot to set `scalar.db.contact_points`, I ran into `java.lang.ArrayIndexOutOfBoundsException: 0` exception. It's not so user friendly for users. This PR adds a validation to confirm if `contactPoints` isn't empty in XxxxConfig classes.