### PR TITLE
Add GHA workflow to automatically create pull requests to apply a merged PR changes

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -1,0 +1,79 @@
+name: Auto-PR
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+env:
+  TERM: dumb
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.CR_PAT }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # This is necessary to avoid unexpected auto-merge in git cherry-pick
+          fetch-depth: 0
+
+      - name: Create pull requests
+        run: |
+          assignee=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F userName=${{ github.event.pull_request.user }} -f query='
+          query($owner: String!, $repoName: String!, $userName: String!) {
+            repository(owner: $owner, name: $repoName) {
+              assignableUsers(first: 100, query: $userName) {
+                nodes {
+                  name,
+                  email
+                }
+              }
+            }
+          }' | jq -r '.data.repository.assignableUsers.nodes[0]'
+          )
+          versions=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F pullRequestId=${{ github.event.number }} -f query='
+          query($owner: String!, $repoName: String!, $pullRequestId: Int!) {
+            repository(owner: $owner, name: $repoName) {
+              pullRequest(number: $pullRequestId) {
+                projectsV2(first: 100) {
+                  edges {
+                    node {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+          ' | jq -r '.data.repository.pullRequest.projectsV2.edges[].node.title' | sed -n 's/^ScalarDB \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p'
+          )
+          echo -------------
+          echo "versions: $versions"
+          echo -------------
+          git config --global user.email $(echo $assignee | jq -r .email)
+          git config --global user.name $(echo $assignee | jq -r .name)
+          git fetch origin
+
+          # TODO: Improve the readability
+          branches=$(echo $versions | ruby -rset -e 'bs = Set.new; STDIN.gets.split.each {|v| parts = v.strip.split(".")[0, 2]; bs << parts[0]; bs << parts.join(".")}; bs.each {|branch| puts branch}')
+
+          echo -------------
+          echo "branches: $branches"
+          echo -------------
+          for branch in $branches; do
+            git checkout $branch
+            new_branch="$branch-pull-${{ github.event.number }}"
+            git checkout -b "$new_branch"
+            git status
+            git cherry-pick --no-rerere-autoupdate -m1 ${{ github.sha }}
+            git push origin "$new_branch"
+            gh pr create --assignee "${{ github.event.pull_request.user.login }}" \
+              --base "$branch" \
+              --title "Backport to $branch : ${{ github.event.pull_request.title }}" \
+              --body "Backport of ${{ github.event.pull_request.url }}"
+          done
+

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Create pull requests
         run: |
           # Get the author of the merged PR
-          assignee=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F userName=${{ github.event.pull_request.user }} -f query='
+          assignee=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F userName=${{ github.event.pull_request.user.login }} -f query='
           query($owner: String!, $repoName: String!, $userName: String!) {
             repository(owner: $owner, name: $repoName) {
               assignableUsers(first: 100, query: $userName) {
@@ -63,12 +63,28 @@ jobs:
             versions = STDIN.read.strip.split
 
             versions.inject(Set.new) {|acc, v|
-              # Drop patch version by getting the first 2 elements
-              parts = v.strip.split(".")[0, 2]
-              # Support branch
-              acc << parts[0]
-              # Release branch
-              acc << parts.join(".")
+              major_version, minor_version, patch_version = v.strip.split(".")
+
+              if patch_version == "0"
+                if minor_version == "0"
+                  # e.g. project: "ScalarDB 4.0.0" -> branch: "master"
+                  #
+                  # This GitHub project corresponds to `main`/`master` branch.
+                  # The target change is already merged to the default branch.
+                  # Nonthing to do.
+                else
+                  # e.g. project: "ScalarDB 3.8.0" -> branch: "3"
+                  #
+                  # This GitHub project corresponds to a support branch.
+                  acc << major_version
+                end
+              else
+                # e.g. project: "ScalarDB 3.7.1" -> branch: "3.7"
+                #
+                # This GitHub project corresponds to a release branch.
+                acc << "#{major_version}.#{minor_version}"
+              end
+
               acc
             }.each {|branch|
               puts branch

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -58,8 +58,24 @@ jobs:
           git config --global user.name $(echo $assignee | jq -r .name)
           git fetch origin
 
-          # TODO: Improve the readability
-          branches=$(echo $versions | ruby -rset -e 'bs = Set.new; STDIN.gets.split.each {|v| parts = v.strip.split(".")[0, 2]; bs << parts[0]; bs << parts.join(".")}; bs.each {|branch| puts branch}')
+          branches=$(echo $versions | ruby -e '
+            require "set"
+
+            versions = STDIN.read.strip.split
+
+            versions.inject(Set.new) {|acc, v|
+              # Drop patch version by getting the first 2 elements
+              parts = v.strip.split(".")[0, 2]
+              # Support branch
+              acc << parts[0]
+              # Release branch
+              acc << parts.join(".")
+              acc
+            }.each {|branch|
+              puts branch
+            }
+          ')
+
 
           echo -------------
           echo "branches: $branches"

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -23,91 +23,29 @@ jobs:
 
       - name: Create pull requests
         run: |
-          # Get the author of the merged PR
-          assignee=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F userName=${{ github.event.pull_request.user.login }} -f query='
-          query($owner: String!, $repoName: String!, $userName: String!) {
-            repository(owner: $owner, name: $repoName) {
-              assignableUsers(first: 100, query: $userName) {
-                nodes {
-                  name,
-                  email
-                }
-              }
-            }
-          }' | jq -r '.data.repository.assignableUsers.nodes[0]'
-          )
+          assignee=$(ci/auto-pr/fetch_gh_user_info "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.pull_request.user.login }}")
+          echo -------------
+          echo "assignee: $assignee"
+          echo -------------
 
-          # Get GitHub projects associated with the merged PR and extract full versions (e.g. "3.7.1")
-          versions=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F pullRequestId=${{ github.event.number }} -f query='
-          query($owner: String!, $repoName: String!, $pullRequestId: Int!) {
-            repository(owner: $owner, name: $repoName) {
-              pullRequest(number: $pullRequestId) {
-                projectsV2(first: 100) {
-                  nodes {
-                    title
-                  }
-                }
-              }
-            }
-          }
-          ' | jq -r '.data.repository.pullRequest.projectsV2.nodes[].title' | sed -n 's/^ScalarDB \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p'
-          )
+          versions=$(ci/auto-pr/fetch_gh_proj_versions "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.number }}")
           echo -------------
           echo "versions: $versions"
           echo -------------
 
-          # Extract target support branch and release branch names from the full versions
-          branches=$(echo $versions | ruby -e '
-            require "set"
-
-            versions = STDIN.read.strip.split
-
-            versions.inject(Set.new) {|acc, v|
-              major_version, minor_version, patch_version = v.strip.split(".")
-
-              if patch_version == "0"
-                if minor_version == "0"
-                  # e.g. project: "ScalarDB 4.0.0" -> branch: "master"
-                  #
-                  # This GitHub project corresponds to `main`/`master` branch.
-                  # The target change is already merged to the default branch.
-                  # Nonthing to do.
-                else
-                  # e.g. project: "ScalarDB 3.8.0" -> branch: "3"
-                  #
-                  # This GitHub project corresponds to a support branch.
-                  acc << major_version
-                end
-              else
-                # e.g. project: "ScalarDB 3.7.1" -> branch: "3.7"
-                #
-                # This GitHub project corresponds to a release branch.
-                acc << "#{major_version}.#{minor_version}"
-              end
-
-              acc
-            }.each {|branch|
-              puts branch
-            }
-          ')
+          branches=$(ci/auto-pr/conv_proj_version_to_branch $versions)
           echo -------------
           echo "branches: $branches"
           echo -------------
 
-          # Create PRs based on the target support branches and release branches
           git config --global user.email $(echo $assignee | jq -r .email)
           git config --global user.name $(echo $assignee | jq -r .name)
-          git fetch origin
-          for branch in $branches; do
-            git checkout $branch
-            new_branch="$branch-pull-${{ github.event.number }}"
-            git checkout -b "$new_branch"
-            git status
-            git cherry-pick --no-rerere-autoupdate -m1 ${{ github.sha }}
-            git push origin "$new_branch"
-            gh pr create --assignee "${{ github.event.pull_request.user.login }}" \
-              --base "$branch" \
-              --title "Backport to $branch : ${{ github.event.pull_request.title }}" \
-              --body "Backport of ${{ github.event.pull_request.url }}"
-          done
+
+          ci/auto-pr/create_pull_requests \
+            "${{ github.event.number }}" \
+            "${{ github.event.pull_request.html_url }}" \
+            "${{ github.event.pull_request.title }}" \
+            "${{ github.sha }}" \
+            "${{ github.event.pull_request.user.login }}" \
+            $branches
 

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Create pull requests
         run: |
+          # Get the author of the merged PR
           assignee=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F userName=${{ github.event.pull_request.user }} -f query='
           query($owner: String!, $repoName: String!, $userName: String!) {
             repository(owner: $owner, name: $repoName) {
@@ -35,6 +36,8 @@ jobs:
             }
           }' | jq -r '.data.repository.assignableUsers.nodes[0]'
           )
+
+          # Get GitHub projects associated with the merged PR and extract full versions (e.g. "3.7.1")
           versions=$(gh api graphql -F owner=${{ github.event.repository.owner.login }} -F repoName=${{ github.event.repository.name }} -F pullRequestId=${{ github.event.number }} -f query='
           query($owner: String!, $repoName: String!, $pullRequestId: Int!) {
             repository(owner: $owner, name: $repoName) {
@@ -54,10 +57,8 @@ jobs:
           echo -------------
           echo "versions: $versions"
           echo -------------
-          git config --global user.email $(echo $assignee | jq -r .email)
-          git config --global user.name $(echo $assignee | jq -r .name)
-          git fetch origin
 
+          # Extract target support branch and release branch names from the full versions
           branches=$(echo $versions | ruby -e '
             require "set"
 
@@ -75,11 +76,14 @@ jobs:
               puts branch
             }
           ')
-
-
           echo -------------
           echo "branches: $branches"
           echo -------------
+
+          # Create PRs based on the target support branches and release branches
+          git config --global user.email $(echo $assignee | jq -r .email)
+          git config --global user.name $(echo $assignee | jq -r .name)
+          git fetch origin
           for branch in $branches; do
             git checkout $branch
             new_branch="$branch-pull-${{ github.event.number }}"

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -43,16 +43,14 @@ jobs:
             repository(owner: $owner, name: $repoName) {
               pullRequest(number: $pullRequestId) {
                 projectsV2(first: 100) {
-                  edges {
-                    node {
-                      title
-                    }
+                  nodes {
+                    title
                   }
                 }
               }
             }
           }
-          ' | jq -r '.data.repository.pullRequest.projectsV2.edges[].node.title' | sed -n 's/^ScalarDB \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p'
+          ' | jq -r '.data.repository.pullRequest.projectsV2.nodes[].title' | sed -n 's/^ScalarDB \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p'
           )
           echo -------------
           echo "versions: $versions"

--- a/ci/auto-pr/conv_proj_version_to_branch
+++ b/ci/auto-pr/conv_proj_version_to_branch
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require "set"
+
+versions = ARGV
+
+versions.inject(Set.new) {|acc, v|
+  major_version, minor_version, patch_version = v.strip.split(".")
+
+  if patch_version == "0"
+    if minor_version == "0"
+      # e.g. project: "ScalarDB 4.0.0" -> branch: "master"
+      #
+      # This GitHub project corresponds to `main`/`master` branch.
+      # The target change is already merged to the default branch.
+      # Nonthing to do.
+    else
+      # e.g. project: "ScalarDB 3.8.0" -> branch: "3"
+      #
+      # This GitHub project corresponds to a support branch.
+      acc << major_version
+    end
+  else
+    # e.g. project: "ScalarDB 3.7.1" -> branch: "3.7"
+    #
+    # This GitHub project corresponds to a release branch.
+    acc << "#{major_version}.#{minor_version}"
+  end
+
+  acc
+}.each {|branch|
+  puts branch
+}
+

--- a/ci/auto-pr/create_pull_requests
+++ b/ci/auto-pr/create_pull_requests
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+if [[ $# < 5 ]]; then
+    echo "usage: $0 pull_request_id pull_request_url pull_request_title commit_sha assignee branches"
+    exit 1
+fi
+
+pull_request_id=$1
+shift
+pull_request_url=$1
+shift
+pull_request_title=$1
+shift
+commit_sha=$1
+shift
+assignee=$1
+shift
+branches=("$@")
+
+function cherry_pick_and_create_pull_request () {
+  local branch=$1
+  local new_branch=$2
+
+  git checkout $branch
+  git checkout -b $new_branch
+  git cherry-pick --no-rerere-autoupdate -m1 $commit_sha
+  git push origin $new_branch
+  git status
+  gh pr create --assignee $assignee \
+    --base "$branch" \
+    --title "Backport to branch($branch) : $pull_request_title" \
+    --body "Backport of $pull_request_url"
+}
+
+function create_issue () {
+  gh issue create --assignee $assignee \
+    --title "Backport to branch($branch) failed: $pull_request_title" \
+    --body "Backport of $pull_request_url to branch($branch) failed"
+}
+
+git fetch origin
+
+# Create PRs based on the target support branches and release branches
+for branch in ${branches[@]}; do
+  new_branch="$branch-pull-$pull_request_id"
+
+  # Create a new temp branch, push it and create a PR for the change.
+  # But create an issue if anything fails.
+  cherry_pick_and_create_pull_request $branch $new_branch || create_issue
+done
+

--- a/ci/auto-pr/fetch_gh_proj_versions
+++ b/ci/auto-pr/fetch_gh_proj_versions
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+if [[ $# != 3 ]]; then
+    echo "usage: $0 repo_owner repo_name pull_request_id"
+    exit 1
+fi
+
+repo_owner=$1
+repo_name=$2
+pull_request_id=$3
+
+# Get GitHub projects associated with the merged PR and extract full versions (e.g. "3.7.1")
+versions_json=$(gh api graphql -F owner=$repo_owner -F repoName=$repo_name -F pullRequestId=$pull_request_id -f query='
+  query($owner: String!, $repoName: String!, $pullRequestId: Int!) {
+    repository(owner: $owner, name: $repoName) {
+      pullRequest(number: $pullRequestId) {
+        projectsV2(first: 100) {
+          nodes {
+            title
+          }
+        }
+      }
+    }
+  }
+')
+
+echo $versions_json | jq -r '.data.repository.pullRequest.projectsV2.nodes[].title' | sed -n 's/^ScalarDB \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p'
+

--- a/ci/auto-pr/fetch_gh_user_info
+++ b/ci/auto-pr/fetch_gh_user_info
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+if [[ $# != 3 ]]; then
+    echo "usage: $0 repo_owner repo_name user"
+    exit 1
+fi
+
+repo_owner=$1
+repo_name=$2
+user=$3
+
+# Get the author of the merged PR
+author_json=$(gh api graphql -F owner=$repo_owner -F repoName=$repo_name -F userName=$user -f query='
+  query($owner: String!, $repoName: String!, $userName: String!) {
+    repository(owner: $owner, name: $repoName) {
+      assignableUsers(first: 100, query: $userName) {
+        nodes {
+          name,
+          email
+        }
+      }
+    }
+  }
+')
+
+echo $author_json | jq -r '.data.repository.assignableUsers.nodes[0]'
+


### PR DESCRIPTION
### Context

We manage the support branches (e.g. `3`) and the release branches (e.g. `3.7`), and manually back-port a merge PR change to them if needed. This kind of operation should be automated as much as possible.

### Change

This PR adds a GitHub Actions workflow that automatically does the following operations
- Check GitHub projects (e.g. `ScalarDB 3.7.1`, `ScalarDB 3.8.1`, `ScalarDB 4.0.0`) associated with the merged PR
- Extract full versions (e.g. `3.7.1`, `3.8.1`, `4.0.0`) from the project names
- Extract support versions (e.g. `3`, `4`) and release versions (e.g. `3.7`, `3.8`, `4.0`) from the full versions
- Checkout those Git branch and apply the merged PR change to them, and create a PR for each branch

Then, the author of the original PR merges the automatically created PR if it's good

### Note

I've tested a similar GHA workflow in a test repository, but this workflow itself isn't tested yet. Some additional PRs might be needed after merging this PR.