### PR TITLE
Remove the log "mutation seems applied already"

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -118,7 +118,6 @@ public class Coordinator {
         storage.put(put);
         break;
       } catch (NoMutationException e) {
-        logger.warn("mutation seems applied already", e);
         throw new CoordinatorConflictException("mutation seems applied already.", e);
       } catch (ExecutionException e) {
         logger.warn("putting state in coordinator failed.", e);


### PR DESCRIPTION
With the changes introduced by https://github.com/scalar-labs/scalardb/pull/786 , In a 2pc scenario, after the first participant commits the transaction, the other participant who will commit will trigger this warning log message to be printed even though it is a nominal execution (cf. https://github.com/scalar-labs/scalardb/pull/786#discussion_r1063237976)
```
[main] WARN com.scalar.db.transaction.consensuscommit.Coordinator - mutation seems applied already
com.scalar.db.exception.storage.NoMutationException: no mutation was applied
	at com.scalar.db.storage.jdbc.JdbcDatabase.put(JdbcDatabase.java:111)
	at com.scalar.db.transaction.consensuscommit.Coordinator.put(Coordinator.java:118)
	at com.scalar.db.transaction.consensuscommit.Coordinator.putState(Coordinator.java:70)
	at com.scalar.db.transaction.consensuscommit.CommitHandler.commitState(CommitHandler.java:114)
	at com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommit.commit(TwoPhaseConsensusCommit.java:145)
	at com.scalar.db.common.AbstractTwoPhaseCommitTransactionManager$StateManagedTransaction.commit(AbstractTwoPhaseCommitTransactionManager.java:195)
	at com.scalar.db.common.ActiveTransactionManagedTwoPhaseCommitTransactionManager$ActiveTransaction.commit(ActiveTransactionManagedTwoPhaseCommitTransactionManager.java:144) ...
```
Seeing this log message, the user may think something is wrong, so it is wiser to remove it.