### PR TITLE
Support conditions for transactional operations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -416,7 +416,7 @@ jobs:
       - name: Setup and execute Gradle 'integrationTestScalarDbServer' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTestScalarDbServer
+          arguments: integrationTestScalarDbServer --tests "ConsensusCommitIntegrationTestWithServer" --tests "TwoPhaseConsensusCommitIntegrationTestWithServer"
 
       - name: Upload Gradle test reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -416,7 +416,7 @@ jobs:
       - name: Setup and execute Gradle 'integrationTestScalarDbServer' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTestScalarDbServer --tests "ConsensusCommitIntegrationTestWithServer" --tests "TwoPhaseConsensusCommitIntegrationTestWithServer"
+          arguments: integrationTestScalarDbServer
 
       - name: Upload Gradle test reports
         uses: actions/upload-artifact@v3

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -1,10 +1,21 @@
 package com.scalar.db.transaction.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransactionIntegrationTestBase;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.storage.jdbc.JdbcEnv;
+import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegrationTestBase {
 
@@ -36,4 +47,102 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
   @Disabled("JDBC transaction doesn't support rollback()")
   @Override
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
+
+  @Test
+  public void put_withPutIfWhenRecordDoesNotExist_shouldThrowCrudException()
+      throws TransactionException {
+
+    // Arrange
+    Put put =
+        Put.newBuilder(preparePut(0, 0))
+            .condition(ConditionBuilder.putIf(ConditionBuilder.column(BALANCE).isNullInt()).build())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> put(put)).isInstanceOf(CrudException.class);
+
+    Optional<Result> result = get(prepareGet(0, 0));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void put_withPutIfExistsWhenRecordDoesNotExist_shouldThrowCrudException()
+      throws TransactionException {
+
+    // Arrange
+    Put put = Put.newBuilder(preparePut(0, 0)).condition(ConditionBuilder.putIfExists()).build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenPut(put)).isInstanceOf(CrudException.class);
+
+    Optional<Result> result = get(prepareGet(0, 0));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void delete_withDeleteIfExistsWhenRecordDoesNotExist_shouldThrowCrudException() {
+    // Arrange
+    Delete deleteIf =
+        Delete.newBuilder(prepareDelete(0, 0)).condition(ConditionBuilder.deleteIfExists()).build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenDelete(deleteIf)).isInstanceOf(CrudException.class);
+  }
+
+  @Test
+  public void delete_withDeleteIfWithNonVerifiedCondition_shouldThrowCrudException()
+      throws TransactionException {
+    // Arrange
+    Put initialData = Put.newBuilder(preparePut(0, 0)).build();
+    put(initialData);
+
+    Delete deleteIf =
+        Delete.newBuilder(prepareDelete(0, 0))
+            .condition(
+                ConditionBuilder.deleteIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenDelete(deleteIf)).isInstanceOf(CrudException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.isNull(BALANCE)).isTrue();
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
+  public void put_withPutIfWithNonVerifiedCondition_shouldThrowCrudException()
+      throws TransactionException {
+    // Arrange
+    Put initialData = Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, INITIAL_BALANCE).build();
+    put(initialData);
+
+    Put putIf =
+        Put.newBuilder(initialData)
+            .intValue(BALANCE, 2)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenPut(putIf)).isInstanceOf(CrudException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -80,6 +80,30 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
   }
 
   @Test
