### PR TITLE
Remove dockerize command from container image

### DIFF
--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -78,6 +78,13 @@ scalar.db.consensus_commit.serializable_strategy=
 scalar.db.consensus_commit.include_metadata.enabled=false
 ```
 
+You can set some sensitive data (e.g., credentials) as the values of properties using environment variables.
+
+```properties
+scalar.db.username=${env:SCALAR_DB_USERNAME}
+scalar.db.password=${env:SCALAR_DB_PASSWORD}
+```
+
 ## Start Scalar DB Server
 
 ### Docker images
@@ -89,17 +96,17 @@ $ docker pull ghcr.io/scalar-labs/scalardb-server:<version>
 
 And then, you can start Scalar DB Server with the following command:
 ```shell
-$ docker run -v <your local property file path>:/scalardb/server/database.properties.tmpl -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local property file path>:/scalardb/server/database.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 ```
 
 You can also start it with DEBUG logging as follows:
 ```shell
-$ docker run -v <your local property file path>:/scalardb/server/database.properties.tmpl -e SCALAR_DB_LOG_LEVEL=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local property file path>:/scalardb/server/database.properties -e SCALAR_DB_LOG_LEVEL=DEBUG -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 ````
 
 You can also start it with your custom log configuration as follows:
 ```shell
-$ docker run -v <your local property file path>:/scalardb/server/database.properties.tmpl -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties.tmpl -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local property file path>:/scalardb/server/database.properties -v <your custom log4j2 configuration file path>:/scalardb/server/log4j2.properties -d -p 60051:60051 -p 8080:8080 ghcr.io/scalar-labs/scalardb-server:<version>
 ```
 
 You can also start it with environment variables as follows:
@@ -109,7 +116,7 @@ $ docker run --env SCALAR_DB_CONTACT_POINTS=cassandra --env SCALAR_DB_CONTACT_PO
 
 You can also start it with JMX as follows:
 ```shell
-$ docker run -v <your local property file path>:/scalardb/server/database.properties.tmpl -e JAVA_OPTS="-Dlog4j.configurationFile=file:log4j2.properties -Djava.rmi.server.hostname=<your container hostname or IP address> -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9990 -Dcom.sun.management.jmxremote.rmi.port=9990 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" -d -p 60051:60051 -p 8080:8080 -p 9990:9990 ghcr.io/scalar-labs/scalardb-server:<version>
+$ docker run -v <your local property file path>:/scalardb/server/database.properties -e JAVA_OPTS="-Dlog4j.configurationFile=file:log4j2.properties -Djava.rmi.server.hostname=<your container hostname or IP address> -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9990 -Dcom.sun.management.jmxremote.rmi.port=9990 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false" -d -p 60051:60051 -p 8080:8080 -p 9990:9990 ghcr.io/scalar-labs/scalardb-server:<version>
 ```
 
 ### Zip archives

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker.io/busybox:1.32 AS tools
 
 ENV GRPC_HEALTH_PROBE_VERSION v0.4.14
-ENV DOCKERIZE_VERSION v0.6.1
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/
@@ -9,23 +8,15 @@ RUN set -x && \
     wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" && \
     chmod +x grpc_health_probe
 
-# Install dockerize
-# Support for use cases where environment variables are used to configure the database
-RUN set -x && \
-    wget -q "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
-    tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
-    ./dockerize --version
-
 FROM ghcr.io/scalar-labs/jre8:1.1.9
 
-COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/
 
 WORKDIR /scalardb
 
 # The path should be relative from build/docker. Running `gradle docker`
 # (provided by com.palantir.docker plugin) will copy this Dockerfile and
-# server.tar, log4j2.properties and database.properties.tmpl to build/docker.
+# server.tar, log4j2.properties and database.properties to build/docker.
 ADD server.tar .
 
 ENV SCALAR_DB_CONTACT_POINTS 'cassandra'
@@ -39,8 +30,8 @@ ENV SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY ''
 
 WORKDIR /scalardb/server
 
-COPY database.properties.tmpl .
-COPY log4j2.properties.tmpl .
+COPY database.properties .
+COPY log4j2.properties .
 COPY docker-entrypoint.sh .
 
 RUN groupadd -r --gid 201 scalardb && \
