### PR TITLE
Make namespace optional on operation builder

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DeleteBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/DeleteBuilder.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
 import com.scalar.db.api.OperationBuilder.ClearCondition;
+import com.scalar.db.api.OperationBuilder.ClearNamespace;
 import com.scalar.db.api.OperationBuilder.ClusteringKey;
 import com.scalar.db.api.OperationBuilder.Condition;
 import com.scalar.db.api.OperationBuilder.Consistency;
@@ -14,7 +15,8 @@ import javax.annotation.Nullable;
 
 public class DeleteBuilder {
 
-  public static class Namespace implements OperationBuilder.Namespace<Table> {
+  public static class Namespace
+      implements OperationBuilder.Namespace<Table>, OperationBuilder.Table<PartitionKey> {
 
     Namespace() {}
 
@@ -22,6 +24,12 @@ public class DeleteBuilder {
     public Table namespace(String namespaceName) {
       checkNotNull(namespaceName);
       return new Table(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(null, tableName);
     }
   }
 
@@ -40,7 +48,7 @@ public class DeleteBuilder {
 
   public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
 
-    private PartitionKey(String namespace, String table) {
+    private PartitionKey(@Nullable String namespace, String table) {
       super(namespace, table);
     }
 
@@ -57,7 +65,7 @@ public class DeleteBuilder {
     @Nullable com.scalar.db.api.Consistency consistency;
     @Nullable MutationCondition condition;
 
-    private Buildable(String namespace, String table, Key partitionKey) {
+    private Buildable(@Nullable String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
     }
 
@@ -102,7 +110,8 @@ public class DeleteBuilder {
           OperationBuilder.Table<BuildableFromExisting>,
           OperationBuilder.PartitionKey<BuildableFromExisting>,
           ClearCondition<BuildableFromExisting>,
-          ClearClusteringKey<BuildableFromExisting> {
+          ClearClusteringKey<BuildableFromExisting>,
+          ClearNamespace<BuildableFromExisting> {
 
     BuildableFromExisting(Delete delete) {
       super(
@@ -163,6 +172,12 @@ public class DeleteBuilder {
     @Override
     public BuildableFromExisting clearClusteringKey() {
       this.clusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearNamespace() {
+      this.namespaceName = null;
       return this;
     }
   }

--- a/core/src/main/java/com/scalar/db/api/GetBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/GetBuilder.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.OperationBuilder.Buildable;
 import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
+import com.scalar.db.api.OperationBuilder.ClearNamespace;
 import com.scalar.db.api.OperationBuilder.ClearProjections;
 import com.scalar.db.api.OperationBuilder.ClusteringKey;
 import com.scalar.db.api.OperationBuilder.Consistency;
@@ -21,7 +22,8 @@ import javax.annotation.Nullable;
 
 public class GetBuilder {
 
-  public static class Namespace implements OperationBuilder.Namespace<Table> {
+  public static class Namespace
+      implements OperationBuilder.Namespace<Table>, OperationBuilder.Table<PartitionKeyOrIndexKey> {
 
     Namespace() {}
 
@@ -29,6 +31,12 @@ public class GetBuilder {
     public Table namespace(String namespaceName) {
       checkNotNull(namespaceName);
       return new Table(namespaceName);
+    }
+
+    @Override
+    public PartitionKeyOrIndexKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKeyOrIndexKey(null, tableName);
     }
   }
 
@@ -48,7 +56,7 @@ public class GetBuilder {
   public static class PartitionKeyOrIndexKey extends PartitionKeyBuilder<BuildableGet>
       implements IndexKey<BuildableGetWithIndex> {
 
-    private PartitionKeyOrIndexKey(String namespace, String table) {
+    private PartitionKeyOrIndexKey(@Nullable String namespace, String table) {
       super(namespace, table);
     }
 
@@ -70,7 +78,7 @@ public class GetBuilder {
     @Nullable Key clusteringKey;
     @Nullable com.scalar.db.api.Consistency consistency;
 
-    private BuildableGet(String namespace, String table, Key partitionKey) {
+    private BuildableGet(@Nullable String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
     }
 
@@ -123,13 +131,13 @@ public class GetBuilder {
 
   public static class BuildableGetWithIndex
       implements Consistency<BuildableGetWithIndex>, Projection<BuildableGetWithIndex> {
-    private final String namespaceName;
+    @Nullable private final String namespaceName;
     private final String tableName;
     private final Key indexKey;
     private final List<String> projections = new ArrayList<>();
     @Nullable private com.scalar.db.api.Consistency consistency;
 
-    private BuildableGetWithIndex(String namespace, String table, Key indexKey) {
+    private BuildableGetWithIndex(@Nullable String namespace, String table, Key indexKey) {
       namespaceName = namespace;
       tableName = table;
       this.indexKey = indexKey;
@@ -180,7 +188,8 @@ public class GetBuilder {
           PartitionKey<BuildableGetOrGetWithIndexFromExisting>,
           IndexKey<BuildableGetOrGetWithIndexFromExisting>,
           ClearProjections<BuildableGetOrGetWithIndexFromExisting>,
-          ClearClusteringKey<BuildableGetOrGetWithIndexFromExisting> {
+          ClearClusteringKey<BuildableGetOrGetWithIndexFromExisting>,
+          ClearNamespace<BuildableGetOrGetWithIndexFromExisting> {
 
     private Key indexKey;
     private final boolean isGetWithIndex;
@@ -268,6 +277,12 @@ public class GetBuilder {
     public BuildableGetOrGetWithIndexFromExisting clearClusteringKey() {
       checkNotGetWithIndex();
       this.clusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableGetOrGetWithIndexFromExisting clearNamespace() {
+      this.namespaceName = null;
       return this;
     }
 

--- a/core/src/main/java/com/scalar/db/api/OperationBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/OperationBuilder.java
@@ -21,6 +21,15 @@ class OperationBuilder {
     T namespace(String namespaceName);
   }
 
+  interface ClearNamespace<T> {
+    /**
+     * Removes the namespace
+     *
+     * @return the operation builder
+     */
+    T clearNamespace();
+  }
+
   interface Table<T> {
     /**
      * Sets the specified target table for this operation
@@ -402,21 +411,21 @@ class OperationBuilder {
   }
 
   abstract static class PartitionKeyBuilder<T> implements PartitionKey<T> {
-    final String namespaceName;
+    @Nullable final String namespaceName;
     final String tableName;
 
-    public PartitionKeyBuilder(String namespaceName, String tableName) {
+    public PartitionKeyBuilder(@Nullable String namespaceName, String tableName) {
       this.namespaceName = namespaceName;
       this.tableName = tableName;
     }
   }
 
   abstract static class Buildable<T> {
-    String namespaceName;
+    @Nullable String namespaceName;
     String tableName;
     Key partitionKey;
 
-    public Buildable(String namespaceName, String tableName, Key partitionKey) {
+    public Buildable(@Nullable String namespaceName, String tableName, Key partitionKey) {
       this.namespaceName = namespaceName;
       this.tableName = tableName;
       this.partitionKey = partitionKey;

--- a/core/src/main/java/com/scalar/db/api/PutBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/PutBuilder.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
 import com.scalar.db.api.OperationBuilder.ClearCondition;
+import com.scalar.db.api.OperationBuilder.ClearNamespace;
 import com.scalar.db.api.OperationBuilder.ClearValues;
 import com.scalar.db.api.OperationBuilder.ClusteringKey;
 import com.scalar.db.api.OperationBuilder.Condition;
@@ -27,7 +28,8 @@ import javax.annotation.Nullable;
 
 public class PutBuilder {
 
-  public static class Namespace implements OperationBuilder.Namespace<Table> {
+  public static class Namespace
+      implements OperationBuilder.Namespace<Table>, OperationBuilder.Table<PartitionKey> {
 
     Namespace() {}
 
@@ -35,6 +37,12 @@ public class PutBuilder {
     public Table namespace(String namespaceName) {
       checkNotNull(namespaceName);
       return new Table(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(null, tableName);
     }
   }
 
@@ -53,7 +61,7 @@ public class PutBuilder {
 
   public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
 
-    private PartitionKey(String namespaceName, String tableName) {
+    private PartitionKey(@Nullable String namespaceName, String tableName) {
       super(namespaceName, tableName);
     }
 
@@ -74,7 +82,7 @@ public class PutBuilder {
     @Nullable com.scalar.db.api.Consistency consistency;
     @Nullable MutationCondition condition;
 
-    private Buildable(String namespace, String table, Key partitionKey) {
+    private Buildable(@Nullable String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
     }
 
@@ -220,7 +228,8 @@ public class PutBuilder {
           OperationBuilder.PartitionKey<BuildableFromExisting>,
           ClearClusteringKey<BuildableFromExisting>,
           ClearValues<BuildableFromExisting>,
-          ClearCondition<BuildableFromExisting> {
+          ClearCondition<BuildableFromExisting>,
+          ClearNamespace<BuildableFromExisting> {
 
     BuildableFromExisting(Put put) {
       super(put.forNamespace().orElse(null), put.forTable().orElse(null), put.getPartitionKey());
@@ -374,6 +383,12 @@ public class PutBuilder {
     @Override
     public BuildableFromExisting clearCondition() {
       this.condition = null;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearNamespace() {
+      this.namespaceName = null;
       return this;
     }
   }

--- a/core/src/test/java/com/scalar/db/api/DeleteBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/DeleteBuilderTest.java
@@ -29,16 +29,10 @@ public class DeleteBuilderTest {
   @Test
   public void build_WithMandatoryParameters_ShouldBuildDeleteWithMandatoryParameters() {
     // Arrange Act
-    Delete actual =
-        Delete.newBuilder()
-            .namespace(NAMESPACE_1)
-            .table(TABLE_1)
-            .partitionKey(partitionKey1)
-            .build();
+    Delete actual = Delete.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual)
-        .isEqualTo(new Delete(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(actual).isEqualTo(new Delete(partitionKey1).forTable(TABLE_1));
   }
 
   @Test
@@ -158,5 +152,18 @@ public class DeleteBuilderTest {
     // Assert
     assertThat(newDelete)
         .isEqualTo(new Delete(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void build_FromExistingAndClearNamespace_ShouldBuildDeleteWithoutNamespace() {
+    // Arrange
+    Delete existingDelete =
+        new Delete(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act
+    Delete newDelete = Delete.newBuilder(existingDelete).clearNamespace().build();
+
+    // Assert
+    assertThat(newDelete).isEqualTo(new Delete(partitionKey1, clusteringKey1).forTable(TABLE_1));
   }
 }

--- a/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/GetBuilderTest.java
@@ -31,12 +31,10 @@ public class GetBuilderTest {
   @Test
   public void buildGet_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
     // Arrange Act
-    Get actual =
-        Get.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).partitionKey(partitionKey1).build();
+    Get actual = Get.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual)
-        .isEqualTo(new Get(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(actual).isEqualTo(new Get(partitionKey1).forTable(TABLE_1));
   }
 
   @Test
@@ -162,11 +160,10 @@ public class GetBuilderTest {
   @Test
   public void buildGetWithIndex_WithMandatoryParameters_ShouldBuildGetWithMandatoryParameters() {
     // Arrange Act
-    Get actual = Get.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).indexKey(indexKey1).build();
+    Get actual = Get.newBuilder().table(TABLE_1).indexKey(indexKey1).build();
 
     // Assert
-    assertThat(actual)
-        .isEqualTo(new GetWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(actual).isEqualTo(new GetWithIndex(indexKey1).forTable(TABLE_1));
   }
 
   @Test
@@ -259,5 +256,49 @@ public class GetBuilderTest {
         .isInstanceOf(UnsupportedOperationException.class);
     assertThatThrownBy(() -> Get.newBuilder(existingGet).clearClusteringKey())
         .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void buildGet_FromExistingAndClearNamespace_ShouldBuildGetWithoutNamespace() {
+    // Arrange
+    Get existingGet =
+        new Get(indexKey1)
+            .forNamespace(NAMESPACE_1)
+            .forTable(TABLE_1)
+            .withProjections(Arrays.asList("c1", "c2"))
+            .withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    Get newGet = Get.newBuilder(existingGet).clearNamespace().build();
+
+    // Assert
+    assertThat(newGet)
+        .isEqualTo(
+            new Get(indexKey1)
+                .forTable(TABLE_1)
+                .withProjections(Arrays.asList("c1", "c2"))
+                .withConsistency(Consistency.LINEARIZABLE));
+  }
+
+  @Test
+  public void buildGetWithIndex_FromExistingAndClearNamespace_ShouldBuildGetWithoutNamespace() {
+    // Arrange
+    GetWithIndex existingGet =
+        new GetWithIndex(indexKey1)
+            .forNamespace(NAMESPACE_1)
+            .forTable(TABLE_1)
+            .withProjections(Arrays.asList("c1", "c2"))
+            .withConsistency(Consistency.LINEARIZABLE);
+
+    // Act
+    Get newGet = Get.newBuilder(existingGet).clearNamespace().build();
+
+    // Assert
+    assertThat(newGet)
+        .isEqualTo(
+            new GetWithIndex(indexKey1)
+                .forTable(TABLE_1)
+                .withProjections(Arrays.asList("c1", "c2"))
+                .withConsistency(Consistency.LINEARIZABLE));
   }
 }

--- a/core/src/test/java/com/scalar/db/api/PutBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutBuilderTest.java
@@ -33,12 +33,10 @@ public class PutBuilderTest {
   @Test
   public void build_WithMandatoryParameters_ShouldBuildPutWithMandatoryParameters() {
     // Arrange Act
-    Put actual =
-        Put.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).partitionKey(partitionKey1).build();
+    Put actual = Put.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual)
-        .isEqualTo(new Put(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(actual).isEqualTo(new Put(partitionKey1).forTable(TABLE_1));
   }
 
   @Test
@@ -320,5 +318,18 @@ public class PutBuilderTest {
     // Assert
     assertThat(newPut)
         .isEqualTo(new Put(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void build_FromExistingAndClearNamespace_ShouldBuildPutWithoutNamespace() {
+    // Arrange
+    Put existingPut =
+        new Put(partitionKey1, clusteringKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act
+    Put newPut = Put.newBuilder(existingPut).clearNamespace().build();
+
+    // Assert
+    assertThat(newPut).isEqualTo(new Put(partitionKey1, clusteringKey1).forTable(TABLE_1));
   }
 }

--- a/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
@@ -38,12 +38,10 @@ public class ScanBuilderTest {
   @Test
   public void buildScan_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
     // Arrange Act
-    Scan actual =
-        Scan.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).partitionKey(partitionKey1).build();
+    Scan actual = Scan.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
 
     // Assert
-    assertThat(actual)
-        .isEqualTo(new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(actual).isEqualTo(new Scan(partitionKey1).forTable(TABLE_1));
   }
 
   @Test
@@ -234,6 +232,18 @@ public class ScanBuilderTest {
   }
 
   @Test
+  public void buildScan_FromExistingAndClearNamespace_ShouldBuildScanWithoutNamespace() {
+    // Arrange
+    Scan existingScan = new Scan(partitionKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act
+    Scan newScan = Scan.newBuilder(existingScan).clearNamespace().build();
+
+    // Assert
+    assertThat(newScan).isEqualTo(new Scan(partitionKey1).forTable(TABLE_1));
+  }
+
+  @Test
   public void
       buildScan_FromExistingWithUnsupportedOperation_ShouldThrowUnsupportedOperationException() {
     // Arrange
@@ -247,10 +257,10 @@ public class ScanBuilderTest {
   @Test
   public void buildScanAll_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
     // Arrange Act
-    Scan actual = Scan.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).all().build();
+    Scan actual = Scan.newBuilder().table(TABLE_1).all().build();
 
     // Assert
-    assertThat(actual).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(actual).isEqualTo(new ScanAll().forTable(TABLE_1));
   }
 
   @Test
@@ -366,14 +376,24 @@ public class ScanBuilderTest {
   }
 
   @Test
-  public void buildScanWithIndex_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
-    // Arrange Act
-    Scan actual =
-        Scan.newBuilder().namespace(NAMESPACE_1).table(TABLE_1).indexKey(indexKey1).build();
+  public void buildScanAll_FromExistingAndClearNamespace_ShouldBuildScanWithoutNamespace() {
+    // Arrange
+    ScanAll existingScan = new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act
+    Scan newScan = Scan.newBuilder(existingScan).clearNamespace().build();
 
     // Assert
-    assertThat(actual)
-        .isEqualTo(new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1));
+    assertThat(newScan).isEqualTo(new ScanAll().forTable(TABLE_1));
+  }
+
+  @Test
+  public void buildScanWithIndex_WithMandatoryParameters_ShouldBuildScanWithMandatoryParameters() {
+    // Arrange Act
+    Scan actual = Scan.newBuilder().table(TABLE_1).indexKey(indexKey1).build();
+
+    // Assert
+    assertThat(actual).isEqualTo(new ScanWithIndex(indexKey1).forTable(TABLE_1));
   }
 
   @Test
@@ -485,5 +505,18 @@ public class ScanBuilderTest {
         .isInstanceOf(UnsupportedOperationException.class);
     assertThatThrownBy(() -> Scan.newBuilder(existingScan).clearEnd())
         .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void buildScanWithIndex_FromExistingAndClearNamespace_ShouldBuildScanWithoutNamespace() {
+    // Arrange
+    ScanWithIndex existingScan =
+        new ScanWithIndex(indexKey1).forNamespace(NAMESPACE_1).forTable(TABLE_1);
+
+    // Act
+    Scan newScan = Scan.newBuilder(existingScan).clearNamespace().build();
+
+    // Assert
+    assertThat(newScan).isEqualTo(new ScanWithIndex(indexKey1).forTable(TABLE_1));
   }
 }


### PR DESCRIPTION
As the first part of the changes to be able to set a default operation namespace via the ScalarDB configuration, this PR : 
- makes it optional to set a namespace in the operation builder
- adds a `clearNamespace()` method when building from an existing operation.
