### PR TITLE
Automatically format source code with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: https://github.com/jguttman94/pre-commit-gradle
+  rev: efaf1704425cc50df91d63920e8353d9d081a622
+  hooks:
+  - id: gradle-task
+    args: [-w, -o, spotlessApply]
+    verbose: true
+

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ Here are the contributors we are especially thankful for:
 - [Toshihiro Suzuki](https://github.com/brfrn169) - created [Phoenix adapter](https://github.com/scalar-labs/scalardb-phoenix) for ScalarDB
 - [Yonezawa-T2](https://github.com/Yonezawa-T2) - reported bugs around Serializable and proposed a new Serializable strategy (now named Extra-Read)
 
+## Development
+
+### Pre-commit hook
+
+This project uses [pre-commit](https://pre-commit.com/) to automate code format and so on as much as possible. If you're interested in the development of ScalarDB, please [install pre-commit](https://pre-commit.com/#installation) and the git hook script as follows.
+
+```
+$ ls -a .pre-commit-config.yaml
+.pre-commit-config.yaml
+$ pre-commit install
+```
+
+The code formatter is automatically executed when commiting files. A commit will fail and be formatted by the formatter when any invalid code format is detected. Try to commit the change again.
+
 ## License
 ScalarDB is dual-licensed under both the Apache 2.0 License (found in the LICENSE file in the root directory) and a commercial license.
 You may select, at your option, one of the above-listed licenses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ To add a dependency using Maven:
 * [Jepsen tests](https://github.com/scalar-labs/scalar-jepsen)
 * [TLA+](https://github.com/scalar-labs/scalardb/tree/master/tla+/consensus-commit)
 
-## Contributing 
+## Contributing
 This library is mainly maintained by the Scalar Engineering Team, but of course we appreciate any help.
 
 * For asking questions, finding answers and helping other users, please go to [stackoverflow](https://stackoverflow.com/) and use [scalardb](https://stackoverflow.com/questions/tagged/scalardb) tag.
@@ -61,6 +61,20 @@ This library is mainly maintained by the Scalar Engineering Team, but of course 
 Here are the contributors we are especially thankful for:
 - [Toshihiro Suzuki](https://github.com/brfrn169) - created [Phoenix adapter](https://github.com/scalar-labs/scalardb-phoenix) for ScalarDB
 - [Yonezawa-T2](https://github.com/Yonezawa-T2) - reported bugs around Serializable and proposed a new Serializable strategy (now named Extra-Read)
+
+## Development
+
+### Pre-commit hook
+
+This project uses [pre-commit](https://pre-commit.com/) to automate code format and so on as much as possible. If you're interested in the development of ScalarDB, please [install pre-commit](https://pre-commit.com/#installation) and the git hook script as follows.
+
+```
+$ ls -a .pre-commit-config.yaml
+.pre-commit-config.yaml
+$ pre-commit install
+```
+
+The code formatter is automatically executed when commiting files. A commit will fail and be formatted by the formatter when any invalid code format is detected. Try to commit the change again.
 
 ## License
 ScalarDB is dual-licensed under both the Apache 2.0 License (found in the LICENSE file in the root directory) and a commercial license.


### PR DESCRIPTION
ScalarDB developers execute `gradlew spotlessApply` or IDE code formatter manually as a part of development. But the manual operation should be automated and documented for new contributors. This PR describes how to setup the automated operation. The drawback is every commit invokes `gradlew spotless` and it would increase the latency of commit a bit (especially for the first invocation of Gradle daemon.)