### PR TITLE
Add validation for consensus commit mutation operation

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -35,6 +35,7 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
   private final boolean isIncludeMetadataEnabled;
+  private final ConsensusCommitMutationOperationChecker mutationOperationChecker;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Inject
@@ -52,6 +53,7 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
     recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    mutationOperationChecker = new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
   ConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -69,6 +71,7 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
     recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    mutationOperationChecker = new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -94,6 +97,8 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
     this.recovery = recovery;
     this.commit = commit;
     this.isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    this.mutationOperationChecker =
+        new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
   @Override
@@ -180,9 +185,8 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
         new Snapshot(txId, isolation, strategy, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled);
-    ConsensusCommitMutationOperationChecker operationChecker =
-        new ConsensusCommitMutationOperationChecker(tableMetadataManager);
-    ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery, operationChecker);
+    ConsensusCommit consensus =
+        new ConsensusCommit(crud, commit, recovery, mutationOperationChecker);
     getNamespace().ifPresent(consensus::withNamespace);
     getTable().ifPresent(consensus::withTable);
     return decorate(consensus);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -180,7 +180,9 @@ public class ConsensusCommitManager extends ActiveTransactionManagedDistributedT
         new Snapshot(txId, isolation, strategy, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled);
-    ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery);
+    ConsensusCommitMutationOperationChecker operationChecker =
+        new ConsensusCommitMutationOperationChecker(tableMetadataManager);
+    ConsensusCommit consensus = new ConsensusCommit(crud, commit, recovery, operationChecker);
     getNamespace().ifPresent(consensus::withNamespace);
     getTable().ifPresent(consensus::withTable);
     return decorate(consensus);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationChecker.java
