### PR TITLE
Increase Trivy timeout

### DIFF
--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -61,7 +61,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
-          timeout: '30m'
+          timeout: '60m'
 
       - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
         if: failure()
@@ -92,7 +92,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
-          timeout: '30m'
+          timeout: '60m'
 
       - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
         if: failure()

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -61,6 +61,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
+          timeout: '30m'
 
       - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
         if: failure()
@@ -91,6 +92,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
+          timeout: '30m'
 
       - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
         if: failure()


### PR DESCRIPTION
Trivy workflow often fails these days. It seems the root cause is that `search.maven.org` API is recently unstable. https://github.com/aquasecurity/trivy/issues/3421

`--offline-scan` might be an option, but it looks to have some security trade offs.

This PR increases Trivy timeout using `--timeout` option without any negative impact.