### PR TITLE
Fix CVE-2022-42898

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.9
+FROM ghcr.io/scalar-labs/jre8:1.1.10
 
 COPY scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,7 @@ RUN set -x && \
     wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" && \
     chmod +x grpc_health_probe
 
-FROM ghcr.io/scalar-labs/jre8:1.1.9
+FROM ghcr.io/scalar-labs/jre8:1.1.10
 
 COPY --from=tools grpc_health_probe /usr/local/bin/
 


### PR DESCRIPTION
This PR fixes CVE-2022-42898 by updating the internal JRE used in docker images. Please take a look!

