### PR TITLE
docs: add SQLite data type mapping in schema-loader doc

### DIFF
--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -429,15 +429,15 @@ By default, the schema loader enables auto-scaling of RU for all tables: RU is s
 
 Here are the supported data types in Scalar DB and their mapping to the data types of other databases.
 
-| Scalar DB | Cassandra | Cosmos DB      | DynamoDB | MySQL    | PostgreSQL       | Oracle         | SQL Server      |
-|-----------|-----------|----------------|----------|----------|------------------|----------------|-----------------|
-| BOOLEAN   | boolean   | boolean (JSON) | BOOL     | boolean  | boolean          | number(1)      | bit             |
-| INT       | int       | number (JSON)  | N        | int      | int              | int            | int             |
-| BIGINT    | bigint    | number (JSON)  | N        | bigint   | bigint           | number(19)     | bigint          |
-| FLOAT     | float     | number (JSON)  | N        | double   | float            | binary_float   | float(24)       |
-| DOUBLE    | double    | number (JSON)  | N        | double   | double precision | binary_double  | float           |
-| TEXT      | text      | string (JSON)  | S        | longtext | text             | varchar2(4000) | varchar(8000)   |
-| BLOB      | blob      | string (JSON)  | B        | longblob | bytea            | RAW(2000)      | varbinary(8000) |
+| Scalar DB | Cassandra | Cosmos DB      | DynamoDB | MySQL    | PostgreSQL       | Oracle         | SQL Server      | SQLite  |
+|-----------|-----------|----------------|----------|----------|------------------|----------------|-----------------|---------|
+| BOOLEAN   | boolean   | boolean (JSON) | BOOL     | boolean  | boolean          | number(1)      | bit             | boolean |
+| INT       | int       | number (JSON)  | N        | int      | int              | int            | int             | int     |
+| BIGINT    | bigint    | number (JSON)  | N        | bigint   | bigint           | number(19)     | bigint          | bigint  |
+| FLOAT     | float     | number (JSON)  | N        | double   | float            | binary_float   | float(24)       | float   |
+| DOUBLE    | double    | number (JSON)  | N        | double   | double precision | binary_double  | float           | double  |
+| TEXT      | text      | string (JSON)  | S        | longtext | text             | varchar2(4000) | varchar(8000)   | text    |
+| BLOB      | blob      | string (JSON)  | B        | longblob | bytea            | RAW(2000)      | varbinary(8000) | blob    |
 
 However, the following types in JDBC databases are converted differently when they are used as a primary key or a secondary index key due to the limitations of RDB data types.
 


### PR DESCRIPTION
Indeed these types are valid in SQLite 3:

```console
% sqlite3
SQLite version 3.37.0 2021-12-09 01:34:53
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> create table t2 (c1 boolean, c2 int, c3 bigint, c4 float, c5 double, c6 text, c7 blob);
```

Note that types in SQLite are quite loose and column types do not affect value types.
(see: https://www.sqlite.org/datatype3.html and https://www.sqlite.org/flextypegood.html if interested)