### PR TITLE
Update supported Java version in getting started

### DIFF
--- a/docs/getting-started-with-scalardb-on-cassandra.md
+++ b/docs/getting-started-with-scalardb-on-cassandra.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with ScalarDB on Cassandr
 
 ScalarDB is written in Java and uses Cassandra as an underlying storage implementation, so the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8) or higher
 * [Casssandra](http://cassandra.apache.org/) 3.11.x (the current stable version as of writing)
     * Take a look at [this document](http://cassandra.apache.org/download/) for how to set up Cassandra.
     * Change `commitlog_sync` from `periodic` to `batch` in `cassandra.yaml` not to lose data when quorum of replica nodes go down

--- a/docs/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/getting-started-with-scalardb-on-cosmosdb.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with ScalarDB on Cosmos D
 
 ScalarDB is written in Java. So the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8) or higher
 * Other libraries used from the above are automatically installed through gradle
 
 ## Cosmos DB for NoSQL setup

--- a/docs/getting-started-with-scalardb-on-dynamodb.md
+++ b/docs/getting-started-with-scalardb-on-dynamodb.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with ScalarDB on DynamoDB
 
 ScalarDB is written in Java. So the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8) or higher
 * Other libraries used from the above are automatically installed through gradle
         
 From here, we assume Oracle JDK 8 is properly installed in your local environment.

--- a/docs/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/getting-started-with-scalardb-on-jdbc.md
@@ -7,7 +7,7 @@ This document briefly explains how you can get started with ScalarDB on JDBC dat
 
 ScalarDB is written in Java and uses a JDBC database as an underlying storage implementation, so the following software is required to run it.
 
-* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8)
+* [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) (or OpenJDK 8) or higher
 * A JDBC database instance. Currently, MySQL, PostgreSQL, Oracle Database, SQL Server, and Amazon Aurora are officially supported
 * Other libraries used from the above are automatically installed through gradle
 

--- a/docs/getting-started/gradle/wrapper/gradle-wrapper.properties
+++ b/docs/getting-started/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the description of the supported Java version in the getting started guide.

In the previous getting started guide, we built ScalarDB itself in that steps. So, we must use Java 8 to build ScalarDB.
However, in the current getting started guide, we can use `Java 8 or higher` since it gets pre-compiled ScalarDB from the Maven repository.

And, I think there is a possibility that the current description may mislead users that `ScalarDB only supports Java 8`.
(Actually, I got a such question from a user.)
So, I think it is better to describe `Java 8 or higher` in the getting started guide.

Also, Gradle 7.1 doesn't support Java 17 or higher.
So, I updated the Gradle version of the getting started project to 7.6 (current latest version).
https://docs.gradle.org/current/userguide/compatibility.html

Please take a look!