### PR TITLE
build(fix): bump-up protobufVersion to 3.21.12 (latest)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'
         grpcVersion = '1.46.1'
-        protobufVersion = '3.20.3'
+        protobufVersion = '3.21.12'
         annotationVersion = '1.3.2'
         picocliVersion = '4.1.4'
         scalarAdminVersion = '1.2.0'

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortRequest.java
@@ -45,7 +45,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-  private volatile java.lang.Object transactionId_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object transactionId_ = "";
   /**
    * <code>string transaction_id = 1;</code>
    * @return The transactionId.
@@ -269,8 +270,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       transactionId_ = "";
-
       return this;
     }
 
@@ -297,9 +298,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.AbortRequest buildPartial() {
       com.scalar.db.rpc.AbortRequest result = new com.scalar.db.rpc.AbortRequest(this);
-      result.transactionId_ = transactionId_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.AbortRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.transactionId_ = transactionId_;
+      }
     }
 
     @java.lang.Override
@@ -348,6 +356,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.AbortRequest.getDefaultInstance()) return this;
       if (!other.getTransactionId().isEmpty()) {
         transactionId_ = other.transactionId_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -378,7 +387,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               transactionId_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -396,6 +405,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object transactionId_ = "";
     /**
@@ -438,11 +448,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTransactionId(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       transactionId_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -451,8 +459,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTransactionId() {
-      
       transactionId_ = getDefaultInstance().getTransactionId();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -463,12 +471,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTransactionIdBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       transactionId_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/AbortResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AbortResponse.java
@@ -45,7 +45,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int STATE_FIELD_NUMBER = 1;
-  private int state_;
+  private int state_ = 0;
   /**
    * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
@@ -58,8 +58,7 @@ private static final long serialVersionUID = 0L;
    * @return The state.
    */
   @java.lang.Override public com.scalar.db.rpc.TransactionState getState() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.valueOf(state_);
+    com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.forNumber(state_);
     return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
   }
 
@@ -250,8 +249,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       state_ = 0;
-
       return this;
     }
 
@@ -278,9 +277,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.AbortResponse buildPartial() {
       com.scalar.db.rpc.AbortResponse result = new com.scalar.db.rpc.AbortResponse(this);
-      result.state_ = state_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.AbortResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.state_ = state_;
+      }
     }
 
     @java.lang.Override
@@ -358,7 +364,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               state_ = input.readEnum();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             default: {
@@ -376,6 +382,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private int state_ = 0;
     /**
@@ -391,8 +398,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setStateValue(int value) {
-      
       state_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -402,8 +409,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionState getState() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.valueOf(state_);
+      com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.forNumber(state_);
       return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
     }
     /**
@@ -415,7 +421,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000001;
       state_ = value.getNumber();
       onChanged();
       return this;
@@ -425,7 +431,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearState() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       state_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/AddNewColumnToTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/AddNewColumnToTableRequest.java
@@ -48,7 +48,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -86,7 +87,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -124,7 +126,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMN_NAME_FIELD_NUMBER = 3;
-  private volatile java.lang.Object columnName_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object columnName_ = "";
   /**
    * <code>string column_name = 3;</code>
    * @return The columnName.
@@ -162,7 +165,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMN_TYPE_FIELD_NUMBER = 4;
-  private int columnType_;
+  private int columnType_ = 0;
   /**
    * <code>.rpc.DataType column_type = 4;</code>
    * @return The enum numeric value on the wire for columnType.
@@ -175,8 +178,7 @@ private static final long serialVersionUID = 0L;
    * @return The columnType.
    */
   @java.lang.Override public com.scalar.db.rpc.DataType getColumnType() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.DataType result = com.scalar.db.rpc.DataType.valueOf(columnType_);
+    com.scalar.db.rpc.DataType result = com.scalar.db.rpc.DataType.forNumber(columnType_);
     return result == null ? com.scalar.db.rpc.DataType.UNRECOGNIZED : result;
   }
 
@@ -397,14 +399,11 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
       columnName_ = "";
-
       columnType_ = 0;
-
       return this;
     }
 
@@ -431,12 +430,25 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.AddNewColumnToTableRequest buildPartial() {
       com.scalar.db.rpc.AddNewColumnToTableRequest result = new com.scalar.db.rpc.AddNewColumnToTableRequest(this);
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      result.columnName_ = columnName_;
-      result.columnType_ = columnType_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.AddNewColumnToTableRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.columnName_ = columnName_;
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.columnType_ = columnType_;
+      }
     }
 
     @java.lang.Override
@@ -485,14 +497,17 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.AddNewColumnToTableRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (!other.getColumnName().isEmpty()) {
         columnName_ = other.columnName_;
+        bitField0_ |= 0x00000004;
         onChanged();
       }
       if (other.columnType_ != 0) {
@@ -526,22 +541,22 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               columnName_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 32: {
               columnType_ = input.readEnum();
-
+              bitField0_ |= 0x00000008;
               break;
             } // case 32
             default: {
@@ -559,6 +574,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -601,11 +617,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -614,8 +628,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -626,12 +640,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -677,11 +689,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -690,8 +700,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -702,12 +712,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -753,11 +761,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setColumnName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       columnName_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -766,8 +772,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearColumnName() {
-      
       columnName_ = getDefaultInstance().getColumnName();
+      bitField0_ = (bitField0_ & ~0x00000004);
       onChanged();
       return this;
     }
@@ -778,12 +784,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setColumnNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       columnName_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -802,8 +806,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setColumnTypeValue(int value) {
-      
       columnType_ = value;
+      bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }
@@ -813,8 +817,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.DataType getColumnType() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.DataType result = com.scalar.db.rpc.DataType.valueOf(columnType_);
+      com.scalar.db.rpc.DataType result = com.scalar.db.rpc.DataType.forNumber(columnType_);
       return result == null ? com.scalar.db.rpc.DataType.UNRECOGNIZED : result;
     }
     /**
@@ -826,7 +829,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000008;
       columnType_ = value.getNumber();
       onChanged();
       return this;
@@ -836,7 +839,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearColumnType() {
-      
+      bitField0_ = (bitField0_ & ~0x00000008);
       columnType_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/Column.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Column.java
@@ -96,7 +96,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
-  private volatile java.lang.Object name_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object name_ = "";
   /**
    * <code>string name = 1;</code>
    * @return The name.
@@ -629,8 +630,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       name_ = "";
-
       valueCase_ = 0;
       value_ = null;
       return this;
@@ -659,31 +660,22 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Column buildPartial() {
       com.scalar.db.rpc.Column result = new com.scalar.db.rpc.Column(this);
-      result.name_ = name_;
-      if (valueCase_ == 2) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 3) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 4) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 5) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 6) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 7) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 8) {
-        result.value_ = value_;
-      }
-      result.valueCase_ = valueCase_;
+      if (bitField0_ != 0) { buildPartial0(result); }
+      buildPartialOneofs(result);
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Column result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.name_ = name_;
+      }
+    }
+
+    private void buildPartialOneofs(com.scalar.db.rpc.Column result) {
+      result.valueCase_ = valueCase_;
+      result.value_ = this.value_;
     }
 
     @java.lang.Override
@@ -732,6 +724,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.Column.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       switch (other.getValueCase()) {
@@ -797,7 +790,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               name_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 16: {
@@ -866,6 +859,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private int bitField0_;
 
     private java.lang.Object name_ = "";
     /**
@@ -908,11 +902,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -921,8 +913,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
       name_ = getDefaultInstance().getName();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -933,12 +925,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -966,6 +956,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setBooleanValue(boolean value) {
+      
       valueCase_ = 2;
       value_ = value;
       onChanged();
@@ -1007,6 +998,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setIntValue(int value) {
+      
       valueCase_ = 3;
       value_ = value;
       onChanged();
@@ -1048,6 +1040,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setBigintValue(long value) {
+      
       valueCase_ = 4;
       value_ = value;
       onChanged();
@@ -1089,6 +1082,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFloatValue(float value) {
+      
       valueCase_ = 5;
       value_ = value;
       onChanged();
@@ -1130,6 +1124,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setDoubleValue(double value) {
+      
       valueCase_ = 6;
       value_ = value;
       onChanged();
@@ -1208,10 +1203,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTextValue(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  valueCase_ = 7;
+      if (value == null) { throw new NullPointerException(); }
+      valueCase_ = 7;
       value_ = value;
       onChanged();
       return this;
@@ -1235,10 +1228,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTextValueBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       valueCase_ = 7;
       value_ = value;
       onChanged();
@@ -1268,10 +1259,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setBlobValue(com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  valueCase_ = 8;
+      if (value == null) { throw new NullPointerException(); }
+      valueCase_ = 8;
       value_ = value;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpression.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ConditionalExpression.java
@@ -208,7 +208,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
-  private volatile java.lang.Object name_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object name_ = "";
   /**
    * <code>string name = 1 [deprecated = true];</code>
    * @deprecated rpc.ConditionalExpression.name is deprecated.
@@ -276,11 +277,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   @java.lang.Deprecated public com.scalar.db.rpc.ValueOrBuilder getValueOrBuilder() {
-    return getValue();
+    return value_ == null ? com.scalar.db.rpc.Value.getDefaultInstance() : value_;
   }
 
   public static final int OPERATOR_FIELD_NUMBER = 3;
-  private int operator_;
+  private int operator_ = 0;
   /**
    * <code>.rpc.ConditionalExpression.Operator operator = 3;</code>
    * @return The enum numeric value on the wire for operator.
@@ -293,8 +294,7 @@ private static final long serialVersionUID = 0L;
    * @return The operator.
    */
   @java.lang.Override public com.scalar.db.rpc.ConditionalExpression.Operator getOperator() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.ConditionalExpression.Operator result = com.scalar.db.rpc.ConditionalExpression.Operator.valueOf(operator_);
+    com.scalar.db.rpc.ConditionalExpression.Operator result = com.scalar.db.rpc.ConditionalExpression.Operator.forNumber(operator_);
     return result == null ? com.scalar.db.rpc.ConditionalExpression.Operator.UNRECOGNIZED : result;
   }
 
