### PR TITLE
DynamoDB supports up to 100 actions per transaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
         cassandraDriverVersion = '3.6.0'
         azureCosmosVersion = '4.39.0'
         jooqVersion = '3.13.2'
-        awssdkVersion = '2.17.69'
+        awssdkVersion = '2.19.16'
         commonsDbcp2Version = '2.8.0'
         mysqlDriverVersion = '8.0.31'
         postgresqlDriverVersion = '42.5.1'

--- a/core/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/BatchHandler.java
@@ -57,16 +57,16 @@ public class BatchHandler {
   }
 
   /**
-   * Execute the specified list of {@link Mutation}s in batch. All the {@link Mutation}s in the list
-   * must be for the same partition.
+   * Executes the specified list of {@link Mutation}s in batch. All the {@link Mutation}s in the
+   * list must be for the same partition.
    *
    * @param mutations a list of {@code Mutation}s to execute
    * @throws NoMutationException if at least one of conditional {@code Mutation}s fails because it
    *     didn't meet the condition
    */
   public void handle(List<? extends Mutation> mutations) throws ExecutionException {
-    if (mutations.size() > 25) {
-      throw new IllegalArgumentException("DynamoDB cannot batch more than 25 mutations at once.");
+    if (mutations.size() > 100) {
+      throw new IllegalArgumentException("DynamoDB cannot batch more than 100 mutations at once.");
     }
 
     TableMetadata tableMetadata = metadataManager.getTableMetadata(mutations.get(0));

--- a/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/BatchHandlerTestBase.java
@@ -93,7 +93,7 @@ public abstract class BatchHandlerTestBase {
   public void handle_TooManyOperationsGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     List<Put> mutations = new ArrayList<>();
-    IntStream.range(0, 26).forEach(i -> mutations.add(preparePut()));
+    IntStream.range(0, 101).forEach(i -> mutations.add(preparePut()));
 
     // Act Assert
     assertThatThrownBy(() -> handler.handle(mutations))


### PR DESCRIPTION
Amazon DynamoDB now supports up to 100 actions per transaction according to the following article:
https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/

So, this PR modifies the DynamoDB adapter based on it. Please take a look!