### PR TITLE
build(fix): bump-up protobufVersion to 3.21.12 (latest)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'
         grpcVersion = '1.46.1'
-        protobufVersion = '3.20.3'
+        protobufVersion = '3.21.12'
         annotationVersion = '1.3.2'
         picocliVersion = '4.1.4'
         scalarAdminVersion = '1.2.0'


### PR DESCRIPTION
## Problem

The following command fails in M1 Mac (osx-aarch_64).

```console
./gradlew :rpc:generateProto  # called from `./gradlew test`, for example
```

```
> Task :rpc:generateProto FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rpc:generateProto'.
> Could not resolve all files for configuration ':rpc:protobufToolsLocator_protoc'.
   > Could not find protoc-3.20.3-osx-aarch_64.exe (com.google.protobuf:protoc:3.20.3).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.20.3/protoc-3.20.3-osx-aarch_64.exe

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/7.0.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 646ms
3 actionable tasks: 1 executed, 2 up-to-date
```

This is because the version 3.20.3 does not include `protoc` binary for `osx-aarch_64` in the maven repository, while 3.21.12 does.

- https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.20.3/
- https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.21.12/

Refs: https://github.com/protocolbuffers/protobuf/issues/8062

## What I did

Bump up `protobufVersion` from 3.20.3 to 3.21.12 (latest).

## I'm not sure...

The command:

```console
./gradlew :rpc:generateProto
```

leads to the following diffs. Currently I don't commit the diffs but I will if necessary.

[rpc-generateProto.diff.txt](https://github.com/scalar-labs/scalardb/files/10250960/rpc-generateProto.diff.txt)
