### PR TITLE
Apply workaround on CI for Dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,13 +79,13 @@ jobs:
       - name: Dockerfile Lint for ScalarDB Server
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :server:dockerfileLint
+          arguments: ':server:dockerfileLint'
 
       - name: Dockerfile Lint for ScalarDB Schema Loader
         if: always()
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :schema-loader:dockerfileLint
+          arguments: ':schema-loader:dockerfileLint'
 
   integration-test-for-cassandra:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Issue** 
Dependabot is failing to parse the current CI file even though it is valid by Github actions standards.
![image](https://user-images.githubusercontent.com/3835021/234201495-d01c7f4f-4d6e-4576-bb9c-e5be6fb71fcb.png)

**Fix**
This is a known issue (cf. https://github.com/dependabot/dependabot-core/issues/5453) for value starting with the semicolon `:` character that the Dependabot parser does not seem to recognize as a string. A workaround is to quote the problematic part to clear up the ambiguity.
