### PR TITLE
Change version in `add-scalardb-to-your-build.md` from `3.8.0` to `3.9.0`

### DIFF
--- a/docs/add-scalardb-to-your-build.md
+++ b/docs/add-scalardb-to-your-build.md
@@ -6,7 +6,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.8.0'
+    implementation 'com.scalar-labs:scalardb:3.9.0'
 }
 ```
 
@@ -15,6 +15,6 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.8.0</version>
+  <version>3.9.0</version>
 </dependency>
 ```


### PR DESCRIPTION
I forgot to update the version in `add-scalardb-to-your-build.md` when releasing `3.9.0`, and this PR fixes it. Please take a look!