### PR TITLE
Update docs how to create a Cosmos DB for NoSQL account

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -54,12 +54,12 @@ With the options, we can set storage adapter specific configurations.
 
 Currently, we can set the following options for the storage adapters:
 
-For Cosmos DB:
+For Cosmos DB for NoSQL:
 
-| name       | value                              | default |
-|------------|------------------------------------|---------|
-| ru         | Base resource unit                 | 400     |
-| no-scaling | Disable auto-scaling for Cosmos DB | false   |
+| name       | value                                        | default |
+|------------|----------------------------------------------|---------|
+| ru         | Base resource unit                           | 400     |
+| no-scaling | Disable auto-scaling for Cosmos DB for NoSQL | false   |
 
 For DynamoDB:
 
@@ -146,7 +146,7 @@ admin.addNewColumnToTable("ns", "tbl", "c6", DataType.INT)
 
 This should be executed with significant consideration as the execution time may vary greatly
 depending on the underlying storage. Please plan accordingly especially if the database runs in production:
-- For Cosmos and Dynamo DB: this operation is almost instantaneous as the table
+- For Cosmos DB for NoSQL and DynamoDB: this operation is almost instantaneous as the table
      schema is not modified. Only the table metadata stored in a separated table are updated.
 - For Cassandra: adding a column will only update the schema metadata and do not modify existing 
   schema records. The cluster topology is the main factor for the execution time. Since the schema 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -65,10 +65,10 @@ To avoid mistakes, it is recommended to use [Cassy](https://github.com/scalar-la
 Cassy is also integrated with `scalar-admin` so it can issue a pause request to the ScalarDB application (or ScalarDB Server) of a Cassandra cluster.
 Please see [the doc](https://github.com/scalar-labs/cassy/blob/master/docs/getting-started.md#take-cluster-wide-consistent-backups) for more details.
 
-**Cosmos DB**
+**Cosmos DB for NoSQL**
 
-You must create a Cosmos DB account with a continuous backup policy enabled to use point-in-time restore (PITR) feature. Backups are created continuously after it is enabled.
-To specify a transactionally-consistent restore point, please pause the ScalarDB application of a Cosmos DB as described [here](#transactionally-consistent-backups-during-pause-duration).
+You must create a Cosmos DB for NoSQL account with a continuous backup policy enabled to use point-in-time restore (PITR) feature. Backups are created continuously after it is enabled.
+To specify a transactionally-consistent restore point, please pause the ScalarDB application of a Cosmos DB for NoSQL as described [here](#transactionally-consistent-backups-during-pause-duration).
 
 **DynamoDB**
 
@@ -96,7 +96,7 @@ You first need to stop all the nodes of a Cassandra cluster. Clean the directori
 To avoid mistakes, it is recommended to use [Cassy](https://github.com/scalar-labs/cassy).
 Please see [the doc](https://github.com/scalar-labs/cassy/blob/master/docs/getting-started.md#take-cluster-wide-consistent-backups) for more details.
 
-### Cosmos DB (restore)
+### Cosmos DB for NoSQL (restore)
 
 You can follow the [azure official guide](https://docs.microsoft.com/en-us/azure/cosmos-db/restore-account-continuous-backup#restore-account-portal). After restoring backups. change the default consistencies of the restored databases to `STRONG`
 It is recommended to use the mid-time of paused duration as a restore point as we explained earlier.

--- a/docs/design.md
+++ b/docs/design.md
@@ -62,7 +62,7 @@ Range scan is only supported for clustering-key access within the same partition
 
 ### Storage
 
-As of writing this, ScalarDB supports Cassandra and Cosmos DB as a storage implementation. More correctly for Cassandra, it supports Cassandra java-driver API. Thus Cassandra java-driver compatible storage systems, such as ScyllaDB, can potentially also be used. The storage abstraction assumes the following features/properties, which most recent distributed storages have:
+As of writing this, ScalarDB supports Cassandra and Cosmos DB for NoSQL as a storage implementation. More correctly for Cassandra, it supports Cassandra java-driver API. Thus Cassandra java-driver compatible storage systems, such as ScyllaDB, can potentially also be used. The storage abstraction assumes the following features/properties, which most recent distributed storages have:
 
 - Atomic CRUD operations (each single-record operation needs to be atomic)
 - Sequential consistency support

--- a/docs/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/getting-started-with-scalardb-on-cosmosdb.md
@@ -13,23 +13,10 @@ ScalarDB is written in Java. So the following software is required to run it.
 ## Cosmos DB for NoSQL setup
 You also need to set up a Cosmos DB for NoSQL account to get started with ScalarDB on Cosmos DB for NoSQL.
 
-This section explains how to set up [Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/introduction) with Azure portal.
-1. Select **Azure Cosmos DB** service from the services on Azure portal.
-2. Select **Add**
-3. On the **Create Azure Cosmos DB Account** page, enter the basic settings for the new **Azure Cosmos DB** account.
-    * Create new or choose the existing **Resource Group**
-    * Enter the Cosmos DB **Account Name**
-    * Choose **API** as `Core (SQL)`
-    * Choose **Location**
-    * Select **Review + create**. You can skip the **Network** and **Tags** sections.
-    * Review the account settings, and then select **Create**.
-    *  Wait some time for **Azure Cosmos DB** account creation.
- 4. Select **Go to resource** to go to the Azure Cosmos DB account page.
- 5. Select **Default consistency** from the left navigation on your Azure Cosmos DB account page.
-    * Change `Consistency Level` from `SESSION` to `STRONG`.
-    * Select **Save**
-        
-From here, we assume Oracle JDK 8 is properly installed in your local environment and the Azure Cosmos DB account is properly configured in Azure.
+1. Create Cosmos DB for NoSQL account according to the official document [Create an Azure Cosmos DB account](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-portal#create-account)
+1. Configure the **default consistency level** to **STRONG** according to the official document [Configure the default consistency level](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-manage-consistency#configure-the-default-consistency-level)
+
+From here, we assume Oracle JDK 8 is properly installed in your local environment and the Azure Cosmos DB for NoSQL account is properly configured in Azure.
 
 ## Configure ScalarDB
     

--- a/docs/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/getting-started-with-scalardb-on-cosmosdb.md
@@ -13,7 +13,7 @@ ScalarDB is written in Java. So the following software is required to run it.
 ## Cosmos DB for NoSQL setup
 You also need to set up a Cosmos DB for NoSQL account to get started with ScalarDB on Cosmos DB for NoSQL.
 
-1. Create Cosmos DB for NoSQL account according to the official document [Create an Azure Cosmos DB account](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-portal#create-account)
+1. Create a Cosmos DB for NoSQL account according to the official document [Create an Azure Cosmos DB account](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-portal#create-account)
 1. Configure the **default consistency level** to **STRONG** according to the official document [Configure the default consistency level](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-manage-consistency#configure-the-default-consistency-level)
 
 From here, we assume Oracle JDK 8 is properly installed in your local environment and the Azure Cosmos DB for NoSQL account is properly configured in Azure.

--- a/docs/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/getting-started-with-scalardb-on-cosmosdb.md
@@ -1,7 +1,7 @@
-# Getting Started with ScalarDB on Cosmos DB
+# Getting Started with ScalarDB on Cosmos DB for NoSQL
 
 ## Overview
-This document briefly explains how you can get started with ScalarDB on Cosmos DB with a simple electronic money application.
+This document briefly explains how you can get started with ScalarDB on Cosmos DB for NoSQL with a simple electronic money application.
 
 ## Install prerequisites
 
@@ -10,8 +10,8 @@ ScalarDB is written in Java. So the following software is required to run it.
 * [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
 * Other libraries used from the above are automatically installed through gradle
 
-## Cosmos DB setup
-You also need to set up a Cosmos DB account to get started with ScalarDB on Cosmos DB.
+## Cosmos DB for NoSQL setup
+You also need to set up a Cosmos DB for NoSQL account to get started with ScalarDB on Cosmos DB for NoSQL.
 
 This section explains how to set up [Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/introduction) with Azure portal.
 1. Select **Azure Cosmos DB** service from the services on Azure portal.
@@ -33,21 +33,21 @@ From here, we assume Oracle JDK 8 is properly installed in your local environmen
 
 ## Configure ScalarDB
     
-The **scalardb.properties** (getting-started/scalardb.properties) file holds the configuration for ScalarDB. You need to update `contact_points` and `password` with your Cosmos DB URI and Cosmos DB key respectively, and `storage` with `cosmos`.
+The **scalardb.properties** (getting-started/scalardb.properties) file holds the configuration for ScalarDB. You need to update `contact_points` and `password` with your Cosmos DB for NoSQL URI and Cosmos DB for NoSQL key respectively, and `storage` with `cosmos`.
     
 ```properties
-# The Cosmos DB URI
-scalar.db.contact_points=<COSMOS_DB_URI>
+# The Cosmos DB for NoSQL URI
+scalar.db.contact_points=<COSMOS_DB_FOR_NOSQL_URI>
 
-# The Cosmos DB key
-scalar.db.password=<COSMOS_DB_KEY>
+# The Cosmos DB for NoSQL key
+scalar.db.password=<COSMOS_DB_FOR_NOSQL_KEY>
 
-# Cosmos DB storage implementation
+# Cosmos DB for NoSQL storage implementation
 scalar.db.storage=cosmos
 
 # The database name for the table metadata. If not specified, the default name ("scalardb") is used
 scalar.db.cosmos.table_metadata.database=
 ```
-Note that you can use a primary key or a secondary key for `<COSMOS_DB_KEY>`.
+Note that you can use a primary key or a secondary key for `<COSMOS_DB_FOR_NOSQL_KEY>`.
 
 Please follow [Getting Started with ScalarDB](getting-started-with-scalardb.md) to run the application.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,6 @@ This document briefly explains how you can get started with ScalarDB with a simp
 
 ## Getting Started
 * [Getting Started with ScalarDB on Cassandra](getting-started-with-scalardb-on-cassandra.md)
-* [Getting Started with ScalarDB on Cosmos DB](getting-started-with-scalardb-on-cosmosdb.md)
+* [Getting Started with ScalarDB on Cosmos DB for NoSQL](getting-started-with-scalardb-on-cosmosdb.md)
 * [Getting Started with ScalarDB on DynamoDB](getting-started-with-scalardb-on-dynamodb.md)
 * [Getting Started with ScalarDB on JDBC databases](getting-started-with-scalardb-on-jdbc.md)

--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -65,7 +65,7 @@ scalar.db.contact_points=localhost
 # Port number for all the contact points. Default port number for each database is used if empty.
 #scalar.db.contact_port=
 
-# Credential information to access the database. For Cosmos DB, username isn't used. For DynamoDB, AWS_ACCESS_KEY_ID is specified by the username and AWS_ACCESS_SECRET_KEY is specified by the password.
+# Credential information to access the database. For Cosmos DB for NoSQL, username isn't used. For DynamoDB, AWS_ACCESS_KEY_ID is specified by the username and AWS_ACCESS_SECRET_KEY is specified by the password.
 scalar.db.username=cassandra
 scalar.db.password=cassandra
 

--- a/docs/scalardb-supported-databases.md
+++ b/docs/scalardb-supported-databases.md
@@ -2,7 +2,7 @@
 
 ScalarDB supports the following databases and the databases that are compatible with those databases.
 * Cassandra
-* Cosmos DB
+* Cosmos DB for NoSQL
 * DynamoDB
 * MySQL
 * PostgreSQL
@@ -13,7 +13,7 @@ ScalarDB supports the following databases and the databases that are compatible 
 
 ## Compatibility matrix
 
-| ScalarDB Version | Cassandra 3.11 | Cassandra 3.0    | Cassandra 2.2   | Cosmos DB | DynamoDB  | MySQL 8.0  | MySQL 5.7  | PostgreSQL 14 | PostgreSQL 13 | PostgreSQL 12 | Oracle 21.3.0-xe   | Oracle 18.4.0-xe | SQL Server 2022 | SQL Server 2019 | SQL Server 2017 | Amazon Aurora MySQL 3 (MySQL 8) | Amazon Aurora MySQL 2 (MySQL 5.7) |  Amazon Aurora PostgreSQL 14 |  Amazon Aurora PostgreSQL 13 | Amazon Aurora PostgreSQL 12 |
+| ScalarDB Version | Cassandra 3.11 | Cassandra 3.0    | Cassandra 2.2   | Cosmos DB for NoSQL | DynamoDB  | MySQL 8.0  | MySQL 5.7  | PostgreSQL 14 | PostgreSQL 13 | PostgreSQL 12 | Oracle 21.3.0-xe   | Oracle 18.4.0-xe | SQL Server 2022 | SQL Server 2019 | SQL Server 2017 | Amazon Aurora MySQL 3 (MySQL 8) | Amazon Aurora MySQL 2 (MySQL 5.7) |  Amazon Aurora PostgreSQL 14 |  Amazon Aurora PostgreSQL 13 | Amazon Aurora PostgreSQL 12 |
 |:------------------|:---------------|:-----------------|:----------------|:----------|:----------|:-----------|:-----------|:--------------|:--------------|:--------------|:-------------------|:-----------------|:----------------|:----------------|:----------------|:-----------------------------|:-------------------------------|:--------------------------|:--------------------------|:-------------------------|
 | ScalarDB 3.7 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | ScalarDB 3.6 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -78,7 +78,7 @@ Create/Delete schemas in the storage defined in the config file
       --ru=<ru>       Base resource unit (supported in DynamoDB, Cosmos DB)
 ```
 
-For Cosmos DB (Deprecated. Please use the command using a config file instead):
+For Cosmos DB for NoSQL (Deprecated. Please use the command using a config file instead):
 ```console
 Usage: java -jar scalardb-schema-loader-<version>.jar --cosmos [-D]
        [--no-scaling] -f=<schemaFile> -h=<uri> -p=<key> [-r=<ru>]
@@ -190,10 +190,10 @@ $ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> 
 
 For using CLI arguments fully for configuration (Deprecated. Please use the command using a config file instead):
 ```console
-# For Cosmos DB
-$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json [-r BASE_RESOURCE_UNIT]
+# For Cosmos DB for NoSQL
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_FOR_NOSQL_ACCOUNT_URI> -p <COSMOS_DB_FOR_NOSQL_KEY> -f schema.json [-r BASE_RESOURCE_UNIT]
 ```
-  - `<COSMOS_DB_KEY>` you can use a primary key or a secondary key.
+  - `<COSMOS_DB_FOR_NOSQL_KEY>` you can use a primary key or a secondary key.
   - `-r BASE_RESOURCE_UNIT` is an option. You can specify the RU of each database. The maximum RU in tables in the database will be set. If you don't specify RU of tables, the database RU will be set with this option. By default, it's 400.
 
 ```console
@@ -201,7 +201,7 @@ $ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_
 $ java -jar scalardb-schema-loader-<version>.jar --dynamo -u <AWS_ACCESS_KEY_ID> -p <AWS_ACCESS_SECRET_KEY> --region <REGION> -f schema.json [-r BASE_RESOURCE_UNIT]
 ```
   - `<REGION>` should be a string to specify an AWS region like `ap-northeast-1`.
-  - `-r` option is almost the same as Cosmos DB option. However, the unit means DynamoDB capacity unit. The read and write capacity units are set the same value.
+  - `-r` option is almost the same as Cosmos DB for NoSQL option. However, the unit means DynamoDB capacity unit. The read and write capacity units are set the same value.
 
 ```console
 # For Cassandra
@@ -233,8 +233,8 @@ For using CLI arguments fully for configuration (Deprecated. Please use the comm
 file instead):
 
 ```console
-# For Cosmos DB
-$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json --alter
+# For Cosmos DB for NoSQL
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_FOR_NOSQL_ACCOUNT_URI> -p <COSMOS_DB_FOR_NOSQL_KEY> -f schema.json --alter
 ```
 
 ```console
@@ -262,8 +262,8 @@ $ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> 
   
 For using CLI arguments fully for configuration (Deprecated. Please use the command using a config file instead):
 ```console
-# For Cosmos DB
-$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json -D
+# For Cosmos DB for NoSQL
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_FOR_NOSQL_ACCOUNT_URI> -p <COSMOS_DB_FOR_NOSQL_KEY> -f schema.json -D
 ```
 
 ```console
@@ -283,7 +283,7 @@ $ java -jar scalardb-schema-loader-<version>.jar --jdbc -j <JDBC URL> -u <USER> 
 
 ### Repair tables
 
-This command will repair the table metadata of existing tables. When using Cosmos DB, it additionally repairs stored procedure attached to each table.
+This command will repair the table metadata of existing tables. When using Cosmos DB for NoSQL, it additionally repairs stored procedure attached to each table.
 
 For using config file (Sample config file can be found [here](https://github.com/scalar-labs/scalardb/blob/master/conf/database.properties)):
 ```console
@@ -293,8 +293,8 @@ $ java -jar scalardb-schema-loader-<version>.jar --config <PATH_TO_CONFIG_FILE> 
 
 For using CLI arguments fully for configuration (Deprecated. Please use the command using a config file instead):
 ```console
-# For Cosmos DB
-$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_ACCOUNT_URI> -p <COSMOS_DB_KEY> -f schema.json --repair-all
+# For Cosmos DB for NoSQL
+$ java -jar scalardb-schema-loader-<version>.jar --cosmos -h <COSMOS_DB_FOR_NOSQL_ACCOUNT_URI> -p <COSMOS_DB_FOR_NOSQL_KEY> -f schema.json --repair-all
 ```
 
 ```console
@@ -409,35 +409,35 @@ The database/storage-specific options you can specify are as follows:
 For Cassandra:
 - `compaction-strategy`, a compaction strategy. It should be `STCS` (SizeTieredCompaction), `LCS` (LeveledCompactionStrategy) or `TWCS` (TimeWindowCompactionStrategy).
 
-For DynamoDB and Cosmos DB:
+For DynamoDB and Cosmos DB for NoSQL:
 - `ru`, a request unit. Please see [RU](#ru) for the details.
 
 ## Scaling Performance
 
 ### RU
 
-You can scale the throughput of Cosmos DB and DynamoDB by specifying `--ru` option (which applies to all the tables) or `ru` parameter for each table. The default values are `400` for Cosmos DB and `10` for DynamoDB respectively, which are set without `--ru` option.
+You can scale the throughput of Cosmos DB for NoSQL and DynamoDB by specifying `--ru` option (which applies to all the tables) or `ru` parameter for each table. The default values are `400` for Cosmos DB for NoSQL and `10` for DynamoDB respectively, which are set without `--ru` option.
 
-Note that the schema loader abstracts [Request Unit](https://docs.microsoft.com/azure/cosmos-db/request-units) of Cosmos DB and [Capacity Unit](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual) of DynamoDB with `RU`.
+Note that the schema loader abstracts [Request Unit](https://docs.microsoft.com/azure/cosmos-db/request-units) of Cosmos DB for NoSQL and [Capacity Unit](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual) of DynamoDB with `RU`.
 So, please set an appropriate value depending on the database implementations. Please also note that the schema loader sets the same value to both Read Capacity Unit and Write Capacity Unit for DynamoDB.
 
 ### Auto-scaling
 
-By default, the schema loader enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload. For example, if you specify `-r 10000`, RU of each table is scaled in or out between 1000 and 10000. Note that auto-scaling of Cosmos DB is enabled only when you set more than or equal to 4000 RU.
+By default, the schema loader enables auto-scaling of RU for all tables: RU is scaled in or out between 10% and 100% of a specified RU depending on a workload. For example, if you specify `-r 10000`, RU of each table is scaled in or out between 1000 and 10000. Note that auto-scaling of Cosmos DB for NoSQL is enabled only when you set more than or equal to 4000 RU.
 
 ## Data type mapping between ScalarDB and the other databases
 
 Here are the supported data types in ScalarDB and their mapping to the data types of other databases.
 
-| ScalarDB | Cassandra | Cosmos DB      | DynamoDB | MySQL    | PostgreSQL       | Oracle         | SQL Server      |
-|-----------|-----------|----------------|----------|----------|------------------|----------------|-----------------|
-| BOOLEAN   | boolean   | boolean (JSON) | BOOL     | boolean  | boolean          | number(1)      | bit             |
-| INT       | int       | number (JSON)  | N        | int      | int              | int            | int             |
-| BIGINT    | bigint    | number (JSON)  | N        | bigint   | bigint           | number(19)     | bigint          |
-| FLOAT     | float     | number (JSON)  | N        | double   | float            | binary_float   | float(24)       |
-| DOUBLE    | double    | number (JSON)  | N        | double   | double precision | binary_double  | float           |
-| TEXT      | text      | string (JSON)  | S        | longtext | text             | varchar2(4000) | varchar(8000)   |
-| BLOB      | blob      | string (JSON)  | B        | longblob | bytea            | RAW(2000)      | varbinary(8000) |
+| ScalarDB  | Cassandra | Cosmos DB for NoSQL | DynamoDB | MySQL    | PostgreSQL       | Oracle         | SQL Server      |
+|-----------|-----------|---------------------|----------|----------|------------------|----------------|-----------------|
+| BOOLEAN   | boolean   | boolean (JSON)      | BOOL     | boolean  | boolean          | number(1)      | bit             |
+| INT       | int       | number (JSON)       | N        | int      | int              | int            | int             |
+| BIGINT    | bigint    | number (JSON)       | N        | bigint   | bigint           | number(19)     | bigint          |
+| FLOAT     | float     | number (JSON)       | N        | double   | float            | binary_float   | float(24)       |
+| DOUBLE    | double    | number (JSON)       | N        | double   | double precision | binary_double  | float           |
+| TEXT      | text      | string (JSON)       | S        | longtext | text             | varchar2(4000) | varchar(8000)   |
+| BLOB      | blob      | string (JSON)       | B        | longblob | bytea            | RAW(2000)      | varbinary(8000) |
 
 However, the following types in JDBC databases are converted differently when they are used as a primary key or a secondary index key due to the limitations of RDB data types.
 

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -291,7 +291,7 @@ admin.addNewColumnToTable("ns", "tbl", "c6", DataType.INT)
 
 This should be executed with significant consideration as the execution time may vary greatly
 depending on the underlying storage. Please plan accordingly especially if the database runs in production:
-- For Cosmos and Dynamo DB: this operation is almost instantaneous as the table
+- For Cosmos DB for NoSQL and DynamoDB: this operation is almost instantaneous as the table
   schema is not modified. Only the table metadata stored in a separated table are updated.
 - For Cassandra: adding a column will only update the schema metadata and do not modify existing
   schema records. The cluster topology is the main factor for the execution time. Since the schema


### PR DESCRIPTION
Note: This PR depends on PR #813.

This PR updates the steps of creating/configuring the `Cosmos DB for NoSQL` account for ScalarDB in the getting started guide.
Before, the getting started guide explains concrete steps based on the Azure portal page, but there is a possibility that the UI of the portal page will be changed in the future.
So, I updated it to describe the overview of steps and add links to the official document.
This can reduce the maintenance cost of documents when the Azure portal UI is changed.

Please take a look!
