### PR TITLE
Rename integration test classes for Server

### DIFF
--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-public class ConsensusCommitAdminIntegrationTestWithDistributedTransactionAdminService
+public class ConsensusCommitAdminIntegrationTestWithServer
     extends ConsensusCommitAdminIntegrationTestBase {
 
   private static final String PORT_FOR_SERVER_WITH_INCLUDE_METADATA_ENABLED = "60053";

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminRepairTableIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminRepairTableIntegrationTestWithServer.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-public class ConsensusCommitAdminRepairTableIntegrationTestWithDistributedTransactionAdminService
+public class ConsensusCommitAdminRepairTableIntegrationTestWithServer
     extends ConsensusCommitAdminRepairTableIntegrationTestBase {
 
   private ScalarDbServer server;

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithServer.java
@@ -3,67 +3,53 @@ package com.scalar.db.server;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
-import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-public class TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransactionService
-    extends TwoPhaseConsensusCommitIntegrationTestBase {
+public class ConsensusCommitIntegrationTestWithServer extends ConsensusCommitIntegrationTestBase {
 
   private static final String PORT_FOR_SERVER_WITH_INCLUDE_METADATA_ENABLED = "60053";
 
-  private ScalarDbServer server1;
-  private ScalarDbServer server2;
+  private ScalarDbServer server;
   private ScalarDbServer serverWithIncludeMetadataEnabled;
   private boolean isExternalServerUsed;
 
   @Override
   protected void initialize(String testName) throws IOException {
-    Properties properties1 = ServerEnv.getServer1Properties(testName);
-    Properties properties2 = ServerEnv.getServer2Properties(testName);
-    if (properties1 != null && properties2 != null) {
-      server1 = new ScalarDbServer(modifyProperties(properties1, testName));
-      server1.start();
+    Properties properties = ServerEnv.getServer1Properties(testName);
+    if (properties != null) {
+      // Add testName as a coordinator namespace suffix
+      String coordinatorNamespace =
+          properties.getProperty(
+              ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+      properties.setProperty(
+          ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
 
-      server2 = new ScalarDbServer(modifyProperties(properties2, testName));
-      server2.start();
+      server = new ScalarDbServer(properties);
+      server.start();
 
-      properties1.setProperty(ConsensusCommitConfig.INCLUDE_METADATA_ENABLED, "true");
-      properties1.setProperty(ServerConfig.PORT, PORT_FOR_SERVER_WITH_INCLUDE_METADATA_ENABLED);
-      serverWithIncludeMetadataEnabled = new ScalarDbServer(properties1);
+      properties.setProperty(ConsensusCommitConfig.INCLUDE_METADATA_ENABLED, "true");
+      properties.setProperty(ServerConfig.PORT, PORT_FOR_SERVER_WITH_INCLUDE_METADATA_ENABLED);
+      serverWithIncludeMetadataEnabled = new ScalarDbServer(properties);
       serverWithIncludeMetadataEnabled.start();
     } else {
       isExternalServerUsed = true;
     }
   }
 
-  private Properties modifyProperties(Properties properties, String testName) {
-    // Add testName as a coordinator namespace suffix
-    String coordinatorNamespace =
-        properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
-    properties.setProperty(
-        ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
-
-    return properties;
-  }
-
   @Override
-  protected Properties getProps1(String testName) {
+  protected Properties getProps(String testName) {
     return ServerEnv.getClient1Properties(testName);
   }
 
   @Override
-  protected Properties getProps2(String testName) {
-    return ServerEnv.getClient2Properties(testName);
-  }
-
-  @Override
   protected Properties getPropsWithIncludeMetadataEnabled(String testName) {
-    Properties properties = getProperties1(testName);
+    Properties properties = getProperties(testName);
     properties.setProperty(
         DatabaseConfig.CONTACT_PORT, PORT_FOR_SERVER_WITH_INCLUDE_METADATA_ENABLED);
     return properties;
@@ -73,11 +59,8 @@ public class TwoPhaseConsensusCommitIntegrationTestWithTwoPhaseCommitTransaction
   @Override
   public void afterAll() throws Exception {
     super.afterAll();
-    if (server1 != null) {
-      server1.shutdown();
-    }
-    if (server2 != null) {
-      server2.shutdown();
+    if (server != null) {
+      server.shutdown();
     }
     if (serverWithIncludeMetadataEnabled != null) {
       serverWithIncludeMetadataEnabled.shutdown();

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageSinglePartitionKeyIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceSinglePartitionKeyIntegrationTest
-    extends DistributedStorageSinglePartitionKeyIntegrationTestBase {
+public class DistributedStorageAdminIntegrationTestWithServer
+    extends DistributedStorageAdminIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminRepairTableIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminRepairTableIntegrationTestWithServer.java
@@ -1,6 +1,6 @@
 package com.scalar.db.server;
 
-import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageAdminRepairTableIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.io.IOException;
 import java.util.Properties;
@@ -8,10 +8,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-public class SchemaLoaderIntegrationTestWithScalarDbServer extends SchemaLoaderIntegrationTestBase {
+public class DistributedStorageAdminRepairTableIntegrationTestWithServer
+    extends DistributedStorageAdminRepairTableIntegrationTestBase {
 
   private ScalarDbServer server;
-  boolean isExternalServerUsed;
+  private boolean isExternalServerUsed;
 
   @Override
   protected void initialize(String testName) throws IOException {
@@ -39,8 +40,8 @@ public class SchemaLoaderIntegrationTestWithScalarDbServer extends SchemaLoaderI
     return new ServerAdminTestUtils(properties);
   }
 
-  @AfterAll
   @Override
+  @AfterAll
   public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
@@ -52,19 +53,24 @@ public class SchemaLoaderIntegrationTestWithScalarDbServer extends SchemaLoaderI
   @Override
   @Test
   @DisabledIf("isExternalServerUsed")
-  public void createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly()
-      throws Exception {
-    super.createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly();
+  public void repairTable_ForDeletedMetadataTable_ShouldRepairProperly() throws Exception {
+    super.repairTable_ForDeletedMetadataTable_ShouldRepairProperly();
   }
 
   /** This test is disabled if {@link #isExternalServerUsed()} return true */
   @Override
   @Test
   @DisabledIf("isExternalServerUsed")
-  public void
-      createTableThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly()
-          throws Exception {
-    super.createTableThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly();
+  public void repairTable_ForTruncatedMetadataTable_ShouldRepairProperly() throws Exception {
+    super.repairTable_ForTruncatedMetadataTable_ShouldRepairProperly();
+  }
+
+  /** This test is disabled if {@link #isExternalServerUsed()} return true */
+  @Override
+  @Test
+  @DisabledIf("isExternalServerUsed")
+  public void repairTable_ForCorruptedMetadataTable_ShouldRepairProperly() throws Exception {
+    super.repairTable_ForCorruptedMetadataTable_ShouldRepairProperly();
   }
 
   @SuppressWarnings("unused")

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageColumnValueIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageColumnValueIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageColumnValueIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageAdminServiceIntegrationTest
-    extends DistributedStorageAdminIntegrationTestBase {
+public class DistributedStorageColumnValueIntegrationTestWithServer
+    extends DistributedStorageColumnValueIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageConditionalMutationIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageConditionalMutationIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageMultiplePartitionKeyIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageConditionalMutationIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceMultiplePartitionKeyIntegrationTest
-    extends DistributedStorageMultiplePartitionKeyIntegrationTestBase {
+public class DistributedStorageConditionalMutationIntegrationTestWithServer
+    extends DistributedStorageConditionalMutationIntegrationTestBase {
 
   private ScalarDbServer server;
 
@@ -31,5 +31,11 @@ public class DistributedStorageServiceMultiplePartitionKeyIntegrationTest
     if (server != null) {
       server.shutdown();
     }
+  }
+
+  @Override
+  protected int getThreadNum() {
+    // Since Deadlock error sometimes happens in MySQL, change the concurrency to 1
+    return 1;
   }
 }

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageSingleClusteringKeyScanIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceSingleClusteringKeyScanIntegrationTest
-    extends DistributedStorageSingleClusteringKeyScanIntegrationTestBase {
+public class DistributedStorageIntegrationTestWithServer
+    extends DistributedStorageIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageMultipleClusteringKeyScanIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageMultipleClusteringKeyScanIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageColumnValueIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageMultipleClusteringKeyScanIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceColumnValueIntegrationTest
-    extends DistributedStorageColumnValueIntegrationTestBase {
+public class DistributedStorageMultipleClusteringKeyScanIntegrationTestWithServer
+    extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageMultiplePartitionKeyIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageMultiplePartitionKeyIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageMultiplePartitionKeyIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceIntegrationTest
-    extends DistributedStorageIntegrationTestBase {
+public class DistributedStorageMultiplePartitionKeyIntegrationTestWithServer
+    extends DistributedStorageMultiplePartitionKeyIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageSecondaryIndexIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageSecondaryIndexIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageMultipleClusteringKeyScanIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageSecondaryIndexIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceMultipleClusteringKeyScanIntegrationTest
-    extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
+public class DistributedStorageSecondaryIndexIntegrationTestWithServer
+    extends DistributedStorageSecondaryIndexIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageSingleClusteringKeyScanIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageSingleClusteringKeyScanIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageSecondaryIndexIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageSingleClusteringKeyScanIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceSecondaryIndexIntegrationTest
-    extends DistributedStorageSecondaryIndexIntegrationTestBase {
+public class DistributedStorageSingleClusteringKeyScanIntegrationTestWithServer
+    extends DistributedStorageSingleClusteringKeyScanIntegrationTestBase {
 
   private ScalarDbServer server;
 

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageSinglePartitionKeyIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageSinglePartitionKeyIntegrationTestWithServer.java
@@ -1,12 +1,12 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageConditionalMutationIntegrationTestBase;
+import com.scalar.db.api.DistributedStorageSinglePartitionKeyIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 
-public class DistributedStorageServiceConditionalMutationIntegrationTest
-    extends DistributedStorageConditionalMutationIntegrationTestBase {
+public class DistributedStorageSinglePartitionKeyIntegrationTestWithServer
+    extends DistributedStorageSinglePartitionKeyIntegrationTestBase {
 
   private ScalarDbServer server;
 
@@ -31,11 +31,5 @@ public class DistributedStorageServiceConditionalMutationIntegrationTest
     if (server != null) {
       server.shutdown();
     }
-  }
-
-  @Override
-  protected int getThreadNum() {
-    // Since Deadlock error sometimes happens in MySQL, change the concurrency to 1
-    return 1;
   }
 }

--- a/server/src/integration-test/java/com/scalar/db/server/SchemaLoaderIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/SchemaLoaderIntegrationTestWithServer.java
@@ -1,6 +1,6 @@
 package com.scalar.db.server;
 
-import com.scalar.db.api.DistributedStorageAdminRepairTableIntegrationTestBase;
+import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.io.IOException;
 import java.util.Properties;
@@ -8,11 +8,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-public class DistributedStorageAdminServiceRepairTableIntegrationTest
-    extends DistributedStorageAdminRepairTableIntegrationTestBase {
+public class SchemaLoaderIntegrationTestWithServer extends SchemaLoaderIntegrationTestBase {
 
   private ScalarDbServer server;
-  private boolean isExternalServerUsed;
+  boolean isExternalServerUsed;
 
   @Override
   protected void initialize(String testName) throws IOException {
@@ -40,8 +39,8 @@ public class DistributedStorageAdminServiceRepairTableIntegrationTest
     return new ServerAdminTestUtils(properties);
   }
 
-  @Override
   @AfterAll
+  @Override
   public void afterAll() throws Exception {
     super.afterAll();
     if (server != null) {
@@ -53,24 +52,19 @@ public class DistributedStorageAdminServiceRepairTableIntegrationTest
   @Override
   @Test
   @DisabledIf("isExternalServerUsed")
-  public void repairTable_ForDeletedMetadataTable_ShouldRepairProperly() throws Exception {
-    super.repairTable_ForDeletedMetadataTable_ShouldRepairProperly();
+  public void createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly()
+      throws Exception {
+    super.createTableThenDropMetadataTableThenRepairTables_ShouldExecuteProperly();
   }
 
   /** This test is disabled if {@link #isExternalServerUsed()} return true */
   @Override
   @Test
   @DisabledIf("isExternalServerUsed")
-  public void repairTable_ForTruncatedMetadataTable_ShouldRepairProperly() throws Exception {
-    super.repairTable_ForTruncatedMetadataTable_ShouldRepairProperly();
-  }
-
-  /** This test is disabled if {@link #isExternalServerUsed()} return true */
-  @Override
-  @Test
-  @DisabledIf("isExternalServerUsed")
-  public void repairTable_ForCorruptedMetadataTable_ShouldRepairProperly() throws Exception {
-    super.repairTable_ForCorruptedMetadataTable_ShouldRepairProperly();
+  public void
+      createTableThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly()
+          throws Exception {
+    super.createTableThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly();
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
This PR renames the integration test classes for Server to `XXXWithServer`. Please take a look!