### PR TITLE
Push SNAPSHOT version container images

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -56,8 +56,7 @@ jobs:
 
       - name: Create SNAPSHOT containers
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
-        run: |
-          ./gradlew docker
+        run: ./gradlew docker
 
       - name: Push SNAPSHOT containers
         if: contains(steps.version.outputs.version, '-SNAPSHOT')

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -46,3 +46,17 @@ jobs:
           -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
           -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
           -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Create and push SNAPSHOT version container images for scalardb-server and scalardb-schema-loader to GitHub Packages
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: |
+          ./gradlew docker
+          docker push ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -54,7 +54,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Create and push SNAPSHOT version container images for scalardb-server and scalardb-schema-loader to GitHub Packages
+      - name: Create SNAPSHOT containers
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: |
+          ./gradlew docker
+
+      - name: Push SNAPSHOT containers
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: |
           ./gradlew docker

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -62,6 +62,5 @@ jobs:
       - name: Push SNAPSHOT containers
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: |
-          ./gradlew docker
           docker push ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}


### PR DESCRIPTION
This PR adds new steps to the SNAPSHOT release workflow. These new steps push the SNAPSHOT version container images.

Sometimes, we need to update Helm Chart based on the new feature of ScalarDB.
However, in the Scalar Helm Chart repository, it uses the container images of the latest release version (not the snapshot version) in the CI.
This causes CI failures of the Helm Chart repository. For example, when the new feature of ScalarDB is merged into the `master` branch, we need to update Helm Chart and test the chart using ScalarDB of the `master` branch (i.e., SNAPSHOT version).
So, I want to push the SNAPSHOT version container images and use them in the CI of the Scalar Helm Chart.

Please take a look!