### PR TITLE
Add ScalarDB Server's license description in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,5 @@ Here are the contributors we are especially thankful for:
 ## License
 Scalar DB is dual-licensed under both the Apache 2.0 License (found in the LICENSE file in the root directory) and a commercial license.
 You may select, at your option, one of the above-listed licenses.
-Scalar DB as a Java library is provided under Apache 2.0 License.
-Scalar DB Server is provided under a commercial license only.
-The commercial license includes several enterprise-grade features such as management tools and declarative query interfaces like GraphQL and SQL interfaces.
+The commercial license includes several enterprise-grade features such as Scalar DB Server, management tools, and declarative query interfaces like GraphQL and SQL interfaces.
 Regarding the commercial license, please [contact us](https://scalar-labs.com/contact_us/) for more information.

--- a/README.md
+++ b/README.md
@@ -65,5 +65,7 @@ Here are the contributors we are especially thankful for:
 ## License
 Scalar DB is dual-licensed under both the Apache 2.0 License (found in the LICENSE file in the root directory) and a commercial license.
 You may select, at your option, one of the above-listed licenses.
+Scalar DB as a Java library is provided under Apache 2.0 License.
+Scalar DB Server is provided under a commercial license only.
 The commercial license includes several enterprise-grade features such as management tools and declarative query interfaces like GraphQL and SQL interfaces.
 Regarding the commercial license, please [contact us](https://scalar-labs.com/contact_us/) for more information.


### PR DESCRIPTION
In the current Github Packages, anyone can pull the `scalardb-server` image despite it being provided only a commercial license.
And, anyone can build the `scalardb-server` image in their local environment since the code and Dockerfile are public.
Also, in AWS/Azure marketplace, it describes that the ScalarDB Server is provided as BYOL clearly.
So, I think it would be better to describe it in the README of the GitHub repository.

Please take a look!