### PR TITLE
Change HTML syntax to Markdown for images (3.5)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -19,9 +19,7 @@ The primary design goal of Scalar DB is achieving ACID transaction capability wi
 
 Scalar DB is composed of universal transaction manager, storage abstraction, and storage adapters. Universal transaction manager and storage abstraction are storage-agnostic. On the other hand, storage adapters are storage-specific so there is an adapter for each storage implementation.
 
-<p align="center">
-<img src="https://github.com/scalar-labs/scalardb/raw/master/docs/images/software_stack.png" width="440" />
-</p>
+![](images/software_stack.png)
 
 ## Data Model
 
@@ -29,10 +27,7 @@ The data model of Scalar DB is a multi-dimensional map based on the key-value da
 
 (partition-key, clustering-key, value-name) -> value-content
 
-
-<p align="center">
-<img src="https://github.com/scalar-labs/scalardb/raw/master/docs/images/data_model.png" width="480" />
-</p>
+![](images/data_model.png)
 
 ### Physical Data Model
 


### PR DESCRIPTION
This PR changes how images are inserted into documentation. 

Previously, the docs used HTML syntax to add images. However, Jekyll, the static site generator that [our docs site](https://developers.scalar-labs.com/docs) is based on, cannot render those images because we have `permalink: pretty` enabled in the site configuration.

> **Note**
> 
> `permalink: pretty` makes URLs a bit easier to read. For more information, see [Built-in formats | Permalinks](https://jekyllrb.com/docs/permalinks/#built-in-formats) and [Permalinks | Jekyll Style Guide](https://ben.balter.com/jekyll-style-guide/permalinks/).

Markdown syntax supports adding images, so I've updated the docs for branch `3.5`, which is under support, to follow that standard.