### PR TITLE
Use a proper PAT in the GHA workflow for automated PR creation

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.CR_PAT }}
+      GH_TOKEN: ${{ secrets.GH_PR_PAT }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is a followup PR of https://github.com/scalar-labs/scalardb/pull/884. The previous PR used a wrong PAT that doesn't have proper permissions. This PR fixes the issue.