### PR TITLE
Change HTML syntax to Markdown for images (master)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -19,9 +19,7 @@ The primary design goal of ScalarDB is achieving ACID transaction capability wit
 
 ScalarDB is composed of universal transaction manager, storage abstraction, and storage adapters. Universal transaction manager and storage abstraction are storage-agnostic. On the other hand, storage adapters are storage-specific so there is an adapter for each storage implementation.
 
-<p align="center">
-<img src="images/software_stack.png" width="440" />
-</p>
+![](images/software_stack.png)
 
 ## Data Model
 
@@ -29,9 +27,7 @@ The data model of ScalarDB is a multi-dimensional map based on the key-value dat
 
 (partition-key, clustering-key, column-name) -> column-value
 
-<p align="center">
-<img src="images/data_model.png" width="480" />
-</p>
+![](images/data_model.png)
 
 ### Physical Data Model
 

--- a/docs/two-phase-commit-transactions.md
+++ b/docs/two-phase-commit-transactions.md
@@ -304,16 +304,12 @@ You may want to create a transaction status table and update it transactionally 
 
 Services using Two-phase Commit Transactions usually execute a transaction by exchanging multiple requests and responses as follows:
 
-<p align="center">
-<img src="images/two_phase_commit_sequence_diagram.png" width="400" />
-</p>
+![](images/two_phase_commit_sequence_diagram.png)
 
 Also, each service typically has multiple servers (or hosts) for scalability and availability and uses server-side (proxy) or client-side load balancing to distribute requests to the servers.
 In such a case, since a transaction processing in Two-phase Commit Transactions is stateful, requests in a transaction must be routed to the same servers while different transactions need to be distributed to balance the load.
 
-<p align="center">
-<img src="images/two_phase_commit_load_balancing.png" width="500" />
-</p>
+![](images/two_phase_commit_load_balancing.png)
 
 There are several approaches to achieve it depending on the protocol between the services. Here, we introduce some approaches for gRPC and HTTP/1.1.
 


### PR DESCRIPTION
This PR changes how images are inserted into documentation. 

Previously, the docs used HTML syntax to add images. However, Jekyll, the static site generator that [our docs site](https://developers.scalar-labs.com/docs) is based on, cannot render those images because we have `permalink: pretty` enabled in the site configuration.

> **Note**
> 
> `permalink: pretty` makes URLs a bit easier to read. For more information, see [Built-in formats | Permalinks](https://jekyllrb.com/docs/permalinks/#built-in-formats) and [Permalinks | Jekyll Style Guide](https://ben.balter.com/jekyll-style-guide/permalinks/).

Markdown syntax supports adding images, so I've updated the docs in the `master` branch to follow that standard.