### PR TITLE
Revert async commit default value

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -101,7 +101,7 @@ public class ConsensusCommitConfig {
         getBoolean(
             databaseConfig.getProperties(), PARALLEL_ROLLBACK_ENABLED, parallelCommitEnabled);
 
-    asyncCommitEnabled = getBoolean(databaseConfig.getProperties(), ASYNC_COMMIT_ENABLED, true);
+    asyncCommitEnabled = getBoolean(databaseConfig.getProperties(), ASYNC_COMMIT_ENABLED, false);
     asyncRollbackEnabled =
         getBoolean(databaseConfig.getProperties(), ASYNC_ROLLBACK_ENABLED, asyncCommitEnabled);
     isIncludeMetadataEnabled =

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -26,8 +26,8 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isParallelValidationEnabled()).isTrue();
     assertThat(config.isParallelCommitEnabled()).isTrue();
     assertThat(config.isParallelRollbackEnabled()).isTrue();
-    assertThat(config.isAsyncCommitEnabled()).isTrue();
-    assertThat(config.isAsyncRollbackEnabled()).isTrue();
+    assertThat(config.isAsyncCommitEnabled()).isFalse();
+    assertThat(config.isAsyncRollbackEnabled()).isFalse();
     assertThat(config.isIncludeMetadataEnabled()).isFalse();
   }
 
@@ -153,15 +153,15 @@ public class ConsensusCommitConfigTest {
   public void constructor_AsyncExecutionRelatedPropertiesGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
-    props.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-    props.setProperty(ConsensusCommitConfig.ASYNC_ROLLBACK_ENABLED, "false");
+    props.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "true");
+    props.setProperty(ConsensusCommitConfig.ASYNC_ROLLBACK_ENABLED, "true");
 
     // Act
     ConsensusCommitConfig config = new ConsensusCommitConfig(new DatabaseConfig(props));
 
     // Assert
-    assertThat(config.isAsyncCommitEnabled()).isFalse();
-    assertThat(config.isAsyncRollbackEnabled()).isFalse();
+    assertThat(config.isAsyncCommitEnabled()).isTrue();
+    assertThat(config.isAsyncRollbackEnabled()).isTrue();
   }
 
   @Test

--- a/docs/configurations-for-consensus-commit.md
+++ b/docs/configurations-for-consensus-commit.md
@@ -30,5 +30,5 @@ The Performance related configurations for Consensus Commit are as follows:
 | scalar.db.consensus_commit.parallel_validation.enabled  | Whether or not the validation phase (in `EXTRA_READ`) is executed in parallel. | The value of `scalar.db.consensus_commit.parallel_commit.enabled` |
 | scalar.db.consensus_commit.parallel_commit.enabled      | Whether or not the commit phase is executed in parallel.                       | true                                                              |
 | scalar.db.consensus_commit.parallel_rollback.enabled    | Whether or not the rollback phase is executed in parallel.                     | The value of `scalar.db.consensus_commit.parallel_commit.enabled` |
-| scalar.db.consensus_commit.async_commit.enabled         | Whether or not the commit phase is executed asynchronously.                    | true                                                              |
+| scalar.db.consensus_commit.async_commit.enabled         | Whether or not the commit phase is executed asynchronously.                    | false                                                             |
 | scalar.db.consensus_commit.async_rollback.enabled       | Whether or not the rollback phase is executed asynchronously.                  | The value of `scalar.db.consensus_commit.async_commit.enabled`    |

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
@@ -45,10 +45,6 @@ public abstract class ConsensusCommitAdminIntegrationTestBase
               ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
-
-      // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-      // it for now.
-      properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
     }
     return properties;
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminRepairTableIntegrationTestBase.java
@@ -20,10 +20,6 @@ public abstract class ConsensusCommitAdminRepairTableIntegrationTestBase
               ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
-
-      // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-      // it for now.
-      properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
     }
     return properties;
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -67,10 +67,6 @@ public abstract class ConsensusCommitIntegrationTestBase
               ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
-
-      // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-      // it for now.
-      properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
     }
     return properties;
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -93,10 +93,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + TEST_NAME);
 
-    // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable it
-    // for now.
-    properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-
     StorageFactory factory = StorageFactory.create(properties);
     admin = factory.getStorageAdmin();
     databaseConfig = new DatabaseConfig(properties);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
@@ -83,10 +83,6 @@ public abstract class TwoPhaseConsensusCommitIntegrationTestBase
         properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
-
-    // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-    // it for now.
-    properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
   }
 
   protected abstract Properties getProps1(String testName);

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -102,10 +102,6 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + TEST_NAME);
 
-    // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable it
-    // for now.
-    properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-
     return properties;
   }
 

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService.java
@@ -33,10 +33,6 @@ public class ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminS
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
-      // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-      // it for now.
-      properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-
       server = new ScalarDbServer(properties);
       server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminRepairTableIntegrationTestWithDistributedTransactionAdminService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminRepairTableIntegrationTestWithDistributedTransactionAdminService.java
@@ -27,10 +27,6 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithDistributedTransa
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
-      // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-      // it for now.
-      properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-
       server = new ScalarDbServer(properties);
       server.start();
     } else {
@@ -50,10 +46,6 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithDistributedTransa
         properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
-
-    // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-    // it for now.
-    properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
 
     return new ServerAdminTestUtils(properties);
   }

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithDistributedTransactionService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithDistributedTransactionService.java
@@ -32,10 +32,6 @@ public class ConsensusCommitIntegrationTestWithDistributedTransactionService
       properties.setProperty(
           ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
-      // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-      // it for now.
-      properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-
       server = new ScalarDbServer(properties);
       server.start();
 

--- a/server/src/integration-test/java/com/scalar/db/server/TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransactionService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransactionService.java
@@ -49,10 +49,6 @@ public class TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransaction
     properties.setProperty(
         ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
-    // Async commit can cause unexpected lazy recoveries, which can fail the tests. So we disable
-    // it for now.
-    properties.setProperty(ConsensusCommitConfig.ASYNC_COMMIT_ENABLED, "false");
-
     return properties;
   }
 


### PR DESCRIPTION
This PR reverts the async commit default value to `false` (disabled) because enabling the async commit feature can cause `UncommittedRecordException` when reading a record right after writing the record in another transaction, which can be an incompatible behavior change. After we add some optimization to avoid that behavior change to the consensus commit, we can re-enable the async commit feature by default. Please take a look.