### PR TITLE
Make overridden methods throw Exception in integration tests

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -113,7 +113,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin.close();
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairTableIntegrationTestBase.java
@@ -93,7 +93,7 @@ public abstract class DistributedStorageAdminRepairTableIntegrationTestBase {
   }
 
   @BeforeEach
-  protected void beforeEach() throws Exception {
+  protected void setUp() throws Exception {
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
     admin = factory.getStorageAdmin();
     createTable();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -99,12 +99,12 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     admin.truncateTable(namespace, TABLE);
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTable();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -121,12 +121,12 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     admin.truncateTable(namespace, TABLE);
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTable();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -104,7 +104,7 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     truncateTable();
     storage.with(namespace, TABLE);
   }
@@ -114,7 +114,7 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTable();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
@@ -97,7 +97,7 @@ public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -112,7 +112,7 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
@@ -96,7 +96,7 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageWithReservedKeywordIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageWithReservedKeywordIntegrationTestBase.java
@@ -103,7 +103,7 @@ public abstract class DistributedStorageWithReservedKeywordIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     truncateTable();
     storage.with(namespace, tableName);
   }
@@ -113,7 +113,7 @@ public abstract class DistributedStorageWithReservedKeywordIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTable();
     admin.close();
     storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -115,7 +115,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin.close();
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairTableIntegrationTestBase.java
@@ -94,7 +94,7 @@ public abstract class DistributedTransactionAdminRepairTableIntegrationTestBase 
   }
 
   @BeforeEach
-  protected void beforeEach() throws Exception {
+  protected void setUp() throws Exception {
     TransactionFactory factory = TransactionFactory.create(getProperties(TEST_NAME));
     admin = factory.getTransactionAdmin();
     createTable();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -95,13 +95,13 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     admin.truncateTable(namespace, TABLE);
     admin.truncateCoordinatorTables();
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin.close();
     manager.close();

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -109,14 +109,14 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     admin1.truncateTable(namespace1, TABLE_1);
     admin1.truncateCoordinatorTables();
     admin2.truncateTable(namespace2, TABLE_2);
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     admin1.close();
     admin2.close();

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -95,7 +95,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     dropTablesIfExist();
   }
 
@@ -268,7 +268,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException, IOException {
+  public void afterAll() throws Exception {
     dropTablesIfExist();
     storageAdmin.close();
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminIntegrationTestBase.java
@@ -8,7 +8,6 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.service.TransactionFactory;
-import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -18,7 +17,7 @@ public abstract class ConsensusCommitAdminIntegrationTestBase
   private DistributedTransactionAdmin adminWithIncludeMetadataEnabled;
 
   @Override
-  protected void initialize(String testName) throws IOException {
+  protected void initialize(String testName) throws Exception {
     Properties includeMetadataEnabledProperties = getPropsWithIncludeMetadataEnabled(testName);
     adminWithIncludeMetadataEnabled =
         TransactionFactory.create(includeMetadataEnabledProperties).getTransactionAdmin();
@@ -26,7 +25,7 @@ public abstract class ConsensusCommitAdminIntegrationTestBase
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
 
     adminWithIncludeMetadataEnabled.close();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -14,7 +14,6 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanBuilder.BuildableScanOrScanAllFromExisting;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
@@ -43,7 +42,7 @@ public abstract class ConsensusCommitIntegrationTestBase
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
 
     managerWithIncludeMetadataEnabled.close();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -139,7 +139,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     truncateTables();
     storage = spy(originalStorage);
     coordinator = spy(new Coordinator(storage, consensusCommitConfig));
@@ -166,7 +166,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     consensusCommitAdmin.close();
     originalStorage.close();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
@@ -14,7 +14,6 @@ import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionIntegrationTestBase;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
@@ -44,7 +43,7 @@ public abstract class TwoPhaseConsensusCommitIntegrationTestBase
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
 
     managerWithWithIncludeMetadataEnabled.close();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -143,7 +143,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @BeforeEach
-  public void setUp() throws ExecutionException {
+  public void setUp() throws Exception {
     truncateTables();
   }
 
@@ -154,7 +154,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @AfterAll
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     dropTables();
     consensusCommitAdmin1.close();
     consensusCommitAdmin2.close();

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService.java
@@ -5,7 +5,6 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
-import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,7 @@ public class ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminS
   private boolean isExternalServerUsed;
 
   @Override
-  protected void initialize(String testName) throws IOException {
+  protected void initialize(String testName) throws Exception {
     super.initialize(testName);
 
     Properties properties = ServerEnv.getServer1Properties(testName);
@@ -60,7 +59,7 @@ public class ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminS
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithDistributedTransactionService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithDistributedTransactionService.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestBase;
@@ -59,7 +58,7 @@ public class ConsensusCommitIntegrationTestWithDistributedTransactionService
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageAdminServiceIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceColumnValueIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceColumnValueIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageColumnValueIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageServiceColumnValueIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceConditionalMutationIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceConditionalMutationIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageConditionalMutationIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageServiceConditionalMutationIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageServiceIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceSecondaryIndexIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceSecondaryIndexIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageSecondaryIndexIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageServiceSecondaryIndexIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceSingleClusteringKeyScanIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceSingleClusteringKeyScanIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageSingleClusteringKeyScanIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageServiceSingleClusteringKeyScanIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceSinglePartitionKeyIntegrationTest.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageServiceSinglePartitionKeyIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageSinglePartitionKeyIntegrationTestBase;
-import com.scalar.db.exception.storage.ExecutionException;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +26,7 @@ public class DistributedStorageServiceSinglePartitionKeyIntegrationTest
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/SchemaLoaderIntegrationTestWithScalarDbServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/SchemaLoaderIntegrationTestWithScalarDbServer.java
@@ -1,6 +1,5 @@
 package com.scalar.db.server;
 
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.io.IOException;
@@ -42,7 +41,7 @@ public class SchemaLoaderIntegrationTestWithScalarDbServer extends SchemaLoaderI
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException, IOException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
       server.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransactionService.java
+++ b/server/src/integration-test/java/com/scalar/db/server/TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransactionService.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
@@ -72,7 +71,7 @@ public class TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransaction
 
   @AfterAll
   @Override
-  public void afterAll() throws ExecutionException {
+  public void afterAll() throws Exception {
     super.afterAll();
     if (server1 != null) {
       server1.shutdown();


### PR DESCRIPTION
This PR makes overridden methods in the integration tests throw `Exception`. We do this because we can't assume which exception will be thrown in the overriding methods. Please take a look!