### PR TITLE
[Dependabot] Ignore patch versions for Aws sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "software.amazon.awssdk:*"
+        update-types: [ "version-update:semver-patch" ]
   # For GitHub Actions workflows, update all actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
**Context** 
Since Aws sdk patch versions are released every few days, Dependabot will end up creating PR to update its version every week, which is not justified.

**Changes**
Dependabot won't update Aws sdk dependencies for patch versions anymore. Eventually, Aws sdk will only be updated when minor versions are released.
