### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+registries:
+  ghcr:
+    type: docker-registry
+    url: https://ghcr.io
+    username: ${{secrets.CR_USER}}
+    password: ${{secrets.CR_PAT}}
+    replaces-base: true
+updates:
+  # For the Schema Loader Docker image, only update the scalar-labs/jre8 container
+  - package-ecosystem: "docker"
+    directory: "/schema-loader/"
+    registries:
+      - ghcr
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
+    allow:
+      - dependency-name: "scalar-labs/jre8"
+  # For the Server Docker image, only update the scalar-labs/jre8 container
+  - package-ecosystem: "docker"
+    directory: "/server/"
+    registries:
+      - ghcr
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
+    allow:
+      - dependency-name: "scalar-labs/jre8"
+  # For Gradle, update dependencies and plugins to the latest non-major version
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  # For GitHub Actions workflows, update all actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"


### PR DESCRIPTION
This enables Dependabot to : 
- For Docker images, update the internal JRE container
- For the Gradle build, update dependencies and plugin to the latest non-major version. This is to avoid introducing incompatible changes.
- For Github Actions workflows, update all the actions