### PR TITLE
Allow to create `before_` prefixed columns in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -86,7 +86,8 @@ public class CommitHandler {
 
   private void prepareRecords(Snapshot snapshot)
       throws ExecutionException, PreparationConflictException {
-    PrepareMutationComposer composer = new PrepareMutationComposer(snapshot.getId());
+    PrepareMutationComposer composer =
+        new PrepareMutationComposer(snapshot.getId(), tableMetadataManager);
     snapshot.to(composer);
     PartitionedMutations mutations = new PartitionedMutations(composer.get());
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadata.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import com.google.common.collect.Streams;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
@@ -15,12 +16,19 @@ import javax.annotation.concurrent.Immutable;
 public class TransactionTableMetadata {
 
   private final TableMetadata tableMetadata;
+  private final ImmutableLinkedHashSet<String> primaryKeyColumnNames;
   private final ImmutableLinkedHashSet<String> transactionMetaColumnNames;
   private final ImmutableLinkedHashSet<String> beforeImageColumnNames;
   private final ImmutableLinkedHashSet<String> afterImageColumnNames;
 
   public TransactionTableMetadata(TableMetadata tableMetadata) {
     this.tableMetadata = tableMetadata;
+    primaryKeyColumnNames =
+        new ImmutableLinkedHashSet<>(
+            Streams.concat(
+                    tableMetadata.getPartitionKeyNames().stream(),
+                    tableMetadata.getClusteringKeyNames().stream())
+                .collect(Collectors.toCollection(LinkedHashSet::new)));
     transactionMetaColumnNames =
         new ImmutableLinkedHashSet<>(
             tableMetadata.getColumnNames().stream()
@@ -68,6 +76,10 @@ public class TransactionTableMetadata {
 
   public Set<String> getSecondaryIndexNames() {
     return tableMetadata.getSecondaryIndexNames();
+  }
+
+  public LinkedHashSet<String> getPrimaryKeyColumnNames() {
+    return primaryKeyColumnNames;
   }
 
   public LinkedHashSet<String> getTransactionMetaColumnNames() {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -7,12 +7,15 @@ import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toVersionValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfNotExists;
@@ -20,6 +23,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.IntColumn;
@@ -28,6 +32,8 @@ import com.scalar.db.io.TextColumn;
 import com.scalar.db.util.ScalarDbUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class PrepareMutationComposerTest {
   private static final String ANY_NAMESPACE_NAME = "namespace";
@@ -43,6 +49,7 @@ public class PrepareMutationComposerTest {
   private static final String ANY_NAME_1 = "name1";
   private static final String ANY_NAME_2 = "name2";
   private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_WITH_BEFORE_PREFIX = "before_x";
   private static final String ANY_TEXT_1 = "text1";
   private static final String ANY_TEXT_2 = "text2";
   private static final int ANY_INT_1 = 100;
@@ -55,15 +62,24 @@ public class PrepareMutationComposerTest {
               .addColumn(ANY_NAME_1, DataType.TEXT)
               .addColumn(ANY_NAME_2, DataType.TEXT)
               .addColumn(ANY_NAME_3, DataType.INT)
+              .addColumn(ANY_NAME_WITH_BEFORE_PREFIX, DataType.INT)
               .addPartitionKey(ANY_NAME_1)
               .addClusteringKey(ANY_NAME_2)
               .build());
 
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
+
   private PrepareMutationComposer composer;
 
   @BeforeEach
-  public void setUp() {
-    composer = new PrepareMutationComposer(ANY_ID_3, ANY_TIME_5);
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    // Arrange
+    composer = new PrepareMutationComposer(ANY_ID_3, ANY_TIME_5, tableMetadataManager);
+
+    when(tableMetadataManager.getTransactionTableMetadata(any(Operation.class)))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
   }
 
   private Put preparePut() {
@@ -72,7 +88,8 @@ public class PrepareMutationComposerTest {
     return new Put(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME)
-        .withValue(ANY_NAME_3, ANY_INT_3);
+        .withValue(ANY_NAME_3, ANY_INT_3)
+        .withValue(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_3);
   }
 
   private Delete prepareDelete() {
@@ -106,6 +123,7 @@ public class PrepareMutationComposerTest {
             .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
             .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
             .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
+            .put(ANY_NAME_WITH_BEFORE_PREFIX, IntColumn.of(ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2))
             .put(Attribute.ID, ScalarDbUtils.toColumn(Attribute.toIdValue(ANY_ID_2)))
             .put(
                 Attribute.PREPARED_AT,
@@ -120,6 +138,9 @@ public class PrepareMutationComposerTest {
             .put(
                 Attribute.BEFORE_PREFIX + ANY_NAME_3,
                 IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
+            .put(
+                Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX,
+                IntColumn.of(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_1))
             .put(Attribute.BEFORE_ID, ScalarDbUtils.toColumn(Attribute.toBeforeIdValue(ANY_ID_1)))
             .put(
                 Attribute.BEFORE_PREPARED_AT,
@@ -137,7 +158,7 @@ public class PrepareMutationComposerTest {
   }
 
   @Test
-  public void add_PutAndResultGiven_ShouldComposePutWithPutIfCondition() {
+  public void add_PutAndResultGiven_ShouldComposePutWithPutIfCondition() throws ExecutionException {
     // Arrange
     Put put = preparePut();
     TransactionResult result = prepareResult();
@@ -162,11 +183,13 @@ public class PrepareMutationComposerTest {
     put.withValue(Attribute.toBeforeStateValue(TransactionState.COMMITTED));
     put.withValue(Attribute.toBeforeVersionValue(2));
     put.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2);
+    put.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2);
     assertThat(actual).isEqualTo(put);
   }
 
   @Test
-  public void add_PutAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition() {
+  public void add_PutAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition()
+      throws ExecutionException {
     // Arrange
     Put put = preparePut();
 
@@ -185,7 +208,8 @@ public class PrepareMutationComposerTest {
   }
 
   @Test
-  public void add_DeleteAndResultGiven_ShouldComposePutWithPutIfCondition() {
+  public void add_DeleteAndResultGiven_ShouldComposePutWithPutIfCondition()
+      throws ExecutionException {
     // Arrange
     Delete delete = prepareDelete();
     TransactionResult result = prepareResult();
@@ -214,11 +238,13 @@ public class PrepareMutationComposerTest {
     expected.withValue(Attribute.toBeforeStateValue(TransactionState.COMMITTED));
     expected.withValue(Attribute.toBeforeVersionValue(2));
     expected.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2);
+    expected.withValue(Attribute.BEFORE_PREFIX + ANY_NAME_WITH_BEFORE_PREFIX, ANY_INT_2);
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
-  public void add_DeleteAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition() {
+  public void add_DeleteAndNullResultGiven_ShouldComposePutWithPutIfNotExistsCondition()
+      throws ExecutionException {
     // Arrange
     Delete delete = prepareDelete();
 
@@ -242,7 +268,8 @@ public class PrepareMutationComposerTest {
 
   @Test
   public void
-      add_GetAndNullResultGiven_ShouldComposePutForPuttingNonExistingRecordForSerializableWithExtraWrite() {
+      add_GetAndNullResultGiven_ShouldComposePutForPuttingNonExistingRecordForSerializableWithExtraWrite()
+          throws ExecutionException {
     // Arrange
     Get get = prepareGet();
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -627,8 +627,8 @@ public class SnapshotTest {
   }
 
   @Test
-  public void
-      toSerializableWithExtraWrite_UnmutatedReadSetExists_ShouldConvertReadSetIntoWriteSet() {
+  public void toSerializableWithExtraWrite_UnmutatedReadSetExists_ShouldConvertReadSetIntoWriteSet()
+      throws ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Get get = prepareAnotherGet();
@@ -655,7 +655,8 @@ public class SnapshotTest {
 
   @Test
   public void
-      toSerializableWithExtraWrite_UnmutatedReadSetForNonExistingExists_ShouldNotThrowAnyException() {
+      toSerializableWithExtraWrite_UnmutatedReadSetForNonExistingExists_ShouldNotThrowAnyException()
+          throws ExecutionException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Get get = prepareAnotherGet();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManagerTest.java
@@ -127,6 +127,7 @@ public class TransactionTableMetadataManagerTest {
     assertThat(actual.getClusteringKeyNames())
         .isEqualTo(new LinkedHashSet<>(Collections.singletonList(ACCOUNT_TYPE)));
     assertThat(actual.getClusteringOrder(ACCOUNT_TYPE)).isEqualTo(Order.ASC);
+    assertThat(actual.getClusteringOrders().get(ACCOUNT_TYPE)).isEqualTo(Order.ASC);
     assertThat(actual.getColumnNames())
         .isEqualTo(
             new LinkedHashSet<>(
@@ -165,6 +166,7 @@ public class TransactionTableMetadataManagerTest {
     assertThat(actual.getColumnDataType(Attribute.BEFORE_COMMITTED_AT)).isEqualTo(DataType.BIGINT);
     assertThat(actual.getSecondaryIndexNames())
         .isEqualTo(new HashSet<>(Collections.singletonList(BRANCH)));
+    assertThat(actual.getPrimaryKeyColumnNames()).containsExactly(ACCOUNT_ID, ACCOUNT_TYPE);
     assertThat(actual.getTransactionMetaColumnNames())
         .isEqualTo(
             new LinkedHashSet<>(


### PR DESCRIPTION
Currently, when we create a non-primary key column with a name that starts with `before_`, the column is not handled correctly. Specifically, the before column is not updated correctly in the prepare phase, as explained in the following comment:
https://github.com/scalar-labs/scalardb/pull/841#discussion_r1171065262

This PR fixes the issue. Please take a look!