### PR TITLE
Add decommissioning state to ScalarDB Server

### DIFF
--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -43,7 +43,7 @@ It contains two sections: ScalarDB Server configurations and underlying storage/
 # ScalarDB Server configurations
 #
 
-# Port number of ScalarDB Server. 60051 by default
+# Port number of ScalarDB Server. 60051 by default.
 scalar.db.server.port=60051
 
 # Prometheus exporter port. Use 8080 if this is not given. Prometheus exporter will not be started if a negative number is given.
@@ -54,6 +54,9 @@ scalar.db.server.grpc.max_inbound_message_size=
 
 # The maximum size of metadata allowed to be received. If not specified, use the gRPC default value.
 scalar.db.server.grpc.max_inbound_metadata_size=
+
+# The decommissioning duration in seconds. 30 seconds by default.                 
+scalar.db.server.decommissioning_duration_secs=30
 
 #
 # Underlying storage/database configurations

--- a/server/src/main/java/com/scalar/db/server/HealthService.java
+++ b/server/src/main/java/com/scalar/db/server/HealthService.java
@@ -4,17 +4,26 @@ import io.grpc.health.v1.HealthCheckRequest;
 import io.grpc.health.v1.HealthCheckResponse;
 import io.grpc.health.v1.HealthGrpc;
 import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public class HealthService extends HealthGrpc.HealthImplBase {
 
+  private final AtomicReference<HealthCheckResponse.ServingStatus> servingStatus =
+      new AtomicReference<>(HealthCheckResponse.ServingStatus.SERVING);
+
   @Override
   public void check(
       HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
     HealthCheckResponse.Builder builder = HealthCheckResponse.newBuilder();
-    builder.setStatus(HealthCheckResponse.ServingStatus.SERVING);
+    builder.setStatus(servingStatus.get());
     responseObserver.onNext(builder.build());
     responseObserver.onCompleted();
+  }
+
+  /** Decommissions the cluster node from the cluster */
+  public void decommission() {
+    servingStatus.set(HealthCheckResponse.ServingStatus.NOT_SERVING);
   }
 }