@@ -1,0 +1,96 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.MutationCondition;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class ConsensusCommitMutationOperationChecker {
+
+  private final TransactionTableMetadataManager transactionTableMetadataManager;
+
+  public ConsensusCommitMutationOperationChecker(
+      TransactionTableMetadataManager transactionTableMetadataManager) {
+    this.transactionTableMetadataManager = transactionTableMetadataManager;
+  }
+
+  private TransactionTableMetadata getTableMetadata(Operation operation) throws ExecutionException {
+    TransactionTableMetadata metadata =
+        transactionTableMetadataManager.getTransactionTableMetadata(operation);
+    if (metadata == null) {
+      throw new IllegalArgumentException(
+          "The specified table is not found: " + operation.forFullTableName().get());
+    }
+    return metadata;
+  }
+
+  public void check(Mutation mutation) throws ExecutionException {
+    if (mutation instanceof Put) {
+      check((Put) mutation);
+    } else if (mutation instanceof Delete) {
+      check((Delete) mutation);
+    }
+  }
+
+  private void check(Put put) throws ExecutionException {
+    put.getCondition()
+        .ifPresent(
+            condition -> {
+              if (!(condition instanceof PutIf
+                  || condition instanceof PutIfNotExists
+                  || condition instanceof PutIfExists)) {
+                throw new IllegalArgumentException("The condition is not allowed on Put operation");
+              }
+            });
+    TransactionTableMetadata metadata = getTableMetadata(put);
+    for (String column : put.getContainedColumnNames()) {
+      if (metadata.getTransactionMetaColumnNames().contains(column)) {
+        throw new IllegalArgumentException(
+            "Mutating transaction metadata columns is not allowed. column: " + column);
+      }
+    }
+    checkConditionIsNotTargetingMetadataColumns(put, metadata);
+  }
+
+  private void check(Delete delete) throws ExecutionException {
+    delete
+        .getCondition()
+        .ifPresent(
+            condition -> {
+              if (!(condition instanceof DeleteIf || condition instanceof DeleteIfExists)) {
+                throw new IllegalArgumentException(
+                    "The condition is not allowed on Delete operation");
+              }
+            });
+    checkConditionIsNotTargetingMetadataColumns(delete, getTableMetadata(delete));
+  }
+
+  private void checkConditionIsNotTargetingMetadataColumns(
+      Mutation mutation, TransactionTableMetadata metadata) {
+    List<ConditionalExpression> expressions =
+        mutation
+            .getCondition()
+            .map(MutationCondition::getExpressions)
+            .orElse(Collections.emptyList());
+    for (ConditionalExpression expression : expressions) {
+      String column = expression.getColumn().getName();
+      if (metadata.getTransactionMetaColumnNames().contains(column)) {
+        throw new IllegalArgumentException(
+            "The condition is not allowed to target transaction metadata columns. column: "
+                + column);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationChecker.java
@@ -36,6 +36,13 @@ public class ConsensusCommitMutationOperationChecker {
     return metadata;
   }
 
+  /**
+   * Checks the mutation validity
+   *
+   * @param mutation a mutation operation
+   * @throws ExecutionException when retrieving the table metadata fails
+   * @throws IllegalArgumentException when the mutation is invalid
+   */
   public void check(Mutation mutation) throws ExecutionException {
     if (mutation instanceof Put) {
       check((Put) mutation);
@@ -51,7 +58,10 @@ public class ConsensusCommitMutationOperationChecker {
               if (!(condition instanceof PutIf
                   || condition instanceof PutIfNotExists
                   || condition instanceof PutIfExists)) {
-                throw new IllegalArgumentException("The condition is not allowed on Put operation");
+                throw new IllegalArgumentException(
+                    "A "
+                        + condition.getClass().getSimpleName()
+                        + " condition is not allowed on Put operation");
               }
             });
     TransactionTableMetadata metadata = getTableMetadata(put);
@@ -71,7 +81,9 @@ public class ConsensusCommitMutationOperationChecker {
             condition -> {
               if (!(condition instanceof DeleteIf || condition instanceof DeleteIfExists)) {
                 throw new IllegalArgumentException(
-                    "The condition is not allowed on Delete operation");
+                    "A "
+                        + condition.getClass().getSimpleName()
+                        + " condition is not allowed on Delete operation");
               }
             });
     checkConditionIsNotTargetingMetadataColumns(delete, getTableMetadata(delete));

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -33,6 +33,7 @@ public class TwoPhaseConsensusCommitManager
   private final RecoveryHandler recovery;
   private final CommitHandler commit;
   private final boolean isIncludeMetadataEnabled;
+  private final ConsensusCommitMutationOperationChecker mutationOperationChecker;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Inject
@@ -50,6 +51,7 @@ public class TwoPhaseConsensusCommitManager
     recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    mutationOperationChecker = new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
   public TwoPhaseConsensusCommitManager(DatabaseConfig databaseConfig) {
@@ -67,6 +69,7 @@ public class TwoPhaseConsensusCommitManager
     recovery = new RecoveryHandler(storage, coordinator, tableMetadataManager);
     commit = new CommitHandler(storage, coordinator, tableMetadataManager, parallelExecutor);
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    mutationOperationChecker = new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -92,6 +95,7 @@ public class TwoPhaseConsensusCommitManager
     this.recovery = recovery;
     this.commit = commit;
     isIncludeMetadataEnabled = config.isIncludeMetadataEnabled();
+    mutationOperationChecker = new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
   @Override
@@ -138,7 +142,8 @@ public class TwoPhaseConsensusCommitManager
     CrudHandler crud =
         new CrudHandler(storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled);
 
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
+    TwoPhaseConsensusCommit transaction =
+        new TwoPhaseConsensusCommit(crud, commit, recovery, mutationOperationChecker);
     getNamespace().ifPresent(transaction::withNamespace);
     getTable().ifPresent(transaction::withTable);
     return decorate(transaction);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationCheckerTest.java
@@ -1,0 +1,189 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.DeleteIfExists;
+import com.scalar.db.api.MutationCondition;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfExists;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ConsensusCommitMutationOperationCheckerTest {
+  private static final String ANY_COL_1 = "any_col_1";
+  private static final String ANY_COL_2 = "any_col_2";
+  private static final String ANY_METADATA_COL_1 = "any_metadata_col_1";
+  private static final String ANY_METADATA_COL_2 = "any_metadata_col_2";
+  @Mock TransactionTableMetadataManager metadataManager;
+  @Mock Put put;
+  @Mock Delete delete;
+  @Mock TransactionTableMetadata tableMetadata;
+  @InjectMocks private ConsensusCommitMutationOperationChecker checker;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(metadataManager.getTransactionTableMetadata(any())).thenReturn(tableMetadata);
+    LinkedHashSet<String> metadataColumns = new LinkedHashSet<>();
+    metadataColumns.add(ANY_METADATA_COL_1);
+    metadataColumns.add(ANY_METADATA_COL_2);
+    when(tableMetadata.getTransactionMetaColumnNames()).thenReturn(metadataColumns);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {DeleteIf.class, DeleteIfExists.class})
+  public void checkForPut_WithNonAllowedCondition_ShouldThrowIllegalArgumentException(
+      Class<? extends MutationCondition> deleteConditonClass) {
+    // Arrange
+    when(put.getCondition()).thenReturn(Optional.of(mock(deleteConditonClass)));
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> checker.check(put))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {PutIf.class, PutIfExists.class, PutIfNotExists.class})
+  public void checkForPut_WithAllowedCondition_ShouldDoNothing(
+      Class<? extends MutationCondition> putConditionClass) {
+    // Arrange
+    when(put.getCondition()).thenReturn(Optional.of(mock(putConditionClass)));
+
+    // Act Assert
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> checker.check(put));
+  }
+
+  @Test
+  public void checkForPut_ThatMutatesMetadataColumns_ShouldThrowIllegalArgumentException()
+      throws ExecutionException {
+    // Arrange
+    Set<String> columns = ImmutableSet.of(ANY_COL_1, ANY_METADATA_COL_1, ANY_COL_2);
+    when(put.getContainedColumnNames()).thenReturn(columns);
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> checker.check(put))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(ANY_METADATA_COL_1);
+    verify(metadataManager).getTransactionTableMetadata(put);
+  }
+
+  @Test
+  public void checkForPut_ThatDoNotMutateMetadataColumns_ShouldDoNothing()
+      throws ExecutionException {
+    // Arrange
+    Set<String> columns = ImmutableSet.of(ANY_COL_1, ANY_COL_2);
+    when(put.getContainedColumnNames()).thenReturn(columns);
+
+    // Act Assert
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> checker.check(put));
+    verify(metadataManager).getTransactionTableMetadata(put);
+  }
+
+  @Test
+  public void
+      checkForPut_WithConditionThatTargetMetadataColumns_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    MutationCondition condition =
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_COL_1).isNullInt())
+            .and(ConditionBuilder.column(ANY_METADATA_COL_1).isNullText())
+            .build();
+    when(put.getCondition()).thenReturn(Optional.of(condition));
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> checker.check(put))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(ANY_METADATA_COL_1);
+    verify(metadataManager).getTransactionTableMetadata(put);
+  }
+
+  @Test
+  public void checkForPut_WithConditionThatDoNotTargetMetadataColumns_ShouldDoNothing()
+      throws ExecutionException {
+    // Arrange
+    MutationCondition condition =
+        ConditionBuilder.putIf(ConditionBuilder.column(ANY_COL_1).isNullInt())
+            .and(ConditionBuilder.column(ANY_COL_2).isNullText())
+            .build();
+    when(put.getCondition()).thenReturn(Optional.of(condition));
+
+    // Act Assert
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> checker.check(put));
+    verify(metadataManager).getTransactionTableMetadata(put);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {PutIf.class, PutIfExists.class, PutIfNotExists.class})
+  public void checkForDelete_WithNonAllowedCondition_ShouldThrowIllegalArgumentException(
+      Class<? extends MutationCondition> putConditionClass) {
+    // Arrange
+    when(delete.getCondition()).thenReturn(Optional.of(mock(putConditionClass)));
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> checker.check(delete))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {DeleteIf.class, DeleteIfExists.class})
+  public void checkForDelete_WithAllowedCondition_ShouldDoNothing(
+      Class<? extends MutationCondition> deleteConditionClass) {
+    // Arrange
+    when(delete.getCondition()).thenReturn(Optional.of(mock(deleteConditionClass)));
+
+    // Act Assert
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> checker.check(delete));
+  }
+
+  @Test
+  public void
+      checkForDelete_WithConditionThatTargetMetadataColumns_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    MutationCondition condition =
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_COL_1).isNullInt())
+            .and(ConditionBuilder.column(ANY_METADATA_COL_1).isNullText())
+            .build();
+    when(delete.getCondition()).thenReturn(Optional.of(condition));
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> checker.check(delete))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(ANY_METADATA_COL_1);
+    verify(metadataManager).getTransactionTableMetadata(delete);
+  }
+
+  @Test
+  public void checkForDelete_WithConditionThatDoNotTargetMetadataColumns_ShouldDoNothing()
+      throws ExecutionException {
+    // Arrange
+    MutationCondition condition =
+        ConditionBuilder.deleteIf(ConditionBuilder.column(ANY_COL_1).isNullInt())
+            .and(ConditionBuilder.column(ANY_COL_2).isNullText())
+            .build();
+    when(delete.getCondition()).thenReturn(Optional.of(condition));
+
+    // Act Assert
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> checker.check(delete));
+    verify(metadataManager).getTransactionTableMetadata(delete);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -15,6 +15,7 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -47,6 +48,8 @@ public class ConsensusCommitTest {
   @SuppressWarnings("unused")
   @Mock
   private ConsensusCommitManager manager;
+
+  @Mock private ConsensusCommitMutationOperationChecker mutationOperationChecker;
 
   @InjectMocks private ConsensusCommit consensus;
 
@@ -134,7 +137,7 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void put_PutGiven_ShouldCallCrudHandlerPut() {
+  public void put_PutGiven_ShouldCallCrudHandlerPut() throws ExecutionException, CrudException {
     // Arrange
     Put put = preparePut();
     doNothing().when(crud).put(put);
@@ -144,10 +147,12 @@ public class ConsensusCommitTest {
 
     // Assert
     verify(crud).put(put);
+    verify(mutationOperationChecker).check(put);
   }
 
   @Test
-  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() {
+  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice()
+      throws ExecutionException, CrudException {
     // Arrange
     Put put = preparePut();
     doNothing().when(crud).put(put);
@@ -157,10 +162,12 @@ public class ConsensusCommitTest {
 
     // Assert
     verify(crud, times(2)).put(put);
+    verify(mutationOperationChecker, times(2)).check(put);
   }
 
   @Test
-  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() {
+  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete()
+      throws CrudException, ExecutionException {
     // Arrange
     Delete delete = prepareDelete();
     doNothing().when(crud).delete(delete);
@@ -170,10 +177,12 @@ public class ConsensusCommitTest {
 
     // Assert
     verify(crud).delete(delete);
+    verify(mutationOperationChecker).check(delete);
   }
 
   @Test
-  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() {
+  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice()
+      throws ExecutionException, CrudException {
     // Arrange
     Delete delete = prepareDelete();
     doNothing().when(crud).delete(delete);
@@ -183,10 +192,12 @@ public class ConsensusCommitTest {
 
     // Assert
     verify(crud, times(2)).delete(delete);
+    verify(mutationOperationChecker, times(2)).check(delete);
   }
 
   @Test
-  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete() {
+  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete()
+      throws CrudException, ExecutionException {
     // Arrange
     Put put = preparePut();
     Delete delete = prepareDelete();
@@ -199,6 +210,8 @@ public class ConsensusCommitTest {
     // Assert
     verify(crud).put(put);
     verify(crud).delete(delete);
+    verify(mutationOperationChecker).check(put);
+    verify(mutationOperationChecker).check(delete);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -14,6 +14,7 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -46,6 +48,8 @@ public class TwoPhaseConsensusCommitTest {
   @Mock private CrudHandler crud;
   @Mock private CommitHandler commit;
   @Mock private RecoveryHandler recovery;
+  @Mock private ConsensusCommitMutationOperationChecker mutationOperationChecker;
+  @InjectMocks private TwoPhaseConsensusCommit transaction;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -86,7 +90,6 @@ public class TwoPhaseConsensusCommitTest {
   public void get_GetGiven_ShouldCallCrudHandlerGet() throws CrudException {
     // Arrange
     Get get = prepareGet();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     TransactionResult result = mock(TransactionResult.class);
     when(crud.get(get)).thenReturn(Optional.of(result));
     when(crud.getSnapshot()).thenReturn(snapshot);
@@ -104,7 +107,6 @@ public class TwoPhaseConsensusCommitTest {
   public void get_GetForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
     // Arrange
     Get get = prepareGet();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     TransactionResult result = mock(TransactionResult.class);
     UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
     when(crud.get(get)).thenThrow(toThrow);
@@ -122,7 +124,6 @@ public class TwoPhaseConsensusCommitTest {
   public void scan_ScanGiven_ShouldCallCrudHandlerScan() throws CrudException {
     // Arrange
     Scan scan = prepareScan();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     TransactionResult result = mock(TransactionResult.class);
     List<Result> results = Collections.singletonList(result);
     when(crud.scan(scan)).thenReturn(results);
@@ -137,10 +138,9 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void put_PutGiven_ShouldCallCrudHandlerPut() {
+  public void put_PutGiven_ShouldCallCrudHandlerPut() throws ExecutionException, CrudException {
     // Arrange
     Put put = preparePut();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -148,13 +148,14 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     verify(crud).put(put);
+    verify(mutationOperationChecker).check(put);
   }
 
   @Test
-  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice() {
+  public void put_TwoPutsGiven_ShouldCallCrudHandlerPutTwice()
+      throws ExecutionException, CrudException {
     // Arrange
     Put put = preparePut();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -162,13 +163,14 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     verify(crud, times(2)).put(put);
+    verify(mutationOperationChecker, times(2)).check(put);
   }
 
   @Test
-  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete() {
+  public void delete_DeleteGiven_ShouldCallCrudHandlerDelete()
+      throws CrudException, ExecutionException {
     // Arrange
     Delete delete = prepareDelete();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -176,13 +178,14 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     verify(crud).delete(delete);
+    verify(mutationOperationChecker).check(delete);
   }
 
   @Test
-  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice() {
+  public void delete_TwoDeletesGiven_ShouldCallCrudHandlerDeleteTwice()
+      throws CrudException, ExecutionException {
     // Arrange
     Delete delete = prepareDelete();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -190,14 +193,15 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     verify(crud, times(2)).delete(delete);
+    verify(mutationOperationChecker, times(2)).check(delete);
   }
 
   @Test
-  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete() {
+  public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete()
+      throws CrudException, ExecutionException {
     // Arrange
     Put put = preparePut();
     Delete delete = prepareDelete();
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -206,12 +210,13 @@ public class TwoPhaseConsensusCommitTest {
     // Assert
     verify(crud).put(put);
     verify(crud).delete(delete);
+    verify(mutationOperationChecker).check(put);
+    verify(mutationOperationChecker).check(delete);
   }
 
   @Test
   public void prepare_ProcessedCrudGiven_ShouldPrepareWithSnapshot() throws PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
 
     // Act
@@ -225,7 +230,6 @@ public class TwoPhaseConsensusCommitTest {
   public void validate_ProcessedCrudGiven_ShouldPerformValidationWithSnapshot()
       throws ValidationException, PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -240,7 +244,6 @@ public class TwoPhaseConsensusCommitTest {
   public void commit_ShouldCommitStateAndRecords()
       throws CommitException, UnknownTransactionStatusException, PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -257,7 +260,6 @@ public class TwoPhaseConsensusCommitTest {
       throws CommitException, UnknownTransactionStatusException, PreparationException,
           ValidationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     transaction.validate();
     when(crud.getSnapshot()).thenReturn(snapshot);
@@ -276,7 +278,6 @@ public class TwoPhaseConsensusCommitTest {
   public void commit_ExtraReadUsedAndPreparedState_ShouldThrowIllegalStateException()
       throws PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
     when(snapshot.getId()).thenReturn(ANY_TX_ID);
@@ -290,7 +291,6 @@ public class TwoPhaseConsensusCommitTest {
   public void rollback_ShouldAbortStateAndRollbackRecords()
       throws RollbackException, UnknownTransactionStatusException, PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
 
@@ -306,7 +306,6 @@ public class TwoPhaseConsensusCommitTest {
   public void rollback_CalledAfterPrepareFails_ShouldAbortStateAndRollbackRecords()
       throws PreparationException, UnknownTransactionStatusException, RollbackException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     when(crud.getSnapshot()).thenReturn(snapshot);
     doThrow(PreparationException.class).when(commit).prepare(snapshot);
 
@@ -324,7 +323,6 @@ public class TwoPhaseConsensusCommitTest {
       throws CommitException, UnknownTransactionStatusException, RollbackException,
           PreparationException {
     // Arrange
-    TwoPhaseConsensusCommit transaction = new TwoPhaseConsensusCommit(crud, commit, recovery);
     transaction.prepare();
     when(crud.getSnapshot()).thenReturn(snapshot);
     doThrow(CommitException.class).when(commit).commitState(snapshot);


### PR DESCRIPTION
**Context**
There is no validation to ensure Put or Delete operations do not mutate consensus commit metadata columns. Since these columns are only for internal use, users should not be allowed to modify them.

**Changes**
A validation step is added to make sure Put or Delete operations do not mutate consensus commit metadata columns. Additionally, setting operation conditions (see https://github.com/scalar-labs/scalardb/pull/837 ) targeting consensus commit metadata columns are also forbidden.