### PR TITLE
docs: write about `busy_timeout` parameter for JDBC SQLite storage

### DIFF
--- a/docs/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/getting-started-with-scalardb-on-jdbc.md
@@ -82,3 +82,15 @@ scalar.db.transaction_manager=jdbc
 
 When using JDBC transaction, the `SERIALIZABLE` isolation level is used by default.
 And you can change it with the `scalar.db.jdbc.isolation_level` property.
+
+## Use SQLite3 storage
+
+You can use SQLite3 as a backend database. To do that, you need to set `scalar.db.contact_points` in **scalardb.properties** as follows.
+
+```properties
+scalar.db.contact_points=jdbc:sqlite:your-db.sqlite3?busy_timeout=10000
+```
+
+Unlike other database servers, [SQLite3 does not fully support concurrent access](https://www.sqlite.org/lang_transaction.html).
+In order to avoid frequent errors caused internally by the [`SQLITE_BUSY`](https://www.sqlite.org/rescode.html#busy),
+it is recommended to set a [`busy_timeout`](https://www.sqlite.org/c3ref/busy_timeout.html) parameter.


### PR DESCRIPTION
As described in https://github.com/scalar-labs/scalardb/pull/819#discussion_r1161205858