### PR TITLE
Explicitly specify driver class in JDBC adapter

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -59,7 +59,7 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   }
 
   private void execute(String sql) throws SQLException {
-    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config);
+    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
         Connection connection = dataSource.getConnection();
         Statement stmt = connection.createStatement()) {
       stmt.execute(sql);

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
@@ -77,7 +77,7 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   }
 
   private void execute(String sql) throws SQLException {
-    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(jdbcConfig);
+    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(jdbcConfig, rdbEngine);
         Connection connection = dataSource.getConnection();
         Statement stmt = connection.createStatement()) {
       stmt.execute(sql);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -57,7 +57,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   public JdbcAdmin(DatabaseConfig databaseConfig) {
     JdbcConfig config = new JdbcConfig(databaseConfig);
     rdbEngine = RdbEngineFactory.create(config);
-    dataSource = JdbcUtils.initDataSourceForAdmin(config);
+    dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
     metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -49,10 +49,10 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     super(databaseConfig);
     JdbcConfig config = new JdbcConfig(databaseConfig);
 
-    dataSource = JdbcUtils.initDataSource(config);
     rdbEngine = RdbEngineFactory.create(config);
+    dataSource = JdbcUtils.initDataSource(config, rdbEngine);
 
-    tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config);
+    tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config, rdbEngine);
     TableMetadataManager tableMetadataManager =
         new TableMetadataManager(
             new JdbcAdmin(tableMetadataDataSource, config),

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -6,12 +6,21 @@ import org.apache.commons.dbcp2.BasicDataSource;
 public final class JdbcUtils {
   private JdbcUtils() {}
 
-  public static BasicDataSource initDataSource(JdbcConfig config) {
-    return initDataSource(config, false);
+  public static BasicDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {
+    return initDataSource(config, rdbEngine, false);
   }
 
-  public static BasicDataSource initDataSource(JdbcConfig config, boolean transactional) {
+  public static BasicDataSource initDataSource(
+      JdbcConfig config, RdbEngineStrategy rdbEngine, boolean transactional) {
     BasicDataSource dataSource = new BasicDataSource();
+
+    /*
+     * We need to set the driver class of an underlying database to the dataSource in order
+     * to avoid the "No suitable driver" error in case when ServiceLoader in java.sql.DriverManager
+     * doesn't work (e.g., when we dynamically load a driver class from a fatJar).
+     */
+    dataSource.setDriver(rdbEngine.getDriverClass());
+
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
@@ -54,8 +63,17 @@ public final class JdbcUtils {
     return dataSource;
   }
 
-  public static BasicDataSource initDataSourceForTableMetadata(JdbcConfig config) {
+  public static BasicDataSource initDataSourceForTableMetadata(
+      JdbcConfig config, RdbEngineStrategy rdbEngine) {
     BasicDataSource dataSource = new BasicDataSource();
+
+    /*
+     * We need to set the driver class of an underlying database to the dataSource in order
+     * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
+     * work (e.g., when we dynamically load a driver class from a fatJar).
+     */
+    dataSource.setDriver(rdbEngine.getDriverClass());
+
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
@@ -65,8 +83,17 @@ public final class JdbcUtils {
     return dataSource;
   }
 
-  public static BasicDataSource initDataSourceForAdmin(JdbcConfig config) {
+  public static BasicDataSource initDataSourceForAdmin(
+      JdbcConfig config, RdbEngineStrategy rdbEngine) {
     BasicDataSource dataSource = new BasicDataSource();
+
+    /*
+     * We need to set the driver class of an underlying database to the dataSource in order
+     * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
+     * work (e.g., when we dynamically load a driver class from a fatJar).
+     */
+    dataSource.setDriver(rdbEngine.getDriverClass());
+
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -19,7 +19,7 @@ public final class JdbcUtils {
      * to avoid the "No suitable driver" error in case when ServiceLoader in java.sql.DriverManager
      * doesn't work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    dataSource.setDriver(rdbEngine.getDriverClass());
+    dataSource.setDriver(rdbEngine.getDriver());
 
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
@@ -72,7 +72,7 @@ public final class JdbcUtils {
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
      * work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    dataSource.setDriver(rdbEngine.getDriverClass());
+    dataSource.setDriver(rdbEngine.getDriver());
 
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
@@ -92,7 +92,7 @@ public final class JdbcUtils {
      * to avoid the "No suitable driver" error when ServiceLoader in java.sql.DriverManager doesn't
      * work (e.g., when we dynamically load a driver class from a fatJar).
      */
-    dataSource.setDriver(rdbEngine.getDriverClass());
+    dataSource.setDriver(rdbEngine.getDriver());
 
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -229,7 +229,7 @@ class RdbEngineMysql implements RdbEngineStrategy {
   }
 
   @Override
-  public Driver getDriverClass() {
+  public Driver getDriver() {
     try {
       return new com.mysql.cj.jdbc.Driver();
     } catch (SQLException e) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -7,6 +7,7 @@ import com.scalar.db.storage.jdbc.query.InsertOnDuplicateKeyUpdateQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
@@ -225,5 +226,14 @@ class RdbEngineMysql implements RdbEngineStrategy {
   @Override
   public String computeBooleanValue(boolean value) {
     return value ? "true" : "false";
+  }
+
+  @Override
+  public Driver getDriverClass() {
+    try {
+      return new com.mysql.cj.jdbc.Driver();
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -9,6 +9,7 @@ import com.scalar.db.storage.jdbc.query.MergeIntoQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithFetchFirstNRowsOnly;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -231,5 +232,10 @@ public class RdbEngineOracle implements RdbEngineStrategy {
   @Override
   public String computeBooleanValue(boolean value) {
     return value ? "1" : "0";
+  }
+
+  @Override
+  public Driver getDriverClass() {
+    return new oracle.jdbc.driver.OracleDriver();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -235,7 +235,7 @@ public class RdbEngineOracle implements RdbEngineStrategy {
   }
 
   @Override
-  public Driver getDriverClass() {
+  public Driver getDriver() {
     return new oracle.jdbc.driver.OracleDriver();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -225,7 +225,7 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
   }
 
   @Override
-  public Driver getDriverClass() {
+  public Driver getDriver() {
     return new org.postgresql.Driver();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -9,6 +9,7 @@ import com.scalar.db.storage.jdbc.query.InsertOnConflictDoUpdateQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -221,5 +222,10 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
   @Override
   public String computeBooleanValue(boolean value) {
     return value ? "true" : "false";
+  }
+
+  @Override
+  public Driver getDriverClass() {
+    return new org.postgresql.Driver();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -209,7 +209,7 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
   }
 
   @Override
-  public Driver getDriverClass() {
+  public Driver getDriver() {
     return new com.microsoft.sqlserver.jdbc.SQLServerDriver();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -7,6 +7,7 @@ import com.scalar.db.storage.jdbc.query.MergeQuery;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithTop;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
@@ -205,5 +206,10 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
   @Override
   public String computeBooleanValue(boolean value) {
     return value ? "1" : "0";
+  }
+
+  @Override
+  public Driver getDriverClass() {
+    return new com.microsoft.sqlserver.jdbc.SQLServerDriver();
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -5,6 +5,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Driver;
 import java.sql.SQLException;
 
 /**
@@ -18,7 +19,7 @@ public interface RdbEngineStrategy {
   boolean isDuplicateKeyError(SQLException e);
 
   boolean isUndefinedTableError(SQLException e);
-  /** Serialization error or deadlock found. */
+
   boolean isConflictError(SQLException e);
 
   String getDataTypeForEngine(DataType dataType);
@@ -75,4 +76,6 @@ public interface RdbEngineStrategy {
   SelectQuery buildSelectQuery(SelectQuery.Builder builder, int limit);
 
   UpsertQuery buildUpsertQuery(UpsertQuery.Builder builder);
+
+  Driver getDriverClass();
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -77,5 +77,5 @@ public interface RdbEngineStrategy {
 
   UpsertQuery buildUpsertQuery(UpsertQuery.Builder builder);
 
-  Driver getDriverClass();
+  Driver getDriver();
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -39,10 +39,10 @@ public class JdbcTransactionManager extends ActiveTransactionManagedDistributedT
     super(databaseConfig);
     JdbcConfig config = new JdbcConfig(databaseConfig);
 
-    dataSource = JdbcUtils.initDataSource(config, true);
     rdbEngine = RdbEngineFactory.create(config);
+    dataSource = JdbcUtils.initDataSource(config, rdbEngine, true);
 
-    tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config);
+    tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config, rdbEngine);
     TableMetadataManager tableMetadataManager =
         new TableMetadataManager(
             new JdbcAdmin(tableMetadataDataSource, config),

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -40,7 +40,7 @@ public class JdbcUtilsTest {
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     Driver driver = new com.mysql.cj.jdbc.Driver();
-    when(rdbEngine.getDriverClass()).thenReturn(driver);
+    when(rdbEngine.getDriver()).thenReturn(driver);
 
     // Act
     BasicDataSource dataSource = JdbcUtils.initDataSource(config, rdbEngine);
@@ -82,7 +82,7 @@ public class JdbcUtilsTest {
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     Driver driver = new org.postgresql.Driver();
-    when(rdbEngine.getDriverClass()).thenReturn(driver);
+    when(rdbEngine.getDriver()).thenReturn(driver);
 
     // Act
     BasicDataSource dataSource = JdbcUtils.initDataSource(config, rdbEngine, true);
@@ -122,7 +122,7 @@ public class JdbcUtilsTest {
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     Driver driver = new oracle.jdbc.driver.OracleDriver();
-    when(rdbEngine.getDriverClass()).thenReturn(driver);
+    when(rdbEngine.getDriver()).thenReturn(driver);
 
     // Act
     BasicDataSource tableMetadataDataSource =
@@ -156,7 +156,7 @@ public class JdbcUtilsTest {
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
     Driver driver = new com.microsoft.sqlserver.jdbc.SQLServerDriver();
-    when(rdbEngine.getDriverClass()).thenReturn(driver);
+    when(rdbEngine.getDriver()).thenReturn(driver);
 
     // Act
     BasicDataSource adminDataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -1,15 +1,27 @@
 package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import com.scalar.db.config.DatabaseConfig;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.Properties;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class JdbcUtilsTest {
+
+  @Mock private RdbEngineStrategy rdbEngine;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
 
   @Test
   public void initDataSource_NonTransactional_ShouldReturnProperDataSource() throws SQLException {
@@ -27,11 +39,14 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "100");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    Driver driver = new com.mysql.cj.jdbc.Driver();
+    when(rdbEngine.getDriverClass()).thenReturn(driver);
 
     // Act
-    BasicDataSource dataSource = JdbcUtils.initDataSource(config);
+    BasicDataSource dataSource = JdbcUtils.initDataSource(config, rdbEngine);
 
     // Assert
+    assertThat(dataSource.getDriver()).isEqualTo(driver);
     assertThat(dataSource.getUrl()).isEqualTo("jdbc:mysql://localhost:3306/");
     assertThat(dataSource.getUsername()).isEqualTo("root");
     assertThat(dataSource.getPassword()).isEqualTo("mysql");
@@ -66,11 +81,14 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN, "200");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    Driver driver = new org.postgresql.Driver();
+    when(rdbEngine.getDriverClass()).thenReturn(driver);
 
     // Act
-    BasicDataSource dataSource = JdbcUtils.initDataSource(config, true);
+    BasicDataSource dataSource = JdbcUtils.initDataSource(config, rdbEngine, true);
 
     // Assert
+    assertThat(dataSource.getDriver()).isEqualTo(driver);
     assertThat(dataSource.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/");
     assertThat(dataSource.getUsername()).isEqualTo("user");
     assertThat(dataSource.getPassword()).isEqualTo("postgres");
@@ -103,11 +121,15 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL, "300");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    Driver driver = new oracle.jdbc.driver.OracleDriver();
+    when(rdbEngine.getDriverClass()).thenReturn(driver);
 
     // Act
-    BasicDataSource tableMetadataDataSource = JdbcUtils.initDataSourceForTableMetadata(config);
+    BasicDataSource tableMetadataDataSource =
+        JdbcUtils.initDataSourceForTableMetadata(config, rdbEngine);
 
     // Assert
+    assertThat(tableMetadataDataSource.getDriver()).isEqualTo(driver);
     assertThat(tableMetadataDataSource.getUrl())
         .isEqualTo("jdbc:oracle:thin:@localhost:1521/XEPDB1");
     assertThat(tableMetadataDataSource.getUsername()).isEqualTo("user");
@@ -133,11 +155,14 @@ public class JdbcUtilsTest {
     properties.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "300");
 
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    Driver driver = new com.microsoft.sqlserver.jdbc.SQLServerDriver();
+    when(rdbEngine.getDriverClass()).thenReturn(driver);
 
     // Act
-    BasicDataSource adminDataSource = JdbcUtils.initDataSourceForAdmin(config);
+    BasicDataSource adminDataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
 
     // Assert
+    assertThat(adminDataSource.getDriver()).isEqualTo(driver);
     assertThat(adminDataSource.getUrl()).isEqualTo("jdbc:sqlserver://localhost:1433");
     assertThat(adminDataSource.getUsername()).isEqualTo("user");
     assertThat(adminDataSource.getPassword()).isEqualTo("sqlserver");

--- a/server/src/integration-test/java/com/scalar/db/server/ServerAdminTestUtils.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ServerAdminTestUtils.java
@@ -65,7 +65,7 @@ public class ServerAdminTestUtils extends AdminTestUtils {
   }
 
   private void execute(String sql) throws SQLException {
-    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config);
+    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
         Connection connection = dataSource.getConnection();
         Statement stmt = connection.createStatement()) {
       stmt.execute(sql);


### PR DESCRIPTION
This PR explicitly specifies a driver class in the JDBC adapter to avoid the "No suitable driver" error in case when `ServiceLoader` in `java.sql.DriverManager` doesn't work (e.g., when we dynamically load a driver class from a fatJar).