### PR TITLE
Add transaction decorator

### DIFF
--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -21,17 +21,17 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class ActiveTransactionManagedTransactionManager
+public abstract class ActiveTransactionManagedDistributedTransactionManager
     extends AbstractDistributedTransactionManager {
 
   private static final long TRANSACTION_EXPIRATION_INTERVAL_MILLIS = 1000;
 
   private static final Logger logger =
-      LoggerFactory.getLogger(ActiveTransactionManagedTransactionManager.class);
+      LoggerFactory.getLogger(ActiveTransactionManagedDistributedTransactionManager.class);
 
   private final ActiveExpiringMap<String, DistributedTransaction> activeTransactions;
 
-  public ActiveTransactionManagedTransactionManager(DatabaseConfig config) {
+  public ActiveTransactionManagedDistributedTransactionManager(DatabaseConfig config) {
     activeTransactions =
         new ActiveExpiringMap<>(
             config.getActiveTransactionManagementExpirationTimeMillis(),
@@ -71,13 +71,13 @@ public abstract class ActiveTransactionManagedTransactionManager
   }
 
   @Override
-  protected DistributedTransaction activate(DistributedTransaction transaction)
+  protected DistributedTransaction decorate(DistributedTransaction transaction)
       throws TransactionException {
-    return new ActiveTransaction(super.activate(transaction));
+    return new ActiveTransaction(super.decorate(transaction));
   }
 
   private class ActiveTransaction extends AbstractDistributedTransaction
-      implements WrappedDistributedTransaction {
+      implements DecoratedDistributedTransaction {
 
     private final DistributedTransaction transaction;
 
@@ -144,8 +144,8 @@ public abstract class ActiveTransactionManagedTransactionManager
 
     @Override
     public DistributedTransaction getOriginalTransaction() {
-      if (transaction instanceof WrappedDistributedTransaction) {
-        return ((WrappedDistributedTransaction) transaction).getOriginalTransaction();
+      if (transaction instanceof DecoratedDistributedTransaction) {
+        return ((DecoratedDistributedTransaction) transaction).getOriginalTransaction();
       }
       return transaction;
     }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -73,13 +73,13 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   }
 
   @Override
-  protected TwoPhaseCommitTransaction activate(TwoPhaseCommitTransaction transaction)
+  protected TwoPhaseCommitTransaction decorate(TwoPhaseCommitTransaction transaction)
       throws TransactionException {
-    return new ActiveTransaction(super.activate(transaction));
+    return new ActiveTransaction(super.decorate(transaction));
   }
 
   private class ActiveTransaction extends AbstractTwoPhaseCommitTransaction
-      implements WrappedTwoPhaseCommitTransaction {
+      implements DecoratedTwoPhaseCommitTransaction {
 
     private final TwoPhaseCommitTransaction transaction;
 
@@ -156,8 +156,8 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
 
     @Override
     public TwoPhaseCommitTransaction getOriginalTransaction() {
-      if (transaction instanceof WrappedTwoPhaseCommitTransaction) {
-        return ((WrappedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
+      if (transaction instanceof DecoratedTwoPhaseCommitTransaction) {
+        return ((DecoratedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
       }
       return transaction;
     }

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
@@ -2,6 +2,6 @@ package com.scalar.db.common;
 
 import com.scalar.db.api.DistributedTransaction;
 
-public interface WrappedDistributedTransaction {
+public interface DecoratedDistributedTransaction extends DistributedTransaction {
   DistributedTransaction getOriginalTransaction();
 }

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -2,6 +2,6 @@ package com.scalar.db.common;
 
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 
-public interface WrappedTwoPhaseCommitTransaction {
+public interface DecoratedTwoPhaseCommitTransaction extends TwoPhaseCommitTransaction {
   TwoPhaseCommitTransaction getOriginalTransaction();
 }

--- a/core/src/main/java/com/scalar/db/common/DistributedTransactionDecorator.java
+++ b/core/src/main/java/com/scalar/db/common/DistributedTransactionDecorator.java
@@ -1,0 +1,8 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.DistributedTransaction;
+
+@FunctionalInterface
+public interface DistributedTransactionDecorator {
+  DecoratedDistributedTransaction decorate(DistributedTransaction transaction);
+}

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitTransactionDecorator.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitTransactionDecorator.java
@@ -1,0 +1,8 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+
+@FunctionalInterface
+public interface TwoPhaseCommitTransactionDecorator {
+  DecoratedTwoPhaseCommitTransaction decorate(TwoPhaseCommitTransaction transaction);
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -10,7 +10,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.common.ActiveTransactionManagedTransactionManager;
+import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class ConsensusCommitManager extends ActiveTransactionManagedTransactionManager {
+public class ConsensusCommitManager extends ActiveTransactionManagedDistributedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(ConsensusCommitManager.class);
   private final DistributedStorage storage;
   private final DistributedStorageAdmin admin;
@@ -183,7 +183,7 @@ public class ConsensusCommitManager extends ActiveTransactionManagedTransactionM
     ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
     getNamespace().ifPresent(consensus::withNamespace);
     getTable().ifPresent(consensus::withTable);
-    return activate(consensus);
+    return decorate(consensus);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -143,7 +143,7 @@ public class TwoPhaseConsensusCommitManager
         new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
     getNamespace().ifPresent(transaction::withNamespace);
     getTable().ifPresent(transaction::withTable);
-    return activate(transaction);
+    return decorate(transaction);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -6,7 +6,7 @@ import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Isolation;
 import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.common.ActiveTransactionManagedTransactionManager;
+import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.config.DatabaseConfig;
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class JdbcTransactionManager extends ActiveTransactionManagedTransactionManager {
+public class JdbcTransactionManager extends ActiveTransactionManagedDistributedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(JdbcTransactionManager.class);
 
   private final BasicDataSource dataSource;
@@ -79,7 +79,7 @@ public class JdbcTransactionManager extends ActiveTransactionManagedTransactionM
           new JdbcTransaction(txId, jdbcService, dataSource.getConnection(), rdbEngine);
       getNamespace().ifPresent(transaction::withNamespace);
       getTable().ifPresent(transaction::withTable);
-      return activate(transaction);
+      return decorate(transaction);
     } catch (SQLException e) {
       throw new TransactionException("failed to start the transaction", e);
     }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionManager.java
@@ -8,7 +8,7 @@ import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Isolation;
 import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.common.ActiveTransactionManagedTransactionManager;
+import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.TransactionException;
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class GrpcTransactionManager extends ActiveTransactionManagedTransactionManager {
+public class GrpcTransactionManager extends ActiveTransactionManagedDistributedTransactionManager {
   private static final Logger logger = LoggerFactory.getLogger(GrpcTransactionManager.class);
 
   static final Retry.ExceptionFactory<TransactionException> EXCEPTION_FACTORY =
@@ -102,7 +102,7 @@ public class GrpcTransactionManager extends ActiveTransactionManagedTransactionM
           GrpcTransaction transaction = new GrpcTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return activate(transaction);
+          return decorate(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -125,7 +125,7 @@ public class GrpcTransactionManager extends ActiveTransactionManagedTransactionM
           GrpcTransaction transaction = new GrpcTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return activate(transaction);
+          return decorate(transaction);
         },
         EXCEPTION_FACTORY);
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionManager.java
@@ -89,7 +89,7 @@ public class GrpcTwoPhaseCommitTransactionManager
               new GrpcTwoPhaseCommitTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return activate(transaction);
+          return decorate(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -114,7 +114,7 @@ public class GrpcTwoPhaseCommitTransactionManager
               new GrpcTwoPhaseCommitTransaction(transactionId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return activate(transaction);
+          return decorate(transaction);
         },
         EXCEPTION_FACTORY);
   }
@@ -129,7 +129,7 @@ public class GrpcTwoPhaseCommitTransactionManager
               new GrpcTwoPhaseCommitTransaction(txId, stream);
           getNamespace().ifPresent(transaction::withNamespace);
           getTable().ifPresent(transaction::withTable);
-          return activate(transaction);
+          return decorate(transaction);
         },
         EXCEPTION_FACTORY);
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -11,7 +11,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.common.WrappedDistributedTransaction;
+import com.scalar.db.common.DecoratedDistributedTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.TransactionException;
@@ -64,7 +64,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -80,7 +80,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin(ANY_TX_ID)).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -96,10 +96,10 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction1 =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
     ConsensusCommit transaction2 =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -131,7 +131,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.start()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -147,7 +147,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.start(ANY_TX_ID)).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.start(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -163,7 +163,7 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction)
+            ((DecoratedDistributedTransaction)
                     manager.start(com.scalar.db.api.Isolation.SERIALIZABLE))
                 .getOriginalTransaction();
 
@@ -190,10 +190,10 @@ public class ConsensusCommitManagerTest {
     // Act
     ConsensusCommit transaction1 =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.start()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.start()).getOriginalTransaction();
     ConsensusCommit transaction2 =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.start()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -11,7 +11,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
-import com.scalar.db.common.WrappedTwoPhaseCommitTransaction;
+import com.scalar.db.common.DecoratedTwoPhaseCommitTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
@@ -67,7 +67,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -83,7 +83,8 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.begin(ANY_TX_ID)).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.begin(ANY_TX_ID))
+                .getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -99,10 +100,10 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction1 =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
     TwoPhaseConsensusCommit transaction2 =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.begin()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -134,7 +135,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isNotNull();
@@ -150,7 +151,8 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.start(ANY_TX_ID)).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.start(ANY_TX_ID))
+                .getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);
@@ -166,10 +168,10 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction1 =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
     TwoPhaseConsensusCommit transaction2 =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.start()).getOriginalTransaction();
 
     // Assert
     assertThat(transaction1.getCrudHandler()).isNotEqualTo(transaction2.getCrudHandler());
@@ -201,7 +203,7 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager.join(ANY_TX_ID)).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager.join(ANY_TX_ID)).getOriginalTransaction();
 
     // Assert
     assertThat(transaction.getCrudHandler().getSnapshot().getId()).isEqualTo(ANY_TX_ID);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -24,7 +24,7 @@ import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
-import com.scalar.db.common.WrappedDistributedTransaction;
+import com.scalar.db.common.DecoratedDistributedTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
@@ -521,7 +521,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -598,7 +598,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -889,7 +889,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -957,7 +957,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     ConsensusCommit transaction =
         (ConsensusCommit)
-            ((WrappedDistributedTransaction) manager.begin()).getOriginalTransaction();
+            ((DecoratedDistributedTransaction) manager.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -17,7 +17,7 @@ import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
-import com.scalar.db.common.WrappedTwoPhaseCommitTransaction;
+import com.scalar.db.common.DecoratedTwoPhaseCommitTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitException;
@@ -498,7 +498,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -577,7 +577,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -878,7 +878,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->
@@ -951,7 +951,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     TwoPhaseConsensusCommit transaction =
         (TwoPhaseConsensusCommit)
-            ((WrappedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
+            ((DecoratedTwoPhaseCommitTransaction) manager1.begin()).getOriginalTransaction();
 
     transaction.setBeforeRecoveryHook(
         () ->


### PR DESCRIPTION
This PR introduces `DistributedTransactionDecorator` and `TwoPhaseCommitTransactionDecorator` that decorate transaction objects (`DistributedTransaction` and `TwoPhaseCommitTransaction` instances) before returning the objects. With this extension point, we can add some behavior to the transaction objects with the decorator pattern.

Please take a look!