### PR TITLE
Add description how to build docker image of ScalarDB Server

### DIFF
--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -27,6 +27,12 @@ $ ./gradlew installDist
 
 Of course, you can archive the jar and libraries by `./gradlew distZip` and so on.
 
+Also, you can build a Docker image from the source as follows.
+
+```shell
+$ ./gradlew :server:docker
+```
+
 ## Configure Scalar DB Server
 
 You need a property file holding the configuration for Scalar DB Server. 


### PR DESCRIPTION
I was not able to find the description of how to build a Docker image of ScalarDB Server from the source code.
From the perspective of customers/users, there is no problem since they can get the docker image from Github Packages or each marketplace.
However, from the perspective of developers (mainly new development members), I think this is useful information.
So, I added it to the document. Please take a look!