### PR TITLE
Add repair section for cosmosdb restore

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -101,6 +101,8 @@ Please see [the doc](https://github.com/scalar-labs/cassy/blob/master/docs/getti
 You can follow the [azure official guide](https://docs.microsoft.com/en-us/azure/cosmos-db/restore-account-continuous-backup#restore-account-portal). After restoring backups. change the default consistencies of the restored databases to `STRONG`
 It is recommended to use the mid-time of paused duration as a restore point as we explained earlier.
 
+ScalarDB tables use stored procedures of Cosmos DB for NoSQL. However, the PITR feature of Cosmos DB for NoSQL doesn't restore stored procedures. So, you must create stored procedures in all tables. You can do it using ScalarDB Schema Loader the `--repair-all` flag. Please refer to the Schema Loader document [Repair tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md#repair-tables).
+
 ### DynamoDB (restore)
 
 You can basically follow [the official doc](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.Tutorial.html). However, a table can only be restored with an alias, so you need to restore a table with an alias and delete the original table and rename the alias to the original name to restore the same named tables.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -101,7 +101,7 @@ Please see [the doc](https://github.com/scalar-labs/cassy/blob/master/docs/getti
 You can follow the [azure official guide](https://docs.microsoft.com/en-us/azure/cosmos-db/restore-account-continuous-backup#restore-account-portal). After restoring backups. change the default consistencies of the restored databases to `STRONG`
 It is recommended to use the mid-time of paused duration as a restore point as we explained earlier.
 
-ScalarDB tables use stored procedures of Cosmos DB for NoSQL. However, the PITR feature of Cosmos DB for NoSQL doesn't restore stored procedures. So, you must create stored procedures in all tables. You can do it using ScalarDB Schema Loader with the `--repair-all` flag. Please refer to the Schema Loader document [Repair tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md#repair-tables).
+ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas with ScalarDB Schema Loader. However, the PITR feature of Cosmos DB doesn't restore stored procedures. So, you need to re-install the required stored procedures for all tables after restoration. You can do it using ScalarDB Schema Loader with the `--repair-all` option. Please refer to the Schema Loader document [Repair tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md#repair-tables) for more details.
 
 ### DynamoDB (restore)
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -101,7 +101,7 @@ Please see [the doc](https://github.com/scalar-labs/cassy/blob/master/docs/getti
 You can follow the [azure official guide](https://docs.microsoft.com/en-us/azure/cosmos-db/restore-account-continuous-backup#restore-account-portal). After restoring backups. change the default consistencies of the restored databases to `STRONG`
 It is recommended to use the mid-time of paused duration as a restore point as we explained earlier.
 
-ScalarDB tables use stored procedures of Cosmos DB for NoSQL. However, the PITR feature of Cosmos DB for NoSQL doesn't restore stored procedures. So, you must create stored procedures in all tables. You can do it using ScalarDB Schema Loader the `--repair-all` flag. Please refer to the Schema Loader document [Repair tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md#repair-tables).
+ScalarDB tables use stored procedures of Cosmos DB for NoSQL. However, the PITR feature of Cosmos DB for NoSQL doesn't restore stored procedures. So, you must create stored procedures in all tables. You can do it using ScalarDB Schema Loader with the `--repair-all` flag. Please refer to the Schema Loader document [Repair tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md#repair-tables).
 
 ### DynamoDB (restore)
 


### PR DESCRIPTION
This PR adds how to repair stored procedures of Cosmos DB for NoSQL.
We must repair tables manually after we restore tables using PITR since it doesn't restore stored procedures automatically.

Please take a look!
