### PR TITLE
Add configurations for gRPC

### DIFF
--- a/core/src/main/java/com/scalar/db/config/ConfigUtils.java
+++ b/core/src/main/java/com/scalar/db/config/ConfigUtils.java
@@ -50,7 +50,8 @@ public final class ConfigUtils {
     try {
       return Integer.parseInt(value);
     } catch (NumberFormatException ignored) {
-      throw new IllegalArgumentException("the specified value of '" + name + "' is not a number");
+      throw new IllegalArgumentException(
+          "the specified value of '" + name + "' is not a number. value: " + value);
     }
   }
 
@@ -62,7 +63,8 @@ public final class ConfigUtils {
     try {
       return Integer.parseInt(value);
     } catch (NumberFormatException ignored) {
-      throw new IllegalArgumentException("the specified value of '" + name + "' is not a number");
+      throw new IllegalArgumentException(
+          "the specified value of '" + name + "' is not a number. value: " + value);
     }
   }
 
@@ -74,7 +76,8 @@ public final class ConfigUtils {
     try {
       return Long.parseLong(value);
     } catch (NumberFormatException ignored) {
-      throw new IllegalArgumentException("the specified value of '" + name + "' is not a number");
+      throw new IllegalArgumentException(
+          "the specified value of '" + name + "' is not a number. value: " + value);
     }
   }
 
@@ -86,7 +89,8 @@ public final class ConfigUtils {
     try {
       return Long.parseLong(value);
     } catch (NumberFormatException ignored) {
-      throw new IllegalArgumentException("the specified value of '" + name + "' is not a number");
+      throw new IllegalArgumentException(
+          "the specified value of '" + name + "' is not a number. value: " + value);
     }
   }
 
@@ -100,7 +104,7 @@ public final class ConfigUtils {
       return Boolean.parseBoolean(value);
     } else {
       throw new IllegalArgumentException(
-          "the specified value of '" + name + "' is not a boolean value");
+          "the specified value of '" + name + "' is not a boolean value. value: " + value);
     }
   }
 
@@ -114,7 +118,7 @@ public final class ConfigUtils {
       return Boolean.parseBoolean(value);
     } else {
       throw new IllegalArgumentException(
-          "the specified value of '" + name + "' is not a boolean value");
+          "the specified value of '" + name + "' is not a boolean value. value: " + value);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/config/ConfigUtils.java
+++ b/core/src/main/java/com/scalar/db/config/ConfigUtils.java
@@ -54,6 +54,18 @@ public final class ConfigUtils {
     }
   }
 