+  public void put_withPutIfNotExistsWhenRecordExists_shouldThrowCrudException()
+      throws TransactionException {
+    // Arrange
+    Put put = preparePut(0, 0);
+    put(put);
+    Put putIfNotExists =
+        Put.newBuilder(put)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenPut(putIfNotExists)).isInstanceOf(CrudException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.isNull(BALANCE)).isTrue();
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
   public void delete_withDeleteIfExistsWhenRecordDoesNotExist_shouldThrowCrudException() {
     // Arrange
     Delete deleteIf =

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -76,7 +76,7 @@ public class CommitHandler {
       prepareRecords(snapshot);
     } catch (NoMutationException e) {
       throw new PreparationConflictException(
-          "preparing record exists or the operation condition is not satisfied",
+          "preparing record exists, or the operation condition is not satisfied",
           e,
           snapshot.getId());
     } catch (RetriableExecutionException e) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -75,7 +75,10 @@ public class CommitHandler {
     try {
       prepareRecords(snapshot);
     } catch (NoMutationException e) {
-      throw new PreparationConflictException("preparing record exists", e, snapshot.getId());
+      throw new PreparationConflictException(
+          "preparing record exists or the operation condition is not satisfied",
+          e,
+          snapshot.getId());
     } catch (RetriableExecutionException e) {
       throw new PreparationConflictException(
           "conflict happened when preparing records", e, snapshot.getId());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
@@ -83,7 +83,7 @@ public class PrepareMutationComposer extends AbstractMutationComposer {
       if (result.isDeemedAsCommitted()) {
         // record is deemed-commit state
         preparationConditions.add(ConditionBuilder.column(ID).isNullText());
-        preparationConditions.add((ConditionBuilder.column(VERSION).isNullInt()));
+        preparationConditions.add(ConditionBuilder.column(VERSION).isNullInt());
       } else {
         preparationConditions.add(ConditionBuilder.column(ID).isEqualToText(result.getId()));
         preparationConditions.add(ConditionBuilder.column(VERSION).isEqualToInt(version));

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -81,14 +81,10 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
   public void put(Put put) throws CrudException {
     put = copyAndSetTargetToIfNot(put);
 
-    // Ignore the condition in the put
-    if (put.getCondition().isPresent()) {
-      logger.warn("ignoring the condition of the mutation: {}", put);
-      put.withCondition(null);
-    }
-
     try {
-      jdbcService.put(put, connection);
+      if (!jdbcService.put(put, connection)) {
+        throw new CrudException("no mutation was applied", txId);
+      }
     } catch (SQLException e) {
       throw createCrudException(e, "put operation failed");
     } catch (ExecutionException e) {
@@ -108,14 +104,10 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
   public void delete(Delete delete) throws CrudException {
     delete = copyAndSetTargetToIfNot(delete);
 
-    // Ignore the condition in the delete
-    if (delete.getCondition().isPresent()) {
-      logger.warn("ignoring the condition of the mutation: {}", delete);
-      delete.withCondition(null);
-    }
-
     try {
-      jdbcService.delete(delete, connection);
+      if (!jdbcService.delete(delete, connection)) {
+        throw new CrudException("no mutation was applied", txId);
+      }
     } catch (SQLException e) {
       throw createCrudException(e, "delete operation failed");
     } catch (ExecutionException e) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -2,34 +2,45 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
+import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
 import static com.scalar.db.transaction.consensuscommit.Attribute.VERSION;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toVersionValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteBuilder;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
 import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.util.ScalarDbUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -55,7 +66,6 @@ public class PrepareMutationComposerTest {
   private static final int ANY_INT_1 = 100;
   private static final int ANY_INT_2 = 200;
   private static final int ANY_INT_3 = 300;
-
   private static final TableMetadata TABLE_METADATA =
       ConsensusCommitUtils.buildTransactionTableMetadata(
           TableMetadata.newBuilder()
@@ -70,6 +80,8 @@ public class PrepareMutationComposerTest {
   @Mock private TransactionTableMetadataManager tableMetadataManager;
 
   private PrepareMutationComposer composer;
+  private @Mock ConditionalExpression condExpression1;
+  private @Mock ConditionalExpression condExpression2;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -82,22 +94,22 @@ public class PrepareMutationComposerTest {
         .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
   }
 
-  private Put preparePut() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Put(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_3)
-        .withValue(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_3);
+  private PutBuilder.Buildable preparePut() {
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .intValue(ANY_NAME_3, ANY_INT_3)
+        .intValue(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_3);
   }
 
-  private Delete prepareDelete() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
+  private DeleteBuilder.Buildable prepareDelete() {
+    return Delete.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2));
   }
 
   private Get prepareGet() {
@@ -160,7 +172,7 @@ public class PrepareMutationComposerTest {
   @Test
   public void add_PutAndResultGiven_ShouldComposePutWithPutIfCondition() throws ExecutionException {
     // Arrange
-    Put put = preparePut();
+    Put put = preparePut().build();
     TransactionResult result = prepareResult();
 
     // Act
@@ -191,7 +203,7 @@ public class PrepareMutationComposerTest {
   public void add_PutAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition()
       throws ExecutionException {
     // Arrange
-    Put put = preparePut();
+    Put put = preparePut().build();
 
     // Act
     composer.add(put, null);
@@ -208,10 +220,160 @@ public class PrepareMutationComposerTest {
   }
 
   @Test
+  public void add_PutWithPutIfConditionAndResultGiven_ShouldComposePutWithPutIfCondition()
+      throws ExecutionException {
+    // Arrange
+    PutIf putIf = mock(PutIf.class);
+    when(putIf.getExpressions()).thenReturn(ImmutableList.of(condExpression1, condExpression2));
+    Put put = preparePut().condition(putIf).build();
+    TransactionResult result = prepareResult();
+
+    // Act
+    composer.add(put, result);
+
+    // Assert
+    Put actual = (Put) composer.get().get(0);
+    assertThat(actual.forNamespace()).get().isEqualTo(ANY_NAMESPACE_NAME);
+    assertThat(actual.forTable()).get().isEqualTo(ANY_TABLE_NAME);
+    assertThat(actual.getPartitionKey().equals(Key.ofText(ANY_NAME_1, ANY_TEXT_1))).isTrue();
+    assertThat(actual.getClusteringKey()).get().isEqualTo(Key.ofText(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.getIntValue(ANY_NAME_3)).isEqualTo(ANY_INT_3);
+    assertThat(actual.getIntValue(ANY_NAME_WITH_BEFORE_PREFIX)).isEqualTo(ANY_INT_3);
+    assertThat(actual.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+    assertThat(actual.getCondition())
+        .get()
+        .isInstanceOf(PutIf.class)
+        .satisfies(
+            c ->
+                assertThat(c.getExpressions())
+                    .containsExactly(
+                        ConditionBuilder.column(VERSION).isEqualToInt(2),
+                        ConditionBuilder.column(ID).isEqualToText(ANY_ID_2),
+                        condExpression1,
+                        condExpression2));
+    assertThat(actual.getTextValue(ID)).isEqualTo(ANY_ID_3);
+    assertThat(actual.getIntValue(STATE)).isEqualTo(TransactionState.PREPARED.get());
+    assertThat(actual.getIntValue(VERSION)).isEqualTo(3);
+    assertThat(actual.getBigIntValue(Attribute.PREPARED_AT)).isEqualTo(ANY_TIME_5);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_PREPARED_AT)).isEqualTo(ANY_TIME_3);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_COMMITTED_AT)).isEqualTo(ANY_TIME_4);
+    assertThat(actual.getTextValue(Attribute.BEFORE_ID)).isEqualTo(ANY_ID_2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_STATE))
+        .isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(actual.getIntValue(Attribute.BEFORE_VERSION)).isEqualTo(2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3)).isEqualTo(ANY_INT_2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX))
+        .isEqualTo(ANY_INT_2);
+  }
+
+  @Test
+  public void add_PutWithPutIfNotExistsConditionAndResultGiven_ShouldThrowNoMutationException() {
+    // Arrange
+    PutIfNotExists putIfNotExists = mock(PutIfNotExists.class);
+    Put put = preparePut().condition(putIfNotExists).build();
+    TransactionResult result = prepareResult();
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> composer.add(put, result))
+        .isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void add_PutWithPutIfExistsConditionAndResultGiven_ShouldComposePutWithPutIfCondition()
+      throws ExecutionException {
+    // Arrange
+    PutIfExists putIfExists = mock(PutIfExists.class);
+    Put put = preparePut().condition(putIfExists).build();
+    TransactionResult result = prepareResult();
+
+    // Act
+    composer.add(put, result);
+
+    // Assert
+    Put actual = (Put) composer.get().get(0);
+    assertThat(actual.forNamespace()).get().isEqualTo(ANY_NAMESPACE_NAME);
+    assertThat(actual.forTable()).get().isEqualTo(ANY_TABLE_NAME);
+    assertThat(actual.getPartitionKey().equals(Key.ofText(ANY_NAME_1, ANY_TEXT_1))).isTrue();
+    assertThat(actual.getClusteringKey()).get().isEqualTo(Key.ofText(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.getIntValue(ANY_NAME_3)).isEqualTo(ANY_INT_3);
+    assertThat(actual.getIntValue(ANY_NAME_WITH_BEFORE_PREFIX)).isEqualTo(ANY_INT_3);
+    assertThat(actual.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+    assertThat(actual.getCondition())
+        .get()
+        .isInstanceOf(PutIf.class)
+        .satisfies(
+            c ->
+                assertThat(c.getExpressions())
+                    .containsExactly(
+                        ConditionBuilder.column(VERSION).isEqualToInt(2),
+                        ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)));
+    assertThat(actual.getTextValue(ID)).isEqualTo(ANY_ID_3);
+    assertThat(actual.getIntValue(STATE)).isEqualTo(TransactionState.PREPARED.get());
+    assertThat(actual.getIntValue(VERSION)).isEqualTo(3);
+    assertThat(actual.getBigIntValue(Attribute.PREPARED_AT)).isEqualTo(ANY_TIME_5);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_PREPARED_AT)).isEqualTo(ANY_TIME_3);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_COMMITTED_AT)).isEqualTo(ANY_TIME_4);
+    assertThat(actual.getTextValue(Attribute.BEFORE_ID)).isEqualTo(ANY_ID_2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_STATE))
+        .isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(actual.getIntValue(Attribute.BEFORE_VERSION)).isEqualTo(2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3)).isEqualTo(ANY_INT_2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX))
+        .isEqualTo(ANY_INT_2);
+  }
+
+  @Test
+  public void add_PutWithPutIfConditionAndNullResultGiven_ShouldThrowNoMutationException() {
+    // Arrange
+    PutIf putIf = mock(PutIf.class);
+    Put put = preparePut().condition(putIf).build();
+
+    // Act Assert
+    assertThatThrownBy(() -> composer.add(put, null)).isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void add_PutWithPutIfExistsConditionAndNullResultGiven_ShouldThrowNoMutationException() {
+    // Arrange
+    PutIfExists putIfExists = mock(PutIfExists.class);
+    Put put = preparePut().condition(putIfExists).build();
+
+    // Act Assert
+    assertThatThrownBy(() -> composer.add(put, null)).isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void
+      add_PutWithPutIfNotExistsAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition()
+          throws ExecutionException {
+    // Arrange
+    PutIfNotExists putIfNotExists = mock(PutIfNotExists.class);
+    Put put = preparePut().condition(putIfNotExists).build();
+
+    // Act
+    composer.add(put, null);
+
+    // Assert
+    Put actual = (Put) composer.get().get(0);
+    assertThat(actual.forNamespace()).get().isEqualTo(ANY_NAMESPACE_NAME);
+    assertThat(actual.forTable()).get().isEqualTo(ANY_TABLE_NAME);
+    assertThat(actual.getPartitionKey().equals(Key.ofText(ANY_NAME_1, ANY_TEXT_1))).isTrue();
+    assertThat(actual.getClusteringKey()).get().isEqualTo(Key.ofText(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.getIntValue(ANY_NAME_3)).isEqualTo(ANY_INT_3);
+    assertThat(actual.getIntValue(ANY_NAME_WITH_BEFORE_PREFIX)).isEqualTo(ANY_INT_3);
+    assertThat(actual.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+    assertThat(put.getCondition()).get().isInstanceOf(PutIfNotExists.class);
+    assertThat(actual.getBigIntValue(Attribute.PREPARED_AT)).isEqualTo(ANY_TIME_5);
+    assertThat(actual.getTextValue(Attribute.ID)).isEqualTo(ANY_ID_3);
+    assertThat(actual.getIntValue(STATE)).isEqualTo(TransactionState.PREPARED.get());
+    assertThat(actual.getIntValue(VERSION)).isEqualTo(1);
+  }
+
+  @Test
   public void add_DeleteAndResultGiven_ShouldComposePutWithPutIfCondition()
       throws ExecutionException {
     // Arrange
-    Delete delete = prepareDelete();
+    Delete delete = prepareDelete().build();
     TransactionResult result = prepareResult();
 
     // Act
@@ -246,7 +408,7 @@ public class PrepareMutationComposerTest {
   public void add_DeleteAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition()
       throws ExecutionException {
     // Arrange
-    Delete delete = prepareDelete();
+    Delete delete = prepareDelete().build();
 
     // Act
     composer.add(delete, null);
@@ -264,6 +426,111 @@ public class PrepareMutationComposerTest {
     expected.withValue(Attribute.toStateValue(TransactionState.DELETED));
     expected.withValue(Attribute.toVersionValue(1));
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void add_DeleteWithDeleteIfConditionAndResultGiven_ShouldComposePutWithPutIfCondition()
+      throws ExecutionException {
+    // Arrange
+    DeleteIf deleteIf = mock(DeleteIf.class);
+    when(deleteIf.getExpressions()).thenReturn(ImmutableList.of(condExpression1, condExpression2));
+    Delete delete = prepareDelete().condition(deleteIf).build();
+    TransactionResult result = prepareResult();
+
+    // Act
+    composer.add(delete, result);
+
+    // Assert
+    Put actual = (Put) composer.get().get(0);
+    assertThat(actual.forNamespace()).get().isEqualTo(ANY_NAMESPACE_NAME);
+    assertThat(actual.forTable()).get().isEqualTo(ANY_TABLE_NAME);
+    assertThat(actual.getPartitionKey().equals(Key.ofText(ANY_NAME_1, ANY_TEXT_1))).isTrue();
+    assertThat(actual.getClusteringKey()).get().isEqualTo(Key.ofText(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+    assertThat(actual.getCondition())
+        .get()
+        .isInstanceOf(PutIf.class)
+        .satisfies(
+            c ->
+                assertThat(c.getExpressions())
+                    .containsExactly(
+                        ConditionBuilder.column(VERSION).isEqualToInt(2),
+                        ConditionBuilder.column(ID).isEqualToText(ANY_ID_2),
+                        condExpression1,
+                        condExpression2));
+    assertThat(actual.getTextValue(ID)).isEqualTo(ANY_ID_3);
+    assertThat(actual.getIntValue(STATE)).isEqualTo(TransactionState.DELETED.get());
+    assertThat(actual.getIntValue(VERSION)).isEqualTo(3);
+    assertThat(actual.getBigIntValue(Attribute.PREPARED_AT)).isEqualTo(ANY_TIME_5);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_PREPARED_AT)).isEqualTo(ANY_TIME_3);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_COMMITTED_AT)).isEqualTo(ANY_TIME_4);
+    assertThat(actual.getTextValue(Attribute.BEFORE_ID)).isEqualTo(ANY_ID_2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_STATE))
+        .isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(actual.getIntValue(Attribute.BEFORE_VERSION)).isEqualTo(2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3)).isEqualTo(ANY_INT_2);
+  }
+
+  @Test
+  public void
+      add_DeleteWithDeleteIfExistsConditionAndResultGiven_ShouldComposePutWithPutIfCondition()
+          throws ExecutionException {
+    // Arrange
+    DeleteIfExists deleteIfExists = mock(DeleteIfExists.class);
+    Delete delete = prepareDelete().condition(deleteIfExists).build();
+    TransactionResult result = prepareResult();
+
+    // Act
+    composer.add(delete, result);
+
+    // Assert
+    Put actual = (Put) composer.get().get(0);
+    assertThat(actual.forNamespace()).get().isEqualTo(ANY_NAMESPACE_NAME);
+    assertThat(actual.forTable()).get().isEqualTo(ANY_TABLE_NAME);
+    assertThat(actual.getPartitionKey().equals(Key.ofText(ANY_NAME_1, ANY_TEXT_1))).isTrue();
+    assertThat(actual.getClusteringKey()).get().isEqualTo(Key.ofText(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(actual.getConsistency()).isEqualTo(Consistency.LINEARIZABLE);
+    assertThat(actual.getCondition())
+        .get()
+        .isInstanceOf(PutIf.class)
+        .satisfies(
+            c ->
+                assertThat(c.getExpressions())
+                    .containsExactly(
+                        ConditionBuilder.column(VERSION).isEqualToInt(2),
+                        ConditionBuilder.column(ID).isEqualToText(ANY_ID_2)));
+    assertThat(actual.getTextValue(ID)).isEqualTo(ANY_ID_3);
+    assertThat(actual.getIntValue(STATE)).isEqualTo(TransactionState.DELETED.get());
+    assertThat(actual.getIntValue(VERSION)).isEqualTo(3);
+    assertThat(actual.getBigIntValue(Attribute.PREPARED_AT)).isEqualTo(ANY_TIME_5);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_PREPARED_AT)).isEqualTo(ANY_TIME_3);
+    assertThat(actual.getBigIntValue(Attribute.BEFORE_COMMITTED_AT)).isEqualTo(ANY_TIME_4);
+    assertThat(actual.getTextValue(Attribute.BEFORE_ID)).isEqualTo(ANY_ID_2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_STATE))
+        .isEqualTo(TransactionState.COMMITTED.get());
+    assertThat(actual.getIntValue(Attribute.BEFORE_VERSION)).isEqualTo(2);
+    assertThat(actual.getIntValue(Attribute.BEFORE_PREFIX + ANY_NAME_3)).isEqualTo(ANY_INT_2);
+  }
+
+  @Test
+  public void add_DeleteWithDeleteIfConditionAndNullResultGiven_ShouldThrowNoMutationException() {
+    // Arrange
+    Delete delete = prepareDelete().condition(mock(DeleteIf.class)).build();
+
+    // Act
+    Assertions.assertThatThrownBy(() -> composer.add(delete, null))
+        .isInstanceOf(NoMutationException.class);
+  }
+
+  @Test
+  public void
+      add_DeleteWithDeleteIfExistsConditionAndNullResultGiven_ShouldThrowNoMutationException() {
+    // Arrange
+    Delete delete = prepareDelete().condition(mock(DeleteIfExists.class)).build();
+
+    // Act
+    Assertions.assertThatThrownBy(() -> composer.add(delete, null))
+        .isInstanceOf(NoMutationException.class);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -207,6 +207,26 @@ public class JdbcTransactionManagerTest {
   }
 
   @Test
+  public void put_withNoMutation_shouldThrowCrudException()
+      throws SQLException, ExecutionException {
+    // Arrange
+    when(jdbcService.put(any(), any())).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              DistributedTransaction transaction = manager.begin();
+              Put put =
+                  new Put(new Key("p1", "val1"))
+                      .withValue("v1", "val2")
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
+              transaction.put(put);
+            })
+        .isInstanceOf(CrudException.class);
+  }
+
+  @Test
   public void
       whenDeleteOperationsExecutedAndJdbcServiceThrowsSQLException_shouldThrowCrudException()
           throws Exception {
@@ -240,6 +260,23 @@ public class JdbcTransactionManagerTest {
               transaction.delete(delete);
             })
         .isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void delete_withNoMutation_shouldThrowCrudException()
+      throws SQLException, ExecutionException {
+    // Arrange
+    when(jdbcService.delete(any(), any())).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              DistributedTransaction transaction = manager.begin();
+              Delete delete =
+                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+              transaction.delete(delete);
+            })
+        .isInstanceOf(CrudException.class);
   }
 
   @Test
@@ -291,6 +328,7 @@ public class JdbcTransactionManagerTest {
   @Test
   public void whenCommitFails_shouldThrowCommitExceptionAndRollback() throws Exception {
     // Arrange
+    when(jdbcService.put(any(), any())).thenReturn(true);
     doThrow(sqlException).when(connection).commit();
 
     // Act Assert
@@ -315,6 +353,7 @@ public class JdbcTransactionManagerTest {
   @Test
   public void whenRollbackFails_shouldThrowAbortException() throws Exception {
     // Arrange
+    when(jdbcService.put(any(), any())).thenReturn(true);
     doThrow(sqlException).when(connection).rollback();
 
     // Act Assert
@@ -338,6 +377,7 @@ public class JdbcTransactionManagerTest {
   @Test
   public void whenRollbackFails_shouldThrowRollbackException() throws Exception {
     // Arrange
+    when(jdbcService.put(any(), any())).thenReturn(true);
     doThrow(sqlException).when(connection).rollback();
 
     // Act Assert
@@ -362,6 +402,7 @@ public class JdbcTransactionManagerTest {
   public void whenCommitAndRollbackFails_shouldThrowUnknownTransactionStatusException()
       throws Exception {
     // Arrange
+    when(jdbcService.put(any(), any())).thenReturn(true);
     doThrow(sqlException).when(connection).commit();
     doThrow(sqlException).when(connection).rollback();
 

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
@@ -217,10 +218,12 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Put put =
-                  new Put(new Key("p1", "val1"))
-                      .withValue("v1", "val2")
-                      .forNamespace(NAMESPACE)
-                      .forTable(TABLE);
+                  Put.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .condition(ConditionBuilder.putIfNotExists())
+                      .build();
               transaction.put(put);
             })
         .isInstanceOf(CrudException.class);
@@ -273,7 +276,12 @@ public class JdbcTransactionManagerTest {
             () -> {
               DistributedTransaction transaction = manager.begin();
               Delete delete =
-                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+                  Delete.newBuilder()
+                      .namespace(NAMESPACE)
+                      .table(TABLE)
+                      .partitionKey(Key.ofText("p1", "val1"))
+                      .condition(ConditionBuilder.deleteIfExists())
+                      .build();
               transaction.delete(delete);
             })
         .isInstanceOf(CrudException.class);

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -583,6 +583,45 @@ Put put =
         .build();
 ```
 
+##### Put with a condition
+
+In a Put operation, you can specify a condition, and only when the specified condition matches, the Put operation is executed.
+It's like a well-known CAS (compare and swap) operation, and the condition comparison and the update are performed atomically.
+
+You can specify a condition in a Put operation as follows:
+
+```java
+// Build a condition
+MutationCondition condition =
+    ConditionBuilder.putIf(ConditionBuilder.column("c4").isEqualToFloat(0.0F))
+        .and(ConditionBuilder.column("c5").isEqualToDouble(0.0))
+        .build();
+
+Put put =
+    Put.newBuilder()
+        .namespace("ns")
+        .table("tbl")
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .floatValue("c4", 1.23F)
+        .doubleValue("c5", 4.56)
+        .condition(condition) // condition
+        .build();
+
+// Execute the Put operation
+transaction.put(put);
+```
+
+Other than the `putIf` condition, you can specify the `putIfExists` and `putIfNotExists` conditions as follows:
+
+```java
+// Build a putIfExists condition
+MutationCondition putIfExistsCondition = ConditionBuilder.putIfExists();
+
+// Build a putIfNotExists condition
+MutationCondition putIfNotExistsCondition = ConditionBuilder.putIfNotExists();
+```
+
 #### Delete operation
 
 `Delete` is an operation to delete a record specified by a primary key.
@@ -605,6 +644,39 @@ Delete delete =
 
 // Execute the Delete operation
 transaction.delete(delete);
+```
+
+##### Delete with a condition
+
+Similar to a Put operation, you can specify a condition in a Delete operation.
+
+You can specify a condition in a Delete operation as follows:
+
+```java
+// Build a condition
+MutationCondition condition =
+    ConditionBuilder.deleteIf(ConditionBuilder.column("c4").isEqualToFloat(0.0F))
+        .and(ConditionBuilder.column("c5").isEqualToDouble(0.0))
+        .build();
+
+Delete delete =
+    Delete.newBuilder()
+        .namespace("ns")
+        .table("tbl")
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .condition(condition)  // condition
+        .build();
+
+// Execute the Delete operation
+transaction.delete(delete);
+```
+
+Other than the `deleteIf` condition, you can specify the `deleteIfExists` condition as follows:
+
+```java
+// Build a deleteIfExists condition
+MutationCondition deleteIfExistsCondition = ConditionBuilder.deleteIfExists();
 ```
 
 #### Mutate operation
@@ -672,9 +744,7 @@ Scan scanUsingSpecifiedNamespace =
 
 #### Notes
 
-- All the builders of the CRUD operations can specify consistency with the `consistency()` methods, but it's ignored, and the `LINEARIZABLE` consistency level is always used in transactions.
-- Also, the builders of the mutation operations (Put and Delete operations) can specify a condition with the `condition()` methods, but it's ignored, too. 
-Please program such conditions in a transaction if you want to implement conditional mutation.
+All the builders of the CRUD operations can specify consistency with the `consistency()` methods, but it's ignored, and the `LINEARIZABLE` consistency level is always used in transactions.
 
 ### Commit a transaction
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -1044,10 +1044,9 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   @Test
   public void put_withPutIfExistsWhenRecordExists_shouldPutProperly() throws TransactionException {
+    // Arrange
     Put put = preparePut(0, 0);
     put(put);
-
-    // Arrange
     Put putIfExists =
         Put.newBuilder(put)
             .intValue(BALANCE, INITIAL_BALANCE)
@@ -1063,6 +1062,25 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
     assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
     assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
+  public void put_withPutIfNotExistsWhenRecordDoesNotExist_shouldPutProperly()
+      throws TransactionException {
+    // Arrange
+    Put putIfNotExists =
+        Put.newBuilder(preparePut(0, 0)).condition(ConditionBuilder.putIfNotExists()).build();
+
+    // Act Assert
+    getThenPut(putIfNotExists);
+
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.isNull(BALANCE)).isTrue();
     assertThat(result.isNull(SOME_COLUMN)).isTrue();
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.scalar.db.api.GetBuilder.BuildableGet;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -1231,6 +1232,279 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       if (manager1WithDefaultNamespace != null) {
         manager1WithDefaultNamespace.close();
       }
+    }
+  }
+
+  @Test
+  public void put_withPutIfWithVerifiedCondition_shouldPutProperly() throws TransactionException {
+    // Arrange
+    int someColumnValue = 10;
+    Put initialData =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .intValue(SOME_COLUMN, someColumnValue)
+            .build();
+    put(initialData);
+
+    int updatedBalance = 2;
+    Put putIf =
+        Put.newBuilder(initialData)
+            .intValue(BALANCE, updatedBalance)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    // Act
+    getThenPut(putIf);
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(updatedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(someColumnValue);
+  }
+
+  @Test
+  public void put_withPutIfWithNonVerifiedCondition_shouldThrowPreparationConflictException()
+      throws TransactionException {
+    // Arrange
+    Put initialData =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    put(initialData);
+
+    Put putIf =
+        Put.newBuilder(initialData)
+            .intValue(BALANCE, 2)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenPut(putIf)).isInstanceOf(PreparationConflictException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
+  public void put_withPutIfWhenRecordDoesNotExist_shouldThrowPreparationConflictException()
+      throws TransactionException {
+
+    // Arrange
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .condition(
+                ConditionBuilder.putIf(ConditionBuilder.column(BALANCE).isNullText()).build())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> put(put)).isInstanceOf(PreparationConflictException.class);
+
+    Optional<Result> result = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void put_withPutIfExistsWhenRecordDoesNotExist_shouldThrowPreparationConflictException()
+      throws TransactionException {
+
+    // Arrange
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .condition(ConditionBuilder.putIfExists())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenPut(put)).isInstanceOf(PreparationConflictException.class);
+
+    Optional<Result> result = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void put_withPutIfExistsWhenRecordExists_shouldPutProperly() throws TransactionException {
+    Put put = preparePut(0, 0, namespace1, TABLE_1);
+    put(put);
+
+    // Arrange
+    Put putIfExists =
+        Put.newBuilder(put)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .condition(ConditionBuilder.putIfExists())
+            .build();
+
+    // Act Assert
+    getThenPut(putIfExists);
+
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
+  public void delete_withDeleteIfWithVerifiedCondition_shouldDeleteProperly()
+      throws TransactionException {
+    // Arrange
+    Put initialData =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    put(initialData);
+
+    Delete deleteIf =
+        Delete.newBuilder(prepareDelete(0, 0, namespace1, TABLE_1))
+            .condition(
+                ConditionBuilder.deleteIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNullInt())
+                    .build())
+            .build();
+
+    // Act
+    getThenDelete(deleteIf);
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isFalse();
+  }
+
+  @Test
+  public void delete_withDeleteIfWithNonVerifiedCondition_shouldThrowPreparationConflictException()
+      throws TransactionException {
+    // Arrange
+    Put initialData = Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).build();
+    put(initialData);
+
+    Delete deleteIf =
+        Delete.newBuilder(prepareDelete(0, 0, namespace1, TABLE_1))
+            .condition(
+                ConditionBuilder.deleteIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenDelete(deleteIf))
+        .isInstanceOf(PreparationConflictException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.isNull(BALANCE)).isTrue();
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
+  public void delete_withDeleteIfExistsWhenRecordsExists_shouldDeleteProperly()
+      throws TransactionException {
+    // Arrange
+    Put initialData = Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).build();
+    put(initialData);
+
+    Delete deleteIf =
+        Delete.newBuilder(prepareDelete(0, 0, namespace1, TABLE_1))
+            .condition(ConditionBuilder.deleteIfExists())
+            .build();
+
+    // Act Assert
+    getThenDelete(deleteIf);
+
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isFalse();
+  }
+  // Fails
+  @Test
+  public void
+      delete_withDeleteIfExistsWhenRecordDoesNotExist_shouldThrowPreparationConflictException() {
+    // Arrange
+    Delete deleteIf =
+        Delete.newBuilder(prepareDelete(0, 0, namespace1, TABLE_1))
+            .condition(ConditionBuilder.deleteIfExists())
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenDelete(deleteIf))
+        .isInstanceOf(PreparationConflictException.class);
+  }
+
+  private Optional<Result> get(Get get) throws TransactionException {
+    TwoPhaseCommitTransaction tx = manager1.start();
+    try {
+      Optional<Result> result = tx.get(get);
+      tx.prepare();
+      tx.validate();
+      tx.commit();
+      return result;
+    } catch (TransactionException e) {
+      tx.rollback();
+      throw e;
+    }
+  }
+
+  private void put(Put put) throws TransactionException {
+    TwoPhaseCommitTransaction tx = manager1.start();
+    try {
+      tx.put(put);
+      tx.prepare();
+      tx.validate();
+      tx.commit();
+    } catch (TransactionException e) {
+      tx.rollback();
+      throw e;
+    }
+  }
+
+  private void getThenPut(Put put) throws TransactionException {
+    getThenMutate(put);
+  }
+
+  private void getThenDelete(Delete delete) throws TransactionException {
+    getThenMutate(delete);
+  }
+
+  private void getThenMutate(Mutation mutation) throws TransactionException {
+    assert mutation.forNamespace().isPresent();
+    assert mutation.forTable().isPresent();
+    BuildableGet get =
+        Get.newBuilder()
+            .namespace(mutation.forNamespace().get())
+            .table(mutation.forTable().get())
+            .partitionKey(mutation.getPartitionKey());
+    mutation.getClusteringKey().ifPresent(get::clusteringKey);
+
+    TwoPhaseCommitTransaction tx = manager1.start();
+    try {
+      tx.get(get.build());
+      tx.mutate(Collections.singletonList(mutation));
+      tx.prepare();
+      tx.validate();
+      tx.commit();
+    } catch (TransactionException e) {
+      tx.rollback();
+      throw e;
     }
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -166,7 +166,6 @@ public abstract class ConsensusCommitIntegrationTestBase
   @Test
   public void put_withPutIfWhenRecordDoesNotExist_shouldThrowCommitConflictException()
       throws TransactionException {
-
     // Arrange
     Put put =
         Put.newBuilder(preparePut(0, 0))
@@ -183,7 +182,6 @@ public abstract class ConsensusCommitIntegrationTestBase
   @Test
   public void put_withPutIfExistsWhenRecordDoesNotExist_shouldThrowCommitConflictException()
       throws TransactionException {
-
     // Arrange
     Put put = Put.newBuilder(preparePut(0, 0)).condition(ConditionBuilder.putIfExists()).build();
 
@@ -192,6 +190,27 @@ public abstract class ConsensusCommitIntegrationTestBase
 
     Optional<Result> result = get(prepareGet(0, 0));
     assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void put_withPutIfNotExistsWhenRecordExists_shouldThrowCommitConflictException()
+      throws TransactionException {
+    // Arrange
+    Put put = preparePut(0, 0);
+    put(put);
+    Put putIfNotExists = Put.newBuilder(put).condition(ConditionBuilder.putIfNotExists()).build();
+
+    // Act Assert
+    assertThatThrownBy(() -> getThenPut(putIfNotExists))
+        .isInstanceOf(CommitConflictException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.isNull(BALANCE)).isTrue();
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
**Context** 
Setting conditions for Put or Delete in a transaction was not supported. Setting conditions in the operation builder was possible, but they were ignored.

**Changes**
Setting condition is now fully supported on Put and Delete operation for consensus commit (regular and 2pc) or Jdbc transactions. For example :

https://github.com/scalar-labs/scalardb/blob/bdf51bd170101939266956a340734f0fe37d300c/docs/api-guide.md?plain=1#L594-L612