### PR TITLE
Make integration test bases for transaction extendable

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -26,25 +26,25 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionAdminIntegrationTestBase {
 
-  private static final String TEST_NAME = "tx_admin";
-  private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
-  private static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
-  private static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
+  protected static final String TEST_NAME = "tx_admin";
+  protected static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
+  protected static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
+  protected static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
   protected static final String TABLE1 = "test_table1";
-  private static final String TABLE2 = "test_table2";
-  private static final String TABLE3 = "test_table3";
-  private static final String TABLE4 = "test_table4";
-  private static final String COL_NAME1 = "c1";
-  private static final String COL_NAME2 = "c2";
-  private static final String COL_NAME3 = "c3";
-  private static final String COL_NAME4 = "c4";
-  private static final String COL_NAME5 = "c5";
-  private static final String COL_NAME6 = "c6";
-  private static final String COL_NAME7 = "c7";
-  private static final String COL_NAME8 = "c8";
-  private static final String COL_NAME9 = "c9";
-  private static final String COL_NAME10 = "c10";
-  private static final String COL_NAME11 = "c11";
+  protected static final String TABLE2 = "test_table2";
+  protected static final String TABLE3 = "test_table3";
+  protected static final String TABLE4 = "test_table4";
+  protected static final String COL_NAME1 = "c1";
+  protected static final String COL_NAME2 = "c2";
+  protected static final String COL_NAME3 = "c3";
+  protected static final String COL_NAME4 = "c4";
+  protected static final String COL_NAME5 = "c5";
+  protected static final String COL_NAME6 = "c6";
+  protected static final String COL_NAME7 = "c7";
+  protected static final String COL_NAME8 = "c8";
+  protected static final String COL_NAME9 = "c9";
+  protected static final String COL_NAME10 = "c10";
+  protected static final String COL_NAME11 = "c11";
 
   protected static final TableMetadata TABLE_METADATA =
       TableMetadata.newBuilder()
@@ -66,11 +66,11 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
           .addSecondaryIndex(COL_NAME5)
           .addSecondaryIndex(COL_NAME6)
           .build();
-  private TransactionFactory transactionFactory;
-  private DistributedTransactionAdmin admin;
-  private String namespace1;
-  private String namespace2;
-  private String namespace3;
+  protected TransactionFactory transactionFactory;
+  protected DistributedTransactionAdmin admin;
+  protected String namespace1;
+  protected String namespace2;
+  protected String namespace3;
 
   @BeforeAll
   public void beforeAll() throws Exception {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
@@ -19,21 +19,21 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase {
 
-  private static final String TEST_NAME = "tx_admin_repair_table";
-  private static final String NAMESPACE = "int_test_" + TEST_NAME;
+  protected static final String TEST_NAME = "tx_admin_repair_table";
+  protected static final String NAMESPACE = "int_test_" + TEST_NAME;
 
-  private static final String TABLE = "test_table";
-  private static final String COL_NAME1 = "c1";
-  private static final String COL_NAME2 = "c2";
-  private static final String COL_NAME3 = "c3";
-  private static final String COL_NAME4 = "c4";
-  private static final String COL_NAME5 = "c5";
-  private static final String COL_NAME6 = "c6";
-  private static final String COL_NAME7 = "c7";
-  private static final String COL_NAME8 = "c8";
-  private static final String COL_NAME9 = "c9";
-  private static final String COL_NAME10 = "c10";
-  private static final String COL_NAME11 = "c11";
+  protected static final String TABLE = "test_table";
+  protected static final String COL_NAME1 = "c1";
+  protected static final String COL_NAME2 = "c2";
+  protected static final String COL_NAME3 = "c3";
+  protected static final String COL_NAME4 = "c4";
+  protected static final String COL_NAME5 = "c5";
+  protected static final String COL_NAME6 = "c6";
+  protected static final String COL_NAME7 = "c7";
+  protected static final String COL_NAME8 = "c8";
+  protected static final String COL_NAME9 = "c9";
+  protected static final String COL_NAME10 = "c10";
+  protected static final String COL_NAME11 = "c11";
 
   protected static final TableMetadata TABLE_METADATA =
       TableMetadata.newBuilder()

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -38,15 +38,15 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionIntegrationTestBase {
 
-  private static final String NAMESPACE_BASE_NAME = "int_test_";
+  protected static final String NAMESPACE_BASE_NAME = "int_test_";
   protected static final String TABLE = "test_table";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";
-  private static final String SOME_COLUMN = "some_column";
+  protected static final String SOME_COLUMN = "some_column";
   protected static final int INITIAL_BALANCE = 1000;
-  private static final int NUM_ACCOUNTS = 4;
-  private static final int NUM_TYPES = 4;
+  protected static final int NUM_ACCOUNTS = 4;
+  protected static final int NUM_TYPES = 4;
   protected static final TableMetadata TABLE_METADATA =
       TableMetadata.newBuilder()
           .addColumn(ACCOUNT_ID, DataType.INT)
@@ -57,8 +57,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
           .addClusteringKey(ACCOUNT_TYPE)
           .addSecondaryIndex(SOME_COLUMN)
           .build();
-  private DistributedTransactionAdmin admin;
-  private DistributedTransactionManager manager;
+  protected DistributedTransactionAdmin admin;
+  protected DistributedTransactionManager manager;
   protected String namespace;
 
   @BeforeAll
@@ -942,7 +942,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         .isInstanceOf(TransactionNotFoundException.class);
   }
 
-  private void populateRecords() throws TransactionException {
+  protected void populateRecords() throws TransactionException {
     DistributedTransaction transaction = manager.start();
     IntStream.range(0, NUM_ACCOUNTS)
         .forEach(
@@ -967,7 +967,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     transaction.commit();
   }
 
-  private void populateSingleRecord() throws TransactionException {
+  protected void populateSingleRecord() throws TransactionException {
     Put put =
         new Put(Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0))
             .forNamespace(namespace)
@@ -987,7 +987,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private List<Get> prepareGets() {
+  protected List<Get> prepareGets() {
     List<Get> gets = new ArrayList<>();
     IntStream.range(0, NUM_ACCOUNTS)
         .forEach(i -> IntStream.range(0, NUM_TYPES).forEach(j -> gets.add(prepareGet(i, j))));
@@ -1004,14 +1004,14 @@ public abstract class DistributedTransactionIntegrationTestBase {
         .withEnd(new Key(ACCOUNT_TYPE, toType));
   }
 
-  private ScanAll prepareScanAll() {
+  protected ScanAll prepareScanAll() {
     return new ScanAll()
         .forNamespace(namespace)
         .forTable(TABLE)
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private Put preparePut(int id, int type) {
+  protected Put preparePut(int id, int type) {
     Key partitionKey = new Key(ACCOUNT_ID, id);
     Key clusteringKey = new Key(ACCOUNT_TYPE, type);
     return new Put(partitionKey, clusteringKey)
@@ -1020,7 +1020,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private List<Put> preparePuts() {
+  protected List<Put> preparePuts() {
     List<Put> puts = new ArrayList<>();
     IntStream.range(0, NUM_ACCOUNTS)
         .forEach(i -> IntStream.range(0, NUM_TYPES).forEach(j -> puts.add(preparePut(i, j))));
@@ -1028,7 +1028,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     return puts;
   }
 
-  private Delete prepareDelete(int id, int type) {
+  protected Delete prepareDelete(int id, int type) {
     Key partitionKey = new Key(ACCOUNT_ID, id);
     Key clusteringKey = new Key(ACCOUNT_TYPE, type);
     return new Delete(partitionKey, clusteringKey)
@@ -1037,7 +1037,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private int getBalance(Result result) {
+  protected int getBalance(Result result) {
     Optional<Value<?>> balance = result.getValue(BALANCE);
     assertThat(balance).isPresent();
     return balance.get().getAsInt();

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -38,16 +38,16 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
-  private static final String NAMESPACE_BASE_NAME = "int_test_";
+  protected static final String NAMESPACE_BASE_NAME = "int_test_";
   protected static final String TABLE_1 = "test_table1";
   protected static final String TABLE_2 = "test_table2";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";
-  private static final String SOME_COLUMN = "some_column";
+  protected static final String SOME_COLUMN = "some_column";
   protected static final int INITIAL_BALANCE = 1000;
-  private static final int NUM_ACCOUNTS = 4;
-  private static final int NUM_TYPES = 4;
+  protected static final int NUM_ACCOUNTS = 4;
+  protected static final int NUM_TYPES = 4;
   protected static final TableMetadata TABLE_METADATA =
       TableMetadata.newBuilder()
           .addColumn(ACCOUNT_ID, DataType.INT)
@@ -58,10 +58,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
           .addClusteringKey(ACCOUNT_TYPE)
           .addSecondaryIndex(SOME_COLUMN)
           .build();
-  private DistributedTransactionAdmin admin1;
-  private DistributedTransactionAdmin admin2;
-  private TwoPhaseCommitTransactionManager manager1;
-  private TwoPhaseCommitTransactionManager manager2;
+  protected DistributedTransactionAdmin admin1;
+  protected DistributedTransactionAdmin admin2;
+  protected TwoPhaseCommitTransactionManager manager1;
+  protected TwoPhaseCommitTransactionManager manager2;
 
   protected String namespace1;
   protected String namespace2;
@@ -1168,7 +1168,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         .isInstanceOf(TransactionNotFoundException.class);
   }
 
-  private void populateRecords(
+  protected void populateRecords(
       TwoPhaseCommitTransactionManager manager, String namespaceName, String tableName)
       throws TransactionException {
     TwoPhaseCommitTransaction transaction = manager.begin();
@@ -1197,7 +1197,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     transaction.commit();
   }
 
-  private void populateSingleRecord(String namespaceName, String tableName)
+  protected void populateSingleRecord(String namespaceName, String tableName)
       throws TransactionException {
     Put put =
         new Put(Key.ofInt(ACCOUNT_ID, 0), Key.ofInt(ACCOUNT_TYPE, 0))
@@ -1220,7 +1220,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private List<Get> prepareGets(String namespaceName, String tableName) {
+  protected List<Get> prepareGets(String namespaceName, String tableName) {
     List<Get> gets = new ArrayList<>();
     IntStream.range(0, NUM_ACCOUNTS)
         .forEach(
@@ -1241,14 +1241,14 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         .withEnd(new Key(ACCOUNT_TYPE, toType));
   }
 
-  private ScanAll prepareScanAll(String namespaceName, String tableName) {
+  protected ScanAll prepareScanAll(String namespaceName, String tableName) {
     return new ScanAll()
         .forNamespace(namespaceName)
         .forTable(tableName)
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private Put preparePut(int id, int type, String namespaceName, String tableName) {
+  protected Put preparePut(int id, int type, String namespaceName, String tableName) {
     Key partitionKey = new Key(ACCOUNT_ID, id);
     Key clusteringKey = new Key(ACCOUNT_TYPE, type);
     return new Put(partitionKey, clusteringKey)
@@ -1257,7 +1257,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private List<Put> preparePuts(String namespaceName, String tableName) {
+  protected List<Put> preparePuts(String namespaceName, String tableName) {
     List<Put> puts = new ArrayList<>();
     IntStream.range(0, NUM_ACCOUNTS)
         .forEach(
@@ -1268,7 +1268,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     return puts;
   }
 
-  private Delete prepareDelete(int id, int type, String namespaceName, String tableName) {
+  protected Delete prepareDelete(int id, int type, String namespaceName, String tableName) {
     Key partitionKey = new Key(ACCOUNT_ID, id);
     Key clusteringKey = new Key(ACCOUNT_TYPE, type);
     return new Delete(partitionKey, clusteringKey)
@@ -1277,7 +1277,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
-  private int getBalance(Result result) {
+  protected int getBalance(Result result) {
     Optional<Value<?>> balance = result.getValue(BALANCE);
     assertThat(balance).isPresent();
     return balance.get().getAsInt();


### PR DESCRIPTION
This PR makes some of the fields and the methods in integration test bases for the transaction API `protected` to make them extendable. Please take a look!