### PR TITLE
Make transaction ID required in UnknownTransactionStatusException

### DIFF
--- a/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
@@ -17,7 +17,7 @@ public class UnknownTransactionStatusException extends TransactionException {
   }
 
   /**
-   * @return a transaction ID that associated with the transaction whose status is unknown
+   * @return a transaction ID associated with the transaction whose status is unknown
    * @deprecated As of release 3.9.0. Will be removed in release 5.0.0
    */
   @Deprecated
@@ -26,9 +26,9 @@ public class UnknownTransactionStatusException extends TransactionException {
   }
 
   /**
-   * Returns a transaction ID that associated with the transaction whose status is unknown.
+   * Returns a transaction ID associated with the transaction whose status is unknown.
    *
-   * @return a transaction ID that associated with the transaction whose status is unknown
+   * @return a transaction ID associated with the transaction whose status is unknown
    */
   public String getTransactionId() {
     return unknownTxId;

--- a/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
@@ -1,25 +1,20 @@
 package com.scalar.db.exception.transaction;
 
-import java.util.Optional;
-
 /** An exception thrown when the transaction status of the committing transaction is unknown. */
 public class UnknownTransactionStatusException extends TransactionException {
-  private Optional<String> unknownTxId = Optional.empty();
+  private final String unknownTxId;
 
-  public UnknownTransactionStatusException(String message) {
+  public UnknownTransactionStatusException(String message, String txId) {
     super(message);
-  }
-
-  public UnknownTransactionStatusException(String message, Throwable cause) {
-    super(message, cause);
+    this.unknownTxId = txId;
   }
 
   public UnknownTransactionStatusException(String message, Throwable cause, String txId) {
     super(message, cause);
-    this.unknownTxId = Optional.ofNullable(txId);
+    this.unknownTxId = txId;
   }
 
-  public Optional<String> getUnknownTransactionId() {
+  public String getUnknownTransactionId() {
     return unknownTxId;
   }
 }

--- a/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/UnknownTransactionStatusException.java
@@ -1,5 +1,7 @@
 package com.scalar.db.exception.transaction;
 
+import java.util.Optional;
+
 /** An exception thrown when the transaction status of the committing transaction is unknown. */
 public class UnknownTransactionStatusException extends TransactionException {
   private final String unknownTxId;
@@ -14,7 +16,21 @@ public class UnknownTransactionStatusException extends TransactionException {
     this.unknownTxId = txId;
   }
 
-  public String getUnknownTransactionId() {
+  /**
+   * @return a transaction ID that associated with the transaction whose status is unknown
+   * @deprecated As of release 3.9.0. Will be removed in release 5.0.0
+   */
+  @Deprecated
+  public Optional<String> getUnknownTransactionId() {
+    return Optional.of(unknownTxId);
+  }
+
+  /**
+   * Returns a transaction ID that associated with the transaction whose status is unknown.
+   *
+   * @return a transaction ID that associated with the transaction whose status is unknown
+   */
+  public String getTransactionId() {
     return unknownTxId;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -151,7 +151,7 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
       try {
         connection.rollback();
       } catch (SQLException sqlException) {
-        throw new UnknownTransactionStatusException("failed to rollback", sqlException);
+        throw new UnknownTransactionStatusException("failed to rollback", sqlException, txId);
       }
       throw createCommitException(e);
     } finally {

--- a/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -474,9 +474,7 @@ public class DistributedTransactionService
                 .build());
       } catch (UnknownTransactionStatusException e) {
         logger.error(
-            "the transaction status is unknown. transaction ID: "
-                + e.getUnknownTransactionId().orElse("null"),
-            e);
+            "the transaction status is unknown. transaction ID: " + e.getUnknownTransactionId(), e);
         responseBuilder.setError(
             TransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)

--- a/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -474,7 +474,7 @@ public class DistributedTransactionService
                 .build());
       } catch (UnknownTransactionStatusException e) {
         logger.error(
-            "the transaction status is unknown. transaction ID: " + e.getUnknownTransactionId(), e);
+            "the transaction status is unknown. transaction ID: " + e.getTransactionId(), e);
         responseBuilder.setError(
             TransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)

--- a/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
@@ -535,9 +535,7 @@ public class TwoPhaseCommitTransactionService
                 .build());
       } catch (UnknownTransactionStatusException e) {
         logger.error(
-            "the transaction status is unknown. transaction ID: "
-                + e.getUnknownTransactionId().orElse("null"),
-            e);
+            "the transaction status is unknown. transaction ID: " + e.getUnknownTransactionId(), e);
         responseBuilder.setError(
             TwoPhaseCommitTransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)

--- a/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/TwoPhaseCommitTransactionService.java
@@ -535,7 +535,7 @@ public class TwoPhaseCommitTransactionService
                 .build());
       } catch (UnknownTransactionStatusException e) {
         logger.error(
-            "the transaction status is unknown. transaction ID: " + e.getUnknownTransactionId(), e);
+            "the transaction status is unknown. transaction ID: " + e.getTransactionId(), e);
         responseBuilder.setError(
             TwoPhaseCommitTransactionResponse.Error.newBuilder()
                 .setErrorCode(ErrorCode.UNKNOWN_TRANSACTION_STATUS)


### PR DESCRIPTION
This PR makes the transaction ID required in `UnknownTransactionStatusException`. Please take a look!