### PR TITLE
Add SLF4J Simple Binding to sample application

### DIFF
--- a/docs/getting-started/build.gradle
+++ b/docs/getting-started/build.gradle
@@ -10,6 +10,7 @@ mainClassName = "sample.ElectronicMoneyMain"
 
 dependencies {
     implementation 'com.scalar-labs:scalardb:3.8.0'
+    implementation 'org.slf4j:slf4j-simple:1.7.30'
 }
 
 sourceCompatibility = 1.8 


### PR DESCRIPTION
This PR adds `slf4j-simple` to the sample application for [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).

The current sample application doesn't include any logging libraries. So, it outputs some WARNING messages of SLF4J as follows.

```console
$ ./gradlew run --args="-action charge -amount 1000 -to user1"

> Task :run
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

BUILD SUCCESSFUL in 1s
2 actionable tasks: 1 executed, 1 up-to-date
```

Sometimes, these messages make users confusing. Users think "Any problem occurs?" by seeing these messages.
(Actually, I got such inquiry/feedback from a user.)

So, I added `slf4j-simple` to remove these WARNING messages. After this fixing, the sample application doesn't output some WARNING messages as follows.

```console
$ ./gradlew run --args="-action charge -amount 1000 -to user1"

BUILD SUCCESSFUL in 1s
2 actionable tasks: 1 executed, 1 up-to-date
```

I think this fixing can reduce users' confusion.

---

However, I would like to discuss this fix a little. I think there are some pros/cons as follows.

*  If we don't include some logging libraries, the sample application outputs WARNING messages. Those messages can tell users "ScalarDB uses SLF4J". In other words, we can tell users "You need to use some logging libraries that SLF4J supports in your application".

* If we include some logging libraries in the sample application, there is a possibility that users cannot notice that "ScalarDB uses SLF4J". But, the same WARNING messages will be output when users create their own application with ScalarDB. So, finally, I think users can notice that when they create their own applications.

Regarding the above two patterns, I couldn't judge which is better. (We should output these WARNING messages or not.)
So, I would like to know your opinions.
What do you think?
(If we should not include some logging libraries in the sample application, I will close this PR.)