+  public static Integer getInt(Properties properties, String name, Integer defaultValue) {
+    String value = trimAndReplace(properties.getProperty(name));
+    if (Strings.isNullOrEmpty(value)) {
+      return defaultValue;
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException ignored) {
+      throw new IllegalArgumentException("the specified value of '" + name + "' is not a number");
+    }
+  }
+
   public static long getLong(Properties properties, String name, long defaultValue) {
     String value = trimAndReplace(properties.getProperty(name));
     if (Strings.isNullOrEmpty(value)) {
@@ -66,7 +78,33 @@ public final class ConfigUtils {
     }
   }
 
+  public static Long getLong(Properties properties, String name, Long defaultValue) {
+    String value = trimAndReplace(properties.getProperty(name));
+    if (Strings.isNullOrEmpty(value)) {
+      return defaultValue;
+    }
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException ignored) {
+      throw new IllegalArgumentException("the specified value of '" + name + "' is not a number");
+    }
+  }
+
   public static boolean getBoolean(Properties properties, String name, boolean defaultValue) {
+    String value = trimAndReplace(properties.getProperty(name));
+    if (Strings.isNullOrEmpty(value)) {
+      return defaultValue;
+    }
+    if (Boolean.TRUE.toString().equalsIgnoreCase(value)
+        || Boolean.FALSE.toString().equalsIgnoreCase(value)) {
+      return Boolean.parseBoolean(value);
+    } else {
+      throw new IllegalArgumentException(
+          "the specified value of '" + name + "' is not a boolean value");
+    }
+  }
+
+  public static Boolean getBoolean(Properties properties, String name, Boolean defaultValue) {
     String value = trimAndReplace(properties.getProperty(name));
     if (Strings.isNullOrEmpty(value)) {
       return defaultValue;

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
@@ -28,7 +28,6 @@ import com.scalar.db.util.ThrowableSupplier;
 import io.grpc.ManagedChannel;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NettyChannelBuilder;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -49,8 +48,7 @@ public class GrpcAdmin implements DistributedStorageAdmin {
   @Inject
   public GrpcAdmin(DatabaseConfig databaseConfig) {
     config = new GrpcConfig(databaseConfig);
-    channel =
-        NettyChannelBuilder.forAddress(config.getHost(), config.getPort()).usePlaintext().build();
+    channel = GrpcUtils.createChannel(config);
     stub = DistributedStorageAdminGrpc.newBlockingStub(channel);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcConfig.java
@@ -1,8 +1,11 @@
 package com.scalar.db.storage.rpc;
 
+import static com.scalar.db.config.ConfigUtils.getInt;
 import static com.scalar.db.config.ConfigUtils.getLong;
 
 import com.scalar.db.config.DatabaseConfig;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -10,6 +13,8 @@ public class GrpcConfig {
 
   public static final String PREFIX = DatabaseConfig.PREFIX + "grpc.";
   public static final String DEADLINE_DURATION_MILLIS = PREFIX + "deadline_duration_millis";
+  public static final String MAX_INBOUND_MESSAGE_SIZE = PREFIX + "max_inbound_message_size";
+  public static final String MAX_INBOUND_METADATA_SIZE = PREFIX + "max_inbound_metadata_size";
 
   public static final int DEFAULT_SCALAR_DB_SERVER_PORT = 60051;
   public static final long DEFAULT_DEADLINE_DURATION_MILLIS = 60000; // 60 seconds
@@ -18,6 +23,8 @@ public class GrpcConfig {
   private final int port;
 
   private final long deadlineDurationMillis;
+  @Nullable private final Integer maxInboundMessageSize;
+  @Nullable private final Integer maxInboundMetadataSize;
 
   public GrpcConfig(DatabaseConfig databaseConfig) {
     String storage = databaseConfig.getStorage();
@@ -38,11 +45,15 @@ public class GrpcConfig {
         databaseConfig.getContactPort() == 0
             ? DEFAULT_SCALAR_DB_SERVER_PORT
             : databaseConfig.getContactPort();
+
     deadlineDurationMillis =
         getLong(
             databaseConfig.getProperties(),
             DEADLINE_DURATION_MILLIS,
             DEFAULT_DEADLINE_DURATION_MILLIS);
+    maxInboundMessageSize = getInt(databaseConfig.getProperties(), MAX_INBOUND_MESSAGE_SIZE, null);
+    maxInboundMetadataSize =
+        getInt(databaseConfig.getProperties(), MAX_INBOUND_METADATA_SIZE, null);
   }
 
   public String getHost() {
@@ -55,5 +66,13 @@ public class GrpcConfig {
 
   public long getDeadlineDurationMillis() {
     return deadlineDurationMillis;
+  }
+
+  public Optional<Integer> getMaxInboundMessageSize() {
+    return Optional.ofNullable(maxInboundMessageSize);
+  }
+
+  public Optional<Integer> getMaxInboundMetadataSize() {
+    return Optional.ofNullable(maxInboundMetadataSize);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcStorage.java
@@ -28,7 +28,6 @@ import com.scalar.db.util.retry.ServiceTemporaryUnavailableException;
 import io.grpc.ManagedChannel;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NettyChannelBuilder;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -60,8 +59,7 @@ public class GrpcStorage extends AbstractDistributedStorage {
   @Inject
   public GrpcStorage(DatabaseConfig databaseConfig) {
     config = new GrpcConfig(databaseConfig);
-    channel =
-        NettyChannelBuilder.forAddress(config.getHost(), config.getPort()).usePlaintext().build();
+    channel = GrpcUtils.createChannel(config);
     stub = DistributedStorageGrpc.newStub(channel);
     blockingStub = DistributedStorageGrpc.newBlockingStub(channel);
     metadataManager =

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcUtils.java
@@ -1,0 +1,17 @@
+package com.scalar.db.storage.rpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.NettyChannelBuilder;
+
+public final class GrpcUtils {
+
+  private GrpcUtils() {}
+
+  public static ManagedChannel createChannel(GrpcConfig config) {
+    NettyChannelBuilder builder =
+        NettyChannelBuilder.forAddress(config.getHost(), config.getPort()).usePlaintext();
+    config.getMaxInboundMessageSize().ifPresent(builder::maxInboundMessageSize);
+    config.getMaxInboundMetadataSize().ifPresent(builder::maxInboundMetadataSize);
+    return builder.build();
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
@@ -31,12 +31,12 @@ import com.scalar.db.rpc.TruncateCoordinatorTablesRequest;
 import com.scalar.db.rpc.TruncateTableRequest;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcConfig;
+import com.scalar.db.storage.rpc.GrpcUtils;
 import com.scalar.db.util.ProtoUtils;
 import com.scalar.db.util.ThrowableSupplier;
 import io.grpc.ManagedChannel;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NettyChannelBuilder;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -57,8 +57,7 @@ public class GrpcTransactionAdmin implements DistributedTransactionAdmin {
   @Inject
   public GrpcTransactionAdmin(DatabaseConfig databaseConfig) {
     config = new GrpcConfig(databaseConfig);
-    channel =
-        NettyChannelBuilder.forAddress(config.getHost(), config.getPort()).usePlaintext().build();
+    channel = GrpcUtils.createChannel(config);
     stub = DistributedTransactionAdminGrpc.newBlockingStub(channel);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
@@ -21,6 +21,7 @@ import com.scalar.db.rpc.RollbackRequest;
 import com.scalar.db.rpc.RollbackResponse;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcConfig;
+import com.scalar.db.storage.rpc.GrpcUtils;
 import com.scalar.db.util.ProtoUtils;
 import com.scalar.db.util.ThrowableSupplier;
 import com.scalar.db.util.retry.Retry;
@@ -28,7 +29,6 @@ import com.scalar.db.util.retry.ServiceTemporaryUnavailableException;
 import io.grpc.ManagedChannel;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NettyChannelBuilder;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -61,8 +61,7 @@ public class GrpcTransactionManager extends ActiveTransactionManagedTransactionM
   public GrpcTransactionManager(DatabaseConfig databaseConfig) {
     super(databaseConfig);
     config = new GrpcConfig(databaseConfig);
-    channel =
-        NettyChannelBuilder.forAddress(config.getHost(), config.getPort()).usePlaintext().build();
+    channel = GrpcUtils.createChannel(config);
     stub = DistributedTransactionGrpc.newStub(channel);
     blockingStub = DistributedTransactionGrpc.newBlockingStub(channel);
     metadataManager =

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
@@ -21,9 +21,9 @@ import com.scalar.db.rpc.RollbackResponse;
 import com.scalar.db.rpc.TwoPhaseCommitTransactionGrpc;
 import com.scalar.db.storage.rpc.GrpcAdmin;
 import com.scalar.db.storage.rpc.GrpcConfig;
+import com.scalar.db.storage.rpc.GrpcUtils;
 import com.scalar.db.util.ProtoUtils;
 import io.grpc.ManagedChannel;
-import io.grpc.netty.NettyChannelBuilder;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -46,8 +46,7 @@ public class GrpcTwoPhaseCommitTransactionManager
   public GrpcTwoPhaseCommitTransactionManager(DatabaseConfig databaseConfig) {
     super(databaseConfig);
     config = new GrpcConfig(databaseConfig);
-    channel =
-        NettyChannelBuilder.forAddress(config.getHost(), config.getPort()).usePlaintext().build();
+    channel = GrpcUtils.createChannel(config);
     stub = TwoPhaseCommitTransactionGrpc.newStub(channel);
     blockingStub = TwoPhaseCommitTransactionGrpc.newBlockingStub(channel);
     metadataManager =

--- a/core/src/test/java/com/scalar/db/config/ConfigUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/config/ConfigUtilsTest.java
@@ -22,6 +22,7 @@ public class ConfigUtilsTest {
     assertThat(ConfigUtils.getString(properties, "name2", "def_value")).isEqualTo("value");
     assertThat(ConfigUtils.getString(properties, "name3", "def_value")).isEqualTo("def_value");
     assertThat(ConfigUtils.getString(properties, "name4", "def_value")).isEqualTo("def_value");
+    assertThat(ConfigUtils.getString(properties, "name5", null)).isNull();
   }
 
   @Test
@@ -40,6 +41,7 @@ public class ConfigUtilsTest {
     assertThat(ConfigUtils.getInt(properties, "name4", 10000)).isEqualTo(10000);
     assertThatThrownBy(() -> ConfigUtils.getInt(properties, "name5", 10000))
         .isInstanceOf(IllegalArgumentException.class);
+    assertThat(ConfigUtils.getInt(properties, "name6", null)).isNull();
   }
 
   @Test
@@ -58,6 +60,7 @@ public class ConfigUtilsTest {
     assertThat(ConfigUtils.getLong(properties, "name4", 10000)).isEqualTo(10000);
     assertThatThrownBy(() -> ConfigUtils.getLong(properties, "name5", 10000))
         .isInstanceOf(IllegalArgumentException.class);
+    assertThat(ConfigUtils.getLong(properties, "name6", null)).isNull();
   }
 
   @Test
@@ -78,6 +81,7 @@ public class ConfigUtilsTest {
     assertThat(ConfigUtils.getBoolean(properties, "name5", false)).isEqualTo(false);
     assertThatThrownBy(() -> ConfigUtils.getBoolean(properties, "name6", false))
         .isInstanceOf(IllegalArgumentException.class);
+    assertThat(ConfigUtils.getBoolean(properties, "name7", null)).isNull();
   }
 
   @Test
@@ -97,6 +101,7 @@ public class ConfigUtilsTest {
         .isEqualTo(new String[] {"xxx", "yyy", "zzz"});
     assertThat(ConfigUtils.getStringArray(properties, "name4", new String[] {"xxx", "yyy", "zzz"}))
         .isEqualTo(new String[] {"xxx", "yyy", "zzz"});
+    assertThat(ConfigUtils.getBoolean(properties, "name5", null)).isNull();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcConfigTest.java
@@ -28,6 +28,8 @@ public class GrpcConfigTest {
     assertThat(config.getPort()).isEqualTo(ANY_PORT);
     assertThat(config.getDeadlineDurationMillis())
         .isEqualTo(GrpcConfig.DEFAULT_DEADLINE_DURATION_MILLIS);
+    assertThat(config.getMaxInboundMessageSize()).isNotPresent();
+    assertThat(config.getMaxInboundMetadataSize()).isNotPresent();
   }
 
   @Test
@@ -87,5 +89,25 @@ public class GrpcConfigTest {
     // Act
     assertThatThrownBy(() -> new GrpcConfig(new DatabaseConfig(props)))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_PropertiesWithMaxInboundMessageSizeAndMaxInboundMetadataSizeGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_HOST);
+    props.setProperty(DatabaseConfig.STORAGE, "grpc");
+    props.setProperty(GrpcConfig.MAX_INBOUND_MESSAGE_SIZE, "1000");
+    props.setProperty(GrpcConfig.MAX_INBOUND_METADATA_SIZE, "2000");
+
+    // Act
+    GrpcConfig config = new GrpcConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getMaxInboundMessageSize()).isPresent();
+    assertThat(config.getMaxInboundMessageSize().get()).isEqualTo(1000);
+    assertThat(config.getMaxInboundMetadataSize()).isPresent();
+    assertThat(config.getMaxInboundMetadataSize().get()).isEqualTo(2000);
   }
 }

--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -43,6 +43,12 @@ scalar.db.server.port=60051
 # Prometheus exporter port. Use 8080 if this is not given. Prometheus exporter will not be started if a negative number is given.
 scalar.db.server.prometheus_exporter_port=8080
 
+# The maximum message size allowed to be received. If not specified, use the gRPC default value.
+scalar.db.server.grpc.max_inbound_message_size=
+
+# The maximum size of metadata allowed to be received. If not specified, use the gRPC default value.
+scalar.db.server.grpc.max_inbound_metadata_size=
+
 #
 # Underlying storage/database configurations
 #
@@ -143,6 +149,12 @@ scalar.db.transaction_manager=grpc
 
 # The deadline duration for gRPC connections. The default is 60000 milliseconds (60 seconds)
 scalar.db.grpc.deadline_duration_millis=60000
+
+# The maximum message size allowed for a single gRPC frame. If not specified, use the gRPC default value.
+scalar.db.grpc.max_inbound_message_size=
+
+# The maximum size of metadata allowed to be received. If not specified, use the gRPC default value.
+scalar.db.grpc.max_inbound_metadata_size=
 ```
 
 ## Further reading

--- a/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
+++ b/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
@@ -107,6 +107,9 @@ public class ScalarDbServer implements Callable<Integer> {
               + "\" to 'jdbc'");
     }
 
+    config.getGrpcMaxInboundMessageSize().ifPresent(builder::maxInboundMessageSize);
+    config.getGrpcMaxInboundMetadataSize().ifPresent(builder::maxInboundMetadataSize);
+
     server = builder.build().start();
 
     logger.info("Scalar DB Server started, listening on {}", config.getPort());

--- a/server/src/main/java/com/scalar/db/server/ServerConfig.java
+++ b/server/src/main/java/com/scalar/db/server/ServerConfig.java
@@ -8,7 +8,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
@@ -19,12 +21,20 @@ public class ServerConfig {
   public static final String PORT = PREFIX + "port";
   public static final String PROMETHEUS_EXPORTER_PORT = PREFIX + "prometheus_exporter_port";
 
+  public static final String GRPC_MAX_INBOUND_MESSAGE_SIZE =
+      PREFIX + "grpc.max_inbound_message_size";
+  public static final String GRPC_MAX_INBOUND_METADATA_SIZE =
+      PREFIX + "grpc.max_inbound_metadata_size";
+
   public static final int DEFAULT_PORT = 60051;
   public static final int DEFAULT_PROMETHEUS_EXPORTER_PORT = 8080;
 
   private final Properties props;
   private int port;
   private int prometheusExporterPort;
+
+  @Nullable private Integer grpcMaxInboundMessageSize;
+  @Nullable private Integer grpcMaxInboundMetadataSize;
 
   public ServerConfig(File propertiesFile) throws IOException {
     try (FileInputStream stream = new FileInputStream(propertiesFile)) {
@@ -60,6 +70,9 @@ public class ServerConfig {
     port = getInt(getProperties(), PORT, DEFAULT_PORT);
     prometheusExporterPort =
         getInt(getProperties(), PROMETHEUS_EXPORTER_PORT, DEFAULT_PROMETHEUS_EXPORTER_PORT);
+
+    grpcMaxInboundMessageSize = getInt(getProperties(), GRPC_MAX_INBOUND_MESSAGE_SIZE, null);
+    grpcMaxInboundMetadataSize = getInt(getProperties(), GRPC_MAX_INBOUND_METADATA_SIZE, null);
   }
 
   public int getPort() {
@@ -68,5 +81,13 @@ public class ServerConfig {
 
   public int getPrometheusExporterPort() {
     return prometheusExporterPort;
+  }
+
+  public Optional<Integer> getGrpcMaxInboundMessageSize() {
+    return Optional.ofNullable(grpcMaxInboundMessageSize);
+  }
+
+  public Optional<Integer> getGrpcMaxInboundMetadataSize() {
+    return Optional.ofNullable(grpcMaxInboundMetadataSize);
   }
 }

--- a/server/src/test/java/com/scalar/db/server/ServerConfigTest.java
+++ b/server/src/test/java/com/scalar/db/server/ServerConfigTest.java
@@ -22,6 +22,8 @@ public class ServerConfigTest {
     assertThat(config.getPort()).isEqualTo(ServerConfig.DEFAULT_PORT);
     assertThat(config.getPrometheusExporterPort())
         .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_EXPORTER_PORT);
+    assertThat(config.getGrpcMaxInboundMessageSize()).isNotPresent();
+    assertThat(config.getGrpcMaxInboundMetadataSize()).isNotPresent();
   }
 
   @Test
@@ -68,5 +70,23 @@ public class ServerConfigTest {
 
     // Act Assert
     assertThatThrownBy(() -> new ServerConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_PropertiesWithMaxInboundMessageSizeAndMaxInboundMetadataSizeGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ServerConfig.GRPC_MAX_INBOUND_MESSAGE_SIZE, "1000");
+    props.setProperty(ServerConfig.GRPC_MAX_INBOUND_METADATA_SIZE, "2000");
+
+    // Act
+    ServerConfig config = new ServerConfig(props);
+
+    // Assert
+    assertThat(config.getGrpcMaxInboundMessageSize()).isPresent();
+    assertThat(config.getGrpcMaxInboundMessageSize().get()).isEqualTo(1000);
+    assertThat(config.getGrpcMaxInboundMetadataSize()).isPresent();
+    assertThat(config.getGrpcMaxInboundMetadataSize().get()).isEqualTo(2000);
   }
 }


### PR DESCRIPTION
This PR adds the following configurations for gRPC:

For the client side:
```properties
# The maximum message size allowed for a single gRPC frame. If not specified, use the gRPC default value.
scalar.db.grpc.max_inbound_message_size=

# The maximum size of metadata allowed to be received. If not specified, use the gRPC default value.
scalar.db.grpc.max_inbound_metadata_size=
```

For the server side:
```properties
# The maximum message size allowed to be received. If not specified, use the gRPC default value.
scalar.db.server.grpc.max_inbound_message_size=

# The maximum size of metadata allowed to be received. If not specified, use the gRPC default value.
scalar.db.server.grpc.max_inbound_metadata_size=
```

Please take a look!