### PR TITLE
Should synchronize in active transaction management

### DIFF
--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -31,7 +31,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   private static final Logger logger =
       LoggerFactory.getLogger(AbstractTwoPhaseCommitTransactionManager.class);
 
-  private final ActiveExpiringMap<String, TwoPhaseCommitTransaction> activeTransactions;
+  private final ActiveExpiringMap<String, ActiveTransaction> activeTransactions;
 
   public ActiveTransactionManagedTwoPhaseCommitTransactionManager(DatabaseConfig config) {
     activeTransactions =
@@ -42,7 +42,7 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
               logger.warn("the transaction is expired. transactionId: {}", t.getId());
               try {
                 t.rollback();
-              } catch (RollbackException e) {
+              } catch (Exception e) {
                 logger.warn("rollback failed", e);
               }
             });
@@ -95,58 +95,58 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     }
 
     @Override
-    public Optional<Result> get(Get get) throws CrudException {
+    public synchronized Optional<Result> get(Get get) throws CrudException {
       return transaction.get(get);
     }
 
     @Override
-    public List<Result> scan(Scan scan) throws CrudException {
+    public synchronized List<Result> scan(Scan scan) throws CrudException {
       return transaction.scan(scan);
     }
 
     @Override
-    public void put(Put put) throws CrudException {
+    public synchronized void put(Put put) throws CrudException {
       transaction.put(put);
     }
 
     @Override
-    public void put(List<Put> puts) throws CrudException {
+    public synchronized void put(List<Put> puts) throws CrudException {
       transaction.put(puts);
     }
 
     @Override
-    public void delete(Delete delete) throws CrudException {
+    public synchronized void delete(Delete delete) throws CrudException {
       transaction.delete(delete);
     }
 
     @Override
-    public void delete(List<Delete> deletes) throws CrudException {
+    public synchronized void delete(List<Delete> deletes) throws CrudException {
       transaction.delete(deletes);
     }
 
     @Override
-    public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    public synchronized void mutate(List<? extends Mutation> mutations) throws CrudException {
       transaction.mutate(mutations);
     }
 
     @Override
-    public void prepare() throws PreparationException {
+    public synchronized void prepare() throws PreparationException {
       transaction.prepare();
     }
 
     @Override
-    public void validate() throws ValidationException {
+    public synchronized void validate() throws ValidationException {
       transaction.validate();
     }
 
     @Override
-    public void commit() throws CommitException, UnknownTransactionStatusException {
+    public synchronized void commit() throws CommitException, UnknownTransactionStatusException {
       transaction.commit();
       remove(getId());
     }
 
     @Override
-    public void rollback() throws RollbackException {
+    public synchronized void rollback() throws RollbackException {
       try {
         transaction.rollback();
       } finally {


### PR DESCRIPTION
In the active transaction management, we hold active transactions in the `ActiveExpiringMap`, which expires and rolls back a transaction in a dedicated thread when the transaction is timed out. 

ActiveTransactionManagedDistributedTransactionManager:
https://github.com/scalar-labs/scalardb/blob/should-synchronize-in-active-transaction-management/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java#L42

ActiveTransactionManagedTwoPhaseCommitTransactionManager:
https://github.com/scalar-labs/scalardb/blob/should-synchronize-in-active-transaction-management/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java#L44

In that case, a transaction object can be accessed by multiple threads at the same time, but the transaction implementations are basically thread-unsafe, so something unexpected can happen. To address this issue, we should synchronize the transaction operations.

Please take a look!