@@ -321,7 +321,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.ColumnOrBuilder getColumnOrBuilder() {
-    return getColumn();
+    return column_ == null ? com.scalar.db.rpc.Column.getDefaultInstance() : column_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -553,20 +553,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       name_ = "";
-
-      if (valueBuilder_ == null) {
-        value_ = null;
-      } else {
-        value_ = null;
+      value_ = null;
+      if (valueBuilder_ != null) {
+        valueBuilder_.dispose();
         valueBuilder_ = null;
       }
       operator_ = 0;
-
-      if (columnBuilder_ == null) {
-        column_ = null;
-      } else {
-        column_ = null;
+      column_ = null;
+      if (columnBuilder_ != null) {
+        columnBuilder_.dispose();
         columnBuilder_ = null;
       }
       return this;
@@ -595,20 +592,29 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.ConditionalExpression buildPartial() {
       com.scalar.db.rpc.ConditionalExpression result = new com.scalar.db.rpc.ConditionalExpression(this);
-      result.name_ = name_;
-      if (valueBuilder_ == null) {
-        result.value_ = value_;
-      } else {
-        result.value_ = valueBuilder_.build();
-      }
-      result.operator_ = operator_;
-      if (columnBuilder_ == null) {
-        result.column_ = column_;
-      } else {
-        result.column_ = columnBuilder_.build();
-      }
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.ConditionalExpression result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.name_ = name_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.value_ = valueBuilder_ == null
+            ? value_
+            : valueBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.operator_ = operator_;
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.column_ = columnBuilder_ == null
+            ? column_
+            : columnBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -657,6 +663,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.ConditionalExpression.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (other.hasValue()) {
@@ -696,26 +703,26 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               name_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               input.readMessage(
                   getValueFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 24: {
               operator_ = input.readEnum();
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 24
             case 34: {
               input.readMessage(
                   getColumnFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             default: {
@@ -733,6 +740,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object name_ = "";
     /**
@@ -781,11 +789,9 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated public Builder setName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -796,8 +802,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearName() {
-      
       name_ = getDefaultInstance().getName();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -810,12 +816,10 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated public Builder setNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -830,7 +834,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the value field is set.
      */
     @java.lang.Deprecated public boolean hasValue() {
-      return valueBuilder_ != null || value_ != null;
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>.rpc.Value value = 2 [deprecated = true];</code>
@@ -854,11 +858,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         value_ = value;
-        onChanged();
       } else {
         valueBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000002;
+      onChanged();
       return this;
     }
     /**
@@ -868,11 +872,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Value.Builder builderForValue) {
       if (valueBuilder_ == null) {
         value_ = builderForValue.build();
-        onChanged();
       } else {
         valueBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000002;
+      onChanged();
       return this;
     }
     /**
@@ -880,38 +884,38 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated public Builder mergeValue(com.scalar.db.rpc.Value value) {
       if (valueBuilder_ == null) {
-        if (value_ != null) {
-          value_ =
-            com.scalar.db.rpc.Value.newBuilder(value_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000002) != 0) &&
+          value_ != null &&
+          value_ != com.scalar.db.rpc.Value.getDefaultInstance()) {
+          getValueBuilder().mergeFrom(value);
         } else {
           value_ = value;
         }
-        onChanged();
       } else {
         valueBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000002;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Builder clearValue() {
-      if (valueBuilder_ == null) {
-        value_ = null;
-        onChanged();
-      } else {
-        value_ = null;
+      bitField0_ = (bitField0_ & ~0x00000002);
+      value_ = null;
+      if (valueBuilder_ != null) {
+        valueBuilder_.dispose();
         valueBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Value value = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.scalar.db.rpc.Value.Builder getValueBuilder() {
-      
+      bitField0_ |= 0x00000002;
       onChanged();
       return getValueFieldBuilder().getBuilder();
     }
@@ -957,8 +961,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setOperatorValue(int value) {
-      
       operator_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -968,8 +972,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.ConditionalExpression.Operator getOperator() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.ConditionalExpression.Operator result = com.scalar.db.rpc.ConditionalExpression.Operator.valueOf(operator_);
+      com.scalar.db.rpc.ConditionalExpression.Operator result = com.scalar.db.rpc.ConditionalExpression.Operator.forNumber(operator_);
       return result == null ? com.scalar.db.rpc.ConditionalExpression.Operator.UNRECOGNIZED : result;
     }
     /**
@@ -981,7 +984,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000004;
       operator_ = value.getNumber();
       onChanged();
       return this;
@@ -991,7 +994,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearOperator() {
-      
+      bitField0_ = (bitField0_ & ~0x00000004);
       operator_ = 0;
       onChanged();
       return this;
@@ -1005,7 +1008,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the column field is set.
      */
     public boolean hasColumn() {
-      return columnBuilder_ != null || column_ != null;
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>.rpc.Column column = 4;</code>
@@ -1027,11 +1030,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         column_ = value;
-        onChanged();
       } else {
         columnBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
@@ -1041,11 +1044,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Column.Builder builderForValue) {
       if (columnBuilder_ == null) {
         column_ = builderForValue.build();
-        onChanged();
       } else {
         columnBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
@@ -1053,38 +1056,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeColumn(com.scalar.db.rpc.Column value) {
       if (columnBuilder_ == null) {
-        if (column_ != null) {
-          column_ =
-            com.scalar.db.rpc.Column.newBuilder(column_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000008) != 0) &&
+          column_ != null &&
+          column_ != com.scalar.db.rpc.Column.getDefaultInstance()) {
+          getColumnBuilder().mergeFrom(value);
         } else {
           column_ = value;
         }
-        onChanged();
       } else {
         columnBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Column column = 4;</code>
      */
     public Builder clearColumn() {
-      if (columnBuilder_ == null) {
-        column_ = null;
-        onChanged();
-      } else {
-        column_ = null;
+      bitField0_ = (bitField0_ & ~0x00000008);
+      column_ = null;
+      if (columnBuilder_ != null) {
+        columnBuilder_.dispose();
         columnBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Column column = 4;</code>
      */
     public com.scalar.db.rpc.Column.Builder getColumnBuilder() {
-      
+      bitField0_ |= 0x00000008;
       onChanged();
       return getColumnFieldBuilder().getBuilder();
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CoordinatorTablesExistResponse.java
@@ -44,7 +44,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int EXIST_FIELD_NUMBER = 1;
-  private boolean exist_;
+  private boolean exist_ = false;
   /**
    * <code>bool exist = 1;</code>
    * @return The exist.
@@ -243,8 +243,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       exist_ = false;
-
       return this;
     }
 
@@ -271,9 +271,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.CoordinatorTablesExistResponse buildPartial() {
       com.scalar.db.rpc.CoordinatorTablesExistResponse result = new com.scalar.db.rpc.CoordinatorTablesExistResponse(this);
-      result.exist_ = exist_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.CoordinatorTablesExistResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.exist_ = exist_;
+      }
     }
 
     @java.lang.Override
@@ -351,7 +358,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               exist_ = input.readBool();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             default: {
@@ -369,6 +376,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private boolean exist_ ;
     /**
@@ -387,6 +395,7 @@ private static final long serialVersionUID = 0L;
     public Builder setExist(boolean value) {
       
       exist_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -395,7 +404,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearExist() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       exist_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequest.java
@@ -67,6 +67,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "");
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.String> options_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.String>
@@ -77,14 +78,12 @@ private static final long serialVersionUID = 0L;
     }
     return options_;
   }
-
   public int getOptionsCount() {
     return internalGetOptions().getMap().size();
   }
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
-
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
@@ -103,7 +102,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
     return internalGetOptions().getMap();
   }
@@ -111,10 +109,11 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
   @java.lang.Override
-
-  public java.lang.String getOptionsOrDefault(
+  public /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue) {
+      /* nullable */
+java.lang.String defaultValue) {
     if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
@@ -124,7 +123,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
   @java.lang.Override
-
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -137,7 +135,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_NOT_EXIST_FIELD_NUMBER = 2;
-  private boolean ifNotExist_;
+  private boolean ifNotExist_ = false;
   /**
    * <code>bool if_not_exist = 2;</code>
    * @return The ifNotExist.
@@ -380,9 +378,9 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       internalGetMutableOptions().clear();
       ifNotExist_ = false;
-
       return this;
     }
 
@@ -409,12 +407,20 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.CreateCoordinatorTablesRequest buildPartial() {
       com.scalar.db.rpc.CreateCoordinatorTablesRequest result = new com.scalar.db.rpc.CreateCoordinatorTablesRequest(this);
-      int from_bitField0_ = bitField0_;
-      result.options_ = internalGetOptions();
-      result.options_.makeImmutable();
-      result.ifNotExist_ = ifNotExist_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.CreateCoordinatorTablesRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.options_ = internalGetOptions();
+        result.options_.makeImmutable();
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.ifNotExist_ = ifNotExist_;
+      }
     }
 
     @java.lang.Override
@@ -463,6 +469,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.CreateCoordinatorTablesRequest.getDefaultInstance()) return this;
       internalGetMutableOptions().mergeFrom(
           other.internalGetOptions());
+      bitField0_ |= 0x00000001;
       if (other.getIfNotExist() != false) {
         setIfNotExist(other.getIfNotExist());
       }
@@ -498,11 +505,12 @@ private static final long serialVersionUID = 0L;
                   OptionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableOptions().getMutableMap().put(
                   options__.getKey(), options__.getValue());
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 16: {
               ifNotExist_ = input.readBool();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 16
             default: {
@@ -525,7 +533,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.String> options_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetOptions() {
+        internalGetOptions() {
       if (options_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -533,8 +541,7 @@ private static final long serialVersionUID = 0L;
       return options_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetMutableOptions() {
-      onChanged();;
+        internalGetMutableOptions() {
       if (options_ == null) {
         options_ = com.google.protobuf.MapField.newMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -542,16 +549,16 @@ private static final long serialVersionUID = 0L;
       if (!options_.isMutable()) {
         options_ = options_.copy();
       }
+      bitField0_ |= 0x00000001;
+      onChanged();
       return options_;
     }
-
     public int getOptionsCount() {
       return internalGetOptions().getMap().size();
     }
     /**
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
-
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
@@ -570,7 +577,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
       return internalGetOptions().getMap();
     }
@@ -578,10 +584,11 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
     @java.lang.Override
-
-    public java.lang.String getOptionsOrDefault(
+    public /* nullable */
+java.lang.String getOptionsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        /* nullable */
+java.lang.String defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
@@ -591,7 +598,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
     @java.lang.Override
-
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -602,8 +608,8 @@ private static final long serialVersionUID = 0L;
       }
       return map.get(key);
     }
-
     public Builder clearOptions() {
+      bitField0_ = (bitField0_ & ~0x00000001);
       internalGetMutableOptions().getMutableMap()
           .clear();
       return this;
@@ -611,7 +617,6 @@ private static final long serialVersionUID = 0L;
     /**
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
-
     public Builder removeOptions(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -624,7 +629,8 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.String>
-    getMutableOptions() {
+        getMutableOptions() {
+      bitField0_ |= 0x00000001;
       return internalGetMutableOptions().getMutableMap();
     }
     /**
@@ -634,22 +640,20 @@ private static final long serialVersionUID = 0L;
         java.lang.String key,
         java.lang.String value) {
       if (key == null) { throw new NullPointerException("map key"); }
-      if (value == null) {
-  throw new NullPointerException("map value");
-}
-
+      if (value == null) { throw new NullPointerException("map value"); }
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000001;
       return this;
     }
     /**
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
-
     public Builder putAllOptions(
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableOptions().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000001;
       return this;
     }
 
@@ -670,6 +674,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfNotExist(boolean value) {
       
       ifNotExist_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -678,7 +683,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfNotExist() {
-      
+      bitField0_ = (bitField0_ & ~0x00000002);
       ifNotExist_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateCoordinatorTablesRequestOrBuilder.java
@@ -30,7 +30,6 @@ public interface CreateCoordinatorTablesRequestOrBuilder extends
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
-
   /* nullable */
 java.lang.String getOptionsOrDefault(
       java.lang.String key,
@@ -39,7 +38,6 @@ java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
-
   java.lang.String getOptionsOrThrow(
       java.lang.String key);
 

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequest.java
@@ -59,7 +59,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -97,7 +98,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -135,7 +137,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMN_NAME_FIELD_NUMBER = 3;
-  private volatile java.lang.Object columnName_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object columnName_ = "";
   /**
    * <code>string column_name = 3;</code>
    * @return The columnName.
@@ -184,6 +187,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "");
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.String> options_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.String>
@@ -194,14 +198,12 @@ private static final long serialVersionUID = 0L;
     }
     return options_;
   }
-
   public int getOptionsCount() {
     return internalGetOptions().getMap().size();
   }
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
@@ -220,7 +222,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
     return internalGetOptions().getMap();
   }
@@ -228,10 +229,11 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
-  public java.lang.String getOptionsOrDefault(
+  public /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue) {
+      /* nullable */
+java.lang.String defaultValue) {
     if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
@@ -241,7 +243,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -254,7 +255,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_NOT_EXISTS_FIELD_NUMBER = 5;
-  private boolean ifNotExists_;
+  private boolean ifNotExists_ = false;
   /**
    * <code>bool if_not_exists = 5;</code>
    * @return The ifNotExists.
@@ -527,15 +528,12 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
       columnName_ = "";
-
       internalGetMutableOptions().clear();
       ifNotExists_ = false;
-
       return this;
     }
 
@@ -562,15 +560,29 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.CreateIndexRequest buildPartial() {
       com.scalar.db.rpc.CreateIndexRequest result = new com.scalar.db.rpc.CreateIndexRequest(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      result.columnName_ = columnName_;
-      result.options_ = internalGetOptions();
-      result.options_.makeImmutable();
-      result.ifNotExists_ = ifNotExists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.CreateIndexRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.columnName_ = columnName_;
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.options_ = internalGetOptions();
+        result.options_.makeImmutable();
+      }
+      if (((from_bitField0_ & 0x00000010) != 0)) {
+        result.ifNotExists_ = ifNotExists_;
+      }
     }
 
     @java.lang.Override
@@ -619,18 +631,22 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.CreateIndexRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (!other.getColumnName().isEmpty()) {
         columnName_ = other.columnName_;
+        bitField0_ |= 0x00000004;
         onChanged();
       }
       internalGetMutableOptions().mergeFrom(
           other.internalGetOptions());
+      bitField0_ |= 0x00000008;
       if (other.getIfNotExists() != false) {
         setIfNotExists(other.getIfNotExists());
       }
@@ -662,17 +678,17 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               columnName_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 34: {
@@ -681,11 +697,12 @@ private static final long serialVersionUID = 0L;
                   OptionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableOptions().getMutableMap().put(
                   options__.getKey(), options__.getValue());
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             case 40: {
               ifNotExists_ = input.readBool();
-
+              bitField0_ |= 0x00000010;
               break;
             } // case 40
             default: {
@@ -746,11 +763,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -759,8 +774,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -771,12 +786,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -822,11 +835,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -835,8 +846,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -847,12 +858,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -898,11 +907,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setColumnName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       columnName_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -911,8 +918,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearColumnName() {
-      
       columnName_ = getDefaultInstance().getColumnName();
+      bitField0_ = (bitField0_ & ~0x00000004);
       onChanged();
       return this;
     }
@@ -923,12 +930,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setColumnNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       columnName_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -936,7 +941,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.String> options_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetOptions() {
+        internalGetOptions() {
       if (options_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -944,8 +949,7 @@ private static final long serialVersionUID = 0L;
       return options_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetMutableOptions() {
-      onChanged();;
+        internalGetMutableOptions() {
       if (options_ == null) {
         options_ = com.google.protobuf.MapField.newMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -953,16 +957,16 @@ private static final long serialVersionUID = 0L;
       if (!options_.isMutable()) {
         options_ = options_.copy();
       }
+      bitField0_ |= 0x00000008;
+      onChanged();
       return options_;
     }
-
     public int getOptionsCount() {
       return internalGetOptions().getMap().size();
     }
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
@@ -981,7 +985,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
       return internalGetOptions().getMap();
     }
@@ -989,10 +992,11 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
-    public java.lang.String getOptionsOrDefault(
+    public /* nullable */
+java.lang.String getOptionsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        /* nullable */
+java.lang.String defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
@@ -1002,7 +1006,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1013,8 +1016,8 @@ private static final long serialVersionUID = 0L;
       }
       return map.get(key);
     }
-
     public Builder clearOptions() {
+      bitField0_ = (bitField0_ & ~0x00000008);
       internalGetMutableOptions().getMutableMap()
           .clear();
       return this;
@@ -1022,7 +1025,6 @@ private static final long serialVersionUID = 0L;
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     public Builder removeOptions(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1035,7 +1037,8 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.String>
-    getMutableOptions() {
+        getMutableOptions() {
+      bitField0_ |= 0x00000008;
       return internalGetMutableOptions().getMutableMap();
     }
     /**
@@ -1045,22 +1048,20 @@ private static final long serialVersionUID = 0L;
         java.lang.String key,
         java.lang.String value) {
       if (key == null) { throw new NullPointerException("map key"); }
-      if (value == null) {
-  throw new NullPointerException("map value");
-}
-
+      if (value == null) { throw new NullPointerException("map value"); }
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000008;
       return this;
     }
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     public Builder putAllOptions(
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableOptions().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000008;
       return this;
     }
 
@@ -1081,6 +1082,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfNotExists(boolean value) {
       
       ifNotExists_ = value;
+      bitField0_ |= 0x00000010;
       onChanged();
       return this;
     }
@@ -1089,7 +1091,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfNotExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000010);
       ifNotExists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateIndexRequestOrBuilder.java
@@ -66,7 +66,6 @@ public interface CreateIndexRequestOrBuilder extends
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   /* nullable */
 java.lang.String getOptionsOrDefault(
       java.lang.String key,
@@ -75,7 +74,6 @@ java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   java.lang.String getOptionsOrThrow(
       java.lang.String key);
 

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequest.java
@@ -57,7 +57,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -106,6 +107,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "");
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.String> options_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.String>
@@ -116,14 +118,12 @@ private static final long serialVersionUID = 0L;
     }
     return options_;
   }
-
   public int getOptionsCount() {
     return internalGetOptions().getMap().size();
   }
   /**
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
-
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
@@ -142,7 +142,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
     return internalGetOptions().getMap();
   }
@@ -150,10 +149,11 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
   @java.lang.Override
-
-  public java.lang.String getOptionsOrDefault(
+  public /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue) {
+      /* nullable */
+java.lang.String defaultValue) {
     if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
@@ -163,7 +163,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
   @java.lang.Override
-
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -176,7 +175,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_NOT_EXISTS_FIELD_NUMBER = 3;
-  private boolean ifNotExists_;
+  private boolean ifNotExists_ = false;
   /**
    * <code>bool if_not_exists = 3;</code>
    * @return The ifNotExists.
@@ -429,11 +428,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       internalGetMutableOptions().clear();
       ifNotExists_ = false;
-
       return this;
     }
 
@@ -460,13 +458,23 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.CreateNamespaceRequest buildPartial() {
       com.scalar.db.rpc.CreateNamespaceRequest result = new com.scalar.db.rpc.CreateNamespaceRequest(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.options_ = internalGetOptions();
-      result.options_.makeImmutable();
-      result.ifNotExists_ = ifNotExists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.CreateNamespaceRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.options_ = internalGetOptions();
+        result.options_.makeImmutable();
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.ifNotExists_ = ifNotExists_;
+      }
     }
 
     @java.lang.Override
@@ -515,10 +523,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.CreateNamespaceRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       internalGetMutableOptions().mergeFrom(
           other.internalGetOptions());
+      bitField0_ |= 0x00000002;
       if (other.getIfNotExists() != false) {
         setIfNotExists(other.getIfNotExists());
       }
@@ -550,7 +560,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
@@ -559,11 +569,12 @@ private static final long serialVersionUID = 0L;
                   OptionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableOptions().getMutableMap().put(
                   options__.getKey(), options__.getValue());
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 24: {
               ifNotExists_ = input.readBool();
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 24
             default: {
@@ -624,11 +635,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -637,8 +646,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -649,12 +658,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -662,7 +669,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.String> options_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetOptions() {
+        internalGetOptions() {
       if (options_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -670,8 +677,7 @@ private static final long serialVersionUID = 0L;
       return options_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetMutableOptions() {
-      onChanged();;
+        internalGetMutableOptions() {
       if (options_ == null) {
         options_ = com.google.protobuf.MapField.newMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -679,16 +685,16 @@ private static final long serialVersionUID = 0L;
       if (!options_.isMutable()) {
         options_ = options_.copy();
       }
+      bitField0_ |= 0x00000002;
+      onChanged();
       return options_;
     }
-
     public int getOptionsCount() {
       return internalGetOptions().getMap().size();
     }
     /**
      * <code>map&lt;string, string&gt; options = 2;</code>
      */
-
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
@@ -707,7 +713,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 2;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
       return internalGetOptions().getMap();
     }
@@ -715,10 +720,11 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 2;</code>
      */
     @java.lang.Override
-
-    public java.lang.String getOptionsOrDefault(
+    public /* nullable */
+java.lang.String getOptionsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        /* nullable */
+java.lang.String defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
@@ -728,7 +734,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 2;</code>
      */
     @java.lang.Override
-
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -739,8 +744,8 @@ private static final long serialVersionUID = 0L;
       }
       return map.get(key);
     }
-
     public Builder clearOptions() {
+      bitField0_ = (bitField0_ & ~0x00000002);
       internalGetMutableOptions().getMutableMap()
           .clear();
       return this;
@@ -748,7 +753,6 @@ private static final long serialVersionUID = 0L;
     /**
      * <code>map&lt;string, string&gt; options = 2;</code>
      */
-
     public Builder removeOptions(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -761,7 +765,8 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.String>
-    getMutableOptions() {
+        getMutableOptions() {
+      bitField0_ |= 0x00000002;
       return internalGetMutableOptions().getMutableMap();
     }
     /**
@@ -771,22 +776,20 @@ private static final long serialVersionUID = 0L;
         java.lang.String key,
         java.lang.String value) {
       if (key == null) { throw new NullPointerException("map key"); }
-      if (value == null) {
-  throw new NullPointerException("map value");
-}
-
+      if (value == null) { throw new NullPointerException("map value"); }
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000002;
       return this;
     }
     /**
      * <code>map&lt;string, string&gt; options = 2;</code>
      */
-
     public Builder putAllOptions(
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableOptions().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000002;
       return this;
     }
 
@@ -807,6 +810,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfNotExists(boolean value) {
       
       ifNotExists_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -815,7 +819,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfNotExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000004);
       ifNotExists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateNamespaceRequestOrBuilder.java
@@ -42,7 +42,6 @@ public interface CreateNamespaceRequestOrBuilder extends
   /**
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
-
   /* nullable */
 java.lang.String getOptionsOrDefault(
       java.lang.String key,
@@ -51,7 +50,6 @@ java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 2;</code>
    */
-
   java.lang.String getOptionsOrThrow(
       java.lang.String key);
 

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequest.java
@@ -58,7 +58,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -96,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -156,7 +158,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
-    return getTableMetadata();
+    return tableMetadata_ == null ? com.scalar.db.rpc.TableMetadata.getDefaultInstance() : tableMetadata_;
   }
 
   public static final int OPTIONS_FIELD_NUMBER = 4;
@@ -171,6 +173,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "");
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.String> options_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.String>
@@ -181,14 +184,12 @@ private static final long serialVersionUID = 0L;
     }
     return options_;
   }
-
   public int getOptionsCount() {
     return internalGetOptions().getMap().size();
   }
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
@@ -207,7 +208,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
     return internalGetOptions().getMap();
   }
@@ -215,10 +215,11 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
-  public java.lang.String getOptionsOrDefault(
+  public /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue) {
+      /* nullable */
+java.lang.String defaultValue) {
     if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
@@ -228,7 +229,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -241,7 +241,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_NOT_EXISTS_FIELD_NUMBER = 5;
-  private boolean ifNotExists_;
+  private boolean ifNotExists_ = false;
   /**
    * <code>bool if_not_exists = 5;</code>
    * @return The ifNotExists.
@@ -520,19 +520,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
-      if (tableMetadataBuilder_ == null) {
-        tableMetadata_ = null;
-      } else {
-        tableMetadata_ = null;
+      tableMetadata_ = null;
+      if (tableMetadataBuilder_ != null) {
+        tableMetadataBuilder_.dispose();
         tableMetadataBuilder_ = null;
       }
       internalGetMutableOptions().clear();
       ifNotExists_ = false;
-
       return this;
     }
 
@@ -559,19 +556,31 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.CreateTableRequest buildPartial() {
       com.scalar.db.rpc.CreateTableRequest result = new com.scalar.db.rpc.CreateTableRequest(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      if (tableMetadataBuilder_ == null) {
-        result.tableMetadata_ = tableMetadata_;
-      } else {
-        result.tableMetadata_ = tableMetadataBuilder_.build();
-      }
-      result.options_ = internalGetOptions();
-      result.options_.makeImmutable();
-      result.ifNotExists_ = ifNotExists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.CreateTableRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.tableMetadata_ = tableMetadataBuilder_ == null
+            ? tableMetadata_
+            : tableMetadataBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.options_ = internalGetOptions();
+        result.options_.makeImmutable();
+      }
+      if (((from_bitField0_ & 0x00000010) != 0)) {
+        result.ifNotExists_ = ifNotExists_;
+      }
     }
 
     @java.lang.Override
@@ -620,10 +629,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.CreateTableRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (other.hasTableMetadata()) {
@@ -631,6 +642,7 @@ private static final long serialVersionUID = 0L;
       }
       internalGetMutableOptions().mergeFrom(
           other.internalGetOptions());
+      bitField0_ |= 0x00000008;
       if (other.getIfNotExists() != false) {
         setIfNotExists(other.getIfNotExists());
       }
@@ -662,19 +674,19 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               input.readMessage(
                   getTableMetadataFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 34: {
@@ -683,11 +695,12 @@ private static final long serialVersionUID = 0L;
                   OptionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableOptions().getMutableMap().put(
                   options__.getKey(), options__.getValue());
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             case 40: {
               ifNotExists_ = input.readBool();
-
+              bitField0_ |= 0x00000010;
               break;
             } // case 40
             default: {
@@ -748,11 +761,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -761,8 +772,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -773,12 +784,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -824,11 +833,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -837,8 +844,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -849,12 +856,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -867,7 +872,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the tableMetadata field is set.
      */
     public boolean hasTableMetadata() {
-      return tableMetadataBuilder_ != null || tableMetadata_ != null;
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 3;</code>
@@ -889,11 +894,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         tableMetadata_ = value;
-        onChanged();
       } else {
         tableMetadataBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -903,11 +908,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.TableMetadata.Builder builderForValue) {
       if (tableMetadataBuilder_ == null) {
         tableMetadata_ = builderForValue.build();
-        onChanged();
       } else {
         tableMetadataBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -915,38 +920,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
-        if (tableMetadata_ != null) {
-          tableMetadata_ =
-            com.scalar.db.rpc.TableMetadata.newBuilder(tableMetadata_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000004) != 0) &&
+          tableMetadata_ != null &&
+          tableMetadata_ != com.scalar.db.rpc.TableMetadata.getDefaultInstance()) {
+          getTableMetadataBuilder().mergeFrom(value);
         } else {
           tableMetadata_ = value;
         }
-        onChanged();
       } else {
         tableMetadataBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder clearTableMetadata() {
-      if (tableMetadataBuilder_ == null) {
-        tableMetadata_ = null;
-        onChanged();
-      } else {
-        tableMetadata_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
+      tableMetadata_ = null;
+      if (tableMetadataBuilder_ != null) {
+        tableMetadataBuilder_.dispose();
         tableMetadataBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public com.scalar.db.rpc.TableMetadata.Builder getTableMetadataBuilder() {
-      
+      bitField0_ |= 0x00000004;
       onChanged();
       return getTableMetadataFieldBuilder().getBuilder();
     }
@@ -981,7 +986,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.String> options_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetOptions() {
+        internalGetOptions() {
       if (options_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -989,8 +994,7 @@ private static final long serialVersionUID = 0L;
       return options_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetMutableOptions() {
-      onChanged();;
+        internalGetMutableOptions() {
       if (options_ == null) {
         options_ = com.google.protobuf.MapField.newMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -998,16 +1002,16 @@ private static final long serialVersionUID = 0L;
       if (!options_.isMutable()) {
         options_ = options_.copy();
       }
+      bitField0_ |= 0x00000008;
+      onChanged();
       return options_;
     }
-
     public int getOptionsCount() {
       return internalGetOptions().getMap().size();
     }
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
@@ -1026,7 +1030,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
       return internalGetOptions().getMap();
     }
@@ -1034,10 +1037,11 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
-    public java.lang.String getOptionsOrDefault(
+    public /* nullable */
+java.lang.String getOptionsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        /* nullable */
+java.lang.String defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
@@ -1047,7 +1051,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1058,8 +1061,8 @@ private static final long serialVersionUID = 0L;
       }
       return map.get(key);
     }
-
     public Builder clearOptions() {
+      bitField0_ = (bitField0_ & ~0x00000008);
       internalGetMutableOptions().getMutableMap()
           .clear();
       return this;
@@ -1067,7 +1070,6 @@ private static final long serialVersionUID = 0L;
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     public Builder removeOptions(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1080,7 +1082,8 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.String>
-    getMutableOptions() {
+        getMutableOptions() {
+      bitField0_ |= 0x00000008;
       return internalGetMutableOptions().getMutableMap();
     }
     /**
@@ -1090,22 +1093,20 @@ private static final long serialVersionUID = 0L;
         java.lang.String key,
         java.lang.String value) {
       if (key == null) { throw new NullPointerException("map key"); }
-      if (value == null) {
-  throw new NullPointerException("map value");
-}
-
+      if (value == null) { throw new NullPointerException("map value"); }
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000008;
       return this;
     }
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     public Builder putAllOptions(
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableOptions().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000008;
       return this;
     }
 
@@ -1126,6 +1127,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfNotExists(boolean value) {
       
       ifNotExists_ = value;
+      bitField0_ |= 0x00000010;
       onChanged();
       return this;
     }
@@ -1134,7 +1136,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfNotExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000010);
       ifNotExists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/CreateTableRequestOrBuilder.java
@@ -69,7 +69,6 @@ public interface CreateTableRequestOrBuilder extends
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   /* nullable */
 java.lang.String getOptionsOrDefault(
       java.lang.String key,
@@ -78,7 +77,6 @@ java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   java.lang.String getOptionsOrThrow(
       java.lang.String key);
 

--- a/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropCoordinatorTablesRequest.java
@@ -44,7 +44,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_EXIST_FIELD_NUMBER = 1;
-  private boolean ifExist_;
+  private boolean ifExist_ = false;
   /**
    * <code>bool if_exist = 1;</code>
    * @return The ifExist.
@@ -243,8 +243,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       ifExist_ = false;
-
       return this;
     }
 
@@ -271,9 +271,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.DropCoordinatorTablesRequest buildPartial() {
       com.scalar.db.rpc.DropCoordinatorTablesRequest result = new com.scalar.db.rpc.DropCoordinatorTablesRequest(this);
-      result.ifExist_ = ifExist_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.DropCoordinatorTablesRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.ifExist_ = ifExist_;
+      }
     }
 
     @java.lang.Override
@@ -351,7 +358,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               ifExist_ = input.readBool();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             default: {
@@ -369,6 +376,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private boolean ifExist_ ;
     /**
@@ -387,6 +395,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfExist(boolean value) {
       
       ifExist_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -395,7 +404,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfExist() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       ifExist_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropIndexRequest.java
@@ -47,7 +47,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -85,7 +86,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -123,7 +125,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMN_NAME_FIELD_NUMBER = 3;
-  private volatile java.lang.Object columnName_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object columnName_ = "";
   /**
    * <code>string column_name = 3;</code>
    * @return The columnName.
@@ -161,7 +164,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_EXISTS_FIELD_NUMBER = 4;
-  private boolean ifExists_;
+  private boolean ifExists_ = false;
   /**
    * <code>bool if_exists = 4;</code>
    * @return The ifExists.
@@ -390,14 +393,11 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
       columnName_ = "";
-
       ifExists_ = false;
-
       return this;
     }
 
@@ -424,12 +424,25 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.DropIndexRequest buildPartial() {
       com.scalar.db.rpc.DropIndexRequest result = new com.scalar.db.rpc.DropIndexRequest(this);
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      result.columnName_ = columnName_;
-      result.ifExists_ = ifExists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.DropIndexRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.columnName_ = columnName_;
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.ifExists_ = ifExists_;
+      }
     }
 
     @java.lang.Override
@@ -478,14 +491,17 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.DropIndexRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (!other.getColumnName().isEmpty()) {
         columnName_ = other.columnName_;
+        bitField0_ |= 0x00000004;
         onChanged();
       }
       if (other.getIfExists() != false) {
@@ -519,22 +535,22 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               columnName_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 32: {
               ifExists_ = input.readBool();
-
+              bitField0_ |= 0x00000008;
               break;
             } // case 32
             default: {
@@ -552,6 +568,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -594,11 +611,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -607,8 +622,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -619,12 +634,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -670,11 +683,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -683,8 +694,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -695,12 +706,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -746,11 +755,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setColumnName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       columnName_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -759,8 +766,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearColumnName() {
-      
       columnName_ = getDefaultInstance().getColumnName();
+      bitField0_ = (bitField0_ & ~0x00000004);
       onChanged();
       return this;
     }
@@ -771,12 +778,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setColumnNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       columnName_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -798,6 +803,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfExists(boolean value) {
       
       ifExists_ = value;
+      bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }
@@ -806,7 +812,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000008);
       ifExists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropNamespaceRequest.java
@@ -45,7 +45,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -83,7 +84,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_EXISTS_FIELD_NUMBER = 2;
-  private boolean ifExists_;
+  private boolean ifExists_ = false;
   /**
    * <code>bool if_exists = 2;</code>
    * @return The ifExists.
@@ -292,10 +293,9 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       ifExists_ = false;
-
       return this;
     }
 
@@ -322,10 +322,19 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.DropNamespaceRequest buildPartial() {
       com.scalar.db.rpc.DropNamespaceRequest result = new com.scalar.db.rpc.DropNamespaceRequest(this);
-      result.namespace_ = namespace_;
-      result.ifExists_ = ifExists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.DropNamespaceRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.ifExists_ = ifExists_;
+      }
     }
 
     @java.lang.Override
@@ -374,6 +383,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.DropNamespaceRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (other.getIfExists() != false) {
@@ -407,12 +417,12 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 16: {
               ifExists_ = input.readBool();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 16
             default: {
@@ -430,6 +440,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -472,11 +483,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -485,8 +494,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -497,12 +506,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -524,6 +531,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfExists(boolean value) {
       
       ifExists_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -532,7 +540,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000002);
       ifExists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/DropTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/DropTableRequest.java
@@ -46,7 +46,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -84,7 +85,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -122,7 +124,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int IF_EXISTS_FIELD_NUMBER = 3;
-  private boolean ifExists_;
+  private boolean ifExists_ = false;
   /**
    * <code>bool if_exists = 3;</code>
    * @return The ifExists.
@@ -341,12 +343,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
       ifExists_ = false;
-
       return this;
     }
 
@@ -373,11 +373,22 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.DropTableRequest buildPartial() {
       com.scalar.db.rpc.DropTableRequest result = new com.scalar.db.rpc.DropTableRequest(this);
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      result.ifExists_ = ifExists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.DropTableRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.ifExists_ = ifExists_;
+      }
     }
 
     @java.lang.Override
@@ -426,10 +437,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.DropTableRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (other.getIfExists() != false) {
@@ -463,17 +476,17 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 24: {
               ifExists_ = input.readBool();
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 24
             default: {
@@ -491,6 +504,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -533,11 +547,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -546,8 +558,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -558,12 +570,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -609,11 +619,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -622,8 +630,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -634,12 +642,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -661,6 +667,7 @@ private static final long serialVersionUID = 0L;
     public Builder setIfExists(boolean value) {
       
       ifExists_ = value;
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -669,7 +676,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIfExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000004);
       ifExists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/Get.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Get.java
@@ -48,7 +48,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -86,7 +87,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -146,7 +148,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
-    return getPartitionKey();
+    return partitionKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : partitionKey_;
   }
 
   public static final int CLUSTERING_KEY_FIELD_NUMBER = 4;
@@ -172,11 +174,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder() {
-    return getClusteringKey();
+    return clusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : clusteringKey_;
   }
 
   public static final int CONSISTENCY_FIELD_NUMBER = 5;
-  private int consistency_;
+  private int consistency_ = 0;
   /**
    * <code>.rpc.Consistency consistency = 5;</code>
    * @return The enum numeric value on the wire for consistency.
@@ -189,12 +191,12 @@ private static final long serialVersionUID = 0L;
    * @return The consistency.
    */
   @java.lang.Override public com.scalar.db.rpc.Consistency getConsistency() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.valueOf(consistency_);
+    com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.forNumber(consistency_);
     return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
   }
 
   public static final int PROJECTIONS_FIELD_NUMBER = 6;
+  @SuppressWarnings("serial")
   private com.google.protobuf.LazyStringList projections_;
   /**
    * <code>repeated string projections = 6;</code>
@@ -485,26 +487,22 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
-      if (partitionKeyBuilder_ == null) {
-        partitionKey_ = null;
-      } else {
-        partitionKey_ = null;
+      partitionKey_ = null;
+      if (partitionKeyBuilder_ != null) {
+        partitionKeyBuilder_.dispose();
         partitionKeyBuilder_ = null;
       }
-      if (clusteringKeyBuilder_ == null) {
-        clusteringKey_ = null;
-      } else {
-        clusteringKey_ = null;
+      clusteringKey_ = null;
+      if (clusteringKeyBuilder_ != null) {
+        clusteringKeyBuilder_.dispose();
         clusteringKeyBuilder_ = null;
       }
       consistency_ = 0;
-
       projections_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000020);
       return this;
     }
 
@@ -531,27 +529,41 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Get buildPartial() {
       com.scalar.db.rpc.Get result = new com.scalar.db.rpc.Get(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      if (partitionKeyBuilder_ == null) {
-        result.partitionKey_ = partitionKey_;
-      } else {
-        result.partitionKey_ = partitionKeyBuilder_.build();
-      }
-      if (clusteringKeyBuilder_ == null) {
-        result.clusteringKey_ = clusteringKey_;
-      } else {
-        result.clusteringKey_ = clusteringKeyBuilder_.build();
-      }
-      result.consistency_ = consistency_;
-      if (((bitField0_ & 0x00000001) != 0)) {
-        projections_ = projections_.getUnmodifiableView();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.projections_ = projections_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.Get result) {
+      if (((bitField0_ & 0x00000020) != 0)) {
+        projections_ = projections_.getUnmodifiableView();
+        bitField0_ = (bitField0_ & ~0x00000020);
+      }
+      result.projections_ = projections_;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Get result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.partitionKey_ = partitionKeyBuilder_ == null
+            ? partitionKey_
+            : partitionKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.clusteringKey_ = clusteringKeyBuilder_ == null
+            ? clusteringKey_
+            : clusteringKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000010) != 0)) {
+        result.consistency_ = consistency_;
+      }
     }
 
     @java.lang.Override
@@ -600,10 +612,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.Get.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (other.hasPartitionKey()) {
@@ -618,7 +632,7 @@ private static final long serialVersionUID = 0L;
       if (!other.projections_.isEmpty()) {
         if (projections_.isEmpty()) {
           projections_ = other.projections_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ = (bitField0_ & ~0x00000020);
         } else {
           ensureProjectionsIsMutable();
           projections_.addAll(other.projections_);
@@ -653,31 +667,31 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               input.readMessage(
                   getPartitionKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 34: {
               input.readMessage(
                   getClusteringKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             case 40: {
               consistency_ = input.readEnum();
-
+              bitField0_ |= 0x00000010;
               break;
             } // case 40
             case 50: {
@@ -744,11 +758,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -757,8 +769,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -769,12 +781,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -820,11 +830,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -833,8 +841,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -845,12 +853,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -863,7 +869,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the partitionKey field is set.
      */
     public boolean hasPartitionKey() {
-      return partitionKeyBuilder_ != null || partitionKey_ != null;
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
@@ -885,11 +891,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         partitionKey_ = value;
-        onChanged();
       } else {
         partitionKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -899,11 +905,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (partitionKeyBuilder_ == null) {
         partitionKey_ = builderForValue.build();
-        onChanged();
       } else {
         partitionKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -911,38 +917,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergePartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
-        if (partitionKey_ != null) {
-          partitionKey_ =
-            com.scalar.db.rpc.Key.newBuilder(partitionKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000004) != 0) &&
+          partitionKey_ != null &&
+          partitionKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getPartitionKeyBuilder().mergeFrom(value);
         } else {
           partitionKey_ = value;
         }
-        onChanged();
       } else {
         partitionKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder clearPartitionKey() {
-      if (partitionKeyBuilder_ == null) {
-        partitionKey_ = null;
-        onChanged();
-      } else {
-        partitionKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
+      partitionKey_ = null;
+      if (partitionKeyBuilder_ != null) {
+        partitionKeyBuilder_.dispose();
         partitionKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.Key.Builder getPartitionKeyBuilder() {
-      
+      bitField0_ |= 0x00000004;
       onChanged();
       return getPartitionKeyFieldBuilder().getBuilder();
     }
@@ -982,7 +988,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the clusteringKey field is set.
      */
     public boolean hasClusteringKey() {
-      return clusteringKeyBuilder_ != null || clusteringKey_ != null;
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>.rpc.Key clustering_key = 4;</code>
@@ -1004,11 +1010,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         clusteringKey_ = value;
-        onChanged();
       } else {
         clusteringKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
@@ -1018,11 +1024,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (clusteringKeyBuilder_ == null) {
         clusteringKey_ = builderForValue.build();
-        onChanged();
       } else {
         clusteringKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
@@ -1030,38 +1036,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeClusteringKey(com.scalar.db.rpc.Key value) {
       if (clusteringKeyBuilder_ == null) {
-        if (clusteringKey_ != null) {
-          clusteringKey_ =
-            com.scalar.db.rpc.Key.newBuilder(clusteringKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000008) != 0) &&
+          clusteringKey_ != null &&
+          clusteringKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getClusteringKeyBuilder().mergeFrom(value);
         } else {
           clusteringKey_ = value;
         }
-        onChanged();
       } else {
         clusteringKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder clearClusteringKey() {
-      if (clusteringKeyBuilder_ == null) {
-        clusteringKey_ = null;
-        onChanged();
-      } else {
-        clusteringKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000008);
+      clusteringKey_ = null;
+      if (clusteringKeyBuilder_ != null) {
+        clusteringKeyBuilder_.dispose();
         clusteringKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key clustering_key = 4;</code>
      */
     public com.scalar.db.rpc.Key.Builder getClusteringKeyBuilder() {
-      
+      bitField0_ |= 0x00000008;
       onChanged();
       return getClusteringKeyFieldBuilder().getBuilder();
     }
@@ -1107,8 +1113,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setConsistencyValue(int value) {
-      
       consistency_ = value;
+      bitField0_ |= 0x00000010;
       onChanged();
       return this;
     }
@@ -1118,8 +1124,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.Consistency getConsistency() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.valueOf(consistency_);
+      com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.forNumber(consistency_);
       return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
     }
     /**
@@ -1131,7 +1136,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000010;
       consistency_ = value.getNumber();
       onChanged();
       return this;
@@ -1141,7 +1146,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearConsistency() {
-      
+      bitField0_ = (bitField0_ & ~0x00000010);
       consistency_ = 0;
       onChanged();
       return this;
@@ -1149,9 +1154,9 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.LazyStringList projections_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     private void ensureProjectionsIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
+      if (!((bitField0_ & 0x00000020) != 0)) {
         projections_ = new com.google.protobuf.LazyStringArrayList(projections_);
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000020;
        }
     }
     /**
@@ -1194,10 +1199,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setProjections(
         int index, java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureProjectionsIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureProjectionsIsMutable();
       projections_.set(index, value);
       onChanged();
       return this;
@@ -1209,10 +1212,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder addProjections(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureProjectionsIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureProjectionsIsMutable();
       projections_.add(value);
       onChanged();
       return this;
@@ -1236,7 +1237,7 @@ private static final long serialVersionUID = 0L;
      */
     public Builder clearProjections() {
       projections_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000020);
       onChanged();
       return this;
     }
@@ -1247,10 +1248,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder addProjectionsBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       ensureProjectionsIsMutable();
       projections_.add(value);
       onChanged();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesRequest.java
@@ -45,7 +45,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -269,8 +270,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       return this;
     }
 
@@ -297,9 +298,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetNamespaceTableNamesRequest buildPartial() {
       com.scalar.db.rpc.GetNamespaceTableNamesRequest result = new com.scalar.db.rpc.GetNamespaceTableNamesRequest(this);
-      result.namespace_ = namespace_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetNamespaceTableNamesRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
     }
 
     @java.lang.Override
@@ -348,6 +356,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.GetNamespaceTableNamesRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -378,7 +387,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -396,6 +405,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -438,11 +448,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -451,8 +459,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -463,12 +471,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetNamespaceTableNamesResponse.java
@@ -45,6 +45,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_NAMES_FIELD_NUMBER = 1;
+  @SuppressWarnings("serial")
   private com.google.protobuf.LazyStringList tableNames_;
   /**
    * <code>repeated string table_names = 1;</code>
@@ -273,6 +274,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       tableNames_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       bitField0_ = (bitField0_ & ~0x00000001);
       return this;
@@ -301,14 +303,22 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetNamespaceTableNamesResponse buildPartial() {
       com.scalar.db.rpc.GetNamespaceTableNamesResponse result = new com.scalar.db.rpc.GetNamespaceTableNamesResponse(this);
-      int from_bitField0_ = bitField0_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.GetNamespaceTableNamesResponse result) {
       if (((bitField0_ & 0x00000001) != 0)) {
         tableNames_ = tableNames_.getUnmodifiableView();
         bitField0_ = (bitField0_ & ~0x00000001);
       }
       result.tableNames_ = tableNames_;
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetNamespaceTableNamesResponse result) {
+      int from_bitField0_ = bitField0_;
     }
 
     @java.lang.Override
@@ -461,10 +471,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableNames(
         int index, java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureTableNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureTableNamesIsMutable();
       tableNames_.set(index, value);
       onChanged();
       return this;
@@ -476,10 +484,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder addTableNames(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureTableNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureTableNamesIsMutable();
       tableNames_.add(value);
       onChanged();
       return this;
@@ -514,10 +520,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder addTableNamesBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       ensureTableNamesIsMutable();
       tableNames_.add(value);
       onChanged();

--- a/rpc/src/main/java/com/scalar/db/rpc/GetRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetRequest.java
@@ -66,7 +66,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
-    return getGet();
+    return get_ == null ? com.scalar.db.rpc.Get.getDefaultInstance() : get_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -262,10 +262,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
-      if (getBuilder_ == null) {
-        get_ = null;
-      } else {
-        get_ = null;
+      bitField0_ = 0;
+      get_ = null;
+      if (getBuilder_ != null) {
+        getBuilder_.dispose();
         getBuilder_ = null;
       }
       return this;
@@ -294,13 +294,18 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetRequest buildPartial() {
       com.scalar.db.rpc.GetRequest result = new com.scalar.db.rpc.GetRequest(this);
-      if (getBuilder_ == null) {
-        result.get_ = get_;
-      } else {
-        result.get_ = getBuilder_.build();
-      }
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.get_ = getBuilder_ == null
+            ? get_
+            : getBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -380,7 +385,7 @@ private static final long serialVersionUID = 0L;
               input.readMessage(
                   getGetFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -398,6 +403,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private com.scalar.db.rpc.Get get_;
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -407,7 +413,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the get field is set.
      */
     public boolean hasGet() {
-      return getBuilder_ != null || get_ != null;
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>.rpc.Get get = 1;</code>
@@ -429,11 +435,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         get_ = value;
-        onChanged();
       } else {
         getBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -443,11 +449,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Get.Builder builderForValue) {
       if (getBuilder_ == null) {
         get_ = builderForValue.build();
-        onChanged();
       } else {
         getBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -455,38 +461,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeGet(com.scalar.db.rpc.Get value) {
       if (getBuilder_ == null) {
-        if (get_ != null) {
-          get_ =
-            com.scalar.db.rpc.Get.newBuilder(get_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000001) != 0) &&
+          get_ != null &&
+          get_ != com.scalar.db.rpc.Get.getDefaultInstance()) {
+          getGetBuilder().mergeFrom(value);
         } else {
           get_ = value;
         }
-        onChanged();
       } else {
         getBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Get get = 1;</code>
      */
     public Builder clearGet() {
-      if (getBuilder_ == null) {
-        get_ = null;
-        onChanged();
-      } else {
-        get_ = null;
+      bitField0_ = (bitField0_ & ~0x00000001);
+      get_ = null;
+      if (getBuilder_ != null) {
+        getBuilder_.dispose();
         getBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Get get = 1;</code>
      */
     public com.scalar.db.rpc.Get.Builder getGetBuilder() {
-      
+      bitField0_ |= 0x00000001;
       onChanged();
       return getGetFieldBuilder().getBuilder();
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetResponse.java
@@ -66,7 +66,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
-    return getResult();
+    return result_ == null ? com.scalar.db.rpc.Result.getDefaultInstance() : result_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -262,10 +262,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
-      if (resultBuilder_ == null) {
-        result_ = null;
-      } else {
-        result_ = null;
+      bitField0_ = 0;
+      result_ = null;
+      if (resultBuilder_ != null) {
+        resultBuilder_.dispose();
         resultBuilder_ = null;
       }
       return this;
@@ -294,13 +294,18 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetResponse buildPartial() {
       com.scalar.db.rpc.GetResponse result = new com.scalar.db.rpc.GetResponse(this);
-      if (resultBuilder_ == null) {
-        result.result_ = result_;
-      } else {
-        result.result_ = resultBuilder_.build();
-      }
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.result_ = resultBuilder_ == null
+            ? result_
+            : resultBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -380,7 +385,7 @@ private static final long serialVersionUID = 0L;
               input.readMessage(
                   getResultFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -398,6 +403,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private com.scalar.db.rpc.Result result_;
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -407,7 +413,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the result field is set.
      */
     public boolean hasResult() {
-      return resultBuilder_ != null || result_ != null;
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>.rpc.Result result = 1;</code>
@@ -429,11 +435,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         result_ = value;
-        onChanged();
       } else {
         resultBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -443,11 +449,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Result.Builder builderForValue) {
       if (resultBuilder_ == null) {
         result_ = builderForValue.build();
-        onChanged();
       } else {
         resultBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -455,38 +461,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeResult(com.scalar.db.rpc.Result value) {
       if (resultBuilder_ == null) {
-        if (result_ != null) {
-          result_ =
-            com.scalar.db.rpc.Result.newBuilder(result_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000001) != 0) &&
+          result_ != null &&
+          result_ != com.scalar.db.rpc.Result.getDefaultInstance()) {
+          getResultBuilder().mergeFrom(value);
         } else {
           result_ = value;
         }
-        onChanged();
       } else {
         resultBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Result result = 1;</code>
      */
     public Builder clearResult() {
-      if (resultBuilder_ == null) {
-        result_ = null;
-        onChanged();
-      } else {
-        result_ = null;
+      bitField0_ = (bitField0_ & ~0x00000001);
+      result_ = null;
+      if (resultBuilder_ != null) {
+        resultBuilder_.dispose();
         resultBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Result result = 1;</code>
      */
     public com.scalar.db.rpc.Result.Builder getResultBuilder() {
-      
+      bitField0_ |= 0x00000001;
       onChanged();
       return getResultFieldBuilder().getBuilder();
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataRequest.java
@@ -46,7 +46,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -84,7 +85,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -318,10 +320,9 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
       return this;
     }
 
@@ -348,10 +349,19 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetTableMetadataRequest buildPartial() {
       com.scalar.db.rpc.GetTableMetadataRequest result = new com.scalar.db.rpc.GetTableMetadataRequest(this);
-      result.namespace_ = namespace_;
-      result.table_ = table_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetTableMetadataRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
     }
 
     @java.lang.Override
@@ -400,10 +410,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.GetTableMetadataRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -434,12 +446,12 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             default: {
@@ -457,6 +469,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -499,11 +512,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -512,8 +523,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -524,12 +535,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -575,11 +584,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -588,8 +595,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -600,12 +607,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTableMetadataResponse.java
@@ -66,7 +66,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
-    return getTableMetadata();
+    return tableMetadata_ == null ? com.scalar.db.rpc.TableMetadata.getDefaultInstance() : tableMetadata_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -262,10 +262,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
-      if (tableMetadataBuilder_ == null) {
-        tableMetadata_ = null;
-      } else {
-        tableMetadata_ = null;
+      bitField0_ = 0;
+      tableMetadata_ = null;
+      if (tableMetadataBuilder_ != null) {
+        tableMetadataBuilder_.dispose();
         tableMetadataBuilder_ = null;
       }
       return this;
@@ -294,13 +294,18 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetTableMetadataResponse buildPartial() {
       com.scalar.db.rpc.GetTableMetadataResponse result = new com.scalar.db.rpc.GetTableMetadataResponse(this);
-      if (tableMetadataBuilder_ == null) {
-        result.tableMetadata_ = tableMetadata_;
-      } else {
-        result.tableMetadata_ = tableMetadataBuilder_.build();
-      }
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetTableMetadataResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.tableMetadata_ = tableMetadataBuilder_ == null
+            ? tableMetadata_
+            : tableMetadataBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -380,7 +385,7 @@ private static final long serialVersionUID = 0L;
               input.readMessage(
                   getTableMetadataFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -398,6 +403,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private com.scalar.db.rpc.TableMetadata tableMetadata_;
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -407,7 +413,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the tableMetadata field is set.
      */
     public boolean hasTableMetadata() {
-      return tableMetadataBuilder_ != null || tableMetadata_ != null;
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 1;</code>
@@ -429,11 +435,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         tableMetadata_ = value;
-        onChanged();
       } else {
         tableMetadataBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -443,11 +449,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.TableMetadata.Builder builderForValue) {
       if (tableMetadataBuilder_ == null) {
         tableMetadata_ = builderForValue.build();
-        onChanged();
       } else {
         tableMetadataBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -455,38 +461,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
-        if (tableMetadata_ != null) {
-          tableMetadata_ =
-            com.scalar.db.rpc.TableMetadata.newBuilder(tableMetadata_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000001) != 0) &&
+          tableMetadata_ != null &&
+          tableMetadata_ != com.scalar.db.rpc.TableMetadata.getDefaultInstance()) {
+          getTableMetadataBuilder().mergeFrom(value);
         } else {
           tableMetadata_ = value;
         }
-        onChanged();
       } else {
         tableMetadataBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public Builder clearTableMetadata() {
-      if (tableMetadataBuilder_ == null) {
-        tableMetadata_ = null;
-        onChanged();
-      } else {
-        tableMetadata_ = null;
+      bitField0_ = (bitField0_ & ~0x00000001);
+      tableMetadata_ = null;
+      if (tableMetadataBuilder_ != null) {
+        tableMetadataBuilder_.dispose();
         tableMetadataBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 1;</code>
      */
     public com.scalar.db.rpc.TableMetadata.Builder getTableMetadataBuilder() {
-      
+      bitField0_ |= 0x00000001;
       onChanged();
       return getTableMetadataFieldBuilder().getBuilder();
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateRequest.java
@@ -45,7 +45,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-  private volatile java.lang.Object transactionId_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object transactionId_ = "";
   /**
    * <code>string transaction_id = 1;</code>
    * @return The transactionId.
@@ -269,8 +270,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       transactionId_ = "";
-
       return this;
     }
 
@@ -297,9 +298,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetTransactionStateRequest buildPartial() {
       com.scalar.db.rpc.GetTransactionStateRequest result = new com.scalar.db.rpc.GetTransactionStateRequest(this);
-      result.transactionId_ = transactionId_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetTransactionStateRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.transactionId_ = transactionId_;
+      }
     }
 
     @java.lang.Override
@@ -348,6 +356,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.GetTransactionStateRequest.getDefaultInstance()) return this;
       if (!other.getTransactionId().isEmpty()) {
         transactionId_ = other.transactionId_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -378,7 +387,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               transactionId_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -396,6 +405,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object transactionId_ = "";
     /**
@@ -438,11 +448,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTransactionId(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       transactionId_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -451,8 +459,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTransactionId() {
-      
       transactionId_ = getDefaultInstance().getTransactionId();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -463,12 +471,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTransactionIdBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       transactionId_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/GetTransactionStateResponse.java
@@ -45,7 +45,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int STATE_FIELD_NUMBER = 1;
-  private int state_;
+  private int state_ = 0;
   /**
    * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
@@ -58,8 +58,7 @@ private static final long serialVersionUID = 0L;
    * @return The state.
    */
   @java.lang.Override public com.scalar.db.rpc.TransactionState getState() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.valueOf(state_);
+    com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.forNumber(state_);
     return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
   }
 
@@ -250,8 +249,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       state_ = 0;
-
       return this;
     }
 
@@ -278,9 +277,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.GetTransactionStateResponse buildPartial() {
       com.scalar.db.rpc.GetTransactionStateResponse result = new com.scalar.db.rpc.GetTransactionStateResponse(this);
-      result.state_ = state_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.GetTransactionStateResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.state_ = state_;
+      }
     }
 
     @java.lang.Override
@@ -358,7 +364,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               state_ = input.readEnum();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             default: {
@@ -376,6 +382,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private int state_ = 0;
     /**
@@ -391,8 +398,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setStateValue(int value) {
-      
       state_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -402,8 +409,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionState getState() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.valueOf(state_);
+      com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.forNumber(state_);
       return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
     }
     /**
@@ -415,7 +421,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000001;
       state_ = value.getNumber();
       onChanged();
       return this;
@@ -425,7 +431,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearState() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       state_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/Key.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Key.java
@@ -46,6 +46,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int VALUE_FIELD_NUMBER = 1;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Value> value_;
   /**
    * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
@@ -86,6 +87,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMNS_FIELD_NUMBER = 2;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Column> columns_;
   /**
    * <code>repeated .rpc.Column columns = 2;</code>
@@ -328,6 +330,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (valueBuilder_ == null) {
         value_ = java.util.Collections.emptyList();
       } else {
@@ -368,7 +371,13 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Key buildPartial() {
       com.scalar.db.rpc.Key result = new com.scalar.db.rpc.Key(this);
-      int from_bitField0_ = bitField0_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.Key result) {
       if (valueBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
           value_ = java.util.Collections.unmodifiableList(value_);
@@ -387,8 +396,10 @@ private static final long serialVersionUID = 0L;
       } else {
         result.columns_ = columnsBuilder_.build();
       }
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Key result) {
+      int from_bitField0_ = bitField0_;
     }
 
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateCondition.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateCondition.java
@@ -181,7 +181,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TYPE_FIELD_NUMBER = 1;
-  private int type_;
+  private int type_ = 0;
   /**
    * <code>.rpc.MutateCondition.Type type = 1;</code>
    * @return The enum numeric value on the wire for type.
@@ -194,12 +194,12 @@ private static final long serialVersionUID = 0L;
    * @return The type.
    */
   @java.lang.Override public com.scalar.db.rpc.MutateCondition.Type getType() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.MutateCondition.Type result = com.scalar.db.rpc.MutateCondition.Type.valueOf(type_);
+    com.scalar.db.rpc.MutateCondition.Type result = com.scalar.db.rpc.MutateCondition.Type.forNumber(type_);
     return result == null ? com.scalar.db.rpc.MutateCondition.Type.UNRECOGNIZED : result;
   }
 
   public static final int EXPRESSIONS_FIELD_NUMBER = 2;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.ConditionalExpression> expressions_;
   /**
    * <code>repeated .rpc.ConditionalExpression expressions = 2;</code>
@@ -439,15 +439,15 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       type_ = 0;
-
       if (expressionsBuilder_ == null) {
         expressions_ = java.util.Collections.emptyList();
       } else {
         expressions_ = null;
         expressionsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000002);
       return this;
     }
 
@@ -474,19 +474,29 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.MutateCondition buildPartial() {
       com.scalar.db.rpc.MutateCondition result = new com.scalar.db.rpc.MutateCondition(this);
-      int from_bitField0_ = bitField0_;
-      result.type_ = type_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.MutateCondition result) {
       if (expressionsBuilder_ == null) {
-        if (((bitField0_ & 0x00000001) != 0)) {
+        if (((bitField0_ & 0x00000002) != 0)) {
           expressions_ = java.util.Collections.unmodifiableList(expressions_);
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.expressions_ = expressions_;
       } else {
         result.expressions_ = expressionsBuilder_.build();
       }
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.MutateCondition result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.type_ = type_;
+      }
     }
 
     @java.lang.Override
@@ -540,7 +550,7 @@ private static final long serialVersionUID = 0L;
         if (!other.expressions_.isEmpty()) {
           if (expressions_.isEmpty()) {
             expressions_ = other.expressions_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ = (bitField0_ & ~0x00000002);
           } else {
             ensureExpressionsIsMutable();
             expressions_.addAll(other.expressions_);
@@ -553,7 +563,7 @@ private static final long serialVersionUID = 0L;
             expressionsBuilder_.dispose();
             expressionsBuilder_ = null;
             expressions_ = other.expressions_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ = (bitField0_ & ~0x00000002);
             expressionsBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getExpressionsFieldBuilder() : null;
@@ -590,7 +600,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               type_ = input.readEnum();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             case 18: {
@@ -637,8 +647,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setTypeValue(int value) {
-      
       type_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -648,8 +658,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.MutateCondition.Type getType() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.MutateCondition.Type result = com.scalar.db.rpc.MutateCondition.Type.valueOf(type_);
+      com.scalar.db.rpc.MutateCondition.Type result = com.scalar.db.rpc.MutateCondition.Type.forNumber(type_);
       return result == null ? com.scalar.db.rpc.MutateCondition.Type.UNRECOGNIZED : result;
     }
     /**
@@ -661,7 +670,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000001;
       type_ = value.getNumber();
       onChanged();
       return this;
@@ -671,7 +680,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearType() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       type_ = 0;
       onChanged();
       return this;
@@ -680,9 +689,9 @@ private static final long serialVersionUID = 0L;
     private java.util.List<com.scalar.db.rpc.ConditionalExpression> expressions_ =
       java.util.Collections.emptyList();
     private void ensureExpressionsIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
+      if (!((bitField0_ & 0x00000002) != 0)) {
         expressions_ = new java.util.ArrayList<com.scalar.db.rpc.ConditionalExpression>(expressions_);
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000002;
        }
     }
 
@@ -832,7 +841,7 @@ private static final long serialVersionUID = 0L;
     public Builder clearExpressions() {
       if (expressionsBuilder_ == null) {
         expressions_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
       } else {
         expressionsBuilder_.clear();
@@ -909,7 +918,7 @@ private static final long serialVersionUID = 0L;
         expressionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.scalar.db.rpc.ConditionalExpression, com.scalar.db.rpc.ConditionalExpression.Builder, com.scalar.db.rpc.ConditionalExpressionOrBuilder>(
                 expressions_,
-                ((bitField0_ & 0x00000001) != 0),
+                ((bitField0_ & 0x00000002) != 0),
                 getParentForChildren(),
                 isClean());
         expressions_ = null;

--- a/rpc/src/main/java/com/scalar/db/rpc/MutateRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/MutateRequest.java
@@ -45,6 +45,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int MUTATIONS_FIELD_NUMBER = 1;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Mutation> mutations_;
   /**
    * <code>repeated .rpc.Mutation mutations = 1;</code>
@@ -274,6 +275,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (mutationsBuilder_ == null) {
         mutations_ = java.util.Collections.emptyList();
       } else {
@@ -307,7 +309,13 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.MutateRequest buildPartial() {
       com.scalar.db.rpc.MutateRequest result = new com.scalar.db.rpc.MutateRequest(this);
-      int from_bitField0_ = bitField0_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.MutateRequest result) {
       if (mutationsBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
           mutations_ = java.util.Collections.unmodifiableList(mutations_);
@@ -317,8 +325,10 @@ private static final long serialVersionUID = 0L;
       } else {
         result.mutations_ = mutationsBuilder_.build();
       }
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.MutateRequest result) {
+      int from_bitField0_ = bitField0_;
     }
 
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/Mutation.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Mutation.java
@@ -158,7 +158,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -196,7 +197,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -256,7 +258,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
-    return getPartitionKey();
+    return partitionKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : partitionKey_;
   }
 
   public static final int CLUSTERING_KEY_FIELD_NUMBER = 4;
@@ -282,11 +284,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getClusteringKeyOrBuilder() {
-    return getClusteringKey();
+    return clusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : clusteringKey_;
   }
 
   public static final int CONSISTENCY_FIELD_NUMBER = 5;
-  private int consistency_;
+  private int consistency_ = 0;
   /**
    * <code>.rpc.Consistency consistency = 5;</code>
    * @return The enum numeric value on the wire for consistency.
@@ -299,8 +301,7 @@ private static final long serialVersionUID = 0L;
    * @return The consistency.
    */
   @java.lang.Override public com.scalar.db.rpc.Consistency getConsistency() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.valueOf(consistency_);
+    com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.forNumber(consistency_);
     return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
   }
 
@@ -327,11 +328,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.MutateConditionOrBuilder getConditionOrBuilder() {
-    return getCondition();
+    return condition_ == null ? com.scalar.db.rpc.MutateCondition.getDefaultInstance() : condition_;
   }
 
   public static final int TYPE_FIELD_NUMBER = 7;
-  private int type_;
+  private int type_ = 0;
   /**
    * <code>.rpc.Mutation.Type type = 7;</code>
    * @return The enum numeric value on the wire for type.
@@ -344,12 +345,12 @@ private static final long serialVersionUID = 0L;
    * @return The type.
    */
   @java.lang.Override public com.scalar.db.rpc.Mutation.Type getType() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.Mutation.Type result = com.scalar.db.rpc.Mutation.Type.valueOf(type_);
+    com.scalar.db.rpc.Mutation.Type result = com.scalar.db.rpc.Mutation.Type.forNumber(type_);
     return result == null ? com.scalar.db.rpc.Mutation.Type.UNRECOGNIZED : result;
   }
 
   public static final int VALUE_FIELD_NUMBER = 8;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Value> value_;
   /**
    * <pre>
@@ -410,6 +411,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMNS_FIELD_NUMBER = 9;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Column> columns_;
   /**
    * <pre>
@@ -760,46 +762,40 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
-      if (partitionKeyBuilder_ == null) {
-        partitionKey_ = null;
-      } else {
-        partitionKey_ = null;
+      partitionKey_ = null;
+      if (partitionKeyBuilder_ != null) {
+        partitionKeyBuilder_.dispose();
         partitionKeyBuilder_ = null;
       }
-      if (clusteringKeyBuilder_ == null) {
-        clusteringKey_ = null;
-      } else {
-        clusteringKey_ = null;
+      clusteringKey_ = null;
+      if (clusteringKeyBuilder_ != null) {
+        clusteringKeyBuilder_.dispose();
         clusteringKeyBuilder_ = null;
       }
       consistency_ = 0;
-
-      if (conditionBuilder_ == null) {
-        condition_ = null;
-      } else {
-        condition_ = null;
+      condition_ = null;
+      if (conditionBuilder_ != null) {
+        conditionBuilder_.dispose();
         conditionBuilder_ = null;
       }
       type_ = 0;
-
       if (valueBuilder_ == null) {
         value_ = java.util.Collections.emptyList();
       } else {
         value_ = null;
         valueBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000080);
       if (columnsBuilder_ == null) {
         columns_ = java.util.Collections.emptyList();
       } else {
         columns_ = null;
         columnsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000002);
+      bitField0_ = (bitField0_ & ~0x00000100);
       return this;
     }
 
@@ -826,46 +822,62 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Mutation buildPartial() {
       com.scalar.db.rpc.Mutation result = new com.scalar.db.rpc.Mutation(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      if (partitionKeyBuilder_ == null) {
-        result.partitionKey_ = partitionKey_;
-      } else {
-        result.partitionKey_ = partitionKeyBuilder_.build();
-      }
-      if (clusteringKeyBuilder_ == null) {
-        result.clusteringKey_ = clusteringKey_;
-      } else {
-        result.clusteringKey_ = clusteringKeyBuilder_.build();
-      }
-      result.consistency_ = consistency_;
-      if (conditionBuilder_ == null) {
-        result.condition_ = condition_;
-      } else {
-        result.condition_ = conditionBuilder_.build();
-      }
-      result.type_ = type_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.Mutation result) {
       if (valueBuilder_ == null) {
-        if (((bitField0_ & 0x00000001) != 0)) {
+        if (((bitField0_ & 0x00000080) != 0)) {
           value_ = java.util.Collections.unmodifiableList(value_);
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ = (bitField0_ & ~0x00000080);
         }
         result.value_ = value_;
       } else {
         result.value_ = valueBuilder_.build();
       }
       if (columnsBuilder_ == null) {
-        if (((bitField0_ & 0x00000002) != 0)) {
+        if (((bitField0_ & 0x00000100) != 0)) {
           columns_ = java.util.Collections.unmodifiableList(columns_);
-          bitField0_ = (bitField0_ & ~0x00000002);
+          bitField0_ = (bitField0_ & ~0x00000100);
         }
         result.columns_ = columns_;
       } else {
         result.columns_ = columnsBuilder_.build();
       }
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Mutation result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.partitionKey_ = partitionKeyBuilder_ == null
+            ? partitionKey_
+            : partitionKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.clusteringKey_ = clusteringKeyBuilder_ == null
+            ? clusteringKey_
+            : clusteringKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000010) != 0)) {
+        result.consistency_ = consistency_;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        result.condition_ = conditionBuilder_ == null
+            ? condition_
+            : conditionBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        result.type_ = type_;
+      }
     }
 
     @java.lang.Override
@@ -914,10 +926,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.Mutation.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (other.hasPartitionKey()) {
@@ -939,7 +953,7 @@ private static final long serialVersionUID = 0L;
         if (!other.value_.isEmpty()) {
           if (value_.isEmpty()) {
             value_ = other.value_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ = (bitField0_ & ~0x00000080);
           } else {
             ensureValueIsMutable();
             value_.addAll(other.value_);
@@ -952,7 +966,7 @@ private static final long serialVersionUID = 0L;
             valueBuilder_.dispose();
             valueBuilder_ = null;
             value_ = other.value_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ = (bitField0_ & ~0x00000080);
             valueBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getValueFieldBuilder() : null;
@@ -965,7 +979,7 @@ private static final long serialVersionUID = 0L;
         if (!other.columns_.isEmpty()) {
           if (columns_.isEmpty()) {
             columns_ = other.columns_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000100);
           } else {
             ensureColumnsIsMutable();
             columns_.addAll(other.columns_);
@@ -978,7 +992,7 @@ private static final long serialVersionUID = 0L;
             columnsBuilder_.dispose();
             columnsBuilder_ = null;
             columns_ = other.columns_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000100);
             columnsBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getColumnsFieldBuilder() : null;
@@ -1015,43 +1029,43 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               input.readMessage(
                   getPartitionKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 34: {
               input.readMessage(
                   getClusteringKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             case 40: {
               consistency_ = input.readEnum();
-
+              bitField0_ |= 0x00000010;
               break;
             } // case 40
             case 50: {
               input.readMessage(
                   getConditionFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000020;
               break;
             } // case 50
             case 56: {
               type_ = input.readEnum();
-
+              bitField0_ |= 0x00000040;
               break;
             } // case 56
             case 66: {
@@ -1138,11 +1152,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -1151,8 +1163,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -1163,12 +1175,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -1214,11 +1224,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -1227,8 +1235,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -1239,12 +1247,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -1257,7 +1263,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the partitionKey field is set.
      */
     public boolean hasPartitionKey() {
-      return partitionKeyBuilder_ != null || partitionKey_ != null;
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
@@ -1279,11 +1285,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         partitionKey_ = value;
-        onChanged();
       } else {
         partitionKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -1293,11 +1299,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (partitionKeyBuilder_ == null) {
         partitionKey_ = builderForValue.build();
-        onChanged();
       } else {
         partitionKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -1305,38 +1311,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergePartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
-        if (partitionKey_ != null) {
-          partitionKey_ =
-            com.scalar.db.rpc.Key.newBuilder(partitionKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000004) != 0) &&
+          partitionKey_ != null &&
+          partitionKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getPartitionKeyBuilder().mergeFrom(value);
         } else {
           partitionKey_ = value;
         }
-        onChanged();
       } else {
         partitionKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder clearPartitionKey() {
-      if (partitionKeyBuilder_ == null) {
-        partitionKey_ = null;
-        onChanged();
-      } else {
-        partitionKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
+      partitionKey_ = null;
+      if (partitionKeyBuilder_ != null) {
+        partitionKeyBuilder_.dispose();
         partitionKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.Key.Builder getPartitionKeyBuilder() {
-      
+      bitField0_ |= 0x00000004;
       onChanged();
       return getPartitionKeyFieldBuilder().getBuilder();
     }
@@ -1376,7 +1382,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the clusteringKey field is set.
      */
     public boolean hasClusteringKey() {
-      return clusteringKeyBuilder_ != null || clusteringKey_ != null;
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>.rpc.Key clustering_key = 4;</code>
@@ -1398,11 +1404,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         clusteringKey_ = value;
-        onChanged();
       } else {
         clusteringKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
@@ -1412,11 +1418,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (clusteringKeyBuilder_ == null) {
         clusteringKey_ = builderForValue.build();
-        onChanged();
       } else {
         clusteringKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
@@ -1424,38 +1430,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeClusteringKey(com.scalar.db.rpc.Key value) {
       if (clusteringKeyBuilder_ == null) {
-        if (clusteringKey_ != null) {
-          clusteringKey_ =
-            com.scalar.db.rpc.Key.newBuilder(clusteringKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000008) != 0) &&
+          clusteringKey_ != null &&
+          clusteringKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getClusteringKeyBuilder().mergeFrom(value);
         } else {
           clusteringKey_ = value;
         }
-        onChanged();
       } else {
         clusteringKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000008;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key clustering_key = 4;</code>
      */
     public Builder clearClusteringKey() {
-      if (clusteringKeyBuilder_ == null) {
-        clusteringKey_ = null;
-        onChanged();
-      } else {
-        clusteringKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000008);
+      clusteringKey_ = null;
+      if (clusteringKeyBuilder_ != null) {
+        clusteringKeyBuilder_.dispose();
         clusteringKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key clustering_key = 4;</code>
      */
     public com.scalar.db.rpc.Key.Builder getClusteringKeyBuilder() {
-      
+      bitField0_ |= 0x00000008;
       onChanged();
       return getClusteringKeyFieldBuilder().getBuilder();
     }
@@ -1501,8 +1507,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setConsistencyValue(int value) {
-      
       consistency_ = value;
+      bitField0_ |= 0x00000010;
       onChanged();
       return this;
     }
@@ -1512,8 +1518,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.Consistency getConsistency() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.valueOf(consistency_);
+      com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.forNumber(consistency_);
       return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
     }
     /**
@@ -1525,7 +1530,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000010;
       consistency_ = value.getNumber();
       onChanged();
       return this;
@@ -1535,7 +1540,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearConsistency() {
-      
+      bitField0_ = (bitField0_ & ~0x00000010);
       consistency_ = 0;
       onChanged();
       return this;
@@ -1549,7 +1554,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the condition field is set.
      */
     public boolean hasCondition() {
-      return conditionBuilder_ != null || condition_ != null;
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <code>.rpc.MutateCondition condition = 6;</code>
@@ -1571,11 +1576,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         condition_ = value;
-        onChanged();
       } else {
         conditionBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000020;
+      onChanged();
       return this;
     }
     /**
@@ -1585,11 +1590,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.MutateCondition.Builder builderForValue) {
       if (conditionBuilder_ == null) {
         condition_ = builderForValue.build();
-        onChanged();
       } else {
         conditionBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000020;
+      onChanged();
       return this;
     }
     /**
@@ -1597,38 +1602,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeCondition(com.scalar.db.rpc.MutateCondition value) {
       if (conditionBuilder_ == null) {
-        if (condition_ != null) {
-          condition_ =
-            com.scalar.db.rpc.MutateCondition.newBuilder(condition_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000020) != 0) &&
+          condition_ != null &&
+          condition_ != com.scalar.db.rpc.MutateCondition.getDefaultInstance()) {
+          getConditionBuilder().mergeFrom(value);
         } else {
           condition_ = value;
         }
-        onChanged();
       } else {
         conditionBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000020;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public Builder clearCondition() {
-      if (conditionBuilder_ == null) {
-        condition_ = null;
-        onChanged();
-      } else {
-        condition_ = null;
+      bitField0_ = (bitField0_ & ~0x00000020);
+      condition_ = null;
+      if (conditionBuilder_ != null) {
+        conditionBuilder_.dispose();
         conditionBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.MutateCondition condition = 6;</code>
      */
     public com.scalar.db.rpc.MutateCondition.Builder getConditionBuilder() {
-      
+      bitField0_ |= 0x00000020;
       onChanged();
       return getConditionFieldBuilder().getBuilder();
     }
@@ -1674,8 +1679,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setTypeValue(int value) {
-      
       type_ = value;
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1685,8 +1690,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.Mutation.Type getType() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.Mutation.Type result = com.scalar.db.rpc.Mutation.Type.valueOf(type_);
+      com.scalar.db.rpc.Mutation.Type result = com.scalar.db.rpc.Mutation.Type.forNumber(type_);
       return result == null ? com.scalar.db.rpc.Mutation.Type.UNRECOGNIZED : result;
     }
     /**
@@ -1698,7 +1702,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000040;
       type_ = value.getNumber();
       onChanged();
       return this;
@@ -1708,7 +1712,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearType() {
-      
+      bitField0_ = (bitField0_ & ~0x00000040);
       type_ = 0;
       onChanged();
       return this;
@@ -1717,9 +1721,9 @@ private static final long serialVersionUID = 0L;
     private java.util.List<com.scalar.db.rpc.Value> value_ =
       java.util.Collections.emptyList();
     private void ensureValueIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
+      if (!((bitField0_ & 0x00000080) != 0)) {
         value_ = new java.util.ArrayList<com.scalar.db.rpc.Value>(value_);
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000080;
        }
     }
 
@@ -1913,7 +1917,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Deprecated public Builder clearValue() {
       if (valueBuilder_ == null) {
         value_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000080);
         onChanged();
       } else {
         valueBuilder_.clear();
@@ -2018,7 +2022,7 @@ private static final long serialVersionUID = 0L;
         valueBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.scalar.db.rpc.Value, com.scalar.db.rpc.Value.Builder, com.scalar.db.rpc.ValueOrBuilder>(
                 value_,
-                ((bitField0_ & 0x00000001) != 0),
+                ((bitField0_ & 0x00000080) != 0),
                 getParentForChildren(),
                 isClean());
         value_ = null;
@@ -2029,9 +2033,9 @@ private static final long serialVersionUID = 0L;
     private java.util.List<com.scalar.db.rpc.Column> columns_ =
       java.util.Collections.emptyList();
     private void ensureColumnsIsMutable() {
-      if (!((bitField0_ & 0x00000002) != 0)) {
+      if (!((bitField0_ & 0x00000100) != 0)) {
         columns_ = new java.util.ArrayList<com.scalar.db.rpc.Column>(columns_);
-        bitField0_ |= 0x00000002;
+        bitField0_ |= 0x00000100;
        }
     }
 
@@ -2225,7 +2229,7 @@ private static final long serialVersionUID = 0L;
     public Builder clearColumns() {
       if (columnsBuilder_ == null) {
         columns_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000100);
         onChanged();
       } else {
         columnsBuilder_.clear();
@@ -2330,7 +2334,7 @@ private static final long serialVersionUID = 0L;
         columnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.scalar.db.rpc.Column, com.scalar.db.rpc.Column.Builder, com.scalar.db.rpc.ColumnOrBuilder>(
                 columns_,
-                ((bitField0_ & 0x00000002) != 0),
+                ((bitField0_ & 0x00000100) != 0),
                 getParentForChildren(),
                 isClean());
         columns_ = null;

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsRequest.java
@@ -45,7 +45,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -269,8 +270,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       return this;
     }
 
@@ -297,9 +298,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.NamespaceExistsRequest buildPartial() {
       com.scalar.db.rpc.NamespaceExistsRequest result = new com.scalar.db.rpc.NamespaceExistsRequest(this);
-      result.namespace_ = namespace_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.NamespaceExistsRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
     }
 
     @java.lang.Override
@@ -348,6 +356,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.NamespaceExistsRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -378,7 +387,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -396,6 +405,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -438,11 +448,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -451,8 +459,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -463,12 +471,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/NamespaceExistsResponse.java
@@ -44,7 +44,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int EXISTS_FIELD_NUMBER = 1;
-  private boolean exists_;
+  private boolean exists_ = false;
   /**
    * <code>bool exists = 1;</code>
    * @return The exists.
@@ -243,8 +243,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       exists_ = false;
-
       return this;
     }
 
@@ -271,9 +271,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.NamespaceExistsResponse buildPartial() {
       com.scalar.db.rpc.NamespaceExistsResponse result = new com.scalar.db.rpc.NamespaceExistsResponse(this);
-      result.exists_ = exists_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.NamespaceExistsResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.exists_ = exists_;
+      }
     }
 
     @java.lang.Override
@@ -351,7 +358,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               exists_ = input.readBool();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             default: {
@@ -369,6 +376,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private boolean exists_ ;
     /**
@@ -387,6 +395,7 @@ private static final long serialVersionUID = 0L;
     public Builder setExists(boolean value) {
       
       exists_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -395,7 +404,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearExists() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       exists_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/Ordering.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Ordering.java
@@ -46,7 +46,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
-  private volatile java.lang.Object name_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object name_ = "";
   /**
    * <code>string name = 1;</code>
    * @return The name.
@@ -84,7 +85,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int ORDER_FIELD_NUMBER = 2;
-  private int order_;
+  private int order_ = 0;
   /**
    * <code>.rpc.Order order = 2;</code>
    * @return The enum numeric value on the wire for order.
@@ -97,8 +98,7 @@ private static final long serialVersionUID = 0L;
    * @return The order.
    */
   @java.lang.Override public com.scalar.db.rpc.Order getOrder() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.Order result = com.scalar.db.rpc.Order.valueOf(order_);
+    com.scalar.db.rpc.Order result = com.scalar.db.rpc.Order.forNumber(order_);
     return result == null ? com.scalar.db.rpc.Order.UNRECOGNIZED : result;
   }
 
@@ -299,10 +299,9 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       name_ = "";
-
       order_ = 0;
-
       return this;
     }
 
@@ -329,10 +328,19 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Ordering buildPartial() {
       com.scalar.db.rpc.Ordering result = new com.scalar.db.rpc.Ordering(this);
-      result.name_ = name_;
-      result.order_ = order_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Ordering result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.name_ = name_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.order_ = order_;
+      }
     }
 
     @java.lang.Override
@@ -381,6 +389,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.Ordering.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (other.order_ != 0) {
@@ -414,12 +423,12 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               name_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 16: {
               order_ = input.readEnum();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 16
             default: {
@@ -437,6 +446,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object name_ = "";
     /**
@@ -479,11 +489,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -492,8 +500,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
       name_ = getDefaultInstance().getName();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -504,12 +512,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -528,8 +534,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setOrderValue(int value) {
-      
       order_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -539,8 +545,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.Order getOrder() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.Order result = com.scalar.db.rpc.Order.valueOf(order_);
+      com.scalar.db.rpc.Order result = com.scalar.db.rpc.Order.forNumber(order_);
       return result == null ? com.scalar.db.rpc.Order.UNRECOGNIZED : result;
     }
     /**
@@ -552,7 +557,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000002;
       order_ = value.getNumber();
       onChanged();
       return this;
@@ -562,7 +567,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearOrder() {
-      
+      bitField0_ = (bitField0_ & ~0x00000002);
       order_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequest.java
@@ -67,6 +67,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "");
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.String> options_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.String>
@@ -77,14 +78,12 @@ private static final long serialVersionUID = 0L;
     }
     return options_;
   }
-
   public int getOptionsCount() {
     return internalGetOptions().getMap().size();
   }
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
-
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
@@ -103,7 +102,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
     return internalGetOptions().getMap();
   }
@@ -111,10 +109,11 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
   @java.lang.Override
-
-  public java.lang.String getOptionsOrDefault(
+  public /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue) {
+      /* nullable */
+java.lang.String defaultValue) {
     if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
@@ -124,7 +123,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
   @java.lang.Override
-
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -357,6 +355,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       internalGetMutableOptions().clear();
       return this;
     }
@@ -384,11 +383,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.RepairCoordinatorTablesRequest buildPartial() {
       com.scalar.db.rpc.RepairCoordinatorTablesRequest result = new com.scalar.db.rpc.RepairCoordinatorTablesRequest(this);
-      int from_bitField0_ = bitField0_;
-      result.options_ = internalGetOptions();
-      result.options_.makeImmutable();
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.RepairCoordinatorTablesRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.options_ = internalGetOptions();
+        result.options_.makeImmutable();
+      }
     }
 
     @java.lang.Override
@@ -437,6 +442,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.RepairCoordinatorTablesRequest.getDefaultInstance()) return this;
       internalGetMutableOptions().mergeFrom(
           other.internalGetOptions());
+      bitField0_ |= 0x00000001;
       this.mergeUnknownFields(other.getUnknownFields());
       onChanged();
       return this;
@@ -469,6 +475,7 @@ private static final long serialVersionUID = 0L;
                   OptionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableOptions().getMutableMap().put(
                   options__.getKey(), options__.getValue());
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -491,7 +498,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.String> options_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetOptions() {
+        internalGetOptions() {
       if (options_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -499,8 +506,7 @@ private static final long serialVersionUID = 0L;
       return options_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetMutableOptions() {
-      onChanged();;
+        internalGetMutableOptions() {
       if (options_ == null) {
         options_ = com.google.protobuf.MapField.newMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -508,16 +514,16 @@ private static final long serialVersionUID = 0L;
       if (!options_.isMutable()) {
         options_ = options_.copy();
       }
+      bitField0_ |= 0x00000001;
+      onChanged();
       return options_;
     }
-
     public int getOptionsCount() {
       return internalGetOptions().getMap().size();
     }
     /**
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
-
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
@@ -536,7 +542,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
       return internalGetOptions().getMap();
     }
@@ -544,10 +549,11 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
     @java.lang.Override
-
-    public java.lang.String getOptionsOrDefault(
+    public /* nullable */
+java.lang.String getOptionsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        /* nullable */
+java.lang.String defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
@@ -557,7 +563,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
     @java.lang.Override
-
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -568,8 +573,8 @@ private static final long serialVersionUID = 0L;
       }
       return map.get(key);
     }
-
     public Builder clearOptions() {
+      bitField0_ = (bitField0_ & ~0x00000001);
       internalGetMutableOptions().getMutableMap()
           .clear();
       return this;
@@ -577,7 +582,6 @@ private static final long serialVersionUID = 0L;
     /**
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
-
     public Builder removeOptions(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -590,7 +594,8 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.String>
-    getMutableOptions() {
+        getMutableOptions() {
+      bitField0_ |= 0x00000001;
       return internalGetMutableOptions().getMutableMap();
     }
     /**
@@ -600,22 +605,20 @@ private static final long serialVersionUID = 0L;
         java.lang.String key,
         java.lang.String value) {
       if (key == null) { throw new NullPointerException("map key"); }
-      if (value == null) {
-  throw new NullPointerException("map value");
-}
-
+      if (value == null) { throw new NullPointerException("map value"); }
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000001;
       return this;
     }
     /**
      * <code>map&lt;string, string&gt; options = 1;</code>
      */
-
     public Builder putAllOptions(
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableOptions().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000001;
       return this;
     }
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairCoordinatorTablesRequestOrBuilder.java
@@ -30,7 +30,6 @@ public interface RepairCoordinatorTablesRequestOrBuilder extends
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
-
   /* nullable */
 java.lang.String getOptionsOrDefault(
       java.lang.String key,
@@ -39,7 +38,6 @@ java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 1;</code>
    */
-
   java.lang.String getOptionsOrThrow(
       java.lang.String key);
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequest.java
@@ -58,7 +58,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -96,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -156,7 +158,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.TableMetadataOrBuilder getTableMetadataOrBuilder() {
-    return getTableMetadata();
+    return tableMetadata_ == null ? com.scalar.db.rpc.TableMetadata.getDefaultInstance() : tableMetadata_;
   }
 
   public static final int OPTIONS_FIELD_NUMBER = 4;
@@ -171,6 +173,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "");
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.String> options_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.String>
@@ -181,14 +184,12 @@ private static final long serialVersionUID = 0L;
     }
     return options_;
   }
-
   public int getOptionsCount() {
     return internalGetOptions().getMap().size();
   }
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   @java.lang.Override
   public boolean containsOptions(
       java.lang.String key) {
@@ -207,7 +208,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
     return internalGetOptions().getMap();
   }
@@ -215,10 +215,11 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
-  public java.lang.String getOptionsOrDefault(
+  public /* nullable */
+java.lang.String getOptionsOrDefault(
       java.lang.String key,
-      java.lang.String defaultValue) {
+      /* nullable */
+java.lang.String defaultValue) {
     if (key == null) { throw new NullPointerException("map key"); }
     java.util.Map<java.lang.String, java.lang.String> map =
         internalGetOptions().getMap();
@@ -228,7 +229,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
   @java.lang.Override
-
   public java.lang.String getOptionsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -497,14 +497,12 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
-      if (tableMetadataBuilder_ == null) {
-        tableMetadata_ = null;
-      } else {
-        tableMetadata_ = null;
+      tableMetadata_ = null;
+      if (tableMetadataBuilder_ != null) {
+        tableMetadataBuilder_.dispose();
         tableMetadataBuilder_ = null;
       }
       internalGetMutableOptions().clear();
@@ -534,18 +532,28 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.RepairTableRequest buildPartial() {
       com.scalar.db.rpc.RepairTableRequest result = new com.scalar.db.rpc.RepairTableRequest(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      if (tableMetadataBuilder_ == null) {
-        result.tableMetadata_ = tableMetadata_;
-      } else {
-        result.tableMetadata_ = tableMetadataBuilder_.build();
-      }
-      result.options_ = internalGetOptions();
-      result.options_.makeImmutable();
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.RepairTableRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.tableMetadata_ = tableMetadataBuilder_ == null
+            ? tableMetadata_
+            : tableMetadataBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.options_ = internalGetOptions();
+        result.options_.makeImmutable();
+      }
     }
 
     @java.lang.Override
@@ -594,10 +602,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.RepairTableRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (other.hasTableMetadata()) {
@@ -605,6 +615,7 @@ private static final long serialVersionUID = 0L;
       }
       internalGetMutableOptions().mergeFrom(
           other.internalGetOptions());
+      bitField0_ |= 0x00000008;
       this.mergeUnknownFields(other.getUnknownFields());
       onChanged();
       return this;
@@ -633,19 +644,19 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               input.readMessage(
                   getTableMetadataFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 34: {
@@ -654,6 +665,7 @@ private static final long serialVersionUID = 0L;
                   OptionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableOptions().getMutableMap().put(
                   options__.getKey(), options__.getValue());
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             default: {
@@ -714,11 +726,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -727,8 +737,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -739,12 +749,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -790,11 +798,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -803,8 +809,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -815,12 +821,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -833,7 +837,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the tableMetadata field is set.
      */
     public boolean hasTableMetadata() {
-      return tableMetadataBuilder_ != null || tableMetadata_ != null;
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 3;</code>
@@ -855,11 +859,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         tableMetadata_ = value;
-        onChanged();
       } else {
         tableMetadataBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -869,11 +873,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.TableMetadata.Builder builderForValue) {
       if (tableMetadataBuilder_ == null) {
         tableMetadata_ = builderForValue.build();
-        onChanged();
       } else {
         tableMetadataBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -881,38 +885,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeTableMetadata(com.scalar.db.rpc.TableMetadata value) {
       if (tableMetadataBuilder_ == null) {
-        if (tableMetadata_ != null) {
-          tableMetadata_ =
-            com.scalar.db.rpc.TableMetadata.newBuilder(tableMetadata_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000004) != 0) &&
+          tableMetadata_ != null &&
+          tableMetadata_ != com.scalar.db.rpc.TableMetadata.getDefaultInstance()) {
+          getTableMetadataBuilder().mergeFrom(value);
         } else {
           tableMetadata_ = value;
         }
-        onChanged();
       } else {
         tableMetadataBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public Builder clearTableMetadata() {
-      if (tableMetadataBuilder_ == null) {
-        tableMetadata_ = null;
-        onChanged();
-      } else {
-        tableMetadata_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
+      tableMetadata_ = null;
+      if (tableMetadataBuilder_ != null) {
+        tableMetadataBuilder_.dispose();
         tableMetadataBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.TableMetadata table_metadata = 3;</code>
      */
     public com.scalar.db.rpc.TableMetadata.Builder getTableMetadataBuilder() {
-      
+      bitField0_ |= 0x00000004;
       onChanged();
       return getTableMetadataFieldBuilder().getBuilder();
     }
@@ -947,7 +951,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.String> options_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetOptions() {
+        internalGetOptions() {
       if (options_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -955,8 +959,7 @@ private static final long serialVersionUID = 0L;
       return options_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetMutableOptions() {
-      onChanged();;
+        internalGetMutableOptions() {
       if (options_ == null) {
         options_ = com.google.protobuf.MapField.newMapField(
             OptionsDefaultEntryHolder.defaultEntry);
@@ -964,16 +967,16 @@ private static final long serialVersionUID = 0L;
       if (!options_.isMutable()) {
         options_ = options_.copy();
       }
+      bitField0_ |= 0x00000008;
+      onChanged();
       return options_;
     }
-
     public int getOptionsCount() {
       return internalGetOptions().getMap().size();
     }
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     @java.lang.Override
     public boolean containsOptions(
         java.lang.String key) {
@@ -992,7 +995,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.String> getOptionsMap() {
       return internalGetOptions().getMap();
     }
@@ -1000,10 +1002,11 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
-    public java.lang.String getOptionsOrDefault(
+    public /* nullable */
+java.lang.String getOptionsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        /* nullable */
+java.lang.String defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetOptions().getMap();
@@ -1013,7 +1016,6 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
     @java.lang.Override
-
     public java.lang.String getOptionsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1024,8 +1026,8 @@ private static final long serialVersionUID = 0L;
       }
       return map.get(key);
     }
-
     public Builder clearOptions() {
+      bitField0_ = (bitField0_ & ~0x00000008);
       internalGetMutableOptions().getMutableMap()
           .clear();
       return this;
@@ -1033,7 +1035,6 @@ private static final long serialVersionUID = 0L;
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     public Builder removeOptions(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1046,7 +1047,8 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.String>
-    getMutableOptions() {
+        getMutableOptions() {
+      bitField0_ |= 0x00000008;
       return internalGetMutableOptions().getMutableMap();
     }
     /**
@@ -1056,22 +1058,20 @@ private static final long serialVersionUID = 0L;
         java.lang.String key,
         java.lang.String value) {
       if (key == null) { throw new NullPointerException("map key"); }
-      if (value == null) {
-  throw new NullPointerException("map value");
-}
-
+      if (value == null) { throw new NullPointerException("map value"); }
       internalGetMutableOptions().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000008;
       return this;
     }
     /**
      * <code>map&lt;string, string&gt; options = 4;</code>
      */
-
     public Builder putAllOptions(
         java.util.Map<java.lang.String, java.lang.String> values) {
       internalGetMutableOptions().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000008;
       return this;
     }
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequestOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RepairTableRequestOrBuilder.java
@@ -69,7 +69,6 @@ public interface RepairTableRequestOrBuilder extends
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   /* nullable */
 java.lang.String getOptionsOrDefault(
       java.lang.String key,
@@ -78,7 +77,6 @@ java.lang.String defaultValue);
   /**
    * <code>map&lt;string, string&gt; options = 4;</code>
    */
-
   java.lang.String getOptionsOrThrow(
       java.lang.String key);
 }

--- a/rpc/src/main/java/com/scalar/db/rpc/Result.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Result.java
@@ -46,6 +46,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int VALUE_FIELD_NUMBER = 1;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Value> value_;
   /**
    * <code>repeated .rpc.Value value = 1 [deprecated = true];</code>
@@ -86,6 +87,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int COLUMNS_FIELD_NUMBER = 2;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Column> columns_;
   /**
    * <code>repeated .rpc.Column columns = 2;</code>
@@ -328,6 +330,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (valueBuilder_ == null) {
         value_ = java.util.Collections.emptyList();
       } else {
@@ -368,7 +371,13 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Result buildPartial() {
       com.scalar.db.rpc.Result result = new com.scalar.db.rpc.Result(this);
-      int from_bitField0_ = bitField0_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.Result result) {
       if (valueBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
           value_ = java.util.Collections.unmodifiableList(value_);
@@ -387,8 +396,10 @@ private static final long serialVersionUID = 0L;
       } else {
         result.columns_ = columnsBuilder_.build();
       }
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Result result) {
+      int from_bitField0_ = bitField0_;
     }
 
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/RollbackRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RollbackRequest.java
@@ -45,7 +45,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-  private volatile java.lang.Object transactionId_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object transactionId_ = "";
   /**
    * <code>string transaction_id = 1;</code>
    * @return The transactionId.
@@ -269,8 +270,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       transactionId_ = "";
-
       return this;
     }
 
@@ -297,9 +298,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.RollbackRequest buildPartial() {
       com.scalar.db.rpc.RollbackRequest result = new com.scalar.db.rpc.RollbackRequest(this);
-      result.transactionId_ = transactionId_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.RollbackRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.transactionId_ = transactionId_;
+      }
     }
 
     @java.lang.Override
@@ -348,6 +356,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.RollbackRequest.getDefaultInstance()) return this;
       if (!other.getTransactionId().isEmpty()) {
         transactionId_ = other.transactionId_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -378,7 +387,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               transactionId_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             default: {
@@ -396,6 +405,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object transactionId_ = "";
     /**
@@ -438,11 +448,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTransactionId(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       transactionId_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -451,8 +459,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTransactionId() {
-      
       transactionId_ = getDefaultInstance().getTransactionId();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -463,12 +471,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTransactionIdBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       transactionId_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/RollbackResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/RollbackResponse.java
@@ -45,7 +45,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int STATE_FIELD_NUMBER = 1;
-  private int state_;
+  private int state_ = 0;
   /**
    * <code>.rpc.TransactionState state = 1;</code>
    * @return The enum numeric value on the wire for state.
@@ -58,8 +58,7 @@ private static final long serialVersionUID = 0L;
    * @return The state.
    */
   @java.lang.Override public com.scalar.db.rpc.TransactionState getState() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.valueOf(state_);
+    com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.forNumber(state_);
     return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
   }
 
@@ -250,8 +249,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       state_ = 0;
-
       return this;
     }
 
@@ -278,9 +277,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.RollbackResponse buildPartial() {
       com.scalar.db.rpc.RollbackResponse result = new com.scalar.db.rpc.RollbackResponse(this);
-      result.state_ = state_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.RollbackResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.state_ = state_;
+      }
     }
 
     @java.lang.Override
@@ -358,7 +364,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 8: {
               state_ = input.readEnum();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 8
             default: {
@@ -376,6 +382,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private int state_ = 0;
     /**
@@ -391,8 +398,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setStateValue(int value) {
-      
       state_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -402,8 +409,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.TransactionState getState() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.valueOf(state_);
+      com.scalar.db.rpc.TransactionState result = com.scalar.db.rpc.TransactionState.forNumber(state_);
       return result == null ? com.scalar.db.rpc.TransactionState.UNRECOGNIZED : result;
     }
     /**
@@ -415,7 +421,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000001;
       state_ = value.getNumber();
       onChanged();
       return this;
@@ -425,7 +431,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearState() {
-      
+      bitField0_ = (bitField0_ & ~0x00000001);
       state_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/Scan.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Scan.java
@@ -49,7 +49,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -87,7 +88,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -147,11 +149,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getPartitionKeyOrBuilder() {
-    return getPartitionKey();
+    return partitionKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : partitionKey_;
   }
 
   public static final int CONSISTENCY_FIELD_NUMBER = 4;
-  private int consistency_;
+  private int consistency_ = 0;
   /**
    * <code>.rpc.Consistency consistency = 4;</code>
    * @return The enum numeric value on the wire for consistency.
@@ -164,12 +166,12 @@ private static final long serialVersionUID = 0L;
    * @return The consistency.
    */
   @java.lang.Override public com.scalar.db.rpc.Consistency getConsistency() {
-    @SuppressWarnings("deprecation")
-    com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.valueOf(consistency_);
+    com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.forNumber(consistency_);
     return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
   }
 
   public static final int PROJECTIONS_FIELD_NUMBER = 5;
+  @SuppressWarnings("serial")
   private com.google.protobuf.LazyStringList projections_;
   /**
    * <code>repeated string projections = 5;</code>
@@ -227,11 +229,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getStartClusteringKeyOrBuilder() {
-    return getStartClusteringKey();
+    return startClusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : startClusteringKey_;
   }
 
   public static final int START_INCLUSIVE_FIELD_NUMBER = 7;
-  private boolean startInclusive_;
+  private boolean startInclusive_ = false;
   /**
    * <code>bool start_inclusive = 7;</code>
    * @return The startInclusive.
@@ -264,11 +266,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.KeyOrBuilder getEndClusteringKeyOrBuilder() {
-    return getEndClusteringKey();
+    return endClusteringKey_ == null ? com.scalar.db.rpc.Key.getDefaultInstance() : endClusteringKey_;
   }
 
   public static final int END_INCLUSIVE_FIELD_NUMBER = 9;
-  private boolean endInclusive_;
+  private boolean endInclusive_ = false;
   /**
    * <code>bool end_inclusive = 9;</code>
    * @return The endInclusive.
@@ -279,6 +281,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int ORDERINGS_FIELD_NUMBER = 10;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Ordering> orderings_;
   /**
    * <code>repeated .rpc.Ordering orderings = 10;</code>
@@ -319,7 +322,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int LIMIT_FIELD_NUMBER = 11;
-  private int limit_;
+  private int limit_ = 0;
   /**
    * <code>int32 limit = 11;</code>
    * @return The limit.
@@ -649,45 +652,37 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
-      if (partitionKeyBuilder_ == null) {
-        partitionKey_ = null;
-      } else {
-        partitionKey_ = null;
+      partitionKey_ = null;
+      if (partitionKeyBuilder_ != null) {
+        partitionKeyBuilder_.dispose();
         partitionKeyBuilder_ = null;
       }
       consistency_ = 0;
-
       projections_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
-      if (startClusteringKeyBuilder_ == null) {
-        startClusteringKey_ = null;
-      } else {
-        startClusteringKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000010);
+      startClusteringKey_ = null;
+      if (startClusteringKeyBuilder_ != null) {
+        startClusteringKeyBuilder_.dispose();
         startClusteringKeyBuilder_ = null;
       }
       startInclusive_ = false;
-
-      if (endClusteringKeyBuilder_ == null) {
-        endClusteringKey_ = null;
-      } else {
-        endClusteringKey_ = null;
+      endClusteringKey_ = null;
+      if (endClusteringKeyBuilder_ != null) {
+        endClusteringKeyBuilder_.dispose();
         endClusteringKeyBuilder_ = null;
       }
       endInclusive_ = false;
-
       if (orderingsBuilder_ == null) {
         orderings_ = java.util.Collections.emptyList();
       } else {
         orderings_ = null;
         orderingsBuilder_.clear();
       }
-      bitField0_ = (bitField0_ & ~0x00000002);
+      bitField0_ = (bitField0_ & ~0x00000200);
       limit_ = 0;
-
       return this;
     }
 
@@ -714,44 +709,64 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Scan buildPartial() {
       com.scalar.db.rpc.Scan result = new com.scalar.db.rpc.Scan(this);
-      int from_bitField0_ = bitField0_;
-      result.namespace_ = namespace_;
-      result.table_ = table_;
-      if (partitionKeyBuilder_ == null) {
-        result.partitionKey_ = partitionKey_;
-      } else {
-        result.partitionKey_ = partitionKeyBuilder_.build();
-      }
-      result.consistency_ = consistency_;
-      if (((bitField0_ & 0x00000001) != 0)) {
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.Scan result) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         projections_ = projections_.getUnmodifiableView();
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000010);
       }
       result.projections_ = projections_;
-      if (startClusteringKeyBuilder_ == null) {
-        result.startClusteringKey_ = startClusteringKey_;
-      } else {
-        result.startClusteringKey_ = startClusteringKeyBuilder_.build();
-      }
-      result.startInclusive_ = startInclusive_;
-      if (endClusteringKeyBuilder_ == null) {
-        result.endClusteringKey_ = endClusteringKey_;
-      } else {
-        result.endClusteringKey_ = endClusteringKeyBuilder_.build();
-      }
-      result.endInclusive_ = endInclusive_;
       if (orderingsBuilder_ == null) {
-        if (((bitField0_ & 0x00000002) != 0)) {
+        if (((bitField0_ & 0x00000200) != 0)) {
           orderings_ = java.util.Collections.unmodifiableList(orderings_);
-          bitField0_ = (bitField0_ & ~0x00000002);
+          bitField0_ = (bitField0_ & ~0x00000200);
         }
         result.orderings_ = orderings_;
       } else {
         result.orderings_ = orderingsBuilder_.build();
       }
-      result.limit_ = limit_;
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Scan result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        result.partitionKey_ = partitionKeyBuilder_ == null
+            ? partitionKey_
+            : partitionKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.consistency_ = consistency_;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        result.startClusteringKey_ = startClusteringKeyBuilder_ == null
+            ? startClusteringKey_
+            : startClusteringKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        result.startInclusive_ = startInclusive_;
+      }
+      if (((from_bitField0_ & 0x00000080) != 0)) {
+        result.endClusteringKey_ = endClusteringKeyBuilder_ == null
+            ? endClusteringKey_
+            : endClusteringKeyBuilder_.build();
+      }
+      if (((from_bitField0_ & 0x00000100) != 0)) {
+        result.endInclusive_ = endInclusive_;
+      }
+      if (((from_bitField0_ & 0x00000400) != 0)) {
+        result.limit_ = limit_;
+      }
     }
 
     @java.lang.Override
@@ -800,10 +815,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.Scan.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       if (other.hasPartitionKey()) {
@@ -815,7 +832,7 @@ private static final long serialVersionUID = 0L;
       if (!other.projections_.isEmpty()) {
         if (projections_.isEmpty()) {
           projections_ = other.projections_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          bitField0_ = (bitField0_ & ~0x00000010);
         } else {
           ensureProjectionsIsMutable();
           projections_.addAll(other.projections_);
@@ -838,7 +855,7 @@ private static final long serialVersionUID = 0L;
         if (!other.orderings_.isEmpty()) {
           if (orderings_.isEmpty()) {
             orderings_ = other.orderings_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000200);
           } else {
             ensureOrderingsIsMutable();
             orderings_.addAll(other.orderings_);
@@ -851,7 +868,7 @@ private static final long serialVersionUID = 0L;
             orderingsBuilder_.dispose();
             orderingsBuilder_ = null;
             orderings_ = other.orderings_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000200);
             orderingsBuilder_ = 
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getOrderingsFieldBuilder() : null;
@@ -891,24 +908,24 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             case 26: {
               input.readMessage(
                   getPartitionKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000004;
               break;
             } // case 26
             case 32: {
               consistency_ = input.readEnum();
-
+              bitField0_ |= 0x00000008;
               break;
             } // case 32
             case 42: {
@@ -921,24 +938,24 @@ private static final long serialVersionUID = 0L;
               input.readMessage(
                   getStartClusteringKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000020;
               break;
             } // case 50
             case 56: {
               startInclusive_ = input.readBool();
-
+              bitField0_ |= 0x00000040;
               break;
             } // case 56
             case 66: {
               input.readMessage(
                   getEndClusteringKeyFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000080;
               break;
             } // case 66
             case 72: {
               endInclusive_ = input.readBool();
-
+              bitField0_ |= 0x00000100;
               break;
             } // case 72
             case 82: {
@@ -956,7 +973,7 @@ private static final long serialVersionUID = 0L;
             } // case 82
             case 88: {
               limit_ = input.readInt32();
-
+              bitField0_ |= 0x00000400;
               break;
             } // case 88
             default: {
@@ -1017,11 +1034,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -1030,8 +1045,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -1042,12 +1057,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -1093,11 +1106,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -1106,8 +1117,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -1118,12 +1129,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -1136,7 +1145,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the partitionKey field is set.
      */
     public boolean hasPartitionKey() {
-      return partitionKeyBuilder_ != null || partitionKey_ != null;
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
@@ -1158,11 +1167,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         partitionKey_ = value;
-        onChanged();
       } else {
         partitionKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -1172,11 +1181,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (partitionKeyBuilder_ == null) {
         partitionKey_ = builderForValue.build();
-        onChanged();
       } else {
         partitionKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
@@ -1184,38 +1193,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergePartitionKey(com.scalar.db.rpc.Key value) {
       if (partitionKeyBuilder_ == null) {
-        if (partitionKey_ != null) {
-          partitionKey_ =
-            com.scalar.db.rpc.Key.newBuilder(partitionKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000004) != 0) &&
+          partitionKey_ != null &&
+          partitionKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getPartitionKeyBuilder().mergeFrom(value);
         } else {
           partitionKey_ = value;
         }
-        onChanged();
       } else {
         partitionKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000004;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
      */
     public Builder clearPartitionKey() {
-      if (partitionKeyBuilder_ == null) {
-        partitionKey_ = null;
-        onChanged();
-      } else {
-        partitionKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000004);
+      partitionKey_ = null;
+      if (partitionKeyBuilder_ != null) {
+        partitionKeyBuilder_.dispose();
         partitionKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key partition_key = 3;</code>
      */
     public com.scalar.db.rpc.Key.Builder getPartitionKeyBuilder() {
-      
+      bitField0_ |= 0x00000004;
       onChanged();
       return getPartitionKeyFieldBuilder().getBuilder();
     }
@@ -1261,8 +1270,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setConsistencyValue(int value) {
-      
       consistency_ = value;
+      bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }
@@ -1272,8 +1281,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.Consistency getConsistency() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.valueOf(consistency_);
+      com.scalar.db.rpc.Consistency result = com.scalar.db.rpc.Consistency.forNumber(consistency_);
       return result == null ? com.scalar.db.rpc.Consistency.UNRECOGNIZED : result;
     }
     /**
@@ -1285,7 +1293,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
         throw new NullPointerException();
       }
-      
+      bitField0_ |= 0x00000008;
       consistency_ = value.getNumber();
       onChanged();
       return this;
@@ -1295,7 +1303,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearConsistency() {
-      
+      bitField0_ = (bitField0_ & ~0x00000008);
       consistency_ = 0;
       onChanged();
       return this;
@@ -1303,9 +1311,9 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.LazyStringList projections_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     private void ensureProjectionsIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
+      if (!((bitField0_ & 0x00000010) != 0)) {
         projections_ = new com.google.protobuf.LazyStringArrayList(projections_);
-        bitField0_ |= 0x00000001;
+        bitField0_ |= 0x00000010;
        }
     }
     /**
@@ -1348,10 +1356,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setProjections(
         int index, java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureProjectionsIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureProjectionsIsMutable();
       projections_.set(index, value);
       onChanged();
       return this;
@@ -1363,10 +1369,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder addProjections(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureProjectionsIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureProjectionsIsMutable();
       projections_.add(value);
       onChanged();
       return this;
@@ -1390,7 +1394,7 @@ private static final long serialVersionUID = 0L;
      */
     public Builder clearProjections() {
       projections_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000010);
       onChanged();
       return this;
     }
@@ -1401,10 +1405,8 @@ private static final long serialVersionUID = 0L;
      */
     public Builder addProjectionsBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       ensureProjectionsIsMutable();
       projections_.add(value);
       onChanged();
@@ -1419,7 +1421,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the startClusteringKey field is set.
      */
     public boolean hasStartClusteringKey() {
-      return startClusteringKeyBuilder_ != null || startClusteringKey_ != null;
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <code>.rpc.Key start_clustering_key = 6;</code>
@@ -1441,11 +1443,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         startClusteringKey_ = value;
-        onChanged();
       } else {
         startClusteringKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000020;
+      onChanged();
       return this;
     }
     /**
@@ -1455,11 +1457,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (startClusteringKeyBuilder_ == null) {
         startClusteringKey_ = builderForValue.build();
-        onChanged();
       } else {
         startClusteringKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000020;
+      onChanged();
       return this;
     }
     /**
@@ -1467,38 +1469,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeStartClusteringKey(com.scalar.db.rpc.Key value) {
       if (startClusteringKeyBuilder_ == null) {
-        if (startClusteringKey_ != null) {
-          startClusteringKey_ =
-            com.scalar.db.rpc.Key.newBuilder(startClusteringKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000020) != 0) &&
+          startClusteringKey_ != null &&
+          startClusteringKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getStartClusteringKeyBuilder().mergeFrom(value);
         } else {
           startClusteringKey_ = value;
         }
-        onChanged();
       } else {
         startClusteringKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000020;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public Builder clearStartClusteringKey() {
-      if (startClusteringKeyBuilder_ == null) {
-        startClusteringKey_ = null;
-        onChanged();
-      } else {
-        startClusteringKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000020);
+      startClusteringKey_ = null;
+      if (startClusteringKeyBuilder_ != null) {
+        startClusteringKeyBuilder_.dispose();
         startClusteringKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key start_clustering_key = 6;</code>
      */
     public com.scalar.db.rpc.Key.Builder getStartClusteringKeyBuilder() {
-      
+      bitField0_ |= 0x00000020;
       onChanged();
       return getStartClusteringKeyFieldBuilder().getBuilder();
     }
@@ -1547,6 +1549,7 @@ private static final long serialVersionUID = 0L;
     public Builder setStartInclusive(boolean value) {
       
       startInclusive_ = value;
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1555,7 +1558,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearStartInclusive() {
-      
+      bitField0_ = (bitField0_ & ~0x00000040);
       startInclusive_ = false;
       onChanged();
       return this;
@@ -1569,7 +1572,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the endClusteringKey field is set.
      */
     public boolean hasEndClusteringKey() {
-      return endClusteringKeyBuilder_ != null || endClusteringKey_ != null;
+      return ((bitField0_ & 0x00000080) != 0);
     }
     /**
      * <code>.rpc.Key end_clustering_key = 8;</code>
@@ -1591,11 +1594,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         endClusteringKey_ = value;
-        onChanged();
       } else {
         endClusteringKeyBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000080;
+      onChanged();
       return this;
     }
     /**
@@ -1605,11 +1608,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Key.Builder builderForValue) {
       if (endClusteringKeyBuilder_ == null) {
         endClusteringKey_ = builderForValue.build();
-        onChanged();
       } else {
         endClusteringKeyBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000080;
+      onChanged();
       return this;
     }
     /**
@@ -1617,38 +1620,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeEndClusteringKey(com.scalar.db.rpc.Key value) {
       if (endClusteringKeyBuilder_ == null) {
-        if (endClusteringKey_ != null) {
-          endClusteringKey_ =
-            com.scalar.db.rpc.Key.newBuilder(endClusteringKey_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000080) != 0) &&
+          endClusteringKey_ != null &&
+          endClusteringKey_ != com.scalar.db.rpc.Key.getDefaultInstance()) {
+          getEndClusteringKeyBuilder().mergeFrom(value);
         } else {
           endClusteringKey_ = value;
         }
-        onChanged();
       } else {
         endClusteringKeyBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000080;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public Builder clearEndClusteringKey() {
-      if (endClusteringKeyBuilder_ == null) {
-        endClusteringKey_ = null;
-        onChanged();
-      } else {
-        endClusteringKey_ = null;
+      bitField0_ = (bitField0_ & ~0x00000080);
+      endClusteringKey_ = null;
+      if (endClusteringKeyBuilder_ != null) {
+        endClusteringKeyBuilder_.dispose();
         endClusteringKeyBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Key end_clustering_key = 8;</code>
      */
     public com.scalar.db.rpc.Key.Builder getEndClusteringKeyBuilder() {
-      
+      bitField0_ |= 0x00000080;
       onChanged();
       return getEndClusteringKeyFieldBuilder().getBuilder();
     }
@@ -1697,6 +1700,7 @@ private static final long serialVersionUID = 0L;
     public Builder setEndInclusive(boolean value) {
       
       endInclusive_ = value;
+      bitField0_ |= 0x00000100;
       onChanged();
       return this;
     }
@@ -1705,7 +1709,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearEndInclusive() {
-      
+      bitField0_ = (bitField0_ & ~0x00000100);
       endInclusive_ = false;
       onChanged();
       return this;
@@ -1714,9 +1718,9 @@ private static final long serialVersionUID = 0L;
     private java.util.List<com.scalar.db.rpc.Ordering> orderings_ =
       java.util.Collections.emptyList();
     private void ensureOrderingsIsMutable() {
-      if (!((bitField0_ & 0x00000002) != 0)) {
+      if (!((bitField0_ & 0x00000200) != 0)) {
         orderings_ = new java.util.ArrayList<com.scalar.db.rpc.Ordering>(orderings_);
-        bitField0_ |= 0x00000002;
+        bitField0_ |= 0x00000200;
        }
     }
 
@@ -1866,7 +1870,7 @@ private static final long serialVersionUID = 0L;
     public Builder clearOrderings() {
       if (orderingsBuilder_ == null) {
         orderings_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000200);
         onChanged();
       } else {
         orderingsBuilder_.clear();
@@ -1943,7 +1947,7 @@ private static final long serialVersionUID = 0L;
         orderingsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
             com.scalar.db.rpc.Ordering, com.scalar.db.rpc.Ordering.Builder, com.scalar.db.rpc.OrderingOrBuilder>(
                 orderings_,
-                ((bitField0_ & 0x00000002) != 0),
+                ((bitField0_ & 0x00000200) != 0),
                 getParentForChildren(),
                 isClean());
         orderings_ = null;
@@ -1968,6 +1972,7 @@ private static final long serialVersionUID = 0L;
     public Builder setLimit(int value) {
       
       limit_ = value;
+      bitField0_ |= 0x00000400;
       onChanged();
       return this;
     }
@@ -1976,7 +1981,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearLimit() {
-      
+      bitField0_ = (bitField0_ & ~0x00000400);
       limit_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanRequest.java
@@ -67,11 +67,11 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
-    return getScan();
+    return scan_ == null ? com.scalar.db.rpc.Scan.getDefaultInstance() : scan_;
   }
 
   public static final int FETCH_COUNT_FIELD_NUMBER = 2;
-  private int fetchCount_;
+  private int fetchCount_ = 0;
   /**
    * <code>optional int32 fetch_count = 2;</code>
    * @return Whether the fetchCount field is set.
@@ -298,14 +298,13 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
-      if (scanBuilder_ == null) {
-        scan_ = null;
-      } else {
-        scan_ = null;
+      bitField0_ = 0;
+      scan_ = null;
+      if (scanBuilder_ != null) {
+        scanBuilder_.dispose();
         scanBuilder_ = null;
       }
       fetchCount_ = 0;
-      bitField0_ = (bitField0_ & ~0x00000001);
       return this;
     }
 
@@ -332,20 +331,24 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.ScanRequest buildPartial() {
       com.scalar.db.rpc.ScanRequest result = new com.scalar.db.rpc.ScanRequest(this);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.ScanRequest result) {
       int from_bitField0_ = bitField0_;
-      int to_bitField0_ = 0;
-      if (scanBuilder_ == null) {
-        result.scan_ = scan_;
-      } else {
-        result.scan_ = scanBuilder_.build();
-      }
       if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.scan_ = scanBuilder_ == null
+            ? scan_
+            : scanBuilder_.build();
+      }
+      int to_bitField0_ = 0;
+      if (((from_bitField0_ & 0x00000002) != 0)) {
         result.fetchCount_ = fetchCount_;
         to_bitField0_ |= 0x00000001;
       }
-      result.bitField0_ = to_bitField0_;
-      onBuilt();
-      return result;
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -428,12 +431,12 @@ private static final long serialVersionUID = 0L;
               input.readMessage(
                   getScanFieldBuilder().getBuilder(),
                   extensionRegistry);
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 16: {
               fetchCount_ = input.readInt32();
-              bitField0_ |= 0x00000001;
+              bitField0_ |= 0x00000002;
               break;
             } // case 16
             default: {
@@ -461,7 +464,7 @@ private static final long serialVersionUID = 0L;
      * @return Whether the scan field is set.
      */
     public boolean hasScan() {
-      return scanBuilder_ != null || scan_ != null;
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>.rpc.Scan scan = 1;</code>
@@ -483,11 +486,11 @@ private static final long serialVersionUID = 0L;
           throw new NullPointerException();
         }
         scan_ = value;
-        onChanged();
       } else {
         scanBuilder_.setMessage(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -497,11 +500,11 @@ private static final long serialVersionUID = 0L;
         com.scalar.db.rpc.Scan.Builder builderForValue) {
       if (scanBuilder_ == null) {
         scan_ = builderForValue.build();
-        onChanged();
       } else {
         scanBuilder_.setMessage(builderForValue.build());
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
@@ -509,38 +512,38 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeScan(com.scalar.db.rpc.Scan value) {
       if (scanBuilder_ == null) {
-        if (scan_ != null) {
-          scan_ =
-            com.scalar.db.rpc.Scan.newBuilder(scan_).mergeFrom(value).buildPartial();
+        if (((bitField0_ & 0x00000001) != 0) &&
+          scan_ != null &&
+          scan_ != com.scalar.db.rpc.Scan.getDefaultInstance()) {
+          getScanBuilder().mergeFrom(value);
         } else {
           scan_ = value;
         }
-        onChanged();
       } else {
         scanBuilder_.mergeFrom(value);
       }
-
+      bitField0_ |= 0x00000001;
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Scan scan = 1;</code>
      */
     public Builder clearScan() {
-      if (scanBuilder_ == null) {
-        scan_ = null;
-        onChanged();
-      } else {
-        scan_ = null;
+      bitField0_ = (bitField0_ & ~0x00000001);
+      scan_ = null;
+      if (scanBuilder_ != null) {
+        scanBuilder_.dispose();
         scanBuilder_ = null;
       }
-
+      onChanged();
       return this;
     }
     /**
      * <code>.rpc.Scan scan = 1;</code>
      */
     public com.scalar.db.rpc.Scan.Builder getScanBuilder() {
-      
+      bitField0_ |= 0x00000001;
       onChanged();
       return getScanFieldBuilder().getBuilder();
     }
@@ -579,7 +582,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public boolean hasFetchCount() {
-      return ((bitField0_ & 0x00000001) != 0);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional int32 fetch_count = 2;</code>
@@ -595,8 +598,9 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFetchCount(int value) {
-      bitField0_ |= 0x00000001;
+      
       fetchCount_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -605,7 +609,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearFetchCount() {
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000002);
       fetchCount_ = 0;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/ScanResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/ScanResponse.java
@@ -45,6 +45,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int RESULTS_FIELD_NUMBER = 2;
+  @SuppressWarnings("serial")
   private java.util.List<com.scalar.db.rpc.Result> results_;
   /**
    * <code>repeated .rpc.Result results = 2;</code>
@@ -85,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int HAS_MORE_RESULTS_FIELD_NUMBER = 3;
-  private boolean hasMoreResults_;
+  private boolean hasMoreResults_ = false;
   /**
    * <code>bool has_more_results = 3;</code>
    * @return The hasMoreResults.
@@ -297,6 +298,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (resultsBuilder_ == null) {
         results_ = java.util.Collections.emptyList();
       } else {
@@ -305,7 +307,6 @@ private static final long serialVersionUID = 0L;
       }
       bitField0_ = (bitField0_ & ~0x00000001);
       hasMoreResults_ = false;
-
       return this;
     }
 
@@ -332,7 +333,13 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.ScanResponse buildPartial() {
       com.scalar.db.rpc.ScanResponse result = new com.scalar.db.rpc.ScanResponse(this);
-      int from_bitField0_ = bitField0_;
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.ScanResponse result) {
       if (resultsBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
           results_ = java.util.Collections.unmodifiableList(results_);
@@ -342,9 +349,13 @@ private static final long serialVersionUID = 0L;
       } else {
         result.results_ = resultsBuilder_.build();
       }
-      result.hasMoreResults_ = hasMoreResults_;
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.ScanResponse result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.hasMoreResults_ = hasMoreResults_;
+      }
     }
 
     @java.lang.Override
@@ -461,7 +472,7 @@ private static final long serialVersionUID = 0L;
             } // case 18
             case 24: {
               hasMoreResults_ = input.readBool();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 24
             default: {
@@ -738,6 +749,7 @@ private static final long serialVersionUID = 0L;
     public Builder setHasMoreResults(boolean value) {
       
       hasMoreResults_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -746,7 +758,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearHasMoreResults() {
-      
+      bitField0_ = (bitField0_ & ~0x00000002);
       hasMoreResults_ = false;
       onChanged();
       return this;

--- a/rpc/src/main/java/com/scalar/db/rpc/TableMetadata.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TableMetadata.java
@@ -72,6 +72,7 @@ private static final long serialVersionUID = 0L;
                 com.google.protobuf.WireFormat.FieldType.ENUM,
                 com.scalar.db.rpc.DataType.DATA_TYPE_BOOLEAN.getNumber());
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.Integer> columns_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.Integer>
@@ -95,14 +96,12 @@ private static final long serialVersionUID = 0L;
         java.lang.String, com.scalar.db.rpc.DataType, java.lang.Integer>(
             map, columnsValueConverter);
   }
-
   public int getColumnsCount() {
     return internalGetColumns().getMap().size();
   }
   /**
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
-
   @java.lang.Override
   public boolean containsColumns(
       java.lang.String key) {
@@ -122,7 +121,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, com.scalar.db.rpc.DataType>
   getColumnsMap() {
     return internalGetAdaptedColumnsMap(
@@ -131,7 +129,6 @@ private static final long serialVersionUID = 0L;
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
-
   public /* nullable */
 com.scalar.db.rpc.DataType getColumnsOrDefault(
       java.lang.String key,
@@ -148,7 +145,6 @@ com.scalar.db.rpc.DataType defaultValue) {
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
-
   public com.scalar.db.rpc.DataType getColumnsOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -172,7 +168,6 @@ com.scalar.db.rpc.DataType defaultValue) {
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.Integer>
   getColumnsValueMap() {
     return internalGetColumns().getMap();
@@ -181,7 +176,6 @@ com.scalar.db.rpc.DataType defaultValue) {
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
-
   public int getColumnsValueOrDefault(
       java.lang.String key,
       int defaultValue) {
@@ -194,7 +188,6 @@ com.scalar.db.rpc.DataType defaultValue) {
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
   @java.lang.Override
-
   public int getColumnsValueOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -207,6 +200,7 @@ com.scalar.db.rpc.DataType defaultValue) {
   }
 
   public static final int PARTITION_KEY_NAMES_FIELD_NUMBER = 2;
+  @SuppressWarnings("serial")
   private com.google.protobuf.LazyStringList partitionKeyNames_;
   /**
    * <code>repeated string partition_key_names = 2;</code>
@@ -242,6 +236,7 @@ com.scalar.db.rpc.DataType defaultValue) {
   }
 
   public static final int CLUSTERING_KEY_NAMES_FIELD_NUMBER = 3;
+  @SuppressWarnings("serial")
   private com.google.protobuf.LazyStringList clusteringKeyNames_;
   /**
    * <code>repeated string clustering_key_names = 3;</code>
@@ -288,6 +283,7 @@ com.scalar.db.rpc.DataType defaultValue) {
                 com.google.protobuf.WireFormat.FieldType.ENUM,
                 com.scalar.db.rpc.Order.ORDER_ASC.getNumber());
   }
+  @SuppressWarnings("serial")
   private com.google.protobuf.MapField<
       java.lang.String, java.lang.Integer> clusteringOrders_;
   private com.google.protobuf.MapField<java.lang.String, java.lang.Integer>
@@ -311,14 +307,12 @@ com.scalar.db.rpc.DataType defaultValue) {
         java.lang.String, com.scalar.db.rpc.Order, java.lang.Integer>(
             map, clusteringOrdersValueConverter);
   }
-
   public int getClusteringOrdersCount() {
     return internalGetClusteringOrders().getMap().size();
   }
   /**
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
-
   @java.lang.Override
   public boolean containsClusteringOrders(
       java.lang.String key) {
@@ -338,7 +332,6 @@ com.scalar.db.rpc.DataType defaultValue) {
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, com.scalar.db.rpc.Order>
   getClusteringOrdersMap() {
     return internalGetAdaptedClusteringOrdersMap(
@@ -347,7 +340,6 @@ com.scalar.db.rpc.DataType defaultValue) {
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
-
   public /* nullable */
 com.scalar.db.rpc.Order getClusteringOrdersOrDefault(
       java.lang.String key,
@@ -364,7 +356,6 @@ com.scalar.db.rpc.Order defaultValue) {
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
-
   public com.scalar.db.rpc.Order getClusteringOrdersOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -388,7 +379,6 @@ com.scalar.db.rpc.Order defaultValue) {
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
-
   public java.util.Map<java.lang.String, java.lang.Integer>
   getClusteringOrdersValueMap() {
     return internalGetClusteringOrders().getMap();
@@ -397,7 +387,6 @@ com.scalar.db.rpc.Order defaultValue) {
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
-
   public int getClusteringOrdersValueOrDefault(
       java.lang.String key,
       int defaultValue) {
@@ -410,7 +399,6 @@ com.scalar.db.rpc.Order defaultValue) {
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
   @java.lang.Override
-
   public int getClusteringOrdersValueOrThrow(
       java.lang.String key) {
     if (key == null) { throw new NullPointerException("map key"); }
@@ -423,6 +411,7 @@ com.scalar.db.rpc.Order defaultValue) {
   }
 
   public static final int SECONDARY_INDEX_NAMES_FIELD_NUMBER = 5;
+  @SuppressWarnings("serial")
   private com.google.protobuf.LazyStringList secondaryIndexNames_;
   /**
    * <code>repeated string secondary_index_names = 5;</code>
@@ -755,6 +744,7 @@ com.scalar.db.rpc.Order defaultValue) {
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       internalGetMutableColumns().clear();
       partitionKeyNames_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       bitField0_ = (bitField0_ & ~0x00000002);
@@ -789,9 +779,13 @@ com.scalar.db.rpc.Order defaultValue) {
     @java.lang.Override
     public com.scalar.db.rpc.TableMetadata buildPartial() {
       com.scalar.db.rpc.TableMetadata result = new com.scalar.db.rpc.TableMetadata(this);
-      int from_bitField0_ = bitField0_;
-      result.columns_ = internalGetColumns();
-      result.columns_.makeImmutable();
+      buildPartialRepeatedFields(result);
+      if (bitField0_ != 0) { buildPartial0(result); }
+      onBuilt();
+      return result;
+    }
+
+    private void buildPartialRepeatedFields(com.scalar.db.rpc.TableMetadata result) {
       if (((bitField0_ & 0x00000002) != 0)) {
         partitionKeyNames_ = partitionKeyNames_.getUnmodifiableView();
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -802,15 +796,23 @@ com.scalar.db.rpc.Order defaultValue) {
         bitField0_ = (bitField0_ & ~0x00000004);
       }
       result.clusteringKeyNames_ = clusteringKeyNames_;
-      result.clusteringOrders_ = internalGetClusteringOrders();
-      result.clusteringOrders_.makeImmutable();
       if (((bitField0_ & 0x00000010) != 0)) {
         secondaryIndexNames_ = secondaryIndexNames_.getUnmodifiableView();
         bitField0_ = (bitField0_ & ~0x00000010);
       }
       result.secondaryIndexNames_ = secondaryIndexNames_;
-      onBuilt();
-      return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.TableMetadata result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.columns_ = internalGetColumns();
+        result.columns_.makeImmutable();
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.clusteringOrders_ = internalGetClusteringOrders();
+        result.clusteringOrders_.makeImmutable();
+      }
     }
 
     @java.lang.Override
@@ -859,6 +861,7 @@ com.scalar.db.rpc.Order defaultValue) {
       if (other == com.scalar.db.rpc.TableMetadata.getDefaultInstance()) return this;
       internalGetMutableColumns().mergeFrom(
           other.internalGetColumns());
+      bitField0_ |= 0x00000001;
       if (!other.partitionKeyNames_.isEmpty()) {
         if (partitionKeyNames_.isEmpty()) {
           partitionKeyNames_ = other.partitionKeyNames_;
@@ -881,6 +884,7 @@ com.scalar.db.rpc.Order defaultValue) {
       }
       internalGetMutableClusteringOrders().mergeFrom(
           other.internalGetClusteringOrders());
+      bitField0_ |= 0x00000008;
       if (!other.secondaryIndexNames_.isEmpty()) {
         if (secondaryIndexNames_.isEmpty()) {
           secondaryIndexNames_ = other.secondaryIndexNames_;
@@ -923,6 +927,7 @@ com.scalar.db.rpc.Order defaultValue) {
                   ColumnsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableColumns().getMutableMap().put(
                   columns__.getKey(), columns__.getValue());
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
@@ -943,6 +948,7 @@ com.scalar.db.rpc.Order defaultValue) {
                   ClusteringOrdersDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               internalGetMutableClusteringOrders().getMutableMap().put(
                   clusteringOrders__.getKey(), clusteringOrders__.getValue());
+              bitField0_ |= 0x00000008;
               break;
             } // case 34
             case 42: {
@@ -971,7 +977,7 @@ com.scalar.db.rpc.Order defaultValue) {
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.Integer> columns_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.Integer>
-    internalGetColumns() {
+        internalGetColumns() {
       if (columns_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             ColumnsDefaultEntryHolder.defaultEntry);
@@ -979,8 +985,7 @@ com.scalar.db.rpc.Order defaultValue) {
       return columns_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.Integer>
-    internalGetMutableColumns() {
-      onChanged();;
+        internalGetMutableColumns() {
       if (columns_ == null) {
         columns_ = com.google.protobuf.MapField.newMapField(
             ColumnsDefaultEntryHolder.defaultEntry);
@@ -988,16 +993,16 @@ com.scalar.db.rpc.Order defaultValue) {
       if (!columns_.isMutable()) {
         columns_ = columns_.copy();
       }
+      bitField0_ |= 0x00000001;
+      onChanged();
       return columns_;
     }
-
     public int getColumnsCount() {
       return internalGetColumns().getMap().size();
     }
     /**
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
-
     @java.lang.Override
     public boolean containsColumns(
         java.lang.String key) {
@@ -1017,7 +1022,6 @@ com.scalar.db.rpc.Order defaultValue) {
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, com.scalar.db.rpc.DataType>
     getColumnsMap() {
       return internalGetAdaptedColumnsMap(
@@ -1026,7 +1030,6 @@ com.scalar.db.rpc.Order defaultValue) {
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
-
     public /* nullable */
 com.scalar.db.rpc.DataType getColumnsOrDefault(
         java.lang.String key,
@@ -1043,7 +1046,6 @@ com.scalar.db.rpc.DataType defaultValue) {
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
-
     public com.scalar.db.rpc.DataType getColumnsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1067,7 +1069,6 @@ com.scalar.db.rpc.DataType defaultValue) {
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.Integer>
     getColumnsValueMap() {
       return internalGetColumns().getMap();
@@ -1076,7 +1077,6 @@ com.scalar.db.rpc.DataType defaultValue) {
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
-
     public int getColumnsValueOrDefault(
         java.lang.String key,
         int defaultValue) {
@@ -1089,7 +1089,6 @@ com.scalar.db.rpc.DataType defaultValue) {
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
     @java.lang.Override
-
     public int getColumnsValueOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1100,8 +1099,8 @@ com.scalar.db.rpc.DataType defaultValue) {
       }
       return map.get(key);
     }
-
     public Builder clearColumns() {
+      bitField0_ = (bitField0_ & ~0x00000001);
       internalGetMutableColumns().getMutableMap()
           .clear();
       return this;
@@ -1109,7 +1108,6 @@ com.scalar.db.rpc.DataType defaultValue) {
     /**
      * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
      */
-
     public Builder removeColumns(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1122,7 +1120,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.scalar.db.rpc.DataType>
-    getMutableColumns() {
+        getMutableColumns() {
+      bitField0_ |= 0x00000001;
       return internalGetAdaptedColumnsMap(
            internalGetMutableColumns().getMutableMap());
     }
@@ -1136,6 +1135,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       
       internalGetMutableColumns().getMutableMap()
           .put(key, columnsValueConverter.doBackward(value));
+      bitField0_ |= 0x00000001;
       return this;
     }
     /**
@@ -1146,6 +1146,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       internalGetAdaptedColumnsMap(
           internalGetMutableColumns().getMutableMap())
               .putAll(values);
+      bitField0_ |= 0x00000001;
       return this;
     }
     /**
@@ -1154,6 +1155,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.Integer>
     getMutableColumnsValue() {
+      bitField0_ |= 0x00000001;
       return internalGetMutableColumns().getMutableMap();
     }
     /**
@@ -1166,6 +1168,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       
       internalGetMutableColumns().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000001;
       return this;
     }
     /**
@@ -1175,6 +1178,7 @@ com.scalar.db.rpc.DataType defaultValue) {
         java.util.Map<java.lang.String, java.lang.Integer> values) {
       internalGetMutableColumns().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000001;
       return this;
     }
 
@@ -1225,10 +1229,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     public Builder setPartitionKeyNames(
         int index, java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensurePartitionKeyNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensurePartitionKeyNamesIsMutable();
       partitionKeyNames_.set(index, value);
       onChanged();
       return this;
@@ -1240,10 +1242,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     public Builder addPartitionKeyNames(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensurePartitionKeyNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensurePartitionKeyNamesIsMutable();
       partitionKeyNames_.add(value);
       onChanged();
       return this;
@@ -1278,10 +1278,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     public Builder addPartitionKeyNamesBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       ensurePartitionKeyNamesIsMutable();
       partitionKeyNames_.add(value);
       onChanged();
@@ -1335,10 +1333,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     public Builder setClusteringKeyNames(
         int index, java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureClusteringKeyNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureClusteringKeyNamesIsMutable();
       clusteringKeyNames_.set(index, value);
       onChanged();
       return this;
@@ -1350,10 +1346,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     public Builder addClusteringKeyNames(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureClusteringKeyNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureClusteringKeyNamesIsMutable();
       clusteringKeyNames_.add(value);
       onChanged();
       return this;
@@ -1388,10 +1382,8 @@ com.scalar.db.rpc.DataType defaultValue) {
      */
     public Builder addClusteringKeyNamesBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       ensureClusteringKeyNamesIsMutable();
       clusteringKeyNames_.add(value);
       onChanged();
@@ -1401,7 +1393,7 @@ com.scalar.db.rpc.DataType defaultValue) {
     private com.google.protobuf.MapField<
         java.lang.String, java.lang.Integer> clusteringOrders_;
     private com.google.protobuf.MapField<java.lang.String, java.lang.Integer>
-    internalGetClusteringOrders() {
+        internalGetClusteringOrders() {
       if (clusteringOrders_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             ClusteringOrdersDefaultEntryHolder.defaultEntry);
@@ -1409,8 +1401,7 @@ com.scalar.db.rpc.DataType defaultValue) {
       return clusteringOrders_;
     }
     private com.google.protobuf.MapField<java.lang.String, java.lang.Integer>
-    internalGetMutableClusteringOrders() {
-      onChanged();;
+        internalGetMutableClusteringOrders() {
       if (clusteringOrders_ == null) {
         clusteringOrders_ = com.google.protobuf.MapField.newMapField(
             ClusteringOrdersDefaultEntryHolder.defaultEntry);
@@ -1418,16 +1409,16 @@ com.scalar.db.rpc.DataType defaultValue) {
       if (!clusteringOrders_.isMutable()) {
         clusteringOrders_ = clusteringOrders_.copy();
       }
+      bitField0_ |= 0x00000008;
+      onChanged();
       return clusteringOrders_;
     }
-
     public int getClusteringOrdersCount() {
       return internalGetClusteringOrders().getMap().size();
     }
     /**
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
-
     @java.lang.Override
     public boolean containsClusteringOrders(
         java.lang.String key) {
@@ -1447,7 +1438,6 @@ com.scalar.db.rpc.DataType defaultValue) {
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, com.scalar.db.rpc.Order>
     getClusteringOrdersMap() {
       return internalGetAdaptedClusteringOrdersMap(
@@ -1456,7 +1446,6 @@ com.scalar.db.rpc.DataType defaultValue) {
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
-
     public /* nullable */
 com.scalar.db.rpc.Order getClusteringOrdersOrDefault(
         java.lang.String key,
@@ -1473,7 +1462,6 @@ com.scalar.db.rpc.Order defaultValue) {
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
-
     public com.scalar.db.rpc.Order getClusteringOrdersOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1497,7 +1485,6 @@ com.scalar.db.rpc.Order defaultValue) {
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
-
     public java.util.Map<java.lang.String, java.lang.Integer>
     getClusteringOrdersValueMap() {
       return internalGetClusteringOrders().getMap();
@@ -1506,7 +1493,6 @@ com.scalar.db.rpc.Order defaultValue) {
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
-
     public int getClusteringOrdersValueOrDefault(
         java.lang.String key,
         int defaultValue) {
@@ -1519,7 +1505,6 @@ com.scalar.db.rpc.Order defaultValue) {
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
     @java.lang.Override
-
     public int getClusteringOrdersValueOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1530,8 +1515,8 @@ com.scalar.db.rpc.Order defaultValue) {
       }
       return map.get(key);
     }
-
     public Builder clearClusteringOrders() {
+      bitField0_ = (bitField0_ & ~0x00000008);
       internalGetMutableClusteringOrders().getMutableMap()
           .clear();
       return this;
@@ -1539,7 +1524,6 @@ com.scalar.db.rpc.Order defaultValue) {
     /**
      * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
      */
-
     public Builder removeClusteringOrders(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
@@ -1552,7 +1536,8 @@ com.scalar.db.rpc.Order defaultValue) {
      */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.scalar.db.rpc.Order>
-    getMutableClusteringOrders() {
+        getMutableClusteringOrders() {
+      bitField0_ |= 0x00000008;
       return internalGetAdaptedClusteringOrdersMap(
            internalGetMutableClusteringOrders().getMutableMap());
     }
@@ -1566,6 +1551,7 @@ com.scalar.db.rpc.Order defaultValue) {
       
       internalGetMutableClusteringOrders().getMutableMap()
           .put(key, clusteringOrdersValueConverter.doBackward(value));
+      bitField0_ |= 0x00000008;
       return this;
     }
     /**
@@ -1576,6 +1562,7 @@ com.scalar.db.rpc.Order defaultValue) {
       internalGetAdaptedClusteringOrdersMap(
           internalGetMutableClusteringOrders().getMutableMap())
               .putAll(values);
+      bitField0_ |= 0x00000008;
       return this;
     }
     /**
@@ -1584,6 +1571,7 @@ com.scalar.db.rpc.Order defaultValue) {
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, java.lang.Integer>
     getMutableClusteringOrdersValue() {
+      bitField0_ |= 0x00000008;
       return internalGetMutableClusteringOrders().getMutableMap();
     }
     /**
@@ -1596,6 +1584,7 @@ com.scalar.db.rpc.Order defaultValue) {
       
       internalGetMutableClusteringOrders().getMutableMap()
           .put(key, value);
+      bitField0_ |= 0x00000008;
       return this;
     }
     /**
@@ -1605,6 +1594,7 @@ com.scalar.db.rpc.Order defaultValue) {
         java.util.Map<java.lang.String, java.lang.Integer> values) {
       internalGetMutableClusteringOrders().getMutableMap()
           .putAll(values);
+      bitField0_ |= 0x00000008;
       return this;
     }
 
@@ -1655,10 +1645,8 @@ com.scalar.db.rpc.Order defaultValue) {
      */
     public Builder setSecondaryIndexNames(
         int index, java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureSecondaryIndexNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureSecondaryIndexNamesIsMutable();
       secondaryIndexNames_.set(index, value);
       onChanged();
       return this;
@@ -1670,10 +1658,8 @@ com.scalar.db.rpc.Order defaultValue) {
      */
     public Builder addSecondaryIndexNames(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureSecondaryIndexNamesIsMutable();
+      if (value == null) { throw new NullPointerException(); }
+      ensureSecondaryIndexNamesIsMutable();
       secondaryIndexNames_.add(value);
       onChanged();
       return this;
@@ -1708,10 +1694,8 @@ com.scalar.db.rpc.Order defaultValue) {
      */
     public Builder addSecondaryIndexNamesBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       ensureSecondaryIndexNamesIsMutable();
       secondaryIndexNames_.add(value);
       onChanged();

--- a/rpc/src/main/java/com/scalar/db/rpc/TableMetadataOrBuilder.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TableMetadataOrBuilder.java
@@ -54,14 +54,12 @@ com.scalar.db.rpc.DataType         defaultValue);
   /**
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
-
   int getColumnsValueOrDefault(
       java.lang.String key,
       int defaultValue);
   /**
    * <code>map&lt;string, .rpc.DataType&gt; columns = 1;</code>
    */
-
   int getColumnsValueOrThrow(
       java.lang.String key);
 
@@ -162,14 +160,12 @@ com.scalar.db.rpc.Order         defaultValue);
   /**
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
-
   int getClusteringOrdersValueOrDefault(
       java.lang.String key,
       int defaultValue);
   /**
    * <code>map&lt;string, .rpc.Order&gt; clustering_orders = 4;</code>
    */
-
   int getClusteringOrdersValueOrThrow(
       java.lang.String key);
 

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionRequest.java
@@ -107,7 +107,8 @@ private static final long serialVersionUID = 0L;
 
     private int bitField0_;
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>optional string transaction_id = 1;</code>
      * @return Whether the transactionId field is set.
@@ -344,8 +345,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -372,15 +373,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionRequest.BeginRequest buildPartial() {
         com.scalar.db.rpc.TransactionRequest.BeginRequest result = new com.scalar.db.rpc.TransactionRequest.BeginRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionRequest.BeginRequest result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
           to_bitField0_ |= 0x00000001;
         }
-        result.transactionId_ = transactionId_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -428,8 +433,8 @@ private static final long serialVersionUID = 0L;
       public Builder mergeFrom(com.scalar.db.rpc.TransactionRequest.BeginRequest other) {
         if (other == com.scalar.db.rpc.TransactionRequest.BeginRequest.getDefaultInstance()) return this;
         if (other.hasTransactionId()) {
-          bitField0_ |= 0x00000001;
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -528,11 +533,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -541,8 +544,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -553,12 +556,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -690,7 +691,8 @@ private static final long serialVersionUID = 0L;
 
     private int bitField0_;
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>optional string transaction_id = 1;</code>
      * @return Whether the transactionId field is set.
@@ -927,8 +929,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -955,15 +957,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionRequest.StartRequest buildPartial() {
         com.scalar.db.rpc.TransactionRequest.StartRequest result = new com.scalar.db.rpc.TransactionRequest.StartRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionRequest.StartRequest result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
           to_bitField0_ |= 0x00000001;
         }
-        result.transactionId_ = transactionId_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -1011,8 +1017,8 @@ private static final long serialVersionUID = 0L;
       public Builder mergeFrom(com.scalar.db.rpc.TransactionRequest.StartRequest other) {
         if (other == com.scalar.db.rpc.TransactionRequest.StartRequest.getDefaultInstance()) return this;
         if (other.hasTransactionId()) {
-          bitField0_ |= 0x00000001;
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -1111,11 +1117,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1124,8 +1128,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1136,12 +1140,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1291,7 +1293,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
-      return getGet();
+      return get_ == null ? com.scalar.db.rpc.Get.getDefaultInstance() : get_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1487,10 +1489,10 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (getBuilder_ == null) {
-          get_ = null;
-        } else {
-          get_ = null;
+        bitField0_ = 0;
+        get_ = null;
+        if (getBuilder_ != null) {
+          getBuilder_.dispose();
           getBuilder_ = null;
         }
         return this;
@@ -1519,13 +1521,18 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionRequest.GetRequest buildPartial() {
         com.scalar.db.rpc.TransactionRequest.GetRequest result = new com.scalar.db.rpc.TransactionRequest.GetRequest(this);
-        if (getBuilder_ == null) {
-          result.get_ = get_;
-        } else {
-          result.get_ = getBuilder_.build();
-        }
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionRequest.GetRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.get_ = getBuilder_ == null
+              ? get_
+              : getBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -1605,7 +1612,7 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(
                     getGetFieldBuilder().getBuilder(),
                     extensionRegistry);
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 18
               default: {
@@ -1623,6 +1630,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private com.scalar.db.rpc.Get get_;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -1632,7 +1640,7 @@ private static final long serialVersionUID = 0L;
        * @return Whether the get field is set.
        */
       public boolean hasGet() {
-        return getBuilder_ != null || get_ != null;
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>.rpc.Get get = 2;</code>
@@ -1654,11 +1662,11 @@ private static final long serialVersionUID = 0L;
             throw new NullPointerException();
           }
           get_ = value;
-          onChanged();
         } else {
           getBuilder_.setMessage(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -1668,11 +1676,11 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Get.Builder builderForValue) {
         if (getBuilder_ == null) {
           get_ = builderForValue.build();
-          onChanged();
         } else {
           getBuilder_.setMessage(builderForValue.build());
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -1680,38 +1688,38 @@ private static final long serialVersionUID = 0L;
        */
       public Builder mergeGet(com.scalar.db.rpc.Get value) {
         if (getBuilder_ == null) {
-          if (get_ != null) {
-            get_ =
-              com.scalar.db.rpc.Get.newBuilder(get_).mergeFrom(value).buildPartial();
+          if (((bitField0_ & 0x00000001) != 0) &&
+            get_ != null &&
+            get_ != com.scalar.db.rpc.Get.getDefaultInstance()) {
+            getGetBuilder().mergeFrom(value);
           } else {
             get_ = value;
           }
-          onChanged();
         } else {
           getBuilder_.mergeFrom(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Get get = 2;</code>
        */
       public Builder clearGet() {
-        if (getBuilder_ == null) {
-          get_ = null;
-          onChanged();
-        } else {
-          get_ = null;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        get_ = null;
+        if (getBuilder_ != null) {
+          getBuilder_.dispose();
           getBuilder_ = null;
         }
-
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Get get = 2;</code>
        */
       public com.scalar.db.rpc.Get.Builder getGetBuilder() {
-        
+        bitField0_ |= 0x00000001;
         onChanged();
         return getGetFieldBuilder().getBuilder();
       }
@@ -1888,7 +1896,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
-      return getScan();
+      return scan_ == null ? com.scalar.db.rpc.Scan.getDefaultInstance() : scan_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2084,10 +2092,10 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (scanBuilder_ == null) {
-          scan_ = null;
-        } else {
-          scan_ = null;
+        bitField0_ = 0;
+        scan_ = null;
+        if (scanBuilder_ != null) {
+          scanBuilder_.dispose();
           scanBuilder_ = null;
         }
         return this;
@@ -2116,13 +2124,18 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionRequest.ScanRequest buildPartial() {
         com.scalar.db.rpc.TransactionRequest.ScanRequest result = new com.scalar.db.rpc.TransactionRequest.ScanRequest(this);
-        if (scanBuilder_ == null) {
-          result.scan_ = scan_;
-        } else {
-          result.scan_ = scanBuilder_.build();
-        }
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionRequest.ScanRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.scan_ = scanBuilder_ == null
+              ? scan_
+              : scanBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -2202,7 +2215,7 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(
                     getScanFieldBuilder().getBuilder(),
                     extensionRegistry);
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 18
               default: {
@@ -2220,6 +2233,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private com.scalar.db.rpc.Scan scan_;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -2229,7 +2243,7 @@ private static final long serialVersionUID = 0L;
        * @return Whether the scan field is set.
        */
       public boolean hasScan() {
-        return scanBuilder_ != null || scan_ != null;
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>.rpc.Scan scan = 2;</code>
@@ -2251,11 +2265,11 @@ private static final long serialVersionUID = 0L;
             throw new NullPointerException();
           }
           scan_ = value;
-          onChanged();
         } else {
           scanBuilder_.setMessage(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -2265,11 +2279,11 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Scan.Builder builderForValue) {
         if (scanBuilder_ == null) {
           scan_ = builderForValue.build();
-          onChanged();
         } else {
           scanBuilder_.setMessage(builderForValue.build());
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -2277,38 +2291,38 @@ private static final long serialVersionUID = 0L;
        */
       public Builder mergeScan(com.scalar.db.rpc.Scan value) {
         if (scanBuilder_ == null) {
-          if (scan_ != null) {
-            scan_ =
-              com.scalar.db.rpc.Scan.newBuilder(scan_).mergeFrom(value).buildPartial();
+          if (((bitField0_ & 0x00000001) != 0) &&
+            scan_ != null &&
+            scan_ != com.scalar.db.rpc.Scan.getDefaultInstance()) {
+            getScanBuilder().mergeFrom(value);
           } else {
             scan_ = value;
           }
-          onChanged();
         } else {
           scanBuilder_.mergeFrom(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder clearScan() {
-        if (scanBuilder_ == null) {
-          scan_ = null;
-          onChanged();
-        } else {
-          scan_ = null;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        scan_ = null;
+        if (scanBuilder_ != null) {
+          scanBuilder_.dispose();
           scanBuilder_ = null;
         }
-
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Scan scan = 2;</code>
        */
       public com.scalar.db.rpc.Scan.Builder getScanBuilder() {
-        
+        bitField0_ |= 0x00000001;
         onChanged();
         return getScanFieldBuilder().getBuilder();
       }
@@ -2473,6 +2487,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int MUTATIONS_FIELD_NUMBER = 2;
+    @SuppressWarnings("serial")
     private java.util.List<com.scalar.db.rpc.Mutation> mutations_;
     /**
      * <code>repeated .rpc.Mutation mutations = 2;</code>
@@ -2702,6 +2717,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (mutationsBuilder_ == null) {
           mutations_ = java.util.Collections.emptyList();
         } else {
@@ -2735,7 +2751,13 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionRequest.MutateRequest buildPartial() {
         com.scalar.db.rpc.TransactionRequest.MutateRequest result = new com.scalar.db.rpc.TransactionRequest.MutateRequest(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(com.scalar.db.rpc.TransactionRequest.MutateRequest result) {
         if (mutationsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             mutations_ = java.util.Collections.unmodifiableList(mutations_);
@@ -2745,8 +2767,10 @@ private static final long serialVersionUID = 0L;
         } else {
           result.mutations_ = mutationsBuilder_.build();
         }
-        onBuilt();
-        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionRequest.MutateRequest result) {
+        int from_bitField0_ = bitField0_;
       }
 
       @java.lang.Override
@@ -4985,6 +5009,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (startRequestBuilder_ != null) {
         startRequestBuilder_.clear();
       }
@@ -5037,65 +5062,51 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.TransactionRequest buildPartial() {
       com.scalar.db.rpc.TransactionRequest result = new com.scalar.db.rpc.TransactionRequest(this);
-      if (requestCase_ == 1) {
-        if (startRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = startRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 2) {
-        if (getRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = getRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 3) {
-        if (scanRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = scanRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 4) {
-        if (mutateRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = mutateRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 5) {
-        if (commitRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = commitRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 6) {
-        if (abortRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = abortRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 7) {
-        if (beginRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = beginRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 8) {
-        if (rollbackRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = rollbackRequestBuilder_.build();
-        }
-      }
-      result.requestCase_ = requestCase_;
+      if (bitField0_ != 0) { buildPartial0(result); }
+      buildPartialOneofs(result);
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.TransactionRequest result) {
+      int from_bitField0_ = bitField0_;
+    }
+
+    private void buildPartialOneofs(com.scalar.db.rpc.TransactionRequest result) {
+      result.requestCase_ = requestCase_;
+      result.request_ = this.request_;
+      if (requestCase_ == 1 &&
+          startRequestBuilder_ != null) {
+        result.request_ = startRequestBuilder_.build();
+      }
+      if (requestCase_ == 2 &&
+          getRequestBuilder_ != null) {
+        result.request_ = getRequestBuilder_.build();
+      }
+      if (requestCase_ == 3 &&
+          scanRequestBuilder_ != null) {
+        result.request_ = scanRequestBuilder_.build();
+      }
+      if (requestCase_ == 4 &&
+          mutateRequestBuilder_ != null) {
+        result.request_ = mutateRequestBuilder_.build();
+      }
+      if (requestCase_ == 5 &&
+          commitRequestBuilder_ != null) {
+        result.request_ = commitRequestBuilder_.build();
+      }
+      if (requestCase_ == 6 &&
+          abortRequestBuilder_ != null) {
+        result.request_ = abortRequestBuilder_.build();
+      }
+      if (requestCase_ == 7 &&
+          beginRequestBuilder_ != null) {
+        result.request_ = beginRequestBuilder_.build();
+      }
+      if (requestCase_ == 8 &&
+          rollbackRequestBuilder_ != null) {
+        result.request_ = rollbackRequestBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -5291,6 +5302,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private int bitField0_;
 
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionRequest.StartRequest, com.scalar.db.rpc.TransactionRequest.StartRequest.Builder, com.scalar.db.rpc.TransactionRequest.StartRequestOrBuilder> startRequestBuilder_;
@@ -5430,7 +5442,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 1;
-      onChanged();;
+      onChanged();
       return startRequestBuilder_;
     }
 
@@ -5572,7 +5584,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 2;
-      onChanged();;
+      onChanged();
       return getRequestBuilder_;
     }
 
@@ -5714,7 +5726,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 3;
-      onChanged();;
+      onChanged();
       return scanRequestBuilder_;
     }
 
@@ -5856,7 +5868,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 4;
-      onChanged();;
+      onChanged();
       return mutateRequestBuilder_;
     }
 
@@ -5998,7 +6010,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 5;
-      onChanged();;
+      onChanged();
       return commitRequestBuilder_;
     }
 
@@ -6140,7 +6152,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 6;
-      onChanged();;
+      onChanged();
       return abortRequestBuilder_;
     }
 
@@ -6282,7 +6294,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 7;
-      onChanged();;
+      onChanged();
       return beginRequestBuilder_;
     }
 
@@ -6424,7 +6436,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 8;
-      onChanged();;
+      onChanged();
       return rollbackRequestBuilder_;
     }
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/TransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TransactionResponse.java
@@ -101,7 +101,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>string transaction_id = 1;</code>
      * @return The transactionId.
@@ -325,8 +326,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-
         return this;
       }
 
@@ -353,9 +354,16 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionResponse.BeginResponse buildPartial() {
         com.scalar.db.rpc.TransactionResponse.BeginResponse result = new com.scalar.db.rpc.TransactionResponse.BeginResponse(this);
-        result.transactionId_ = transactionId_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionResponse.BeginResponse result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
+        }
       }
 
       @java.lang.Override
@@ -404,6 +412,7 @@ private static final long serialVersionUID = 0L;
         if (other == com.scalar.db.rpc.TransactionResponse.BeginResponse.getDefaultInstance()) return this;
         if (!other.getTransactionId().isEmpty()) {
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -434,7 +443,7 @@ private static final long serialVersionUID = 0L;
                 break;
               case 10: {
                 transactionId_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -452,6 +461,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private java.lang.Object transactionId_ = "";
       /**
@@ -494,11 +504,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -507,8 +515,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -519,12 +527,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -650,7 +656,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>string transaction_id = 1;</code>
      * @return The transactionId.
@@ -874,8 +881,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-
         return this;
       }
 
@@ -902,9 +909,16 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionResponse.StartResponse buildPartial() {
         com.scalar.db.rpc.TransactionResponse.StartResponse result = new com.scalar.db.rpc.TransactionResponse.StartResponse(this);
-        result.transactionId_ = transactionId_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionResponse.StartResponse result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
+        }
       }
 
       @java.lang.Override
@@ -953,6 +967,7 @@ private static final long serialVersionUID = 0L;
         if (other == com.scalar.db.rpc.TransactionResponse.StartResponse.getDefaultInstance()) return this;
         if (!other.getTransactionId().isEmpty()) {
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -983,7 +998,7 @@ private static final long serialVersionUID = 0L;
                 break;
               case 10: {
                 transactionId_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -1001,6 +1016,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private java.lang.Object transactionId_ = "";
       /**
@@ -1043,11 +1059,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1056,8 +1070,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1068,12 +1082,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1223,7 +1235,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
-      return getResult();
+      return result_ == null ? com.scalar.db.rpc.Result.getDefaultInstance() : result_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1419,10 +1431,10 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (resultBuilder_ == null) {
-          result_ = null;
-        } else {
-          result_ = null;
+        bitField0_ = 0;
+        result_ = null;
+        if (resultBuilder_ != null) {
+          resultBuilder_.dispose();
           resultBuilder_ = null;
         }
         return this;
@@ -1451,13 +1463,18 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionResponse.GetResponse buildPartial() {
         com.scalar.db.rpc.TransactionResponse.GetResponse result = new com.scalar.db.rpc.TransactionResponse.GetResponse(this);
-        if (resultBuilder_ == null) {
-          result.result_ = result_;
-        } else {
-          result.result_ = resultBuilder_.build();
-        }
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionResponse.GetResponse result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.result_ = resultBuilder_ == null
+              ? result_
+              : resultBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -1537,7 +1554,7 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(
                     getResultFieldBuilder().getBuilder(),
                     extensionRegistry);
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -1555,6 +1572,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private com.scalar.db.rpc.Result result_;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -1564,7 +1582,7 @@ private static final long serialVersionUID = 0L;
        * @return Whether the result field is set.
        */
       public boolean hasResult() {
-        return resultBuilder_ != null || result_ != null;
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>.rpc.Result result = 1;</code>
@@ -1586,11 +1604,11 @@ private static final long serialVersionUID = 0L;
             throw new NullPointerException();
           }
           result_ = value;
-          onChanged();
         } else {
           resultBuilder_.setMessage(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -1600,11 +1618,11 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Result.Builder builderForValue) {
         if (resultBuilder_ == null) {
           result_ = builderForValue.build();
-          onChanged();
         } else {
           resultBuilder_.setMessage(builderForValue.build());
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -1612,38 +1630,38 @@ private static final long serialVersionUID = 0L;
        */
       public Builder mergeResult(com.scalar.db.rpc.Result value) {
         if (resultBuilder_ == null) {
-          if (result_ != null) {
-            result_ =
-              com.scalar.db.rpc.Result.newBuilder(result_).mergeFrom(value).buildPartial();
+          if (((bitField0_ & 0x00000001) != 0) &&
+            result_ != null &&
+            result_ != com.scalar.db.rpc.Result.getDefaultInstance()) {
+            getResultBuilder().mergeFrom(value);
           } else {
             result_ = value;
           }
-          onChanged();
         } else {
           resultBuilder_.mergeFrom(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Result result = 1;</code>
        */
       public Builder clearResult() {
-        if (resultBuilder_ == null) {
-          result_ = null;
-          onChanged();
-        } else {
-          result_ = null;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        result_ = null;
+        if (resultBuilder_ != null) {
+          resultBuilder_.dispose();
           resultBuilder_ = null;
         }
-
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Result result = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder getResultBuilder() {
-        
+        bitField0_ |= 0x00000001;
         onChanged();
         return getResultFieldBuilder().getBuilder();
       }
@@ -1808,6 +1826,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int RESULTS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<com.scalar.db.rpc.Result> results_;
     /**
      * <code>repeated .rpc.Result results = 1;</code>
@@ -2037,6 +2056,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (resultsBuilder_ == null) {
           results_ = java.util.Collections.emptyList();
         } else {
@@ -2070,7 +2090,13 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionResponse.ScanResponse buildPartial() {
         com.scalar.db.rpc.TransactionResponse.ScanResponse result = new com.scalar.db.rpc.TransactionResponse.ScanResponse(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(com.scalar.db.rpc.TransactionResponse.ScanResponse result) {
         if (resultsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             results_ = java.util.Collections.unmodifiableList(results_);
@@ -2080,8 +2106,10 @@ private static final long serialVersionUID = 0L;
         } else {
           result.results_ = resultsBuilder_.build();
         }
-        onBuilt();
-        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionResponse.ScanResponse result) {
+        int from_bitField0_ = bitField0_;
       }
 
       @java.lang.Override
@@ -2709,7 +2737,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int ERROR_CODE_FIELD_NUMBER = 1;
-    private int errorCode_;
+    private int errorCode_ = 0;
     /**
      * <code>.rpc.TransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The enum numeric value on the wire for errorCode.
@@ -2722,13 +2750,13 @@ private static final long serialVersionUID = 0L;
      * @return The errorCode.
      */
     @java.lang.Override public com.scalar.db.rpc.TransactionResponse.Error.ErrorCode getErrorCode() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.TransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.valueOf(errorCode_);
+      com.scalar.db.rpc.TransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.forNumber(errorCode_);
       return result == null ? com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.UNRECOGNIZED : result;
     }
 
     public static final int MESSAGE_FIELD_NUMBER = 2;
-    private volatile java.lang.Object message_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object message_ = "";
     /**
      * <code>string message = 2;</code>
      * @return The message.
@@ -2962,10 +2990,9 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         errorCode_ = 0;
-
         message_ = "";
-
         return this;
       }
 
@@ -2992,10 +3019,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TransactionResponse.Error buildPartial() {
         com.scalar.db.rpc.TransactionResponse.Error result = new com.scalar.db.rpc.TransactionResponse.Error(this);
-        result.errorCode_ = errorCode_;
-        result.message_ = message_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TransactionResponse.Error result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.errorCode_ = errorCode_;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.message_ = message_;
+        }
       }
 
       @java.lang.Override
@@ -3047,6 +3083,7 @@ private static final long serialVersionUID = 0L;
         }
         if (!other.getMessage().isEmpty()) {
           message_ = other.message_;
+          bitField0_ |= 0x00000002;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -3077,12 +3114,12 @@ private static final long serialVersionUID = 0L;
                 break;
               case 8: {
                 errorCode_ = input.readEnum();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 8
               case 18: {
                 message_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000002;
                 break;
               } // case 18
               default: {
@@ -3100,6 +3137,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private int errorCode_ = 0;
       /**
@@ -3115,8 +3153,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder setErrorCodeValue(int value) {
-        
         errorCode_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3126,8 +3164,7 @@ private static final long serialVersionUID = 0L;
        */
       @java.lang.Override
       public com.scalar.db.rpc.TransactionResponse.Error.ErrorCode getErrorCode() {
-        @SuppressWarnings("deprecation")
-        com.scalar.db.rpc.TransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.valueOf(errorCode_);
+        com.scalar.db.rpc.TransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.forNumber(errorCode_);
         return result == null ? com.scalar.db.rpc.TransactionResponse.Error.ErrorCode.UNRECOGNIZED : result;
       }
       /**
@@ -3139,7 +3176,7 @@ private static final long serialVersionUID = 0L;
         if (value == null) {
           throw new NullPointerException();
         }
-        
+        bitField0_ |= 0x00000001;
         errorCode_ = value.getNumber();
         onChanged();
         return this;
@@ -3149,7 +3186,7 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearErrorCode() {
-        
+        bitField0_ = (bitField0_ & ~0x00000001);
         errorCode_ = 0;
         onChanged();
         return this;
@@ -3196,11 +3233,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setMessage(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         message_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3209,8 +3244,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearMessage() {
-        
         message_ = getDefaultInstance().getMessage();
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
         return this;
       }
@@ -3221,12 +3256,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setMessageBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         message_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3757,6 +3790,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (startResponseBuilder_ != null) {
         startResponseBuilder_.clear();
       }
@@ -3800,44 +3834,39 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.TransactionResponse buildPartial() {
       com.scalar.db.rpc.TransactionResponse result = new com.scalar.db.rpc.TransactionResponse(this);
-      if (responseCase_ == 1) {
-        if (startResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = startResponseBuilder_.build();
-        }
-      }
-      if (responseCase_ == 2) {
-        if (getResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = getResponseBuilder_.build();
-        }
-      }
-      if (responseCase_ == 3) {
-        if (scanResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = scanResponseBuilder_.build();
-        }
-      }
-      if (responseCase_ == 4) {
-        if (errorBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = errorBuilder_.build();
-        }
-      }
-      if (responseCase_ == 5) {
-        if (beginResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = beginResponseBuilder_.build();
-        }
-      }
-      result.responseCase_ = responseCase_;
+      if (bitField0_ != 0) { buildPartial0(result); }
+      buildPartialOneofs(result);
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.TransactionResponse result) {
+      int from_bitField0_ = bitField0_;
+    }
+
+    private void buildPartialOneofs(com.scalar.db.rpc.TransactionResponse result) {
+      result.responseCase_ = responseCase_;
+      result.response_ = this.response_;
+      if (responseCase_ == 1 &&
+          startResponseBuilder_ != null) {
+        result.response_ = startResponseBuilder_.build();
+      }
+      if (responseCase_ == 2 &&
+          getResponseBuilder_ != null) {
+        result.response_ = getResponseBuilder_.build();
+      }
+      if (responseCase_ == 3 &&
+          scanResponseBuilder_ != null) {
+        result.response_ = scanResponseBuilder_.build();
+      }
+      if (responseCase_ == 4 &&
+          errorBuilder_ != null) {
+        result.response_ = errorBuilder_.build();
+      }
+      if (responseCase_ == 5 &&
+          beginResponseBuilder_ != null) {
+        result.response_ = beginResponseBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -4000,6 +4029,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private int bitField0_;
 
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TransactionResponse.StartResponse, com.scalar.db.rpc.TransactionResponse.StartResponse.Builder, com.scalar.db.rpc.TransactionResponse.StartResponseOrBuilder> startResponseBuilder_;
@@ -4139,7 +4169,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 1;
-      onChanged();;
+      onChanged();
       return startResponseBuilder_;
     }
 
@@ -4281,7 +4311,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 2;
-      onChanged();;
+      onChanged();
       return getResponseBuilder_;
     }
 
@@ -4423,7 +4453,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 3;
-      onChanged();;
+      onChanged();
       return scanResponseBuilder_;
     }
 
@@ -4565,7 +4595,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 4;
-      onChanged();;
+      onChanged();
       return errorBuilder_;
     }
 
@@ -4707,7 +4737,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 5;
-      onChanged();;
+      onChanged();
       return beginResponseBuilder_;
     }
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TruncateTableRequest.java
@@ -46,7 +46,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAMESPACE_FIELD_NUMBER = 1;
-  private volatile java.lang.Object namespace_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object namespace_ = "";
   /**
    * <code>string namespace = 1;</code>
    * @return The namespace.
@@ -84,7 +85,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int TABLE_FIELD_NUMBER = 2;
-  private volatile java.lang.Object table_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object table_ = "";
   /**
    * <code>string table = 2;</code>
    * @return The table.
@@ -318,10 +320,9 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       namespace_ = "";
-
       table_ = "";
-
       return this;
     }
 
@@ -348,10 +349,19 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.TruncateTableRequest buildPartial() {
       com.scalar.db.rpc.TruncateTableRequest result = new com.scalar.db.rpc.TruncateTableRequest(this);
-      result.namespace_ = namespace_;
-      result.table_ = table_;
+      if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.TruncateTableRequest result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.namespace_ = namespace_;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
+        result.table_ = table_;
+      }
     }
 
     @java.lang.Override
@@ -400,10 +410,12 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.TruncateTableRequest.getDefaultInstance()) return this;
       if (!other.getNamespace().isEmpty()) {
         namespace_ = other.namespace_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       if (!other.getTable().isEmpty()) {
         table_ = other.table_;
+        bitField0_ |= 0x00000002;
         onChanged();
       }
       this.mergeUnknownFields(other.getUnknownFields());
@@ -434,12 +446,12 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               namespace_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 18: {
               table_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000002;
               break;
             } // case 18
             default: {
@@ -457,6 +469,7 @@ private static final long serialVersionUID = 0L;
       } // finally
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object namespace_ = "";
     /**
@@ -499,11 +512,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespace(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -512,8 +523,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNamespace() {
-      
       namespace_ = getDefaultInstance().getNamespace();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -524,12 +535,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNamespaceBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       namespace_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -575,11 +584,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTable(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
@@ -588,8 +595,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearTable() {
-      
       table_ = getDefaultInstance().getTable();
+      bitField0_ = (bitField0_ & ~0x00000002);
       onChanged();
       return this;
     }
@@ -600,12 +607,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setTableBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       table_ = value;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionRequest.java
@@ -107,7 +107,8 @@ private static final long serialVersionUID = 0L;
 
     private int bitField0_;
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>optional string transaction_id = 1;</code>
      * @return Whether the transactionId field is set.
@@ -344,8 +345,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -372,15 +373,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
           to_bitField0_ |= 0x00000001;
         }
-        result.transactionId_ = transactionId_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -428,8 +433,8 @@ private static final long serialVersionUID = 0L;
       public Builder mergeFrom(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest other) {
         if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.BeginRequest.getDefaultInstance()) return this;
         if (other.hasTransactionId()) {
-          bitField0_ |= 0x00000001;
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -528,11 +533,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -541,8 +544,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -553,12 +556,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -690,7 +691,8 @@ private static final long serialVersionUID = 0L;
 
     private int bitField0_;
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>optional string transaction_id = 1;</code>
      * @return Whether the transactionId field is set.
@@ -927,8 +929,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -955,15 +957,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
           to_bitField0_ |= 0x00000001;
         }
-        result.transactionId_ = transactionId_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -1011,8 +1017,8 @@ private static final long serialVersionUID = 0L;
       public Builder mergeFrom(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest other) {
         if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.getDefaultInstance()) return this;
         if (other.hasTransactionId()) {
-          bitField0_ |= 0x00000001;
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -1111,11 +1117,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1124,8 +1128,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1136,12 +1140,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1267,7 +1269,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>string transaction_id = 1;</code>
      * @return The transactionId.
@@ -1491,8 +1494,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-
         return this;
       }
 
@@ -1519,9 +1522,16 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest(this);
-        result.transactionId_ = transactionId_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
+        }
       }
 
       @java.lang.Override
@@ -1570,6 +1580,7 @@ private static final long serialVersionUID = 0L;
         if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.JoinRequest.getDefaultInstance()) return this;
         if (!other.getTransactionId().isEmpty()) {
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -1600,7 +1611,7 @@ private static final long serialVersionUID = 0L;
                 break;
               case 10: {
                 transactionId_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -1618,6 +1629,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private java.lang.Object transactionId_ = "";
       /**
@@ -1660,11 +1672,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1673,8 +1683,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1685,12 +1695,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1840,7 +1848,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.GetOrBuilder getGetOrBuilder() {
-      return getGet();
+      return get_ == null ? com.scalar.db.rpc.Get.getDefaultInstance() : get_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2036,10 +2044,10 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (getBuilder_ == null) {
-          get_ = null;
-        } else {
-          get_ = null;
+        bitField0_ = 0;
+        get_ = null;
+        if (getBuilder_ != null) {
+          getBuilder_.dispose();
           getBuilder_ = null;
         }
         return this;
@@ -2068,13 +2076,18 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest(this);
-        if (getBuilder_ == null) {
-          result.get_ = get_;
-        } else {
-          result.get_ = getBuilder_.build();
-        }
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.GetRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.get_ = getBuilder_ == null
+              ? get_
+              : getBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -2154,7 +2167,7 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(
                     getGetFieldBuilder().getBuilder(),
                     extensionRegistry);
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 18
               default: {
@@ -2172,6 +2185,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private com.scalar.db.rpc.Get get_;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -2181,7 +2195,7 @@ private static final long serialVersionUID = 0L;
        * @return Whether the get field is set.
        */
       public boolean hasGet() {
-        return getBuilder_ != null || get_ != null;
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>.rpc.Get get = 2;</code>
@@ -2203,11 +2217,11 @@ private static final long serialVersionUID = 0L;
             throw new NullPointerException();
           }
           get_ = value;
-          onChanged();
         } else {
           getBuilder_.setMessage(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -2217,11 +2231,11 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Get.Builder builderForValue) {
         if (getBuilder_ == null) {
           get_ = builderForValue.build();
-          onChanged();
         } else {
           getBuilder_.setMessage(builderForValue.build());
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -2229,38 +2243,38 @@ private static final long serialVersionUID = 0L;
        */
       public Builder mergeGet(com.scalar.db.rpc.Get value) {
         if (getBuilder_ == null) {
-          if (get_ != null) {
-            get_ =
-              com.scalar.db.rpc.Get.newBuilder(get_).mergeFrom(value).buildPartial();
+          if (((bitField0_ & 0x00000001) != 0) &&
+            get_ != null &&
+            get_ != com.scalar.db.rpc.Get.getDefaultInstance()) {
+            getGetBuilder().mergeFrom(value);
           } else {
             get_ = value;
           }
-          onChanged();
         } else {
           getBuilder_.mergeFrom(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Get get = 2;</code>
        */
       public Builder clearGet() {
-        if (getBuilder_ == null) {
-          get_ = null;
-          onChanged();
-        } else {
-          get_ = null;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        get_ = null;
+        if (getBuilder_ != null) {
+          getBuilder_.dispose();
           getBuilder_ = null;
         }
-
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Get get = 2;</code>
        */
       public com.scalar.db.rpc.Get.Builder getGetBuilder() {
-        
+        bitField0_ |= 0x00000001;
         onChanged();
         return getGetFieldBuilder().getBuilder();
       }
@@ -2437,7 +2451,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.ScanOrBuilder getScanOrBuilder() {
-      return getScan();
+      return scan_ == null ? com.scalar.db.rpc.Scan.getDefaultInstance() : scan_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2633,10 +2647,10 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (scanBuilder_ == null) {
-          scan_ = null;
-        } else {
-          scan_ = null;
+        bitField0_ = 0;
+        scan_ = null;
+        if (scanBuilder_ != null) {
+          scanBuilder_.dispose();
           scanBuilder_ = null;
         }
         return this;
@@ -2665,13 +2679,18 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest(this);
-        if (scanBuilder_ == null) {
-          result.scan_ = scan_;
-        } else {
-          result.scan_ = scanBuilder_.build();
-        }
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.ScanRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.scan_ = scanBuilder_ == null
+              ? scan_
+              : scanBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -2751,7 +2770,7 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(
                     getScanFieldBuilder().getBuilder(),
                     extensionRegistry);
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 18
               default: {
@@ -2769,6 +2788,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private com.scalar.db.rpc.Scan scan_;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -2778,7 +2798,7 @@ private static final long serialVersionUID = 0L;
        * @return Whether the scan field is set.
        */
       public boolean hasScan() {
-        return scanBuilder_ != null || scan_ != null;
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>.rpc.Scan scan = 2;</code>
@@ -2800,11 +2820,11 @@ private static final long serialVersionUID = 0L;
             throw new NullPointerException();
           }
           scan_ = value;
-          onChanged();
         } else {
           scanBuilder_.setMessage(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -2814,11 +2834,11 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Scan.Builder builderForValue) {
         if (scanBuilder_ == null) {
           scan_ = builderForValue.build();
-          onChanged();
         } else {
           scanBuilder_.setMessage(builderForValue.build());
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -2826,38 +2846,38 @@ private static final long serialVersionUID = 0L;
        */
       public Builder mergeScan(com.scalar.db.rpc.Scan value) {
         if (scanBuilder_ == null) {
-          if (scan_ != null) {
-            scan_ =
-              com.scalar.db.rpc.Scan.newBuilder(scan_).mergeFrom(value).buildPartial();
+          if (((bitField0_ & 0x00000001) != 0) &&
+            scan_ != null &&
+            scan_ != com.scalar.db.rpc.Scan.getDefaultInstance()) {
+            getScanBuilder().mergeFrom(value);
           } else {
             scan_ = value;
           }
-          onChanged();
         } else {
           scanBuilder_.mergeFrom(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Scan scan = 2;</code>
        */
       public Builder clearScan() {
-        if (scanBuilder_ == null) {
-          scan_ = null;
-          onChanged();
-        } else {
-          scan_ = null;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        scan_ = null;
+        if (scanBuilder_ != null) {
+          scanBuilder_.dispose();
           scanBuilder_ = null;
         }
-
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Scan scan = 2;</code>
        */
       public com.scalar.db.rpc.Scan.Builder getScanBuilder() {
-        
+        bitField0_ |= 0x00000001;
         onChanged();
         return getScanFieldBuilder().getBuilder();
       }
@@ -3022,6 +3042,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int MUTATIONS_FIELD_NUMBER = 2;
+    @SuppressWarnings("serial")
     private java.util.List<com.scalar.db.rpc.Mutation> mutations_;
     /**
      * <code>repeated .rpc.Mutation mutations = 2;</code>
@@ -3251,6 +3272,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (mutationsBuilder_ == null) {
           mutations_ = java.util.Collections.emptyList();
         } else {
@@ -3284,7 +3306,13 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest result) {
         if (mutationsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             mutations_ = java.util.Collections.unmodifiableList(mutations_);
@@ -3294,8 +3322,10 @@ private static final long serialVersionUID = 0L;
         } else {
           result.mutations_ = mutationsBuilder_.build();
         }
-        onBuilt();
-        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.MutateRequest result) {
+        int from_bitField0_ = bitField0_;
       }
 
       @java.lang.Override
@@ -6478,6 +6508,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (startRequestBuilder_ != null) {
         startRequestBuilder_.clear();
       }
@@ -6539,86 +6570,63 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionRequest buildPartial() {
       com.scalar.db.rpc.TwoPhaseCommitTransactionRequest result = new com.scalar.db.rpc.TwoPhaseCommitTransactionRequest(this);
-      if (requestCase_ == 1) {
-        if (startRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = startRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 2) {
-        if (joinRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = joinRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 3) {
-        if (getRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = getRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 4) {
-        if (scanRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = scanRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 5) {
-        if (mutateRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = mutateRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 6) {
-        if (prepareRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = prepareRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 7) {
-        if (validateRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = validateRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 8) {
-        if (commitRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = commitRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 9) {
-        if (rollbackRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = rollbackRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 10) {
-        if (beginRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = beginRequestBuilder_.build();
-        }
-      }
-      if (requestCase_ == 11) {
-        if (abortRequestBuilder_ == null) {
-          result.request_ = request_;
-        } else {
-          result.request_ = abortRequestBuilder_.build();
-        }
-      }
-      result.requestCase_ = requestCase_;
+      if (bitField0_ != 0) { buildPartial0(result); }
+      buildPartialOneofs(result);
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest result) {
+      int from_bitField0_ = bitField0_;
+    }
+
+    private void buildPartialOneofs(com.scalar.db.rpc.TwoPhaseCommitTransactionRequest result) {
+      result.requestCase_ = requestCase_;
+      result.request_ = this.request_;
+      if (requestCase_ == 1 &&
+          startRequestBuilder_ != null) {
+        result.request_ = startRequestBuilder_.build();
+      }
+      if (requestCase_ == 2 &&
+          joinRequestBuilder_ != null) {
+        result.request_ = joinRequestBuilder_.build();
+      }
+      if (requestCase_ == 3 &&
+          getRequestBuilder_ != null) {
+        result.request_ = getRequestBuilder_.build();
+      }
+      if (requestCase_ == 4 &&
+          scanRequestBuilder_ != null) {
+        result.request_ = scanRequestBuilder_.build();
+      }
+      if (requestCase_ == 5 &&
+          mutateRequestBuilder_ != null) {
+        result.request_ = mutateRequestBuilder_.build();
+      }
+      if (requestCase_ == 6 &&
+          prepareRequestBuilder_ != null) {
+        result.request_ = prepareRequestBuilder_.build();
+      }
+      if (requestCase_ == 7 &&
+          validateRequestBuilder_ != null) {
+        result.request_ = validateRequestBuilder_.build();
+      }
+      if (requestCase_ == 8 &&
+          commitRequestBuilder_ != null) {
+        result.request_ = commitRequestBuilder_.build();
+      }
+      if (requestCase_ == 9 &&
+          rollbackRequestBuilder_ != null) {
+        result.request_ = rollbackRequestBuilder_.build();
+      }
+      if (requestCase_ == 10 &&
+          beginRequestBuilder_ != null) {
+        result.request_ = beginRequestBuilder_.build();
+      }
+      if (requestCase_ == 11 &&
+          abortRequestBuilder_ != null) {
+        result.request_ = abortRequestBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -6847,6 +6855,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private int bitField0_;
 
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequest.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionRequest.StartRequestOrBuilder> startRequestBuilder_;
@@ -6986,7 +6995,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 1;
-      onChanged();;
+      onChanged();
       return startRequestBuilder_;
     }
 
@@ -7128,7 +7137,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 2;
-      onChanged();;
+      onChanged();
       return joinRequestBuilder_;
     }
 
@@ -7270,7 +7279,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 3;
-      onChanged();;
+      onChanged();
       return getRequestBuilder_;
     }
 
@@ -7412,7 +7421,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 4;
-      onChanged();;
+      onChanged();
       return scanRequestBuilder_;
     }
 
@@ -7554,7 +7563,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 5;
-      onChanged();;
+      onChanged();
       return mutateRequestBuilder_;
     }
 
@@ -7696,7 +7705,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 6;
-      onChanged();;
+      onChanged();
       return prepareRequestBuilder_;
     }
 
@@ -7838,7 +7847,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 7;
-      onChanged();;
+      onChanged();
       return validateRequestBuilder_;
     }
 
@@ -7980,7 +7989,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 8;
-      onChanged();;
+      onChanged();
       return commitRequestBuilder_;
     }
 
@@ -8122,7 +8131,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 9;
-      onChanged();;
+      onChanged();
       return rollbackRequestBuilder_;
     }
 
@@ -8264,7 +8273,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 10;
-      onChanged();;
+      onChanged();
       return beginRequestBuilder_;
     }
 
@@ -8406,7 +8415,7 @@ private static final long serialVersionUID = 0L;
         request_ = null;
       }
       requestCase_ = 11;
-      onChanged();;
+      onChanged();
       return abortRequestBuilder_;
     }
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/TwoPhaseCommitTransactionResponse.java
@@ -101,7 +101,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>string transaction_id = 1;</code>
      * @return The transactionId.
@@ -325,8 +326,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-
         return this;
       }
 
@@ -353,9 +354,16 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse(this);
-        result.transactionId_ = transactionId_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
+        }
       }
 
       @java.lang.Override
@@ -404,6 +412,7 @@ private static final long serialVersionUID = 0L;
         if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.BeginResponse.getDefaultInstance()) return this;
         if (!other.getTransactionId().isEmpty()) {
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -434,7 +443,7 @@ private static final long serialVersionUID = 0L;
                 break;
               case 10: {
                 transactionId_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -452,6 +461,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private java.lang.Object transactionId_ = "";
       /**
@@ -494,11 +504,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -507,8 +515,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -519,12 +527,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -650,7 +656,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object transactionId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object transactionId_ = "";
     /**
      * <code>string transaction_id = 1;</code>
      * @return The transactionId.
@@ -874,8 +881,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         transactionId_ = "";
-
         return this;
       }
 
@@ -902,9 +909,16 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse(this);
-        result.transactionId_ = transactionId_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.transactionId_ = transactionId_;
+        }
       }
 
       @java.lang.Override
@@ -953,6 +967,7 @@ private static final long serialVersionUID = 0L;
         if (other == com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.getDefaultInstance()) return this;
         if (!other.getTransactionId().isEmpty()) {
           transactionId_ = other.transactionId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -983,7 +998,7 @@ private static final long serialVersionUID = 0L;
                 break;
               case 10: {
                 transactionId_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -1001,6 +1016,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private java.lang.Object transactionId_ = "";
       /**
@@ -1043,11 +1059,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1056,8 +1070,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearTransactionId() {
-        
         transactionId_ = getDefaultInstance().getTransactionId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1068,12 +1082,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setTransactionIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         transactionId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1223,7 +1235,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public com.scalar.db.rpc.ResultOrBuilder getResultOrBuilder() {
-      return getResult();
+      return result_ == null ? com.scalar.db.rpc.Result.getDefaultInstance() : result_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1419,10 +1431,10 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (resultBuilder_ == null) {
-          result_ = null;
-        } else {
-          result_ = null;
+        bitField0_ = 0;
+        result_ = null;
+        if (resultBuilder_ != null) {
+          resultBuilder_.dispose();
           resultBuilder_ = null;
         }
         return this;
@@ -1451,13 +1463,18 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse(this);
-        if (resultBuilder_ == null) {
-          result.result_ = result_;
-        } else {
-          result.result_ = resultBuilder_.build();
-        }
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.GetResponse result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.result_ = resultBuilder_ == null
+              ? result_
+              : resultBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -1537,7 +1554,7 @@ private static final long serialVersionUID = 0L;
                 input.readMessage(
                     getResultFieldBuilder().getBuilder(),
                     extensionRegistry);
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 10
               default: {
@@ -1555,6 +1572,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private com.scalar.db.rpc.Result result_;
       private com.google.protobuf.SingleFieldBuilderV3<
@@ -1564,7 +1582,7 @@ private static final long serialVersionUID = 0L;
        * @return Whether the result field is set.
        */
       public boolean hasResult() {
-        return resultBuilder_ != null || result_ != null;
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>.rpc.Result result = 1;</code>
@@ -1586,11 +1604,11 @@ private static final long serialVersionUID = 0L;
             throw new NullPointerException();
           }
           result_ = value;
-          onChanged();
         } else {
           resultBuilder_.setMessage(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -1600,11 +1618,11 @@ private static final long serialVersionUID = 0L;
           com.scalar.db.rpc.Result.Builder builderForValue) {
         if (resultBuilder_ == null) {
           result_ = builderForValue.build();
-          onChanged();
         } else {
           resultBuilder_.setMessage(builderForValue.build());
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -1612,38 +1630,38 @@ private static final long serialVersionUID = 0L;
        */
       public Builder mergeResult(com.scalar.db.rpc.Result value) {
         if (resultBuilder_ == null) {
-          if (result_ != null) {
-            result_ =
-              com.scalar.db.rpc.Result.newBuilder(result_).mergeFrom(value).buildPartial();
+          if (((bitField0_ & 0x00000001) != 0) &&
+            result_ != null &&
+            result_ != com.scalar.db.rpc.Result.getDefaultInstance()) {
+            getResultBuilder().mergeFrom(value);
           } else {
             result_ = value;
           }
-          onChanged();
         } else {
           resultBuilder_.mergeFrom(value);
         }
-
+        bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Result result = 1;</code>
        */
       public Builder clearResult() {
-        if (resultBuilder_ == null) {
-          result_ = null;
-          onChanged();
-        } else {
-          result_ = null;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        result_ = null;
+        if (resultBuilder_ != null) {
+          resultBuilder_.dispose();
           resultBuilder_ = null;
         }
-
+        onChanged();
         return this;
       }
       /**
        * <code>.rpc.Result result = 1;</code>
        */
       public com.scalar.db.rpc.Result.Builder getResultBuilder() {
-        
+        bitField0_ |= 0x00000001;
         onChanged();
         return getResultFieldBuilder().getBuilder();
       }
@@ -1808,6 +1826,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int RESULTS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<com.scalar.db.rpc.Result> results_;
     /**
      * <code>repeated .rpc.Result results = 1;</code>
@@ -2037,6 +2056,7 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (resultsBuilder_ == null) {
           results_ = java.util.Collections.emptyList();
         } else {
@@ -2070,7 +2090,13 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse result) {
         if (resultsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             results_ = java.util.Collections.unmodifiableList(results_);
@@ -2080,8 +2106,10 @@ private static final long serialVersionUID = 0L;
         } else {
           result.results_ = resultsBuilder_.build();
         }
-        onBuilt();
-        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.ScanResponse result) {
+        int from_bitField0_ = bitField0_;
       }
 
       @java.lang.Override
@@ -2709,7 +2737,7 @@ private static final long serialVersionUID = 0L;
     }
 
     public static final int ERROR_CODE_FIELD_NUMBER = 1;
-    private int errorCode_;
+    private int errorCode_ = 0;
     /**
      * <code>.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode error_code = 1;</code>
      * @return The enum numeric value on the wire for errorCode.
@@ -2722,13 +2750,13 @@ private static final long serialVersionUID = 0L;
      * @return The errorCode.
      */
     @java.lang.Override public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode getErrorCode() {
-      @SuppressWarnings("deprecation")
-      com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.valueOf(errorCode_);
+      com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.forNumber(errorCode_);
       return result == null ? com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.UNRECOGNIZED : result;
     }
 
     public static final int MESSAGE_FIELD_NUMBER = 2;
-    private volatile java.lang.Object message_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object message_ = "";
     /**
      * <code>string message = 2;</code>
      * @return The message.
@@ -2962,10 +2990,9 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         errorCode_ = 0;
-
         message_ = "";
-
         return this;
       }
 
@@ -2992,10 +3019,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error buildPartial() {
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error(this);
-        result.errorCode_ = errorCode_;
-        result.message_ = message_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.errorCode_ = errorCode_;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.message_ = message_;
+        }
       }
 
       @java.lang.Override
@@ -3047,6 +3083,7 @@ private static final long serialVersionUID = 0L;
         }
         if (!other.getMessage().isEmpty()) {
           message_ = other.message_;
+          bitField0_ |= 0x00000002;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -3077,12 +3114,12 @@ private static final long serialVersionUID = 0L;
                 break;
               case 8: {
                 errorCode_ = input.readEnum();
-
+                bitField0_ |= 0x00000001;
                 break;
               } // case 8
               case 18: {
                 message_ = input.readStringRequireUtf8();
-
+                bitField0_ |= 0x00000002;
                 break;
               } // case 18
               default: {
@@ -3100,6 +3137,7 @@ private static final long serialVersionUID = 0L;
         } // finally
         return this;
       }
+      private int bitField0_;
 
       private int errorCode_ = 0;
       /**
@@ -3115,8 +3153,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder setErrorCodeValue(int value) {
-        
         errorCode_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3126,8 +3164,7 @@ private static final long serialVersionUID = 0L;
        */
       @java.lang.Override
       public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode getErrorCode() {
-        @SuppressWarnings("deprecation")
-        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.valueOf(errorCode_);
+        com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode result = com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.forNumber(errorCode_);
         return result == null ? com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.Error.ErrorCode.UNRECOGNIZED : result;
       }
       /**
@@ -3139,7 +3176,7 @@ private static final long serialVersionUID = 0L;
         if (value == null) {
           throw new NullPointerException();
         }
-        
+        bitField0_ |= 0x00000001;
         errorCode_ = value.getNumber();
         onChanged();
         return this;
@@ -3149,7 +3186,7 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearErrorCode() {
-        
+        bitField0_ = (bitField0_ & ~0x00000001);
         errorCode_ = 0;
         onChanged();
         return this;
@@ -3196,11 +3233,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setMessage(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        if (value == null) { throw new NullPointerException(); }
         message_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3209,8 +3244,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearMessage() {
-        
         message_ = getDefaultInstance().getMessage();
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
         return this;
       }
@@ -3221,12 +3256,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setMessageBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         message_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3757,6 +3790,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       if (startResponseBuilder_ != null) {
         startResponseBuilder_.clear();
       }
@@ -3800,44 +3834,39 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.TwoPhaseCommitTransactionResponse buildPartial() {
       com.scalar.db.rpc.TwoPhaseCommitTransactionResponse result = new com.scalar.db.rpc.TwoPhaseCommitTransactionResponse(this);
-      if (responseCase_ == 1) {
-        if (startResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = startResponseBuilder_.build();
-        }
-      }
-      if (responseCase_ == 2) {
-        if (getResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = getResponseBuilder_.build();
-        }
-      }
-      if (responseCase_ == 3) {
-        if (scanResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = scanResponseBuilder_.build();
-        }
-      }
-      if (responseCase_ == 4) {
-        if (errorBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = errorBuilder_.build();
-        }
-      }
-      if (responseCase_ == 5) {
-        if (beginResponseBuilder_ == null) {
-          result.response_ = response_;
-        } else {
-          result.response_ = beginResponseBuilder_.build();
-        }
-      }
-      result.responseCase_ = responseCase_;
+      if (bitField0_ != 0) { buildPartial0(result); }
+      buildPartialOneofs(result);
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse result) {
+      int from_bitField0_ = bitField0_;
+    }
+
+    private void buildPartialOneofs(com.scalar.db.rpc.TwoPhaseCommitTransactionResponse result) {
+      result.responseCase_ = responseCase_;
+      result.response_ = this.response_;
+      if (responseCase_ == 1 &&
+          startResponseBuilder_ != null) {
+        result.response_ = startResponseBuilder_.build();
+      }
+      if (responseCase_ == 2 &&
+          getResponseBuilder_ != null) {
+        result.response_ = getResponseBuilder_.build();
+      }
+      if (responseCase_ == 3 &&
+          scanResponseBuilder_ != null) {
+        result.response_ = scanResponseBuilder_.build();
+      }
+      if (responseCase_ == 4 &&
+          errorBuilder_ != null) {
+        result.response_ = errorBuilder_.build();
+      }
+      if (responseCase_ == 5 &&
+          beginResponseBuilder_ != null) {
+        result.response_ = beginResponseBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -4000,6 +4029,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private int bitField0_;
 
     private com.google.protobuf.SingleFieldBuilderV3<
         com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponse.Builder, com.scalar.db.rpc.TwoPhaseCommitTransactionResponse.StartResponseOrBuilder> startResponseBuilder_;
@@ -4139,7 +4169,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 1;
-      onChanged();;
+      onChanged();
       return startResponseBuilder_;
     }
 
@@ -4281,7 +4311,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 2;
-      onChanged();;
+      onChanged();
       return getResponseBuilder_;
     }
 
@@ -4423,7 +4453,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 3;
-      onChanged();;
+      onChanged();
       return scanResponseBuilder_;
     }
 
@@ -4565,7 +4595,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 4;
-      onChanged();;
+      onChanged();
       return errorBuilder_;
     }
 
@@ -4707,7 +4737,7 @@ private static final long serialVersionUID = 0L;
         response_ = null;
       }
       responseCase_ = 5;
-      onChanged();;
+      onChanged();
       return beginResponseBuilder_;
     }
     @java.lang.Override

--- a/rpc/src/main/java/com/scalar/db/rpc/Value.java
+++ b/rpc/src/main/java/com/scalar/db/rpc/Value.java
@@ -112,7 +112,8 @@ private static final long serialVersionUID = 0L;
 
     private int bitField0_;
     public static final int VALUE_FIELD_NUMBER = 1;
-    private volatile java.lang.Object value_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object value_ = "";
     /**
      * <code>optional string value = 1;</code>
      * @return Whether the value field is set.
@@ -349,8 +350,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         value_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -377,15 +378,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.Value.TextValue buildPartial() {
         com.scalar.db.rpc.Value.TextValue result = new com.scalar.db.rpc.Value.TextValue(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.Value.TextValue result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.value_ = value_;
           to_bitField0_ |= 0x00000001;
         }
-        result.value_ = value_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -433,8 +438,8 @@ private static final long serialVersionUID = 0L;
       public Builder mergeFrom(com.scalar.db.rpc.Value.TextValue other) {
         if (other == com.scalar.db.rpc.Value.TextValue.getDefaultInstance()) return this;
         if (other.hasValue()) {
-          bitField0_ |= 0x00000001;
           value_ = other.value_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -533,11 +538,9 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setValue(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         value_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -546,8 +549,8 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder clearValue() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         value_ = getDefaultInstance().getValue();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -558,12 +561,10 @@ private static final long serialVersionUID = 0L;
        */
       public Builder setValueBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
         value_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -689,7 +690,7 @@ private static final long serialVersionUID = 0L;
 
     private int bitField0_;
     public static final int VALUE_FIELD_NUMBER = 1;
-    private com.google.protobuf.ByteString value_;
+    private com.google.protobuf.ByteString value_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <code>optional bytes value = 1;</code>
      * @return Whether the value field is set.
@@ -900,8 +901,8 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         value_ = com.google.protobuf.ByteString.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -928,15 +929,19 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.scalar.db.rpc.Value.BlobValue buildPartial() {
         com.scalar.db.rpc.Value.BlobValue result = new com.scalar.db.rpc.Value.BlobValue(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(com.scalar.db.rpc.Value.BlobValue result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.value_ = value_;
           to_bitField0_ |= 0x00000001;
         }
-        result.value_ = value_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -1057,11 +1062,9 @@ private static final long serialVersionUID = 0L;
        * @return This builder for chaining.
        */
       public Builder setValue(com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         value_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1191,7 +1194,8 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
-  private volatile java.lang.Object name_;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object name_ = "";
   /**
    * <code>string name = 1;</code>
    * @return The name.
@@ -1716,8 +1720,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
+      bitField0_ = 0;
       name_ = "";
-
       if (textValueBuilder_ != null) {
         textValueBuilder_.clear();
       }
@@ -1752,39 +1756,30 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.scalar.db.rpc.Value buildPartial() {
       com.scalar.db.rpc.Value result = new com.scalar.db.rpc.Value(this);
-      result.name_ = name_;
-      if (valueCase_ == 2) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 3) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 4) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 5) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 6) {
-        result.value_ = value_;
-      }
-      if (valueCase_ == 7) {
-        if (textValueBuilder_ == null) {
-          result.value_ = value_;
-        } else {
-          result.value_ = textValueBuilder_.build();
-        }
-      }
-      if (valueCase_ == 8) {
-        if (blobValueBuilder_ == null) {
-          result.value_ = value_;
-        } else {
-          result.value_ = blobValueBuilder_.build();
-        }
-      }
-      result.valueCase_ = valueCase_;
+      if (bitField0_ != 0) { buildPartial0(result); }
+      buildPartialOneofs(result);
       onBuilt();
       return result;
+    }
+
+    private void buildPartial0(com.scalar.db.rpc.Value result) {
+      int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.name_ = name_;
+      }
+    }
+
+    private void buildPartialOneofs(com.scalar.db.rpc.Value result) {
+      result.valueCase_ = valueCase_;
+      result.value_ = this.value_;
+      if (valueCase_ == 7 &&
+          textValueBuilder_ != null) {
+        result.value_ = textValueBuilder_.build();
+      }
+      if (valueCase_ == 8 &&
+          blobValueBuilder_ != null) {
+        result.value_ = blobValueBuilder_.build();
+      }
     }
 
     @java.lang.Override
@@ -1833,6 +1828,7 @@ private static final long serialVersionUID = 0L;
       if (other == com.scalar.db.rpc.Value.getDefaultInstance()) return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
+        bitField0_ |= 0x00000001;
         onChanged();
       }
       switch (other.getValueCase()) {
@@ -1896,7 +1892,7 @@ private static final long serialVersionUID = 0L;
               break;
             case 10: {
               name_ = input.readStringRequireUtf8();
-
+              bitField0_ |= 0x00000001;
               break;
             } // case 10
             case 16: {
@@ -1968,6 +1964,7 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
+    private int bitField0_;
 
     private java.lang.Object name_ = "";
     /**
@@ -2010,11 +2007,9 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setName(
         java.lang.String value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      if (value == null) { throw new NullPointerException(); }
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -2023,8 +2018,8 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
       name_ = getDefaultInstance().getName();
+      bitField0_ = (bitField0_ & ~0x00000001);
       onChanged();
       return this;
     }
@@ -2035,12 +2030,10 @@ private static final long serialVersionUID = 0L;
      */
     public Builder setNameBytes(
         com.google.protobuf.ByteString value) {
-      if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
       name_ = value;
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -2068,6 +2061,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setBooleanValue(boolean value) {
+      
       valueCase_ = 2;
       value_ = value;
       onChanged();
@@ -2109,6 +2103,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setIntValue(int value) {
+      
       valueCase_ = 3;
       value_ = value;
       onChanged();
@@ -2150,6 +2145,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setBigintValue(long value) {
+      
       valueCase_ = 4;
       value_ = value;
       onChanged();
@@ -2191,6 +2187,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setFloatValue(float value) {
+      
       valueCase_ = 5;
       value_ = value;
       onChanged();
@@ -2232,6 +2229,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setDoubleValue(double value) {
+      
       valueCase_ = 6;
       value_ = value;
       onChanged();
@@ -2388,7 +2386,7 @@ private static final long serialVersionUID = 0L;
         value_ = null;
       }
       valueCase_ = 7;
-      onChanged();;
+      onChanged();
       return textValueBuilder_;
     }
 
@@ -2530,7 +2528,7 @@ private static final long serialVersionUID = 0L;
         value_ = null;
       }
       valueCase_ = 8;
-      onChanged();;
+      onChanged();
       return blobValueBuilder_;
     }
     @java.lang.Override


### PR DESCRIPTION
## Problem

The following command fails in M1 Mac (osx-aarch_64).

```console
./gradlew :rpc:generateProto  # called from `./gradlew test`, for example
```

```
> Task :rpc:generateProto FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rpc:generateProto'.
> Could not resolve all files for configuration ':rpc:protobufToolsLocator_protoc'.
   > Could not find protoc-3.20.3-osx-aarch_64.exe (com.google.protobuf:protoc:3.20.3).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.20.3/protoc-3.20.3-osx-aarch_64.exe

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/7.0.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 646ms
3 actionable tasks: 1 executed, 2 up-to-date
```

This is because the version 3.20.3 does not include `protoc` binary for `osx-aarch_64` in the maven repository, while 3.21.12 does.

- https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.20.3/
- https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.21.12/

Refs: https://github.com/protocolbuffers/protobuf/issues/8062

## What I did

Bump up `protobufVersion` from 3.20.3 to 3.21.12 (latest).

## I'm not sure...

The command:

```console
./gradlew :rpc:generateProto
```

leads to the following diffs. Currently I don't commit the diffs but I will if necessary.

[rpc-generateProto.diff.txt](https://github.com/scalar-labs/scalardb/files/10250960/rpc-generateProto.diff.txt)
