### PR TITLE
feat: SQLite support implementations and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,7 +345,7 @@ jobs:
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=5000&journal_mode=WAL
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000
 
       - name: Upload Gradle test reports
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,7 +345,7 @@ jobs:
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=5000&journal_mode=WAL
 
       - name: Upload Gradle test reports
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,7 +345,7 @@ jobs:
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqltie3
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3
 
       - name: Upload Gradle test reports
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -327,6 +327,33 @@ jobs:
           name: gradle_jdbc_sqlserver_integration_test_reports
           path: core/build/reports/tests/integrationTestJdbc
 
+  integration-test-for-jdbc-sqlite:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Set up SQLite3
+        run: sudo apt-get install -y sqlite3
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqltie3
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: gradle_jdbc_sqlite_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
   integration-test-for-multi-storage:
     runs-on: ubuntu-latest
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ subprojects {
         postgresqlDriverVersion = '42.5.1'
         oracleDriverVersion = '21.8.0.0'
         sqlserverDriverVersion = '11.2.2.jre8'
+        sqliteDriverVersion = '3.40.0.0'
         grpcVersion = '1.51.0'
         protobufVersion = '3.21.12'
         annotationVersion = '1.3.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,6 +97,7 @@ dependencies {
     implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
     implementation "com.oracle.database.jdbc:ojdbc8:${oracleDriverVersion}"
     implementation "com.microsoft.sqlserver:mssql-jdbc:${sqlserverDriverVersion}"
+    implementation "org.xerial:sqlite-jdbc:${sqliteDriverVersion}"
     implementation "org.apache.commons:commons-text:${commonsTextVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -1,13 +1,51 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     extends ConsensusCommitAdminIntegrationTestBase {
 
+  private static final String PROP_JDBC_URL = "scalardb.jdbc.url";
+  private static final String DEFAULT_JDBC_URL = "jdbc:mysql://localhost:3306/";
+
   @Override
   protected Properties getProps(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are
+  // different from the other adapters. So disable several tests that check such behaviors.
+
+  private boolean isSqlite() {
+    String jdbcUrl = System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL);
+    return jdbcUrl.startsWith("jdbc:sqlite:");
+  }
+
+  @Test
+  @Override
+  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
+      throws ExecutionException {
+    if (!isSqlite()) {
+      super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
+    }
+  }
+
+  @Test
+  @Override
+  public void createNamespace_ForExistingNamespace_ShouldThrowExecutionException() {
+    if (!isSqlite()) {
+      super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
+    }
+  }
+
+  @Test
+  @Override
+  public void dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException() {
+    if (!isSqlite()) {
+      super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -4,6 +4,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -26,26 +27,23 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
       throws ExecutionException {
-    if (!isSqlite()) {
-      super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
-    }
+    super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
   }
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void createNamespace_ForExistingNamespace_ShouldThrowExecutionException() {
-    if (!isSqlite()) {
-      super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
-    }
+    super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
   }
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException() {
-    if (!isSqlite()) {
-      super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
-    }
+    super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -1,12 +1,50 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.exception.storage.ExecutionException;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
+
+  private static final String PROP_JDBC_URL = "scalardb.jdbc.url";
+  private static final String DEFAULT_JDBC_URL = "jdbc:mysql://localhost:3306/";
 
   @Override
   protected Properties getProperties(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are
+  // different from the other adapters. So disable several tests that check such behaviors.
+
+  private boolean isSqlite() {
+    String jdbcUrl = System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL);
+    return jdbcUrl.startsWith("jdbc:sqlite:");
+  }
+
+  @Test
+  @Override
+  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
+      throws ExecutionException {
+    if (!isSqlite()) {
+      super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
+    }
+  }
+
+  @Test
+  @Override
+  public void createNamespace_ForExistingNamespace_ShouldThrowExecutionException() {
+    if (!isSqlite()) {
+      super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
+    }
+  }
+
+  @Test
+  @Override
+  public void dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException() {
+    if (!isSqlite()) {
+      super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
+    }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import com.scalar.db.exception.storage.ExecutionException;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
 
@@ -25,26 +26,23 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
       throws ExecutionException {
-    if (!isSqlite()) {
-      super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
-    }
+    super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
   }
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void createNamespace_ForExistingNamespace_ShouldThrowExecutionException() {
-    if (!isSqlite()) {
-      super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
-    }
+    super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
   }
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException() {
-    if (!isSqlite()) {
-      super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
-    }
+    super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -7,7 +7,6 @@ import com.scalar.db.util.AdminTestUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Properties;
 import org.apache.commons.dbcp2.BasicDataSource;
 
@@ -54,9 +53,8 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
 
   private void execute(String sql) throws SQLException {
     try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config);
-        Connection connection = dataSource.getConnection();
-        Statement stmt = connection.createStatement()) {
-      stmt.execute(sql);
+        Connection connection = dataSource.getConnection(); ) {
+      JdbcAdmin.execute(connection, sql);
     }
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -41,8 +41,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   @Override
   public void truncateMetadataTable() throws Exception {
     String truncateTableStatement =
-        "TRUNCATE TABLE "
-            + rdbEngine.encloseFullTableName(metadataSchema, JdbcAdmin.METADATA_TABLE);
+        rdbEngine.truncateTableSql(metadataSchema, JdbcAdmin.METADATA_TABLE);
     execute(truncateTableStatement);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -29,12 +29,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
     execute(
         "DROP TABLE " + rdbEngine.encloseFullTableName(metadataSchema, JdbcAdmin.METADATA_TABLE));
 
-    String dropNamespaceStatement;
-    if (rdbEngine instanceof RdbEngineOracle) {
-      dropNamespaceStatement = "DROP USER " + rdbEngine.enclose(metadataSchema);
-    } else {
-      dropNamespaceStatement = "DROP SCHEMA " + rdbEngine.enclose(metadataSchema);
-    }
+    String dropNamespaceStatement = rdbEngine.dropNamespaceSql(metadataSchema);
     execute(dropNamespaceStatement);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -6,6 +6,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class JdbcTransactionAdminIntegrationTest
     extends DistributedTransactionAdminIntegrationTestBase {
@@ -31,26 +32,23 @@ public class JdbcTransactionAdminIntegrationTest
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
       throws ExecutionException {
-    if (!isSqlite()) {
-      super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
-    }
+    super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
   }
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void createNamespace_ForExistingNamespace_ShouldThrowExecutionException() {
-    if (!isSqlite()) {
-      super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
-    }
+    super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
   }
 
   @Test
   @Override
+  @DisabledIf("isSqlite")
   public void dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException() {
-    if (!isSqlite()) {
-      super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
-    }
+    super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -2,11 +2,16 @@ package com.scalar.db.transaction.jdbc;
 
 import com.scalar.db.api.DistributedTransactionAdminIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 public class JdbcTransactionAdminIntegrationTest
     extends DistributedTransactionAdminIntegrationTestBase {
+
+  private static final String PROP_JDBC_URL = "scalardb.jdbc.url";
+  private static final String DEFAULT_JDBC_URL = "jdbc:mysql://localhost:3306/";
 
   @Override
   protected Properties getProperties(String testName) {
@@ -14,5 +19,38 @@ public class JdbcTransactionAdminIntegrationTest
     properties.putAll(JdbcEnv.getProperties(testName));
     properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
     return properties;
+  }
+
+  // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are
+  // different from the other adapters. So disable several tests that check such behaviors.
+
+  private boolean isSqlite() {
+    String jdbcUrl = System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL);
+    return jdbcUrl.startsWith("jdbc:sqlite:");
+  }
+
+  @Test
+  @Override
+  public void createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly()
+      throws ExecutionException {
+    if (!isSqlite()) {
+      super.createNamespace_ForNonExistingNamespace_ShouldCreateNamespaceProperly();
+    }
+  }
+
+  @Test
+  @Override
+  public void createNamespace_ForExistingNamespace_ShouldThrowExecutionException() {
+    if (!isSqlite()) {
+      super.createNamespace_ForExistingNamespace_ShouldThrowExecutionException();
+    }
+  }
+
+  @Test
+  @Override
+  public void dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException() {
+    if (!isSqlite()) {
+      super.dropNamespace_ForNonExistingNamespace_ShouldThrowExecutionException();
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -484,7 +484,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement preparedStatement =
             connection.prepareStatement(namespaceExistsStatement)) {
-      preparedStatement.setString(1, namespace);
+      preparedStatement.setString(1, rdbEngine.namespaceExistsPlaceholder(namespace));
       return preparedStatement.executeQuery().next();
     } catch (SQLException e) {
       throw new ExecutionException("checking if the namespace exists failed", e);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -89,7 +89,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       addTableMetadata(connection, namespace, table, metadata, true);
     } catch (SQLException e) {
       throw new ExecutionException(
-          "creating the table failed: " + getFullTableName(namespace, table), e);
+          "creating the table failed: " + rdbEngine.encloseFullTableName(namespace, table), e);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -367,7 +367,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
   @Override
   public void truncateTable(String namespace, String table) throws ExecutionException {
-    String truncateTableStatement = "TRUNCATE TABLE " + encloseFullTableName(namespace, table);
+    String truncateTableStatement = rdbEngine.truncateTableSql(namespace, table);
     try (Connection connection = dataSource.getConnection()) {
       execute(connection, truncateTableStatement);
     } catch (SQLException e) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.jdbc;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -30,7 +31,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -710,7 +710,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   }
 
   static void execute(Connection connection, String sql) throws SQLException {
-    if (StringUtils.isEmpty(sql)) {
+    if (Strings.isNullOrEmpty(sql)) {
       return;
     }
     try (Statement stmt = connection.createStatement()) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -84,6 +84,10 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   public void createTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
+    if (!rdbEngine.isValidTableName(table)) {
+      throw new ExecutionException("table name is not acceptable: " + table);
+    }
+
     try (Connection connection = dataSource.getConnection()) {
       createTableInternal(connection, namespace, table, metadata);
       createIndex(connection, namespace, table, metadata);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -709,6 +710,9 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   }
 
   static void execute(Connection connection, String sql) throws SQLException {
+    if (StringUtils.isEmpty(sql)) {
+      return;
+    }
     try (Statement stmt = connection.createStatement()) {
       stmt.execute(sql);
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -94,7 +94,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       addTableMetadata(connection, namespace, table, metadata, true);
     } catch (SQLException e) {
       throw new ExecutionException(
-          "creating the table failed: " + rdbEngine.encloseFullTableName(namespace, table), e);
+          "creating the table failed: " + getFullTableName(namespace, table), e);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
@@ -27,6 +27,8 @@ public final class RdbEngineFactory {
       return new RdbEngineOracle();
     } else if (jdbcUrl.startsWith("jdbc:sqlserver:")) {
       return new RdbEngineSqlServer();
+    } else if (jdbcUrl.startsWith("jdbc:sqlite:")) {
+      return new RdbEngineSqlite();
     } else {
       throw new IllegalArgumentException("the rdb engine is not supported: " + jdbcUrl);
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -1,0 +1,241 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.storage.jdbc.query.InsertOnConflictDoUpdateQuery;
+import com.scalar.db.storage.jdbc.query.SelectQuery;
+import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
+import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A RdnEngineStrategy implementation for SQLite.
+ *
+ * <p>Namespace: Added to table prefix like `${namespace}_${tableName}`.
+ *
+ * <p>Error handling: SQLite has limited variety of error codes compared to other JDBC databases. We
+ * need to heavily rely on error messages, which may be changed in SQLite implementation in the
+ * future. Since <a
+ * href="https://github.com/xerial/sqlite-jdbc#sqlite-jdbc-driver">xerial/sqlite-jdbc contains a
+ * native SQLite library in JAR</a>, we should assure the real error messages in
+ * RdbEngineStrategyTest.
+ */
+public class RdbEngineSqlite implements RdbEngineStrategy {
+  @Override
+  public boolean isDuplicateTableError(SQLException e) {
+    // Error code: SQLITE_ERROR (1)
+    // Message: SQL error or missing database (table XXX already exists)
+
+    return e.getErrorCode() == 1
+        && e.getMessage().contains("(table")
+        && e.getMessage().endsWith("already exists)");
+  }
+
+  @Override
+  public boolean isDuplicateKeyError(SQLException e) {
+    // Error code: SQLITE_ERROR (1)
+    // Message: SQL error or missing database (index XXX already exists)
+
+    return e.getErrorCode() == 1
+        && e.getMessage().contains("(index")
+        && e.getMessage().endsWith("already exists)");
+  }
+
+  @Override
+  public boolean isUndefinedTableError(SQLException e) {
+    // Error code: SQLITE_ERROR (1)
+    // Message: SQL error or missing database (no such table: XXX)
+
+    return e.getErrorCode() == 1 && e.getMessage().contains("no such table:");
+  }
+
+  @Override
+  public boolean isConflictError(SQLException e) {
+    // Error code: SQLITE_BUSY (5)
+    // Message: The database file is locked (database is locked)
+
+    // Error code: SQLITE_BUSY (6)
+    // Message: A table in the database is locked (database table is locked)
+
+    return e.getErrorCode() == 5 || e.getErrorCode() == 6;
+  }
+
+  @Override
+  public String getDataTypeForEngine(DataType scalarDbDataType) {
+    switch (scalarDbDataType) {
+      case BOOLEAN:
+        return "BOOLEAN";
+      case INT:
+        return "INT";
+      case BIGINT:
+        return "BIGINT";
+      case FLOAT:
+        return "FLOAT";
+      case DOUBLE:
+        return "DOUBLE";
+      case TEXT:
+        return "TEXT";
+      case BLOB:
+        return "BLOB";
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @Override
+  public String getDataTypeForKey(DataType dataType) {
+    return null;
+  }
+
+  @Override
+  public int getSqlTypes(DataType dataType) {
+    switch (dataType) {
+      case BOOLEAN:
+        return Types.BOOLEAN;
+      case INT:
+        return Types.INTEGER;
+      case BIGINT:
+        return Types.BIGINT;
+      case FLOAT:
+        return Types.FLOAT;
+      case DOUBLE:
+        return Types.DOUBLE;
+      case TEXT:
+        return Types.VARCHAR;
+      case BLOB:
+        return Types.BLOB;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @Override
+  public String getTextType(int charLength) {
+    return "TEXT";
+  }
+
+  @Override
+  public String computeBooleanValue(boolean value) {
+    return value ? "TRUE" : "FALSE";
+  }
+
+  @Override
+  public String[] createNamespaceSqls(String fullNamespace) {
+    // In SQLite storage, namespace will be added to table names as prefix along with underscore
+    // separator.
+    return new String[0];
+  }
+
+  /**
+   * @param hasDescClusteringOrder Ignored. SQLite cannot handle key order.
+   * @see <a href="https://www.sqlite.org/syntax/table-constraint.html">table-constraint</a>
+   */
+  @Override
+  public String createTableInternalPrimaryKeyClause(
+      boolean hasDescClusteringOrder, TableMetadata metadata) {
+    return "PRIMARY KEY ("
+        + Stream.concat(
+                metadata.getPartitionKeyNames().stream(), metadata.getClusteringKeyNames().stream())
+            .map(this::enclose)
+            .collect(Collectors.joining(","))
+        + "))";
+  }
+
+  @Override
+  public String[] createTableInternalSqlsAfterCreateTable(
+      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata) {
+    // do nothing
+    return new String[] {};
+  }
+
+  @Override
+  public String tryAddIfNotExistsToCreateTableSql(String createTableSql) {
+    return createTableSql.replace("CREATE TABLE", "CREATE TABLE IF NOT EXISTS");
+  }
+
+  @Override
+  public String[] createMetadataSchemaIfNotExistsSql(String metadataSchema) {
+    // Do nothing. Namespace is just a table prefix in the SQLite implementation.
+    return new String[0];
+  }
+
+  @Override
+  public boolean isCreateMetadataSchemaDuplicateSchemaError(SQLException e) {
+    // Namespace is never created
+    return false;
+  }
+
+  @Override
+  public String deleteMetadataSchemaSql(String metadataSchema) {
+    // Do nothing. Metadata schema is just a prefix to the metadata table in the SQLite
+    // implementation.
+    return null;
+  }
+
+  @Override
+  public String dropNamespaceSql(String namespace) {
+    // Do nothing. Namespace is just a table prefix in the SQLite implementation.
+    return null;
+  }
+
+  @Override
+  public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
+      throws ExecutionException {
+    throw new AssertionError("dropNamespace never happen in SQLite implementation");
+  }
+
+  @Override
+  public String namespaceExistsStatement() {
+    return "SELECT 1 FROM sqlite_master WHERE "
+        + enclose("type")
+        + " = \"table\" AND "
+        + enclose("tbl_name")
+        + " LIKE ?";
+  }
+
+  @Override
+  public String namespaceExistsPlaceholder(String namespace) {
+    return namespace + "_%";
+  }
+
+  @Override
+  public String alterColumnTypeSql(
+      String namespace, String table, String columnName, String columnType) {
+    throw new AssertionError(
+        "SQLite does not require changes in column data types when making indices.");
+  }
+
+  @Override
+  public String tableExistsInternalTableCheckSql(String fullTableName) {
+    return "SELECT 1 FROM " + fullTableName + " LIMIT 1";
+  }
+
+  @Override
+  public String dropIndexSql(String schema, String table, String indexName) {
+    return "DROP INDEX " + enclose(indexName);
+  }
+
+  @Override
+  public String enclose(String name) {
+    return "\"" + name + "\"";
+  }
+
+  @Override
+  public String encloseFullTableName(String schema, String table) {
+    return enclose(schema + "_" + table);
+  }
+
+  @Override
+  public SelectQuery buildSelectQuery(SelectQuery.Builder builder, int limit) {
+    return new SelectWithLimitQuery(builder, limit);
+  }
+
+  @Override
+  public UpsertQuery buildUpsertQuery(UpsertQuery.Builder builder) {
+    return new InsertOnConflictDoUpdateQuery(builder);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -7,6 +7,7 @@ import com.scalar.db.storage.jdbc.query.InsertOnConflictDoUpdateQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
@@ -39,6 +40,7 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
         && e.getMessage().endsWith("already exists)");
   }
 
+  @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
     // Error code: SQLITE_CONSTRAINT_PRIMARYKEY (1555)

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -121,6 +121,11 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
   }
 
   @Override
+  public boolean isValidTableName(String tableName) {
+    return !tableName.contains(NAMESPACE_SEPARATOR);
+  }
+
+  @Override
   public String computeBooleanValue(boolean value) {
     return value ? "TRUE" : "FALSE";
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -15,7 +15,7 @@ import java.util.stream.Stream;
 /**
  * A RdnEngineStrategy implementation for SQLite.
  *
- * <p>Namespace: Added to table prefix like `${namespace}_${tableName}`.
+ * <p>Namespace: Added to table prefix like `${namespace}${NAMESPACE_SEPARATOR}${tableName}`.
  *
  * <p>Error handling: SQLite has limited variety of error codes compared to other JDBC databases. We
  * need to heavily rely on error messages, which may be changed in SQLite implementation in the
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
  * RdbEngineStrategyTest.
  */
 public class RdbEngineSqlite implements RdbEngineStrategy {
+  private final String NAMESPACE_SEPARATOR = "$";
+
   @Override
   public boolean isDuplicateTableError(SQLException e) {
     // Error code: SQLITE_ERROR (1)
@@ -199,7 +201,7 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
 
   @Override
   public String namespaceExistsPlaceholder(String namespace) {
-    return namespace + "_%";
+    return namespace + NAMESPACE_SEPARATOR + "%";
   }
 
   @Override
@@ -226,7 +228,7 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
 
   @Override
   public String encloseFullTableName(String schema, String table) {
-    return enclose(schema + "_" + table);
+    return enclose(schema + NAMESPACE_SEPARATOR + table);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -190,6 +190,12 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
   }
 
   @Override
+  public String truncateTableSql(String namespace, String table) {
+    // SQLite does not support TRUNCATE TABLE statement.
+    return "DELETE FROM " + encloseFullTableName(namespace, table);
+  }
+
+  @Override
   public void dropNamespaceTranslateSQLException(SQLException e, String namespace)
       throws ExecutionException {
     throw new AssertionError("dropNamespace never happen in SQLite implementation");

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -11,6 +11,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.sqlite.SQLiteErrorCode;
+import org.sqlite.SQLiteException;
 
 /**
  * A RdnEngineStrategy implementation for SQLite.
@@ -39,12 +41,12 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
-    // Error code: SQLITE_ERROR (1)
-    // Message: SQL error or missing database (index XXX already exists)
+    // Error code: SQLITE_CONSTRAINT_PRIMARYKEY (1555)
 
-    return e.getErrorCode() == 1
-        && e.getMessage().contains("(index")
-        && e.getMessage().endsWith("already exists)");
+    // Error code: SQLITE_CONSTRAINT_UNIQUE (2067)
+
+    return ((SQLiteException) e).getResultCode() == SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY
+        || ((SQLiteException) e).getResultCode() == SQLiteErrorCode.SQLITE_CONSTRAINT_UNIQUE;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
  * RdbEngineStrategyTest.
  */
 public class RdbEngineSqlite implements RdbEngineStrategy {
-  private final String NAMESPACE_SEPARATOR = "$";
+  private static final String NAMESPACE_SEPARATOR = "$";
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -53,6 +53,10 @@ public interface RdbEngineStrategy {
 
   String dropNamespaceSql(String namespace);
 
+  default String truncateTableSql(String namespace, String table) {
+    return "TRUNCATE TABLE " + encloseFullTableName(namespace, table);
+  }
+
   void dropNamespaceTranslateSQLException(SQLException e, String namespace)
       throws ExecutionException;
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -33,6 +33,10 @@ public interface RdbEngineStrategy {
 
   String[] createNamespaceSqls(String fullNamespace);
 
+  default boolean isValidTableName(String tableName) {
+    return true;
+  }
+
   String createTableInternalPrimaryKeyClause(
       boolean hasDescClusteringOrder, TableMetadata metadata);
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -54,6 +54,10 @@ public interface RdbEngineStrategy {
 
   String namespaceExistsStatement();
 
+  default String namespaceExistsPlaceholder(String namespace) {
+    return namespace;
+  }
+
   String alterColumnTypeSql(String namespace, String table, String columnName, String columnType);
 
   String tableExistsInternalTableCheckSql(String fullTableName);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -276,6 +276,23 @@ public abstract class JdbcAdminTestBase {
   }
 
   @Test
+  public void createTable_forSqlite_withInvalidTableName_shouldThrowExecutionException()
+      throws SQLException, ExecutionException {
+    // Arrange
+    String namespace = "my_ns";
+    String table = "foo$table"; // contains namespace separator
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addPartitionKey("c1").addColumn("c1", DataType.TEXT).build();
+
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.SQLITE);
+
+    // Act
+    // Assert
+    assertThatThrownBy(() -> admin.createTable(namespace, table, metadata, new HashMap<>()))
+        .isInstanceOf(ExecutionException.class);
+  }
+
+  @Test
   public void createTable_forMysql_shouldExecuteCreateTableStatement()
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -151,7 +151,7 @@ public abstract class JdbcAdminTestBase {
         RdbEngine.SQLITE,
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+            + "$metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
   }
 
   private void getTableMetadata_forX_ShouldReturnTableMetadata(
@@ -447,12 +447,12 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.SQLITE,
-        "CREATE TABLE \"my_ns_foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns_foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns_foo_table\" (\"c1\")",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
-            + "_metadata\"("
+            + "$metadata\"("
             + "\"full_table_name\" TEXT,"
             + "\"column_name\" TEXT,"
             + "\"data_type\" TEXT NOT NULL,"
@@ -463,25 +463,25 @@ public abstract class JdbcAdminTestBase {
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,FALSE,1)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,FALSE,1)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',TRUE,2)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','ASC',TRUE,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',TRUE,3)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',TRUE,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,FALSE,4)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,FALSE,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,FALSE,5)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,FALSE,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,FALSE,6)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,FALSE,6)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,FALSE,7)");
+            + "$metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,FALSE,7)");
   }
 
   private void createTable_forX_shouldExecuteCreateTableStatement(
@@ -701,12 +701,12 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
         RdbEngine.SQLITE,
-        "CREATE TABLE \"my_ns_foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns_foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns_foo_table\" (\"c1\")",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
-            + "_metadata\"("
+            + "$metadata\"("
             + "\"full_table_name\" TEXT,"
             + "\"column_name\" TEXT,"
             + "\"data_type\" TEXT NOT NULL,"
@@ -717,25 +717,25 @@ public abstract class JdbcAdminTestBase {
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,FALSE,1)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,FALSE,1)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',TRUE,2)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c1','TEXT','CLUSTERING','DESC',TRUE,2)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',TRUE,3)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c4','BLOB','CLUSTERING','ASC',TRUE,3)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,FALSE,4)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c2','BIGINT',NULL,NULL,FALSE,4)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,FALSE,5)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c5','INT',NULL,NULL,FALSE,5)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,FALSE,6)",
+            + "$metadata\" VALUES ('my_ns.foo_table','c6','DOUBLE',NULL,NULL,FALSE,6)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,FALSE,7)");
+            + "$metadata\" VALUES ('my_ns.foo_table','c7','FLOAT',NULL,NULL,FALSE,7)");
   }
 
   private void createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
@@ -849,7 +849,7 @@ public abstract class JdbcAdminTestBase {
   public void truncateTable_forSqlite_shouldExecuteTruncateTableStatement()
       throws SQLException, ExecutionException {
     truncateTable_forX_shouldExecuteTruncateTableStatement(
-        RdbEngine.SQLITE, "TRUNCATE TABLE \"my_ns_foo_table\"");
+        RdbEngine.SQLITE, "TRUNCATE TABLE \"my_ns$foo_table\"");
   }
 
   private void truncateTable_forX_shouldExecuteTruncateTableStatement(
@@ -934,12 +934,12 @@ public abstract class JdbcAdminTestBase {
       throws Exception {
     dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
         RdbEngine.SQLITE,
-        "DROP TABLE \"my_ns_foo_table\"",
+        "DROP TABLE \"my_ns$foo_table\"",
         "DELETE FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
-        "SELECT DISTINCT \"full_table_name\" FROM \"" + tableMetadataSchemaName + "_metadata\"",
-        "DROP TABLE \"" + tableMetadataSchemaName + "_metadata\"");
+            + "$metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"" + tableMetadataSchemaName + "$metadata\"",
+        "DROP TABLE \"" + tableMetadataSchemaName + "$metadata\"");
   }
 
   private void dropTable_forXWithNoMoreMetadataAfterDeletion_shouldDropTableAndDeleteMetadata(
@@ -1043,11 +1043,11 @@ public abstract class JdbcAdminTestBase {
           throws Exception {
     dropTable_forXWithOtherMetadataAfterDeletion_ShouldDropTableAndDeleteMetadataButNotMetadataTable(
         RdbEngine.SQLITE,
-        "DROP TABLE \"my_ns_foo_table\"",
+        "DROP TABLE \"my_ns$foo_table\"",
         "DELETE FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
-        "SELECT DISTINCT \"full_table_name\" FROM \"" + tableMetadataSchemaName + "_metadata\"");
+            + "$metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+        "SELECT DISTINCT \"full_table_name\" FROM \"" + tableMetadataSchemaName + "$metadata\"");
   }
 
   private void
@@ -1176,7 +1176,7 @@ public abstract class JdbcAdminTestBase {
         RdbEngine.SQLITE,
         "SELECT DISTINCT \"full_table_name\" FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\" LIKE ?");
+            + "$metadata\" WHERE \"full_table_name\" LIKE ?");
   }
 
   private void getNamespaceTables_forX_ShouldReturnTableNames(
@@ -1247,7 +1247,7 @@ public abstract class JdbcAdminTestBase {
     namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
         RdbEngine.SQLITE,
         "SELECT 1 FROM sqlite_master WHERE \"type\" = \"table\" AND \"tbl_name\" LIKE ?",
-        "_%");
+        "$%");
   }
 
   private void namespaceExists_forXWithExistingNamespace_ShouldReturnTrue(
@@ -1342,11 +1342,11 @@ public abstract class JdbcAdminTestBase {
         RdbEngine.SQLITE,
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
-        "CREATE INDEX \"index_my_ns_my_tbl_my_column\" ON \"my_ns_my_tbl\" (\"my_column\")",
+            + "$metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+        "CREATE INDEX \"index_my_ns_my_tbl_my_column\" ON \"my_ns$my_tbl\" (\"my_column\")",
         "UPDATE \""
             + tableMetadataSchemaName
-            + "_metadata\" SET \"indexed\"=TRUE WHERE \"full_table_name\"='my_ns.my_tbl' AND \"column_name\"='my_column'");
+            + "$metadata\" SET \"indexed\"=TRUE WHERE \"full_table_name\"='my_ns.my_tbl' AND \"column_name\"='my_column'");
   }
 
   private void createIndex_ForColumnTypeWithoutRequiredAlterationForX_ShouldCreateIndexProperly(
@@ -1553,11 +1553,11 @@ public abstract class JdbcAdminTestBase {
         RdbEngine.SQLITE,
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+            + "$metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
         "DROP INDEX \"index_my_ns_my_tbl_my_column\"",
         "UPDATE \""
             + tableMetadataSchemaName
-            + "_metadata\" SET \"indexed\"=FALSE WHERE \"full_table_name\"='my_ns.my_tbl' AND \"column_name\"='my_column'");
+            + "$metadata\" SET \"indexed\"=FALSE WHERE \"full_table_name\"='my_ns.my_tbl' AND \"column_name\"='my_column'");
   }
 
   private void dropIndex_forColumnTypeWithoutRequiredAlterationForX_ShouldDropIndexProperly(
@@ -1770,14 +1770,14 @@ public abstract class JdbcAdminTestBase {
           throws SQLException, ExecutionException {
     repairTable_WithMissingMetadataTableForX_shouldCreateMetadataTableAndAddMetadataForTable(
         RdbEngine.SQLITE,
-        "SELECT 1 FROM \"my_ns_foo_table\" LIMIT 1",
-        "SELECT 1 FROM \"" + tableMetadataSchemaName + "_metadata\" LIMIT 1",
+        "SELECT 1 FROM \"my_ns$foo_table\" LIMIT 1",
+        "SELECT 1 FROM \"" + tableMetadataSchemaName + "$metadata\" LIMIT 1",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
-            + "_metadata\"(\"full_table_name\" TEXT,\"column_name\" TEXT,\"data_type\" TEXT NOT NULL,\"key_type\" TEXT,\"clustering_order\" TEXT,\"indexed\" BOOLEAN NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+            + "$metadata\"(\"full_table_name\" TEXT,\"column_name\" TEXT,\"data_type\" TEXT NOT NULL,\"key_type\" TEXT,\"clustering_order\" TEXT,\"indexed\" BOOLEAN NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,FALSE,1)");
+            + "$metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,FALSE,1)");
   }
 
   private void
@@ -1882,14 +1882,14 @@ public abstract class JdbcAdminTestBase {
       throws SQLException, ExecutionException {
     repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
         RdbEngine.SQLITE,
-        "SELECT 1 FROM \"my_ns_foo_table\" LIMIT 1",
-        "SELECT 1 FROM \"" + tableMetadataSchemaName + "_metadata\" LIMIT 1",
+        "SELECT 1 FROM \"my_ns$foo_table\" LIMIT 1",
+        "SELECT 1 FROM \"" + tableMetadataSchemaName + "$metadata\" LIMIT 1",
         "DELETE FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
+            + "$metadata\" WHERE \"full_table_name\" = 'my_ns.foo_table'",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,FALSE,1)");
+            + "$metadata\" VALUES ('my_ns.foo_table','c1','TEXT','PARTITION',NULL,FALSE,1)");
   }
 
   private void repairTable_ExistingMetadataTableForX_shouldDeleteThenAddMetadataForTable(
@@ -1959,7 +1959,7 @@ public abstract class JdbcAdminTestBase {
       repairTable_WithNonExistingTableToRepairForSqlite_shouldThrowIllegalArgumentException()
           throws SQLException {
     repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
-        RdbEngine.SQLITE, "SELECT 1 FROM \"my_ns_foo_table\" LIMIT 1");
+        RdbEngine.SQLITE, "SELECT 1 FROM \"my_ns$foo_table\" LIMIT 1");
   }
 
   private void repairTable_WithNonExistingTableToRepairForX_shouldThrowIllegalArgumentException(
@@ -2039,7 +2039,7 @@ public abstract class JdbcAdminTestBase {
         RdbEngine.SQLITE,
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
+            + "$metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC");
   }
 
   private void
@@ -2158,17 +2158,17 @@ public abstract class JdbcAdminTestBase {
         RdbEngine.SQLITE,
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
-        "ALTER TABLE \"ns_table\" ADD \"c2\" INT",
+            + "$metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
+        "ALTER TABLE \"ns$table\" ADD \"c2\" INT",
         "DELETE FROM \""
             + tableMetadataSchemaName
-            + "_metadata\" WHERE \"full_table_name\" = 'ns.table'",
+            + "$metadata\" WHERE \"full_table_name\" = 'ns.table'",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('ns.table','c1','TEXT','PARTITION',NULL,FALSE,1)",
+            + "$metadata\" VALUES ('ns.table','c1','TEXT','PARTITION',NULL,FALSE,1)",
         "INSERT INTO \""
             + tableMetadataSchemaName
-            + "_metadata\" VALUES ('ns.table','c2','INT',NULL,NULL,FALSE,2)");
+            + "$metadata\" VALUES ('ns.table','c2','INT',NULL,NULL,FALSE,2)");
   }
 
   private void addNewColumnToTable_ForX_ShouldWorkProperly(

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -866,7 +866,7 @@ public abstract class JdbcAdminTestBase {
   public void truncateTable_forSqlite_shouldExecuteTruncateTableStatement()
       throws SQLException, ExecutionException {
     truncateTable_forX_shouldExecuteTruncateTableStatement(
-        RdbEngine.SQLITE, "TRUNCATE TABLE \"my_ns$foo_table\"");
+        RdbEngine.SQLITE, "DELETE FROM \"my_ns$foo_table\"");
   }
 
   private void truncateTable_forX_shouldExecuteTruncateTableStatement(

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngine.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngine.java
@@ -9,7 +9,8 @@ public enum RdbEngine {
   MYSQL,
   POSTGRESQL,
   ORACLE,
-  SQL_SERVER;
+  SQL_SERVER,
+  SQLITE;
 
   public static RdbEngineStrategy createRdbEngineStrategy(RdbEngine rdbEngine) {
     switch (rdbEngine) {
@@ -21,6 +22,8 @@ public enum RdbEngine {
         return new RdbEngineOracle();
       case SQL_SERVER:
         return new RdbEngineSqlServer();
+      case SQLITE:
+        return new RdbEngineSqlite();
       default:
         throw new AssertionError();
     }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
@@ -1,0 +1,112 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RdbEngineSqliteTest {
+
+  private RdbEngineSqlite rdbEngine;
+
+  private Connection connection;
+  private Statement statement;
+  private File dbFile;
+
+  @BeforeEach
+  void setUp() throws SQLException, IOException {
+    dbFile = File.createTempFile(getClass().getName(), ".db");
+    connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile.getAbsolutePath());
+    statement = connection.createStatement();
+
+    rdbEngine = new RdbEngineSqlite();
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    statement.close();
+    connection.close();
+
+    boolean r = dbFile.delete();
+    assertTrue(r);
+  }
+
+  private SQLException causeSyntaxError() {
+    return (SQLException) catchThrowable(() -> statement.executeUpdate("invalid sql"));
+  }
+
+  @Test
+  void isDuplicateTableError_True() throws SQLException {
+    statement.executeUpdate("create table t (c integer)");
+
+    SQLException e =
+        (SQLException) catchThrowable(() -> statement.executeUpdate("create table t (c integer)"));
+    assertTrue(rdbEngine.isDuplicateTableError(e));
+  }
+
+  @Test
+  void isDuplicateTableError_False() {
+    assertFalse(rdbEngine.isDuplicateTableError(causeSyntaxError()));
+  }
+
+  @Test
+  void isDuplicateKeyError_True() throws SQLException {
+    statement.executeUpdate("create table t (c1 integer, c2 integer)");
+    statement.executeUpdate("create index i on t (c1)");
+
+    SQLException e =
+        (SQLException) catchThrowable(() -> statement.executeUpdate("create index i on t (c2)"));
+    assertTrue(rdbEngine.isDuplicateKeyError(e));
+  }
+
+  @Test
+  void isDuplicateKeyError_False() {
+    assertFalse(rdbEngine.isDuplicateTableError(causeSyntaxError()));
+  }
+
+  @Test
+  void isUndefinedTableError_True() {
+    SQLException e =
+        (SQLException) catchThrowable(() -> statement.executeUpdate("select 1 from t404"));
+    assertTrue(rdbEngine.isUndefinedTableError(e));
+  }
+
+  @Test
+  void isUndefinedTableError_False() {
+    assertFalse(rdbEngine.isUndefinedTableError(causeSyntaxError()));
+  }
+
+  @Test
+  void isConflictError_True_SQLITE_BUSY_WhenUpdatingBeingDeletedTableInSeparateConnection()
+      throws SQLException {
+    statement.executeUpdate("create table t (c integer)");
+    statement.executeUpdate("insert into t values (1)");
+
+    Connection connection2 = DriverManager.getConnection("jdbc:sqlite:" + dbFile.getAbsolutePath());
+    Statement statement2 = connection2.createStatement();
+
+    statement.executeUpdate("begin");
+    statement2.executeUpdate("begin");
+
+    statement.executeUpdate("delete from t where c = 1");
+
+    SQLException e =
+        (SQLException)
+            catchThrowable(() -> statement2.executeUpdate("update t set c = c + 1 where c = 1"));
+    assertTrue(rdbEngine.isConflictError(e));
+  }
+
+  @Test
+  void isConflictError_False() {
+    assertFalse(rdbEngine.isConflictError(causeSyntaxError()));
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
@@ -109,4 +109,14 @@ class RdbEngineSqliteTest {
   void isConflictError_False() {
     assertFalse(rdbEngine.isConflictError(causeSyntaxError()));
   }
+
+  @Test
+  void isValidTableName_True() {
+    assertTrue(rdbEngine.isValidTableName("a_b"));
+  }
+
+  @Test
+  void isValidTableName_False_WhenContainsNamespaceSeparator() {
+    assertFalse(rdbEngine.isValidTableName("a$b"));
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineSqliteTest.java
@@ -59,12 +59,22 @@ class RdbEngineSqliteTest {
   }
 
   @Test
-  void isDuplicateKeyError_True() throws SQLException {
-    statement.executeUpdate("create table t (c1 integer, c2 integer)");
-    statement.executeUpdate("create index i on t (c1)");
+  void isDuplicateKeyError_True_OnPrimaryKeyConstraintViolation() throws SQLException {
+    statement.executeUpdate("create table t (c1 integer, c2 integer, primary key (c1))");
+    statement.executeUpdate("insert into t values (1, 2)");
 
     SQLException e =
-        (SQLException) catchThrowable(() -> statement.executeUpdate("create index i on t (c2)"));
+        (SQLException) catchThrowable(() -> statement.executeUpdate("insert into t values (1, 3)"));
+    assertTrue(rdbEngine.isDuplicateKeyError(e));
+  }
+
+  @Test
+  void isDuplicateKeyError_True_OnUniqueConstraintViolation() throws SQLException {
+    statement.executeUpdate("create table t (c1 integer, c2 integer, unique (c1))");
+    statement.executeUpdate("insert into t values (1, 2)");
+
+    SQLException e =
+        (SQLException) catchThrowable(() -> statement.executeUpdate("insert into t values (1, 3)"));
     assertTrue(rdbEngine.isDuplicateKeyError(e));
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -276,7 +276,7 @@ public class QueryBuilderTest {
     verify(preparedStatement).setString(2, "c1StartValue");
     verify(preparedStatement).setString(3, "c1EndValue");
 
-    String expectedQuery;
+    String expectedQuery = "";
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
@@ -290,10 +290,14 @@ public class QueryBuilderTest {
                 + "ORDER BY c1 ASC,c2 DESC FETCH FIRST 10 ROWS ONLY";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "SELECT TOP 10 c1,c2 FROM n1.t1 WHERE p1=? AND c1>=? AND c1<=? "
                 + "ORDER BY c1 ASC,c2 DESC";
+        break;
+      case SQLITE:
+        expectedQuery =
+            "SELECT c1,c2 FROM \"n1_t1\" WHERE p1=? AND c1>=? AND c1<=? "
+                + "ORDER BY c1 ASC,c2 DESC LIMIT 10";
         break;
     }
     preparedStatement = mock(PreparedStatement.class);
@@ -799,7 +803,7 @@ public class QueryBuilderTest {
     RdbEngineStrategy rdbEngine = RdbEngine.createRdbEngineStrategy(rdbEngineType);
     QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);
 
-    String expectedQuery;
+    String expectedQuery = "";
     UpsertQuery query;
     PreparedStatement preparedStatement;
 
@@ -827,11 +831,15 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1,v1,v2,v3) VALUES (?,?,?,?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1) t2 ON (t1.p1=t2.p1) "
                 + "WHEN MATCHED THEN UPDATE SET v1=?,v2=?,v3=? "
                 + "WHEN NOT MATCHED THEN INSERT (p1,v1,v2,v3) VALUES (?,?,?,?);";
+        break;
+      case SQLITE:
+        expectedQuery =
+            "INSERT INTO \"n1_t1\" (p1,v1,v2,v3) VALUES (?,?,?,?) "
+                + "ON CONFLICT (p1) DO UPDATE SET v1=?,v2=?,v3=?";
         break;
     }
     query =
@@ -844,6 +852,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "v1Value");
         verify(preparedStatement).setString(3, "v2Value");
@@ -885,12 +894,16 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1,? c1) t2 "
                 + "ON (t1.p1=t2.p1 AND t1.c1=t2.c1) "
                 + "WHEN MATCHED THEN UPDATE SET v1=?,v2=?,v3=? "
                 + "WHEN NOT MATCHED THEN INSERT (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?);";
+        break;
+      case SQLITE:
+        expectedQuery =
+            "INSERT INTO \"n1_t1\" (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?) "
+                + "ON CONFLICT (p1,c1) DO UPDATE SET v1=?,v2=?,v3=?";
         break;
     }
     query =
@@ -903,6 +916,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "c1Value");
         verify(preparedStatement).setString(3, "v1Value");
@@ -949,12 +963,16 @@ public class QueryBuilderTest {
                 + "VALUES (?,?,?,?,?,?,?,?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1,? p2,? c1,? c2) t2 "
                 + "ON (t1.p1=t2.p1 AND t1.p2=t2.p2 AND t1.c1=t2.c1 AND t1.c2=t2.c2) "
                 + "WHEN MATCHED THEN UPDATE SET v1=?,v2=?,v3=?,v4=? "
                 + "WHEN NOT MATCHED THEN INSERT (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?);";
+        break;
+      case SQLITE:
+        expectedQuery =
+            "INSERT INTO \"n1_t1\" (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?) "
+                + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=?,v2=?,v3=?,v4=?";
         break;
     }
     query =
@@ -970,6 +988,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");
         verify(preparedStatement).setString(3, "c1Value");
@@ -1026,13 +1045,17 @@ public class QueryBuilderTest {
                 + "VALUES (?,?,?,?,?,?,?,?,?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1,? p2,? c1,? c2) t2 "
                 + "ON (t1.p1=t2.p1 AND t1.p2=t2.p2 AND t1.c1=t2.c1 AND t1.c2=t2.c2) "
                 + "WHEN MATCHED THEN UPDATE SET v1=?,v2=?,v3=?,v4=?,v5=? "
                 + "WHEN NOT MATCHED THEN INSERT (p1,p2,c1,c2,v1,v2,v3,v4,v5) "
                 + "VALUES (?,?,?,?,?,?,?,?,?);";
+        break;
+      case SQLITE:
+        expectedQuery =
+            "INSERT INTO \"n1_t1\" (p1,p2,c1,c2,v1,v2,v3,v4,v5) VALUES (?,?,?,?,?,?,?,?,?) "
+                + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=?,v2=?,v3=?,v4=?,v5=?";
         break;
     }
     query =
@@ -1048,6 +1071,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");
         verify(preparedStatement).setString(3, "c1Value");
@@ -1093,7 +1117,7 @@ public class QueryBuilderTest {
     RdbEngineStrategy rdbEngine = RdbEngine.createRdbEngineStrategy(rdbEngineType);
     QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);
 
-    String expectedQuery;
+    String expectedQuery = "";
     UpsertQuery query;
     PreparedStatement preparedStatement;
 
@@ -1111,10 +1135,12 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1) VALUES (?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1) t2 ON (t1.p1=t2.p1) "
                 + "WHEN NOT MATCHED THEN INSERT (p1) VALUES (?);";
+        break;
+      case SQLITE:
+        expectedQuery = "INSERT INTO \"n1_t1\" (p1) VALUES (?) ON CONFLICT (p1) DO NOTHING";
         break;
     }
     query =
@@ -1127,6 +1153,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         break;
       case ORACLE:
@@ -1151,11 +1178,13 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1,c1) VALUES (?,?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1,? c1) t2 "
                 + "ON (t1.p1=t2.p1 AND t1.c1=t2.c1) "
                 + "WHEN NOT MATCHED THEN INSERT (p1,c1) VALUES (?,?);";
+        break;
+      case SQLITE:
+        expectedQuery = "INSERT INTO \"n1_t1\" (p1,c1) VALUES (?,?) ON CONFLICT (p1,c1) DO NOTHING";
         break;
     }
     query =
@@ -1171,6 +1200,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "c1Value");
         break;
@@ -1200,11 +1230,15 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1,p2,c1,c2) VALUES (?,?,?,?)";
         break;
       case SQL_SERVER:
-      default:
         expectedQuery =
             "MERGE n1.t1 t1 USING (SELECT ? p1,? p2,? c1,? c2) t2 "
                 + "ON (t1.p1=t2.p1 AND t1.p2=t2.p2 AND t1.c1=t2.c1 AND t1.c2=t2.c2) "
                 + "WHEN NOT MATCHED THEN INSERT (p1,p2,c1,c2) VALUES (?,?,?,?);";
+        break;
+      case SQLITE:
+        expectedQuery =
+            "INSERT INTO \"n1_t1\" (p1,p2,c1,c2) VALUES (?,?,?,?) "
+                + "ON CONFLICT (p1,p2,c1,c2) DO NOTHING";
         break;
     }
     query =
@@ -1220,6 +1254,7 @@ public class QueryBuilderTest {
     switch (rdbEngineType) {
       case MYSQL:
       case POSTGRESQL:
+      case SQLITE:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");
         verify(preparedStatement).setString(3, "c1Value");
@@ -1240,7 +1275,7 @@ public class QueryBuilderTest {
   }
 
   private String encloseSql(String sql, RdbEngineStrategy rdbEngine) {
-    return sql.replace("n1.t1", rdbEngine.enclose("n1") + "." + rdbEngine.enclose("t1"))
+    return sql.replace("n1.t1", rdbEngine.encloseFullTableName("n1", "t1"))
         .replace("p1", rdbEngine.enclose("p1"))
         .replace("p2", rdbEngine.enclose("p2"))
         .replace("c1", rdbEngine.enclose("c1"))

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -296,7 +296,7 @@ public class QueryBuilderTest {
         break;
       case SQLITE:
         expectedQuery =
-            "SELECT c1,c2 FROM \"n1_t1\" WHERE p1=? AND c1>=? AND c1<=? "
+            "SELECT c1,c2 FROM \"n1$t1\" WHERE p1=? AND c1>=? AND c1<=? "
                 + "ORDER BY c1 ASC,c2 DESC LIMIT 10";
         break;
     }
@@ -838,7 +838,7 @@ public class QueryBuilderTest {
         break;
       case SQLITE:
         expectedQuery =
-            "INSERT INTO \"n1_t1\" (p1,v1,v2,v3) VALUES (?,?,?,?) "
+            "INSERT INTO \"n1$t1\" (p1,v1,v2,v3) VALUES (?,?,?,?) "
                 + "ON CONFLICT (p1) DO UPDATE SET v1=?,v2=?,v3=?";
         break;
     }
@@ -902,7 +902,7 @@ public class QueryBuilderTest {
         break;
       case SQLITE:
         expectedQuery =
-            "INSERT INTO \"n1_t1\" (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?) "
+            "INSERT INTO \"n1$t1\" (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?) "
                 + "ON CONFLICT (p1,c1) DO UPDATE SET v1=?,v2=?,v3=?";
         break;
     }
@@ -971,7 +971,7 @@ public class QueryBuilderTest {
         break;
       case SQLITE:
         expectedQuery =
-            "INSERT INTO \"n1_t1\" (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?) "
+            "INSERT INTO \"n1$t1\" (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?) "
                 + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=?,v2=?,v3=?,v4=?";
         break;
     }
@@ -1054,7 +1054,7 @@ public class QueryBuilderTest {
         break;
       case SQLITE:
         expectedQuery =
-            "INSERT INTO \"n1_t1\" (p1,p2,c1,c2,v1,v2,v3,v4,v5) VALUES (?,?,?,?,?,?,?,?,?) "
+            "INSERT INTO \"n1$t1\" (p1,p2,c1,c2,v1,v2,v3,v4,v5) VALUES (?,?,?,?,?,?,?,?,?) "
                 + "ON CONFLICT (p1,p2,c1,c2) DO UPDATE SET v1=?,v2=?,v3=?,v4=?,v5=?";
         break;
     }
@@ -1140,7 +1140,7 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1) VALUES (?);";
         break;
       case SQLITE:
-        expectedQuery = "INSERT INTO \"n1_t1\" (p1) VALUES (?) ON CONFLICT (p1) DO NOTHING";
+        expectedQuery = "INSERT INTO \"n1$t1\" (p1) VALUES (?) ON CONFLICT (p1) DO NOTHING";
         break;
     }
     query =
@@ -1184,7 +1184,7 @@ public class QueryBuilderTest {
                 + "WHEN NOT MATCHED THEN INSERT (p1,c1) VALUES (?,?);";
         break;
       case SQLITE:
-        expectedQuery = "INSERT INTO \"n1_t1\" (p1,c1) VALUES (?,?) ON CONFLICT (p1,c1) DO NOTHING";
+        expectedQuery = "INSERT INTO \"n1$t1\" (p1,c1) VALUES (?,?) ON CONFLICT (p1,c1) DO NOTHING";
         break;
     }
     query =
@@ -1237,7 +1237,7 @@ public class QueryBuilderTest {
         break;
       case SQLITE:
         expectedQuery =
-            "INSERT INTO \"n1_t1\" (p1,p2,c1,c2) VALUES (?,?,?,?) "
+            "INSERT INTO \"n1$t1\" (p1,p2,c1,c2) VALUES (?,?,?,?) "
                 + "ON CONFLICT (p1,p2,c1,c2) DO NOTHING";
         break;
     }


### PR DESCRIPTION
PR to #762 

I intend to finish all the implementations and automated tests to support SQLite.
I mean, after this PR is merged to `feat/jdbc-sqlite` branch, #762 can be merged to master.

If I miss anything, please let me know.

- ~~@brfrn169 [requested to add integration tests](https://github.com/scalar-labs/scalardb/pull/819#pullrequestreview-1300899804). I will do it in another PR.~~ -> TODO in this PR
- @feeblefakie [requested to add doc comments in RdbEngineStrategy](https://github.com/scalar-labs/scalardb/pull/819#discussion_r1111946857)

## Manual testing

I conducted the following manual tests.

1. Modified `core/build.gradle` to create a shadow JAR: <https://github.com/scalar-labs/scalardb/pull/816/files#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0>
2. Modified `docs/getting-started/` like <https://github.com/scalar-labs/scalardb/pull/816/files#diff-4bc33c2a620f18071ca55c5c91db323fa1e526f59b3a929570339d1083e32d7f>
3. Run the following commands:

    ```console
    cd docs/getting-started

    java -jar ../../schema-loader/build/libs/scalardb-schema-loader-4.0.0-SNAPSHOT.jar --config scalardb-sqlite.properties --schema-file emoney.json --coordinator

    ./gradlew run --args="-config scalardb-sqlite.properties -action charge -amount 100 -to user1"

    ./gradlew run --args="-config scalardb-sqlite.properties -action getBalance -id user1"
    -> The balance for user1 is 100

    sqlite3 sample.db 'select * from emoney$account;'
    -> user1|100|f758bab8-ab57-4cae-97c7-e302271aaa9e|3|1|1676373645114|1676373645134||||||
    ```