### PR TITLE
Allow commit() and rollback() to be called in parallel in all coordinator/participant processes in 2PC transactions

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -116,7 +116,7 @@ public class TwoPhaseConsensusCommitManager
   @VisibleForTesting
   TwoPhaseCommitTransaction begin(String txId, Isolation isolation, SerializableStrategy strategy)
       throws TransactionException {
-    return createNewTransaction(txId, true, isolation, strategy);
+    return createNewTransaction(txId, isolation, strategy);
   }
 
   @Override
@@ -128,19 +128,17 @@ public class TwoPhaseConsensusCommitManager
   @VisibleForTesting
   TwoPhaseCommitTransaction join(String txId, Isolation isolation, SerializableStrategy strategy)
       throws TransactionException {
-    return createNewTransaction(txId, false, isolation, strategy);
+    return createNewTransaction(txId, isolation, strategy);
   }
 
   private TwoPhaseCommitTransaction createNewTransaction(
-      String txId, boolean isCoordinator, Isolation isolation, SerializableStrategy strategy)
-      throws TransactionException {
+      String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
     Snapshot snapshot =
         new Snapshot(txId, isolation, strategy, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled);
 
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     getNamespace().ifPresent(transaction::withNamespace);
     getTable().ifPresent(transaction::withTable);
     return decorate(transaction);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -86,8 +86,7 @@ public class TwoPhaseConsensusCommitTest {
   public void get_GetGiven_ShouldCallCrudHandlerGet() throws CrudException {
     // Arrange
     Get get = prepareGet();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     TransactionResult result = mock(TransactionResult.class);
     when(crud.get(get)).thenReturn(Optional.of(result));
     when(crud.getSnapshot()).thenReturn(snapshot);
@@ -105,8 +104,7 @@ public class TwoPhaseConsensusCommitTest {
   public void get_GetForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
     // Arrange
     Get get = prepareGet();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     TransactionResult result = mock(TransactionResult.class);
     UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
     when(crud.get(get)).thenThrow(toThrow);
@@ -124,8 +122,7 @@ public class TwoPhaseConsensusCommitTest {
   public void scan_ScanGiven_ShouldCallCrudHandlerScan() throws CrudException {
     // Arrange
     Scan scan = prepareScan();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     TransactionResult result = mock(TransactionResult.class);
     List<Result> results = Collections.singletonList(result);
     when(crud.scan(scan)).thenReturn(results);
@@ -143,8 +140,7 @@ public class TwoPhaseConsensusCommitTest {
   public void put_PutGiven_ShouldCallCrudHandlerPut() {
     // Arrange
     Put put = preparePut();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -158,8 +154,7 @@ public class TwoPhaseConsensusCommitTest {
   public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() {
     // Arrange
     Put put = preparePut();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -173,8 +168,7 @@ public class TwoPhaseConsensusCommitTest {
   public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() {
     // Arrange
     Delete delete = prepareDelete();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -188,8 +182,7 @@ public class TwoPhaseConsensusCommitTest {
   public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() {
     // Arrange
     Delete delete = prepareDelete();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -204,8 +197,7 @@ public class TwoPhaseConsensusCommitTest {
     // Arrange
     Put put = preparePut();
     Delete delete = prepareDelete();
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -219,8 +211,7 @@ public class TwoPhaseConsensusCommitTest {
   @Test
   public void prepare_ProcessedCrudGiven_ShouldPrepareWithSnapshot() throws PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -234,8 +225,7 @@ public class TwoPhaseConsensusCommitTest {
   public void validate_ProcessedCrudGiven_ShouldPerformValidationWithSnapshot()
       throws ValidationException, PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, false);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -247,12 +237,10 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void commit_CalledWithCoordinator_ShouldCommitStateAndRecords()
+  public void commit_ShouldCommitStateAndRecords()
       throws CommitException, UnknownTransactionStatusException, PreparationException {
     // Arrange
-    boolean isCoordinator = true;
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -265,32 +253,11 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void commit_CalledWithParticipant_ShouldCommitRecordsOnly()
-      throws CommitException, UnknownTransactionStatusException, PreparationException {
-    // Arrange
-    boolean isCoordinator = false; // means it's a participant process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
-    transaction.prepare();
-    when(crud.getSnapshot()).thenReturn(snapshot);
-    when(snapshot.getId()).thenReturn(ANY_TX_ID);
-
-    // Act
-    transaction.commit();
-
-    // Assert
-    verify(commit, never()).commitState(snapshot);
-    verify(commit).commitRecords(snapshot);
-  }
-
-  @Test
   public void commit_ExtraReadUsedAndValidatedState_ShouldCommitProperly()
       throws CommitException, UnknownTransactionStatusException, PreparationException,
           ValidationException {
     // Arrange
-    boolean isCoordinator = true; // means it's a coordinator process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     transaction.validate();
     when(crud.getSnapshot()).thenReturn(snapshot);
@@ -309,9 +276,7 @@ public class TwoPhaseConsensusCommitTest {
   public void commit_ExtraReadUsedAndPreparedState_ShouldThrowIllegalStateException()
       throws PreparationException {
     // Arrange
-    boolean isCoordinator = true; // means it's a coordinator process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
@@ -322,12 +287,10 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void rollback_CalledWithCoordinator_ShouldAbortStateAndRollbackRecords()
+  public void rollback_ShouldAbortStateAndRollbackRecords()
       throws RollbackException, UnknownTransactionStatusException, PreparationException {
     // Arrange
-    boolean isCoordinator = true; // means it's a coordinator process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -340,12 +303,10 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void rollback_CalledWithCoordinatorAfterPrepareFails_ShouldAbortStateAndRollbackRecords()
+  public void rollback_CalledAfterPrepareFails_ShouldAbortStateAndRollbackRecords()
       throws PreparationException, UnknownTransactionStatusException, RollbackException {
     // Arrange
-    boolean isCoordinator = true; // means it's a coordinator process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
     doThrow(PreparationException.class).when(commit).prepare(snapshot);
 
@@ -359,14 +320,11 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void
-      rollback_CalledWithCoordinatorAfterCommitFails_ShouldNeverAbortStateAndRollbackRecords()
-          throws CommitException, UnknownTransactionStatusException, RollbackException,
-              PreparationException {
+  public void rollback_CalledAfterCommitFails_ShouldNeverAbortStateAndRollbackRecords()
+      throws CommitException, UnknownTransactionStatusException, RollbackException,
+          PreparationException {
     // Arrange
-    boolean isCoordinator = true; // means it's a coordinator process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
+    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
     doThrow(CommitException.class).when(commit).commitState(snapshot);
@@ -378,42 +336,5 @@ public class TwoPhaseConsensusCommitTest {
     // Assert
     verify(commit, never()).abortState(snapshot.getId());
     verify(commit, never()).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void rollback_CalledWithParticipant_ShouldRollbackRecordsOnly()
-      throws RollbackException, PreparationException {
-    // Arrange
-    boolean isCoordinator = false; // means it's a participant process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
-    transaction.prepare();
-    when(crud.getSnapshot()).thenReturn(snapshot);
-    when(snapshot.getId()).thenReturn(ANY_TX_ID);
-
-    // Act
-    transaction.rollback();
-
-    // Assert
-    verify(commit).rollbackRecords(snapshot);
-  }
-
-  @Test
-  public void rollback_CalledWithParticipantAfterPrepareFails_ShouldRollbackRecords()
-      throws PreparationException, RollbackException {
-    // Arrange
-    boolean isCoordinator = false; // means it's a participant process
-    TwoPhaseConsensusCommit transaction =
-        new TwoPhaseConsensusCommit(crud, commit, recovery, isCoordinator);
-    when(crud.getSnapshot()).thenReturn(snapshot);
-    when(snapshot.getId()).thenReturn(ANY_TX_ID);
-    doThrow(PreparationException.class).when(commit).prepare(snapshot);
-
-    // Act
-    assertThatThrownBy(transaction::prepare).isInstanceOf(PreparationException.class);
-    transaction.rollback();
-
-    // Assert
-    verify(commit).rollbackRecords(snapshot);
   }
 }

--- a/docs/two-phase-commit-transactions.md
+++ b/docs/two-phase-commit-transactions.md
@@ -147,7 +147,7 @@ tx.put(toPut);
 
 After finishing CRUD operations, you need to commit the transaction.
 Like a well-known two-phase commit protocol, there are two phases: prepare and commit phases.
-You first need to prepare the transaction in all the coordinator/participant processes, then you need to call in the order of coordinator's `commit()` and the participants' `commit()` as follows:
+You first need to prepare the transaction in all the coordinator/participant processes, and then you need to commit the transaction in all the coordinator/participant processes as follows:
 ```java
 TwoPhaseCommitTransaction tx = ...
 
@@ -170,10 +170,8 @@ try {
 ```
 
 If an error happens, you need to call `rollback()` (or `abort()`) in all the coordinator/participant processes.
-Note that you need to call it in the coordinator process first, and then call it in the participant processes in parallel.
 
-You can call `prepare()` in the coordinator/participant processes in parallel.
-Similarly, you can also call `commit()` in the participant processes in parallel.
+You can call `prepare()`, `commit()`, `rollback()` in the coordinator/participant processes in parallel for better performance.
 
 #### Validate the transaction
 
@@ -192,7 +190,7 @@ tx.commit();
 ...
 ```
 
-Similar to `prepare()`, you can call `validate()` in the coordinator/participant processes in parallel.
+Similar to `prepare()`, you can call `validate()` in the coordinator/participant processes in parallel for better performance.
 
 Currently, you need to call `validate()` when you use the `Consensus Commit` transaction manager with `EXTRA_READ` serializable strategy in `SERIALIZABLE` isolation level.
 In other cases, `validate()` does nothing.


### PR DESCRIPTION
Before this change, one of the limitations in 2PC transaction was that we need to call `commit()`/`rollback()` in a coordinator process before calling `commit()`/`rollback()` in participant processes. This PR gets rid of this limitation. After this change, we can call `commit()`/`rollback()` in parallel in all coordinator/participant processes.

I'll add inline comments for the details. Please take a look!