### PR TITLE
Handle PRs created by dependabot in auto-pr GHA workflow

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -28,8 +28,8 @@ jobs:
           echo "assignee: $assignee"
           echo -------------
           if [[ -z $assignee ]]; then
-            # For instance, we can't assign `dependabot` to a new PR.
-            new_pr_assignee=''
+            # For instance, we can't assign `debendabot` to a new PR.
+            new_pr_assignee="${{ github.event.pull_request.merged_by.login }}"
           else
             new_pr_assignee="${{ github.event.pull_request.user.login }}"
           fi

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "assignee: $assignee"
           echo -------------
           if [[ -z $assignee ]]; then
-            # For instance, we can't assign `debendabot` to a new PR.
+            # For instance, we can't assign `dependabot` to a new PR.
             new_pr_assignee=''
           else
             new_pr_assignee="${{ github.event.pull_request.user.login }}"

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -23,6 +23,17 @@ jobs:
 
       - name: Create pull requests
         run: |
+          assignee=$(ci/auto-pr/fetch_gh_user_info "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.pull_request.user.login }}")
+          echo -------------
+          echo "assignee: $assignee"
+          echo -------------
+          if [[ -z $assignee ]]; then
+            # For instance, we can't assign `debendabot` to a new PR.
+            new_pr_assignee=''
+          else
+            new_pr_assignee="${{ github.event.pull_request.user.login }}"
+          fi
+
           versions=$(ci/auto-pr/fetch_gh_proj_versions "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.number }}")
           echo -------------
           echo "versions: $versions"
@@ -38,6 +49,6 @@ jobs:
             "${{ github.event.pull_request.html_url }}" \
             "${{ github.event.pull_request.title }}" \
             "${{ github.sha }}" \
-            "${{ github.event.pull_request.user.login }}" \
+            "$new_pr_assignee" \
             $branches
 

--- a/ci/auto-pr/create_pull_requests
+++ b/ci/auto-pr/create_pull_requests
@@ -32,29 +32,16 @@ function cherry_pick_and_create_pull_request () {
   git cherry-pick --no-rerere-autoupdate -m1 $commit_sha
   git push origin $new_branch
   git status
-  if [[ -z $assignee ]]; then
-    gh pr create \
-      --base "$branch" \
-      --title "Backport to branch($branch) : $pull_request_title" \
-      --body "Backport of $pull_request_url"
-  else
-    gh pr create --assignee $assignee \
-      --base "$branch" \
-      --title "Backport to branch($branch) : $pull_request_title" \
-      --body "Backport of $pull_request_url"
-  fi
+  gh pr create --assignee $assignee \
+    --base "$branch" \
+    --title "Backport to branch($branch) : $pull_request_title" \
+    --body "Backport of $pull_request_url"
 }
 
 function create_issue () {
-  if [[ -z $assignee ]]; then
-    gh issue create \
-      --title "Backport to branch($branch) failed: $pull_request_title" \
-      --body "Backport of $pull_request_url to branch($branch) failed"
-  else
-    gh issue create --assignee $assignee \
-      --title "Backport to branch($branch) failed: $pull_request_title" \
-      --body "Backport of $pull_request_url to branch($branch) failed"
-  fi
+  gh issue create --assignee $assignee \
+    --title "Backport to branch($branch) failed: $pull_request_title" \
+    --body "Backport of $pull_request_url to branch($branch) failed"
 }
 
 git fetch origin

--- a/ci/auto-pr/create_pull_requests
+++ b/ci/auto-pr/create_pull_requests
@@ -32,16 +32,29 @@ function cherry_pick_and_create_pull_request () {
   git cherry-pick --no-rerere-autoupdate -m1 $commit_sha
   git push origin $new_branch
   git status
-  gh pr create --assignee $assignee \
-    --base "$branch" \
-    --title "Backport to branch($branch) : $pull_request_title" \
-    --body "Backport of $pull_request_url"
+  if [[ -z $assignee ]]; then
+    gh pr create \
+      --base "$branch" \
+      --title "Backport to branch($branch) : $pull_request_title" \
+      --body "Backport of $pull_request_url"
+  else
+    gh pr create --assignee $assignee \
+      --base "$branch" \
+      --title "Backport to branch($branch) : $pull_request_title" \
+      --body "Backport of $pull_request_url"
+  fi
 }
 
 function create_issue () {
-  gh issue create --assignee $assignee \
-    --title "Backport to branch($branch) failed: $pull_request_title" \
-    --body "Backport of $pull_request_url to branch($branch) failed"
+  if [[ -z $assignee ]]; then
+    gh issue create \
+      --title "Backport to branch($branch) failed: $pull_request_title" \
+      --body "Backport of $pull_request_url to branch($branch) failed"
+  else
+    gh issue create --assignee $assignee \
+      --title "Backport to branch($branch) failed: $pull_request_title" \
+      --body "Backport of $pull_request_url to branch($branch) failed"
+  fi
 }
 
 git fetch origin

--- a/ci/auto-pr/fetch_gh_user_info
+++ b/ci/auto-pr/fetch_gh_user_info
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+if [[ $# != 3 ]]; then
+    echo "usage: $0 repo_owner repo_name user"
+    exit 1
+fi
+
+repo_owner=$1
+repo_name=$2
+user=$3
+
+# Get the author of the merged PR
+author_json=$(gh api graphql -F owner=$repo_owner -F repoName=$repo_name -F userName=$user -f query='
+  query($owner: String!, $repoName: String!, $userName: String!) {
+    repository(owner: $owner, name: $repoName) {
+      assignableUsers(first: 100, query: $userName) {
+        nodes {
+          name,
+          email
+        }
+      }
+    }
+  }
+')
+
+# Return empty string not "null" if it's not found
+echo $author_json | jq -r '.data.repository.assignableUsers.nodes[0] // empty'
+


### PR DESCRIPTION
### Context

We've introduced https://github.com/scalar-labs/scalardb/pull/884 and related changes. But we ran into a failure https://github.com/scalar-labs/scalardb/actions/runs/5183834740/jobs/9342161161 that occurred as the original PR creator `dependabot` wasn't an actual GitHub user and the workflow failed to assign `dependabot` to the new PRs.

### Changes

This PR updates the GHA workflow and related scripts to avoid assigning someone to new PRs and issues if it can't get GitHub user information based on the original PR creator name.