@@ -54,8 +45,6 @@ ENV JAVA_OPTS '-Dlog4j.configurationFile=file:log4j2.properties'
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-CMD ["dockerize", "-template", "database.properties.tmpl:database.properties", \
-    "-template", "log4j2.properties.tmpl:log4j2.properties", \
-    "./bin/scalardb-server", "--config=database.properties"]
+CMD ["./bin/scalardb-server", "--config=database.properties"]
 
 EXPOSE 60051 8080

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -69,7 +69,7 @@ application {
 
 docker {
     name "ghcr.io/scalar-labs/scalardb-server:${project.version}"
-    files tasks.distTar.outputs, 'conf/log4j2.properties.tmpl', 'conf/database.properties.tmpl', 'docker-entrypoint.sh'
+    files tasks.distTar.outputs, 'conf/log4j2.properties', 'conf/database.properties', 'docker-entrypoint.sh'
 }
 
 task dockerfileLint(type: Exec) {

--- a/server/conf/database.properties
+++ b/server/conf/database.properties
@@ -1,29 +1,29 @@
 # Comma separated contact points. For DynamoDB, the region is specified by this parameter.
-scalar.db.contact_points={{ default .Env.SCALAR_DB_CONTACT_POINTS "" }}
+scalar.db.contact_points=${env:SCALAR_DB_CONTACT_POINTS}
 
 # Port number for all the contact points. Default port number for each database is used if empty.
-scalar.db.contact_port={{ default .Env.SCALAR_DB_CONTACT_PORT "" }}
+scalar.db.contact_port=${env:SCALAR_DB_CONTACT_PORT}
 
 # Credential information to access the database. For Cosmos DB, username isn't used. For DynamoDB, AWS_ACCESS_KEY_ID is specified by the username and AWS_ACCESS_SECRET_KEY is specified by the password.
-scalar.db.username={{ default .Env.SCALAR_DB_USERNAME "" }}
-scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
+scalar.db.username=${env:SCALAR_DB_USERNAME}
+scalar.db.password=${env:SCALAR_DB_PASSWORD}
 
 # Storage implementation. "cassandra" or "cosmos" or "dynamo" or "jdbc" or "grpc" can be set. Default storage is "cassandra".
-scalar.db.storage={{ default .Env.SCALAR_DB_STORAGE "" }}
+scalar.db.storage=${env:SCALAR_DB_STORAGE}
 
 # The type of the transaction manager. "consensus-commit" or "jdbc" or "grpc" can be set. The default is "consensus-commit"
-scalar.db.transaction_manager={{ default .Env.SCALAR_DB_TRANSACTION_MANAGER "" }}
+scalar.db.transaction_manager=${env:SCALAR_DB_TRANSACTION_MANAGER}
 
 # Isolation level used for ConsensusCommit. Either SNAPSHOT or SERIALIZABLE can be specified. SNAPSHOT is used by default.
-scalar.db.consensus_commit.isolation_level={{ default .Env.SCALAR_DB_CONSENSUSCOMMIT_ISOLATION_LEVEL "" }}
+scalar.db.consensus_commit.isolation_level=${env:SCALAR_DB_CONSENSUSCOMMIT_ISOLATION_LEVEL}
 
 # For backward compatibility
-scalar.db.isolation_level={{ default .Env.SCALAR_DB_ISOLATION_LEVEL "" }}
+scalar.db.isolation_level=${env:SCALAR_DB_ISOLATION_LEVEL}
 
 # Serializable strategy used for ConsensusCommit transaction manager.
 # Either EXTRA_READ or EXTRA_WRITE can be specified. EXTRA_READ is used by default.
 # If SNAPSHOT is specified in the property "scalar.db.consensus_commit.isolation_level", this is ignored.
-scalar.db.consensus_commit.serializable_strategy={{ default .Env.SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY "" }}
+scalar.db.consensus_commit.serializable_strategy=${env:SCALAR_DB_CONSENSUSCOMMIT_SERIALIZABLE_STRATEGY}
 
 # Port number for grpc server. Default port number is 60051.
-scalar.db.server.port={{ default .Env.SCALAR_DB_SERVER_PORT "" }}
+scalar.db.server.port=${env:SCALAR_DB_SERVER_PORT}

--- a/server/conf/log4j2.properties
+++ b/server/conf/log4j2.properties
@@ -1,4 +1,4 @@
-rootLogger.level={{ default .Env.SCALAR_DB_LOG_LEVEL "INFO" }}
+rootLogger.level=${env:SCALAR_DB_LOG_LEVEL:-INFO}
 rootLogger.appenderRef.stdout.ref=STDOUT
 appender.console.type=Console
 appender.console.name=STDOUT


### PR DESCRIPTION
Note: **This PR does NOT keep backward compatibility** since users cannot use the `dockerize (Go text/template)` syntax to configure some properties in the properties file.

This PR removes the `dockerize` command from the ScalarDB Server container image and renames/updates related files.

Before, we use the template feature of the `dockerize` command to set credentials to properties files from environment variables. And, we use the `dockerize` command to use this feature only.

However, the ScalarDB Server natively supports setting credentials from environment variables now.  
https://github.com/scalar-labs/scalardb/pull/770

So, we don't need to use the `dockerize` command now.
Please take a look!

---

For your reference, I was able to run the ScalarDB Server image without the `dockerize` command as follows.

### Deploy new image (without `dockerize`)
```shell
$ kubectl get pod
NAME                              READY   STATUS    RESTARTS   AGE
postgresql-scalardb-0             1/1     Running   0          47m
scalardb-7766964d6-j8cn8          1/1     Running   0          6s
scalardb-envoy-84c475f77b-txszj   1/1     Running   0          38m
```

### Confirm files in the container
```shell
$ kubectl exec -it scalardb-7766964d6-j8cn8 -- ls -lF
total 88
drwxr-xr-x 1 scalardb scalardb  4096 Dec 27 05:51 bin/
-rw-r--r-- 1 root     root       398 Dec 27 07:02 database.properties
-rwxr-xr-x 1 scalardb scalardb   135 Dec 27 05:51 docker-entrypoint.sh*
drwxr-xr-x 1 scalardb scalardb 12288 Dec 27 05:51 lib/
-rw-r--r-- 1 scalardb scalardb   243 Dec 27 05:51 log4j2.properties
-rw-r--r-- 1 scalardb scalardb 57414 Nov 17 06:54 scalardb-server-4.0.0-SNAPSHOT.jar
```
* There is no `.tmpl` files ([database.properties|log4j2.properties].tmpl) that were used by `dockerize`.

### Confirm `database.properties` in the container
```shell
$ kubectl exec -it scalardb-7766964d6-j8cn8 -- cat database.properties
scalar.db.storage=jdbc
scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
scalar.db.username=${env:SCALAR_DB_POSTGRES_USERNAME}
scalar.db.password=${env:SCALAR_DB_POSTGRES_PASSWORD}
scalar.db.metadata.cache_expiration_time_secs=3
scalar.db.consensus_commit.isolation_level=SERIALIZABLE
scalar.db.consensus_commit.serializable_strategy=EXTRA_READ
```
* I use the `Apache Commons Text` syntax to set credentials from environment variables. This feature is supported by ScalarDB Server natively.

### Confirm `log4j2.properties` in the container
```shell
$ kubectl exec -it scalardb-7766964d6-j8cn8 -- cat log4j2.properties
rootLogger.level=${env:SCALAR_DB_LOG_LEVEL:-INFO}
rootLogger.appenderRef.stdout.ref=STDOUT
appender.console.type=Console
appender.console.name=STDOUT
appender.console.layout.type=PatternLayout
appender.console.layout.pattern=%d [%-5p %c] %m%n
```
* Log4j2 also supports the same syntax to set configurations from environment variables.  
  https://logging.apache.org/log4j/2.x/manual/configuration.html#PropertySubstitution

### Confirm environment variables that include credentials
```shell
$ kubectl exec -it scalardb-7766964d6-j8cn8 -- env | grep SCALAR_DB_POSTGRES_
SCALAR_DB_POSTGRES_PASSWORD=postgres
SCALAR_DB_POSTGRES_USERNAME=postgres
```

### Confirm environment variable that includes log level configuration for log4j2
```shell
$ kubectl exec -it scalardb-7766964d6-j8cn8 -- env | grep SCALAR_DB_LOG_LEVEL
SCALAR_DB_LOG_LEVEL=DEBUG
```

### Run some CRUD API (query) from a client (for testing I use ScalarDB SQL CLI)
```sql
$ java -jar scalardb-sql-cli-3.7.0-all.jar --config database.properties
sqlline version 1.12.0
0: scalardb>
0: scalardb> CREATE COORDINATOR TABLES;
No rows affected (0.565 seconds)
0: scalardb>
0: scalardb> CREATE NAMESPACE ns;
No rows affected (0.016 seconds)
0: scalardb>
0: scalardb> USE ns;
No rows affected (0.022 seconds)
0: scalardb>
0: scalardb> CREATE TABLE foo (a INT PRIMARY KEY, b INT);
No rows affected (0.079 seconds)
0: scalardb>
0: scalardb> INSERT INTO foo VALUES (1, 100);
1 row affected (0.214 seconds)
0: scalardb>
0: scalardb> SELECT * FROM foo;
+---+-----+
| a |  b  |
+---+-----+
| 1 | 100 |
+---+-----+
1 row selected (0.126 seconds)
0: scalardb>
```
```sql
$ kubectl exec -it postgresql-scalardb-0 -- psql -U postgres -c "SELECT * FROM ns.foo"
Password for user postgres:
 a |  b  |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at | before_tx_id | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_b
---+-----+--------------------------------------+----------+------------+----------------+-----------------+--------------+-----------------+-------------------+-----------------------+------------------------+----------
 1 | 100 | 3b67e1e4-8d43-4aa5-90b3-f9c54ec78f1c |        3 |          1 |  1672124822094 |   1672124822254 |              |                 |                   |                       |                        |
(1 row)
```
* ScalarDB Server works fine (i.e., it accesses backend PostgreSQL properly using credentials that are set as environment variables).

### Confirm ScalarDB Server log (log level is set as DEBUG)
```shell
$ kubectl logs scalardb-7766964d6-j8cn8 | tail -n 1
2022-12-27 07:05:20,648 [DEBUG io.grpc.netty.NettyServerHandler] [id: 0xd50085a3, L:/172.17.0.5:60051 - R:/172.17.0.4:57156] OUTBOUND HEADERS: streamId=53 headers=GrpcHttp2OutboundHeaders[grpc-status: 0] padding=0 endStream=true
```
* The log level (DEBUG) that is set as an environment variable is applied.