--- a/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
+++ b/server/src/main/java/com/scalar/db/server/ScalarDbServer.java
@@ -1,6 +1,7 @@
 package com.scalar.db.server;
 
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
@@ -27,7 +28,8 @@ import picocli.CommandLine.Command;
 @Command(name = "scalardb-server", description = "Starts ScalarDB Server.")
 public class ScalarDbServer implements Callable<Integer> {
   private static final Logger logger = LoggerFactory.getLogger(ScalarDbServer.class);
-  private static final long MAX_WAIT_TIME_MILLIS = 60000; // 60 seconds
+
+  private static final long MAX_SHUTDOWN_WAIT_TIME_MILLIS = 60000;
 
   @CommandLine.Option(
       names = {"--properties", "--config"},
@@ -38,6 +40,7 @@ public class ScalarDbServer implements Callable<Integer> {
 
   private ServerConfig config;
   private Server server;
+  private final HealthService healthService = new HealthService();
 
   private DistributedStorage storage;
   private DistributedStorageAdmin storageAdmin;
@@ -89,7 +92,7 @@ public class ScalarDbServer implements Callable<Integer> {
                     transactionManager, tableMetadataManager, gateKeeper, metrics))
             .addService(new DistributedTransactionAdminService(transactionAdmin, metrics))
             .addService(new AdminService(gateKeeper))
-            .addService(new HealthService())
+            .addService(healthService)
             .addService(ProtoReflectionService.newInstance());
 
     // Two-phase commit for JDBC is not supported for now
@@ -120,10 +123,18 @@ public class ScalarDbServer implements Callable<Integer> {
         .addShutdownHook(
             new Thread(
                 () -> {
-                  logger.info("Signal received. Shutting down the server ...");
-                  shutdown(MAX_WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS);
-                  logger.info("The server shut down.");
+                  logger.info("Signal received. Decommissioning ...");
+                  decommission();
+                  logger.info("Decommissioned. Shutting down.");
+                  shutdown(MAX_SHUTDOWN_WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS);
+                  logger.info("ScalarDB Server shut down.");
                 }));
+  }
+
+  public void decommission() {
+    healthService.decommission();
+    Uninterruptibles.sleepUninterruptibly(
+        config.getDecommissioningDurationSecs(), TimeUnit.SECONDS);
   }
 
   public void shutdown() {

--- a/server/src/main/java/com/scalar/db/server/ServerConfig.java
+++ b/server/src/main/java/com/scalar/db/server/ServerConfig.java
@@ -26,8 +26,14 @@ public class ServerConfig {
   public static final String GRPC_MAX_INBOUND_METADATA_SIZE =
       PREFIX + "grpc.max_inbound_metadata_size";
 
+  /** The decommissioning duration in seconds. */
+  public static final String DECOMMISSIONING_DURATION_SECS =
+      PREFIX + "decommissioning_duration_secs";
+
   public static final int DEFAULT_PORT = 60051;
   public static final int DEFAULT_PROMETHEUS_EXPORTER_PORT = 8080;
+
+  public static final int DEFAULT_DECOMMISSIONING_DURATION_SECS = 30;
 
   private final Properties props;
   private int port;
@@ -35,6 +41,8 @@ public class ServerConfig {
 
   @Nullable private Integer grpcMaxInboundMessageSize;
   @Nullable private Integer grpcMaxInboundMetadataSize;
+
+  private int decommissioningDurationSecs;
 
   public ServerConfig(File propertiesFile) throws IOException {
     try (FileInputStream stream = new FileInputStream(propertiesFile)) {
@@ -73,6 +81,10 @@ public class ServerConfig {
 
     grpcMaxInboundMessageSize = getInt(getProperties(), GRPC_MAX_INBOUND_MESSAGE_SIZE, null);
     grpcMaxInboundMetadataSize = getInt(getProperties(), GRPC_MAX_INBOUND_METADATA_SIZE, null);
+
+    decommissioningDurationSecs =
+        getInt(
+            getProperties(), DECOMMISSIONING_DURATION_SECS, DEFAULT_DECOMMISSIONING_DURATION_SECS);
   }
 
   public int getPort() {
@@ -89,5 +101,9 @@ public class ServerConfig {
 
   public Optional<Integer> getGrpcMaxInboundMetadataSize() {
     return Optional.ofNullable(grpcMaxInboundMetadataSize);
+  }
+
+  public int getDecommissioningDurationSecs() {
+    return decommissioningDurationSecs;
   }
 }

--- a/server/src/test/java/com/scalar/db/server/ServerConfigTest.java
+++ b/server/src/test/java/com/scalar/db/server/ServerConfigTest.java
@@ -24,6 +24,7 @@ public class ServerConfigTest {
         .isEqualTo(ServerConfig.DEFAULT_PROMETHEUS_EXPORTER_PORT);
     assertThat(config.getGrpcMaxInboundMessageSize()).isNotPresent();
     assertThat(config.getGrpcMaxInboundMetadataSize()).isNotPresent();
+    assertThat(config.getDecommissioningDurationSecs()).isEqualTo(30);
   }
 
   @Test
@@ -88,5 +89,18 @@ public class ServerConfigTest {
     assertThat(config.getGrpcMaxInboundMessageSize().get()).isEqualTo(1000);
     assertThat(config.getGrpcMaxInboundMetadataSize()).isPresent();
     assertThat(config.getGrpcMaxInboundMetadataSize().get()).isEqualTo(2000);
+  }
+
+  @Test
+  public void constructor_DecommissioningDurationSecsGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties properties = new Properties();
+    properties.setProperty(ServerConfig.DECOMMISSIONING_DURATION_SECS, "60");
+
+    // Act
+    ServerConfig config = new ServerConfig(properties);
+
+    // Assert
+    assertThat(config.getDecommissioningDurationSecs()).isEqualTo(60);
   }
 }


### PR DESCRIPTION
This PR adds a decommissioning state to ScalarDB Server to achieve graceful shutdown. Please take a look!