### PR TITLE
Remove untagged container images

### DIFF
--- a/.github/workflows/remove-untagged-images.yaml
+++ b/.github/workflows/remove-untagged-images.yaml
@@ -1,0 +1,28 @@
+# When we push a new SNAPSHOT image, the old SNAPSHOT image remains as an untagged
+# image in GitHub Packages. We remove those untagged images by using this workflow.
+
+name: Remove untagged images
+
+on:
+  schedule:
+    # UTC
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  remove-untagged-container-images:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: scalardb-server
+        uses: camargo/delete-untagged-action@v1
+        with:
+          github-token: ${{ secrets.CR_PAT }}
+          package-name: scalardb-server
+
+      - name: scalardb-schema-loader
+        uses: camargo/delete-untagged-action@v1
+        with:
+          github-token: ${{ secrets.CR_PAT }}
+          package-name: scalardb-schema-loader


### PR DESCRIPTION
This PR adds a new workflow that removes untagged container images in the GitHub Packages.

When we push a new SNAPSHOT image, the old SNAPSHOT image remains as an untagged image in GitHub Packages. We remove those untagged images by using this workflow.

I use the [camargo/delete-untagged-action](https://github.com/camargo/delete-untagged-action) since this is a simple action. It only removes untagged images. There are no other features.

For your reference, I tested this workflow in the following repository.

* [GitHub Packages (Container registry)](https://github.com/users/kota2and3kan/packages/container/package/untagged-image-test)
* [Workflow file](https://github.com/kota2and3kan/untagged-image-test/blob/main/.github/workflows/remove-untagged-image.yaml)
* [Result of workflow](https://github.com/kota2and3kan/untagged-image-test/actions/runs/5065092900)

Please take a look!