### PR TITLE
Fix CVE-2022-21363 and CVE-2021-2471

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
         jooqVersion = '3.13.2'
         awssdkVersion = '2.17.69'
         commonsDbcp2Version = '2.8.0'
-        mysqlDriverVersion = '8.0.22'
+        mysqlDriverVersion = '8.0.31'
         postgresqlDriverVersion = '42.4.1'
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'


### PR DESCRIPTION
This PR fixes CVE-2022-21363 and CVE-2021-2471 by upgrading the MySQL driver. These vulnerabilities are detected in https://mvnrepository.com/artifact/com.scalar-labs/scalardb/3.7.2.

Please take a look!