### PR TITLE
Replace usage of gradle by gradle wrapper in Github workflows

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -33,14 +33,14 @@ jobs:
       - name: Set version
         id: version
         run: |
-          VERSION=$(gradle :core:properties -q | grep "version:" | awk '{print $2}')
+          VERSION=$(./gradlew :core:properties -q | grep "version:" | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Upload SNAPSHOT versions for scalardb, scalardb-server, scalardb-rpc, scalardb-schema-loader, and scalardb-integration-test to Maven Snapshot Repository
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: |
           echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > ~/.gradle/secring.gpg
-          gradle publish \
+          ./gradlew publish \
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
           -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
           -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
           registries: ${{ secrets.AWS_MARKETPLACE_ECR_ID }}
 
       - name: Create containers
-        run: gradle docker
+        run: ./gradlew docker
 
       - name: Push containers
         run: |
@@ -98,7 +98,7 @@ jobs:
       - name: Upload scalardb, scalardb-server, scalardb-rpc, scalardb-schema-loader, and scalardb-integration-test to Maven Central Repository
         run: |
           echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > ~/.gradle/secring.gpg
-          gradle publish \
+          ./gradlew publish \
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
           -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
           -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
@@ -117,7 +117,7 @@ jobs:
           prerelease: false
 
       - name: Build scalardb-server zip
-        run: gradle :server:distZip
+        run: ./gradlew :server:distZip
 
       - name: Upload scalardb-server zip
         uses: actions/upload-release-asset@v1
@@ -130,7 +130,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Build scalardb-schema-loader jar
-        run: gradle :schema-loader:shadowJar
+        run: ./gradlew :schema-loader:shadowJar
 
       - name: Upload scalardb-schema-loader jar
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -13,6 +13,7 @@ on:
         required: true
       SLACK_SECURITY_WEBHOOK_URL:
         required: true
+  pull_request:
 
 env:
   TERM: dumb
@@ -49,7 +50,9 @@ jobs:
         if: always()
         id: version
         run: |
-          VERSION=$(gradle :core:properties -q | grep "version:" | awk '{print $2}')
+          gradle -v
+          ./gradlew -v
+          VERSION=$(./gradlew :core:properties -q | grep "version:" | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner for ScalarDB Server
@@ -63,25 +66,25 @@ jobs:
           severity: 'CRITICAL,HIGH'
           timeout: '60m'
 
-      - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
-        if: failure()
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Server on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#      - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
+#        if: failure()
+#        uses: slackapi/slack-github-action@v1.23.0
+#        with:
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Server on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Run Trivy vulnerability scanner for ScalarDB Schema Loader
         if: always()
@@ -94,23 +97,23 @@ jobs:
           severity: 'CRITICAL,HIGH'
           timeout: '60m'
 
-      - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
-        if: failure()
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Schema Loader on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#      - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
+#        if: failure()
+#        uses: slackapi/slack-github-action@v1.23.0
+#        with:
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Schema Loader on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
+#                  }
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -13,7 +13,6 @@ on:
         required: true
       SLACK_SECURITY_WEBHOOK_URL:
         required: true
-  pull_request:
 
 env:
   TERM: dumb
@@ -50,8 +49,6 @@ jobs:
         if: always()
         id: version
         run: |
-          gradle -v
-          ./gradlew -v
           VERSION=$(./gradlew :core:properties -q | grep "version:" | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -66,25 +63,25 @@ jobs:
           severity: 'CRITICAL,HIGH'
           timeout: '60m'
 
-#      - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
-#        if: failure()
-#        uses: slackapi/slack-github-action@v1.23.0
-#        with:
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Server on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Server on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Run Trivy vulnerability scanner for ScalarDB Schema Loader
         if: always()
@@ -97,23 +94,23 @@ jobs:
           severity: 'CRITICAL,HIGH'
           timeout: '60m'
 
-#      - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
-#        if: failure()
-#        uses: slackapi/slack-github-action@v1.23.0
-#        with:
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Schema Loader on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
-#                  }
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Schema Loader on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ inputs.target-ref }}`"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 


### PR DESCRIPTION
**Problem** 
All vulnerability checks actions are failing because the "set-version" step of the `vuln-check` workflow fails. 

**Root cause**
This step is using gradle that comes preinstalled with the workflow image. Lately, the pre-installed gradle version was updated to gradle 8 which does not seem compatible with  the `com.palantir.docker` plugin.
![image](https://user-images.githubusercontent.com/3835021/220491543-dac16db1-5267-478a-8397-96550c5db1d0.png)

**Fix**
Use the project `./gradlew` instead of `gradle` which will use gradle 7 in the `vuln-check` WF as well in all other WF as a preemptive measure.

**Validation**
I confirmed the step is working properly with `./gradlew`  on this commit https://github.com/scalar-labs/scalardb/pull/822/commits/3a34f7b128d5ae44f5ebac8eda5d6599fb996555. 
You can see the full `vuln-check` workflow run for this commit here : https://github.com/scalar-labs/scalardb/actions/runs/4238143702/jobs/7364890062
![image](https://user-images.githubusercontent.com/3835021/220490569-1233e41d-65f1-413d-98f8-86b500d9cc00.png)
