### PR TITLE
docs: Clearer description on when to use online backups

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -52,7 +52,11 @@ Note that when you use a point-in-time-restore/recovery mechanism, it is recomme
 Otherwise, the time you get as a paused duration might be too different from the time in which the pause was actually conducted, which could restore to a point where ongoing transactions exist.
 Also, it is recommended to pause a long enough time (e.g., 10 seconds) and use the mid-time of the paused duration as a restore point since clock synchronization cannot perfectly synchronize clocks between nodes.
 
-#### Database-specific ways to create a transactionally-consistent backup   
+#### Database-specific ways to create a transactionally-consistent backup
+
+**Databases with transaction support**
+
+See subsections in the [online backup](#online-backup).
 
 **Cassandra**
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -27,15 +27,15 @@ That means that you need to create a consistent snapshot by dumping all tables i
 The ways to create transactional backups are different among each database product.
 We show some examples for some database products but you are requested to find the safe ways to a transactional backup from your databases at your own risk.
 
-#### MySQL
+#### MySQL (backup)
 
 Use the `mysqldump` command with `--single-transaction` option.
 
-#### PostgreSQL
+#### PostgreSQL (backup)
 
 Use the `pg_dump` command.
 
-#### Amazon RDS or Azure Database for MySQL/PostgreSQL
+#### Amazon RDS or Azure Database for MySQL/PostgreSQL (backup)
 
 You can restore to any point within the backup retention period with the automated backup feature.
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -82,12 +82,17 @@ To specify a transactionally-consistent restore point, please pause the Scalar D
 
 ## Restore Backup
 
-### JDBC databases
+### MySQL (restore)
 
-You need to restore backups appropriately depending on how the backups are created.
-For example, if you use MySQL and `mysqldump` to create a backup file, use `mysql` command to restore the file as specified [in the MySQL doc](https://dev.mysql.com/doc/mysql-backup-excerpt/8.0/en/reloading-sql-format-dumps.html). If you use PostgreSQL and `pg_dump` to create a backup file, use `psql` command to restore the file as specified in [the PostgreSQL doc](https://www.postgresql.org/docs/current/backup-dump.html#BACKUP-DUMP-RESTORE).
-If you use Amazon RDS (Relational Database Service) or Azure Database for MySQL/PostgreSQL,
-you can restore to any point within the backup retention period with the automated backup feature.
+If you use MySQL and `mysqldump` to create a backup file, use `mysql` command to restore the file as specified [in the MySQL doc](https://dev.mysql.com/doc/mysql-backup-excerpt/8.0/en/reloading-sql-format-dumps.html).
+
+### PostgreSQL (restore)
+
+If you use PostgreSQL and `pg_dump` to create a backup file, use `psql` command to restore the file as specified in [the PostgreSQL doc](https://www.postgresql.org/docs/current/backup-dump.html#BACKUP-DUMP-RESTORE).
+
+### Amazon RDS or Azure Database for MySQL/PostgreSQL (restore)
+
+You can restore to any point within the backup retention period with the automated backup feature.
 
 ### Cassandra
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -94,19 +94,19 @@ If you use PostgreSQL and `pg_dump` to create a backup file, use `psql` command 
 
 You can restore to any point within the backup retention period with the automated backup feature.
 
-### Cassandra
+### Cassandra (restore)
 
 You first need to stop all the nodes of a Cassandra cluster. Clean the directories (`data`, `commitlogs`, and `hints`) and place backups (snapshots) in each node. Then, start all the nodes.
 
 To avoid mistakes, it is recommended to use [Cassy](https://github.com/scalar-labs/cassy).
 Please see [the doc](https://github.com/scalar-labs/cassy/blob/master/docs/getting-started.md#take-cluster-wide-consistent-backups) for more details.
 
-### Cosmos DB
+### Cosmos DB (restore)
 
 You can follow the [azure official guide](https://docs.microsoft.com/en-us/azure/cosmos-db/restore-account-continuous-backup#restore-account-portal). After restoring backups. change the default consistencies of the restored databases to `STRONG`
 It is recommended to use the mid-time of paused duration as a restore point as we explained earlier.
 
-### DynamoDB
+### DynamoDB (restore)
 
 You can basically follow [the official doc](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.Tutorial.html). However, a table can only be restored with an alias, so you need to restore a table with an alias and delete the original table and rename the alias to the original name to restore the same named tables.
 


### PR DESCRIPTION
## Problem

`backup-restore.md` could be read as the following:

- It is safe to make backups for MySQL and PostgreSQL (both are under a Scalar DB instance) using `mysqldump` and `pg_dump` while the Scalar DB instance is accepting new transactions

But it should (quite naturally) cause inconsistent tables among the MySQL and PostgreSQL.

## What I did

- Divide two ways to create backups: online or using pause duration
- Add a flowchart for when to use online backup
- Clearly write the responsibility of creating an online backup belongs to users
- Break "JDBC database" sections into ones for each DB product