### PR TITLE
Change version in `add-scalardb-to-your-build.md` from `3.8.0` to `3.9.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1-SNAPSHOT'
+    implementation 'com.scalar-labs:scalardb:3.9.0'
 }
 ```
 
@@ -22,7 +22,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.9.1-SNAPSHOT</version>
+  <version>3.9.0</version>
 </dependency>
 ```
 

--- a/docs/add-scalardb-to-your-build.md
+++ b/docs/add-scalardb-to-your-build.md
@@ -6,7 +6,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1-SNAPSHOT'
+    implementation 'com.scalar-labs:scalardb:3.9.0'
 }
 ```
 
@@ -15,6 +15,6 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.9.1-SNAPSHOT</version>
+  <version>3.9.0</version>
 </dependency>
 ```

--- a/docs/add-scalardb-to-your-build.md
+++ b/docs/add-scalardb-to-your-build.md
@@ -6,7 +6,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.8.0'
+    implementation 'com.scalar-labs:scalardb:3.9.1-SNAPSHOT'
 }
 ```
 
@@ -15,6 +15,6 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.8.0</version>
+  <version>3.9.1-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/getting-started/build.gradle
+++ b/docs/getting-started/build.gradle
@@ -9,7 +9,7 @@ repositories {
 mainClassName = "sample.ElectronicMoneyMain"
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1-SNAPSHOT'
+    implementation 'com.scalar-labs:scalardb:3.9.0'
     implementation 'org.slf4j:slf4j-simple:1.7.30'
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1-SNAPSHOT'
+    implementation 'com.scalar-labs:scalardb:3.9.0'
 }
 ```
 
@@ -22,7 +22,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.9.1-SNAPSHOT</version>
+  <version>3.9.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This PR changes the version of ScalarDB mentioned in the `docs/add-scalardb-to-your-build.md` doc (`3.8.0`) to match the version that is mentioned in the repository's `README.md` (`3.9.1-SNAPSHOT`).

I think we might need to update `docs/add-scalardb-to-your-build.md` and `README.md` in the `master` branch as well. If the changes in this PR look OK, I will submit a similar PR for the `master` branch.