### PR TITLE
Support multiple platforms

### DIFF
--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -36,6 +36,9 @@ docker {
     dependsOn shadowJar
     name "ghcr.io/scalar-labs/scalardb-schema-loader:${project.version}"
     files tasks.shadowJar.outputs
+    buildx true
+    platform "linux/amd64,linux/arm64/v8"
+    builder "multi_platform_builder"
 }
 
 task dockerfileLint(type: Exec) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -70,6 +70,9 @@ application {
 docker {
     name "ghcr.io/scalar-labs/scalardb-server:${project.version}"
     files tasks.distTar.outputs, 'conf/log4j2.properties', 'conf/database.properties', 'docker-entrypoint.sh'
+    buildx true
+    platform "linux/amd64,linux/arm64/v8"
+    builder "multi_platform_builder"
 }
 
 task dockerfileLint(type: Exec) {


### PR DESCRIPTION
This PR changes the Gradle docker plugin configuration according to https://github.com/palantir/gradle-docker

```
buildx (optional) a boolean argument which defines whether Docker build should use buildx for cross platform builds; defaults to false
platform (optional) a list of strings argument which defines which platforms buildx should target; defaults to empty
builder (optional) a string argument which defines which builder buildx should use; defaults to null
```

TODO: we also need to revise the GitHub Action workflow to create the builder.