### PR TITLE
Run vulnerability check twice a week

### DIFF
--- a/.github/workflows/scheduled-vuln-check.yaml
+++ b/.github/workflows/scheduled-vuln-check.yaml
@@ -3,7 +3,7 @@ name: Scheduled Vulnerability Check
 on:
   schedule:
     # UTC
-    - cron: '0 20 * * *'
+    - cron: '0 20 * * MON,THU'
 
 env:
   TERM: dumb


### PR DESCRIPTION
We increased the timeout of the vulnerability check workflow to mitigate Trivy timeout issue. It's been working fine, but it might be increasing the consumption of GitHub Action execution time budget. This PR reduces the frequency of the vulnerability check.