### PR TITLE
Add RetriableTransactionException

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransaction.java
@@ -69,8 +69,8 @@ public interface DistributedTransaction extends TransactionCrudOperable {
   /**
    * Commits a transaction.
    *
-   * @throws CommitConflictException if conflicts happened. You can retry the transaction in this
-   *     case
+   * @throws CommitConflictException if conflicts happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CommitException if the operation fails
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
    */

--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -1,5 +1,6 @@
 package com.scalar.db.api;
 
+import com.scalar.db.exception.transaction.RetriableTransactionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
@@ -56,9 +57,11 @@ public interface DistributedTransactionManager {
    * Begins a new transaction.
    *
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if beginning the transaction fails
    */
-  DistributedTransaction begin() throws TransactionException;
+  DistributedTransaction begin() throws RetriableTransactionException, TransactionException;
 
   /**
    * Begins a new transaction with the specified transaction ID. It is users' responsibility to
@@ -67,17 +70,23 @@ public interface DistributedTransactionManager {
    *
    * @param txId an user-provided unique transaction ID
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if beginning the transaction fails
    */
-  DistributedTransaction begin(String txId) throws TransactionException;
+  DistributedTransaction begin(String txId)
+      throws RetriableTransactionException, TransactionException;
 
   /**
    * Starts a new transaction. This method is an alias of {@link #begin()}.
    *
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if starting the transaction fails
    */
-  default DistributedTransaction start() throws TransactionException {
+  default DistributedTransaction start()
+      throws RetriableTransactionException, TransactionException {
     return begin();
   }
 
@@ -87,9 +96,12 @@ public interface DistributedTransactionManager {
    *
    * @param txId an user-provided unique transaction ID
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if starting the transaction fails
    */
-  default DistributedTransaction start(String txId) throws TransactionException {
+  default DistributedTransaction start(String txId)
+      throws RetriableTransactionException, TransactionException {
     return begin(txId);
   }
 
@@ -184,9 +196,12 @@ public interface DistributedTransactionManager {
    * @param txId the transaction ID
    * @return {@link DistributedTransaction}
    * @throws TransactionNotFoundException if the transaction associated with the specified
-   *     transaction ID is not found
+   *     transaction ID is not found. You can retry the same transaction from the beginning in this
+   *     case
+   * @throws TransactionException if resuming the transaction fails
    */
-  DistributedTransaction resume(String txId) throws TransactionNotFoundException;
+  DistributedTransaction resume(String txId)
+      throws TransactionNotFoundException, TransactionException;
 
   /**
    * Returns the state of a given transaction.

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -18,7 +18,8 @@ public interface TransactionCrudOperable {
    *
    * @param get a {@code Get} command
    * @return an {@code Optional} with the returned result
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   Optional<Result> get(Get get) throws CrudConflictException, CrudException;
@@ -30,7 +31,8 @@ public interface TransactionCrudOperable {
    *
    * @param scan a {@code Scan} command
    * @return a list of {@link Result}
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   List<Result> scan(Scan scan) throws CrudConflictException, CrudException;
@@ -41,7 +43,8 @@ public interface TransactionCrudOperable {
    * a transaction if you want to implement conditional mutation.
    *
    * @param put a {@code Put} command
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   void put(Put put) throws CrudConflictException, CrudException;
@@ -52,7 +55,8 @@ public interface TransactionCrudOperable {
    * such conditions in a transaction if you want to implement conditional mutation.
    *
    * @param puts a list of {@code Put} commands
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   void put(List<Put> puts) throws CrudConflictException, CrudException;
@@ -63,7 +67,8 @@ public interface TransactionCrudOperable {
    * in a transaction if you want to implement conditional mutation.
    *
    * @param delete a {@code Delete} command
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   void delete(Delete delete) throws CrudConflictException, CrudException;
@@ -74,7 +79,8 @@ public interface TransactionCrudOperable {
    * conditions in a transaction if you want to implement conditional mutation.
    *
    * @param deletes a list of {@code Delete} commands
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   void delete(List<Delete> deletes) throws CrudConflictException, CrudException;
@@ -85,7 +91,8 @@ public interface TransactionCrudOperable {
    * such conditions in a transaction if you want to implement conditional mutation.
    *
    * @param mutations a list of {@code Mutation} commands
-   * @throws CrudConflictException if conflicts happened. You can retry the transaction in this case
+   * @throws CrudConflictException if a conflict happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CrudException if the operation fails
    */
   void mutate(List<? extends Mutation> mutations) throws CrudConflictException, CrudException;

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransaction.java
@@ -73,8 +73,8 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
   /**
    * Prepares a transaction.
    *
-   * @throws PreparationConflictException if conflicts happened. You can retry the transaction in
-   *     this case
+   * @throws PreparationConflictException if conflicts happened. You can retry the same transaction
+   *     from the beginning in this case
    * @throws PreparationException if the operation fails
    */
   void prepare() throws PreparationConflictException, PreparationException;
@@ -83,8 +83,8 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
    * Validates a transaction. Depending on the concurrency control algorithm, you need a validation
    * phase for a transaction.
    *
-   * @throws ValidationConflictException if conflicts happened. You can retry the transaction in
-   *     this case
+   * @throws ValidationConflictException if conflicts happened. You can retry the same transaction
+   *     from the beginning in this case
    * @throws ValidationException if the operation fails
    */
   void validate() throws ValidationConflictException, ValidationException;
@@ -92,8 +92,8 @@ public interface TwoPhaseCommitTransaction extends TransactionCrudOperable {
   /**
    * Commits a transaction.
    *
-   * @throws CommitConflictException if conflicts happened. You can retry the transaction in this
-   *     case
+   * @throws CommitConflictException if conflicts happened. You can retry the same transaction from
+   *     the beginning in this case
    * @throws CommitException if the operation fails
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
    */

--- a/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionManager.java
@@ -1,5 +1,6 @@
 package com.scalar.db.api;
 
+import com.scalar.db.exception.transaction.RetriableTransactionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
@@ -65,9 +66,11 @@ public interface TwoPhaseCommitTransactionManager {
    * Begins a new transaction. This method is assumed to be called by a coordinator process.
    *
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if beginning the transaction fails
    */
-  TwoPhaseCommitTransaction begin() throws TransactionException;
+  TwoPhaseCommitTransaction begin() throws RetriableTransactionException, TransactionException;;
 
   /**
    * Begins a new transaction with the specified transaction ID. It is users' responsibility to
@@ -76,17 +79,23 @@ public interface TwoPhaseCommitTransactionManager {
    *
    * @param txId an user-provided unique transaction ID
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if beginning the transaction fails
    */
-  TwoPhaseCommitTransaction begin(String txId) throws TransactionException;
+  TwoPhaseCommitTransaction begin(String txId)
+      throws RetriableTransactionException, TransactionException;;
 
   /**
    * Starts a new transaction. This method is an alias of {@link #begin()}.
    *
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if starting the transaction fails
    */
-  default TwoPhaseCommitTransaction start() throws TransactionException {
+  default TwoPhaseCommitTransaction start()
+      throws RetriableTransactionException, TransactionException {
     return begin();
   }
 
@@ -96,9 +105,12 @@ public interface TwoPhaseCommitTransactionManager {
    *
    * @param txId an user-provided unique transaction ID
    * @return {@link DistributedTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if starting the transaction fails
    */
-  default TwoPhaseCommitTransaction start(String txId) throws TransactionException {
+  default TwoPhaseCommitTransaction start(String txId)
+      throws RetriableTransactionException, TransactionException {
     return begin(txId);
   }
 
@@ -108,9 +120,12 @@ public interface TwoPhaseCommitTransactionManager {
    *
    * @param txId the transaction ID
    * @return {@link TwoPhaseCommitTransaction}
+   * @throws RetriableTransactionException if something retriable situation happens. You can retry
+   *     the same transaction from the beginning in this case
    * @throws TransactionException if participating the transaction fails
    */
-  TwoPhaseCommitTransaction join(String txId) throws TransactionException;
+  TwoPhaseCommitTransaction join(String txId)
+      throws RetriableTransactionException, TransactionException;
 
   /**
    * Resumes an ongoing transaction associated with the specified transaction ID.
@@ -118,9 +133,12 @@ public interface TwoPhaseCommitTransactionManager {
    * @param txId the transaction ID
    * @return {@link TwoPhaseCommitTransaction}
    * @throws TransactionNotFoundException if the transaction associated with the specified
-   *     transaction ID is not found
+   *     transaction ID is not found. You can retry the same transaction from the beginning in this
+   *     case
+   * @throws TransactionException if resuming the transaction fails
    */
-  TwoPhaseCommitTransaction resume(String txId) throws TransactionNotFoundException;
+  TwoPhaseCommitTransaction resume(String txId)
+      throws TransactionNotFoundException, TransactionException;
 
   /**
    * Returns the state of a given transaction.

--- a/core/src/main/java/com/scalar/db/exception/transaction/AbortException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/AbortException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** An exception thrown when aborting (rolling back) a transaction fails. */
 public class AbortException extends TransactionException {
 
   public AbortException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/CommitConflictException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/CommitConflictException.java
@@ -1,5 +1,9 @@
 package com.scalar.db.exception.transaction;
 
+/**
+ * An exception thrown when a transaction conflict occurs at the commit phase. You can retry the
+ * same transaction from the beginning in this case.
+ */
 public class CommitConflictException extends CommitException {
 
   public CommitConflictException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/CommitException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/CommitException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** An exception thrown when committing a transaction fails. */
 public class CommitException extends TransactionException {
 
   public CommitException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/CrudConflictException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/CrudConflictException.java
@@ -1,5 +1,9 @@
 package com.scalar.db.exception.transaction;
 
+/**
+ * An exception thrown when a transaction conflict occurs during executing a CRUD operation. You can
+ * retry the same transaction from the beginning in this case.
+ */
 public class CrudConflictException extends CrudException {
 
   public CrudConflictException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/CrudException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/CrudException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** An exception thrown when a CRUD operation in a transaction fails. */
 public class CrudException extends TransactionException {
 
   public CrudException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/PreparationConflictException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/PreparationConflictException.java
@@ -1,5 +1,9 @@
 package com.scalar.db.exception.transaction;
 
+/**
+ * An exception thrown when a transaction conflict occurs at the prepare phase. You can retry the
+ * same transaction from the beginning in this case.
+ */
 public class PreparationConflictException extends PreparationException {
 
   public PreparationConflictException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/PreparationException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/PreparationException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** An exception thrown when preparing a transaction fails. */
 public class PreparationException extends TransactionException {
 
   public PreparationException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/RetriableTransactionException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/RetriableTransactionException.java
@@ -1,0 +1,15 @@
+package com.scalar.db.exception.transaction;
+
+/**
+ * An exception thrown when something retriable situation happens. You can retry the same
+ * transaction from the beginning in this case.
+ */
+public class RetriableTransactionException extends TransactionException {
+  public RetriableTransactionException(String message) {
+    super(message);
+  }
+
+  public RetriableTransactionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/com/scalar/db/exception/transaction/RollbackException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/RollbackException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** An exception thrown when rolling back a transaction fails. */
 public class RollbackException extends TransactionException {
 
   public RollbackException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/TransactionException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/TransactionException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** Base class for all exceptions thrown by the Transaction API. */
 public class TransactionException extends Exception {
 
   public TransactionException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/TransactionNotFoundException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/TransactionNotFoundException.java
@@ -1,6 +1,10 @@
 package com.scalar.db.exception.transaction;
 
-public class TransactionNotFoundException extends TransactionException {
+/**
+ * An exception thrown when a transaction you are trying to resume is not found. You can retry the
+ * same transaction from the beginning in this case.
+ */
+public class TransactionNotFoundException extends RetriableTransactionException {
 
   public TransactionNotFoundException(String message) {
     super(message);

--- a/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
@@ -2,6 +2,7 @@ package com.scalar.db.exception.transaction;
 
 import java.util.Optional;
 
+/** An exception thrown when the transaction status of the committing transaction is unknown. */
 public class UnknownTransactionStatusException extends TransactionException {
   private Optional<String> unknownTxId = Optional.empty();
 

--- a/core/src/main/java/com/scalar/db/exception/transaction/ValidationConflictException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/ValidationConflictException.java
@@ -1,5 +1,9 @@
 package com.scalar.db.exception.transaction;
 
+/**
+ * An exception thrown when a transaction conflict occurs at the validation phase. You can retry the
+ * same transaction from the beginning in this case.
+ */
 public class ValidationConflictException extends ValidationException {
 
   public ValidationConflictException(String message) {

--- a/core/src/main/java/com/scalar/db/exception/transaction/ValidationException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/ValidationException.java
@@ -1,5 +1,6 @@
 package com.scalar.db.exception.transaction;
 
+/** An exception thrown when validating a transaction fails. */
 public class ValidationException extends TransactionException {
 
   public ValidationException(String message) {

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -7,7 +7,6 @@ import com.scalar.db.api.Isolation;
 import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.transaction.TransactionException;
-import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -124,7 +123,7 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
-  public DistributedTransaction resume(String txId) throws TransactionNotFoundException {
+  public DistributedTransaction resume(String txId) throws TransactionException {
     return manager.resume(txId);
   }
 

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -5,7 +5,6 @@ import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.TransactionException;
-import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 
@@ -81,7 +80,7 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   }
 
   @Override
-  public TwoPhaseCommitTransaction resume(String txId) throws TransactionNotFoundException {
+  public TwoPhaseCommitTransaction resume(String txId) throws TransactionException {
     return manager.resume(txId);
   }
 


### PR DESCRIPTION
This PR adds `RetriableTransactionException` which indicates that a retriable situation has occurred. And this PR makes `begin()`/`start()`/`join()` throw `RetriableTransactionException` so that we can retry a transaction if a retriable situation happens in those operations. This PR also makes some changes to the Javadoc. I'm adding inline comments for the details. Please take a look!