### PR TITLE
Fix CVE-2023-0286

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.10
+FROM ghcr.io/scalar-labs/jre8:1.1.11
 
 COPY scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,7 @@ RUN set -x && \
     wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" && \
     chmod +x grpc_health_probe
 
-FROM ghcr.io/scalar-labs/jre8:1.1.10
+FROM ghcr.io/scalar-labs/jre8:1.1.11
 
 COPY --from=tools grpc_health_probe /usr/local/bin/
 


### PR DESCRIPTION
This fixes the CVE-2023-0286 by updating the internal JRE8 version to 1.1.11
I confirmed the vulnerability check is passing with https://github.com/scalar-labs/scalardb/actions/runs/4199712570