### PR TITLE
Add relational scan for JDBC storage and consensus commit transaction

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseRelationalScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseRelationalScanIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.DistributedStorageRelationalScanIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
+import com.scalar.db.util.ScalarDbUtils;
+import java.util.Properties;
+import java.util.Random;
+
+public class JdbcDatabaseRelationalScanIntegrationTest
+    extends DistributedStorageRelationalScanIntegrationTestBase {
+
+  private RdbEngineStrategy rdbEngine;
+
+  @Override
+  protected Properties getProperties(String testName) {
+    Properties properties = JdbcEnv.getProperties(testName);
+    JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    rdbEngine = RdbEngineFactory.create(config);
+    return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected int getThreadNum() {
+    if (rdbEngine instanceof RdbEngineOracle) {
+      return 1;
+    }
+    return super.getThreadNum();
+  }
+
+  @Override
+  protected Column<?> getRandomColumn(Random random, String columnName, DataType dataType) {
+    if (rdbEngine instanceof RdbEngineOracle) {
+      if (dataType == DataType.DOUBLE) {
+        return ScalarDbUtils.toColumn(JdbcTestUtils.getRandomOracleDoubleValue(random, columnName));
+      }
+    }
+    return super.getRandomColumn(random, columnName, dataType);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -303,7 +303,8 @@ public class Scan extends Selection {
   }
 
   /**
-   * Returns the set of {@code Conjunction}.
+   * Returns the set of {@code Conjunction}. We regard this set as a disjunction of conjunctions
+   * (i.e., a disjunctive normal form, DNF).
    *
    * <p>This method is primarily for internal use. Breaking changes can and will be introduced to
    * this method. Users should not depend on it.
@@ -488,8 +489,8 @@ public class Scan extends Selection {
   /**
    * A conjunctive set of {@link ConditionalExpression}, and it is an internal representation of the
    * optional parameter for a {@link Scan} command, which specifies arbitrary conditions with a
-   * disjunctive set of {@link Conjunction} (i.e., a disjunctive normal form, DNF). Its
-   * functionality is similar to {@link ScanBuilder.AndConditionSet}, but unlike {@link
+   * disjunction of {@link Conjunction}s (i.e., a disjunctive normal form, DNF). Its functionality
+   * is similar to {@link ScanBuilder.AndConditionSet}, but unlike {@link
    * ScanBuilder.AndConditionSet}, this class is primarily used for an internal purpose. Breaking
    * changes can and will be introduced to this class. Users should not depend on it.
    */

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -64,6 +65,7 @@ public class Cassandra extends AbstractDistributedStorage {
     operationChecker = new OperationChecker(metadataManager);
   }
 
+  @VisibleForTesting
   Cassandra(
       DatabaseConfig config,
       ClusterManager clusterManager,

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -69,6 +70,7 @@ public class Cosmos extends AbstractDistributedStorage {
     logger.info("Cosmos DB object is created properly.");
   }
 
+  @VisibleForTesting
   Cosmos(
       DatabaseConfig databaseConfig,
       CosmosClient client,

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -79,6 +80,7 @@ public class Dynamo extends AbstractDistributedStorage {
     logger.info("DynamoDB object is created properly.");
   }
 
+  @VisibleForTesting
   Dynamo(
       DatabaseConfig databaseConfig,
       DynamoDbClient client,

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -16,6 +16,7 @@ import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -78,6 +79,23 @@ public class Dynamo extends AbstractDistributedStorage {
     logger.info("DynamoDB object is created properly.");
   }
 
+  Dynamo(
+      DatabaseConfig databaseConfig,
+      DynamoDbClient client,
+      SelectStatementHandler select,
+      PutStatementHandler put,
+      DeleteStatementHandler delete,
+      BatchHandler batch,
+      OperationChecker operationChecker) {
+    super(databaseConfig);
+    this.client = client;
+    this.selectStatementHandler = select;
+    this.putStatementHandler = put;
+    this.deleteStatementHandler = delete;
+    this.batchHandler = batch;
+    this.operationChecker = operationChecker;
+  }
+
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {
@@ -107,6 +125,11 @@ public class Dynamo extends AbstractDistributedStorage {
   public Scanner scan(Scan scan) throws ExecutionException {
     scan = copyAndSetTargetToIfNot(scan);
     operationChecker.check(scan);
+
+    if (ScalarDbUtils.isRelational(scan)) {
+      throw new UnsupportedOperationException(
+          "scanning all records with orderings or conditions is not supported in DynamoDB");
+    }
 
     return selectStatementHandler.handle(scan);
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectQuery.java
@@ -1,6 +1,8 @@
 package com.scalar.db.storage.jdbc.query;
 
+import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Conjunction;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.Column;
 import com.scalar.db.io.Key;
@@ -9,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface SelectQuery extends Query {
 
@@ -30,6 +33,8 @@ public interface SelectQuery extends Query {
     boolean isRangeQuery;
     Optional<String> indexedColumn = Optional.empty();
     boolean isConditionalQuery;
+    boolean isRelationalQuery;
+    Set<Conjunction> conjunctions = Collections.emptySet();
 
     Builder(RdbEngineStrategy rdbEngine, List<String> projections) {
       this.rdbEngine = rdbEngine;
@@ -116,6 +121,15 @@ public interface SelectQuery extends Query {
       }
 
       indexedColumn = Optional.of(column);
+    }
+
+    /*
+     * Assumes this is called by relational scan operations
+     */
+    public Builder where(Set<Conjunction> conjunctions) {
+      isRelationalQuery = true;
+      this.conjunctions = ImmutableSet.copyOf(conjunctions);
+      return this;
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SimpleSelectQuery.java
@@ -62,11 +62,10 @@ public class SimpleSelectQuery implements SelectQuery {
   @Override
   public String sql() {
     StringBuilder builder =
-        new StringBuilder(
-            "SELECT "
-                + projectionSqlString()
-                + " FROM "
-                + rdbEngine.encloseFullTableName(schema, table));
+        new StringBuilder("SELECT ")
+            .append(projectionSqlString())
+            .append(" FROM ")
+            .append(rdbEngine.encloseFullTableName(schema, table));
     if (isRelationalQuery) {
       // for relational abstraction
       builder.append(relationalConditionSqlString());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -73,6 +73,20 @@ public class CrudHandler {
   }
 
   public List<Result> scan(Scan scan) throws CrudException {
+    List<Result> results = scanInternal(scan);
+
+    if (ScalarDbUtils.isRelational(scan)) {
+      // We verify if this scan does not overlap previous writes using the results obtained from
+      // the actual scan since the condition (i.e., where clause) is arbitrary in the relational
+      // scan, and thus, the write command may not have columns used in the condition, which are
+      // necessary to determine overlaps.
+      snapshot.verify(scan);
+    }
+
+    return results;
+  }
+
+  private List<Result> scanInternal(Scan scan) throws CrudException {
     List<String> originalProjections = new ArrayList<>(scan.getProjections());
 
     List<Result> results = new ArrayList<>();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -75,13 +75,13 @@ public class CrudHandler {
   public List<Result> scan(Scan scan) throws CrudException {
     List<Result> results = scanInternal(scan);
 
-    if (ScalarDbUtils.isRelational(scan)) {
-      // We verify if this scan does not overlap previous writes using the results obtained from
-      // the actual scan since the condition (i.e., where clause) is arbitrary in the relational
-      // scan, and thus, the write command may not have columns used in the condition, which are
-      // necessary to determine overlaps.
-      snapshot.verify(scan);
-    }
+    // We verify if this scan does not overlap previous writes after the actual scan. For a
+    // relational scan, this must be done here, using the obtained results. This is because the
+    // condition (i.e., where clause) is arbitrary in the relational scan, and thus, the write
+    // command may not have columns used in the condition, which are necessary to determine
+    // overlaps. For a scan with clustering keys, we can determine overlaps without the actual
+    // scan, but we also check it here for consistent logic and readability.
+    snapshot.verify(scan);
 
     return results;
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -76,11 +76,11 @@ public class CrudHandler {
     List<Result> results = scanInternal(scan);
 
     // We verify if this scan does not overlap previous writes after the actual scan. For a
-    // relational scan, this must be done here, using the obtained results. This is because the
-    // condition (i.e., where clause) is arbitrary in the relational scan, and thus, the write
-    // command may not have columns used in the condition, which are necessary to determine
-    // overlaps. For a scan with clustering keys, we can determine overlaps without the actual
-    // scan, but we also check it here for consistent logic and readability.
+    // relational scan, this must be done here, using the obtained keys in the scan set and scan
+    // condition. This is because the condition (i.e., where clause) is arbitrary in the relational
+    // scan, and thus, the write command may not have columns used in the condition, which are
+    // necessary to determine overlaps. For a scan with clustering keys, we can determine overlaps
+    // without the actual scan, but we also check it here for consistent logic and readability.
     snapshot.verify(scan);
 
     return results;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -181,11 +181,6 @@ public class Snapshot {
   }
 
   public Optional<List<Key>> get(Scan scan) {
-    if (!ScalarDbUtils.isRelational(scan) && isWriteSetOverlappedWith(scan)) {
-      // Verify overlaps only for non-relational scan since we do it later for relational scan
-      // (right before returning the results).
-      throw new IllegalArgumentException("reading already written data is not allowed");
-    }
     if (scanSet.containsKey(scan)) {
       return Optional.ofNullable(scanSet.get(scan));
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -291,7 +291,7 @@ public class Snapshot {
         continue;
       }
 
-      if (scan.getConjunctions().size() == 0) {
+      if (scan.getConjunctions().isEmpty()) {
         return true;
       }
 
@@ -335,7 +335,7 @@ public class Snapshot {
       case LTE:
         return column.compareTo((Column<T>) condition.getColumn()) <= 0;
       default:
-        throw new IllegalArgumentException("unknown operator");
+        throw new IllegalArgumentException("unknown operator: " + condition.getOperator());
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -193,7 +193,8 @@ public class Snapshot {
   }
 
   public void verify(Scan scan) {
-    if (isWriteSetOverlappedWithRelational(scan)) {
+    if ((ScalarDbUtils.isRelational(scan) && isWriteSetOverlappedWithRelational(scan))
+        || (!ScalarDbUtils.isRelational(scan) && isWriteSetOverlappedWith(scan))) {
       throw new IllegalArgumentException("reading already written data is not allowed");
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -188,8 +188,9 @@ public class Snapshot {
   }
 
   public void verify(Scan scan) {
-    if ((ScalarDbUtils.isRelational(scan) && isWriteSetOverlappedWithRelational(scan))
-        || (!ScalarDbUtils.isRelational(scan) && isWriteSetOverlappedWith(scan))) {
+    boolean isRelational = ScalarDbUtils.isRelational(scan);
+    if ((isRelational && isWriteSetOverlappedWithRelational(scan))
+        || (!isRelational && isWriteSetOverlappedWith(scan))) {
       throw new IllegalArgumentException("reading already written data is not allowed");
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -2,6 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
+import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -10,6 +11,7 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Conjunction;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
@@ -17,6 +19,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
+import com.scalar.db.io.Column;
 import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
 import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
@@ -178,13 +181,21 @@ public class Snapshot {
   }
 
   public Optional<List<Key>> get(Scan scan) {
-    if (isWriteSetOverlappedWith(scan)) {
+    if (!ScalarDbUtils.isRelational(scan) && isWriteSetOverlappedWith(scan)) {
+      // Verify overlaps only for non-relational scan since we do it later for relational scan
+      // (right before returning the results).
       throw new IllegalArgumentException("reading already written data is not allowed");
     }
     if (scanSet.containsKey(scan)) {
       return Optional.ofNullable(scanSet.get(scan));
     }
     return Optional.empty();
+  }
+
+  public void verify(Scan scan) {
+    if (isWriteSetOverlappedWithRelational(scan)) {
+      throw new IllegalArgumentException("reading already written data is not allowed");
+    }
   }
 
   public void to(MutationComposer composer)
@@ -263,6 +274,68 @@ public class Snapshot {
       }
     }
     return false;
+  }
+
+  private boolean isWriteSetOverlappedWithRelational(Scan scan) {
+    for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
+      if (scanSet.get(scan).contains(entry.getKey())) {
+        return true;
+      }
+
+      // the following check prevents scan-after-write even if the update record potentially matches
+      // the scan that can be overlooked above check.
+      Put put = entry.getValue();
+      if (!put.forNamespace().equals(scan.forNamespace())
+          || !put.forTable().equals(scan.forTable())) {
+        continue;
+      }
+
+      if (scan.getConjunctions().size() == 0) {
+        return true;
+      }
+
+      Map<String, Column<?>> columns = new HashMap<>(put.getColumns());
+      put.getPartitionKey().getColumns().forEach(column -> columns.put(column.getName(), column));
+      put.getClusteringKey()
+          .ifPresent(
+              key -> key.getColumns().forEach(column -> columns.put(column.getName(), column)));
+      for (Conjunction conjunction : scan.getConjunctions()) {
+        boolean allMatched = true;
+        for (ConditionalExpression condition : conjunction.getConditions()) {
+          if (!columns.containsKey(condition.getColumn().getName())
+              || !match(columns.get(condition.getColumn().getName()), condition)) {
+            allMatched = false;
+            break;
+          }
+        }
+        if (allMatched) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private <T> boolean match(Column<T> column, ConditionalExpression condition) {
+    assert column.getClass() == condition.getColumn().getClass();
+    switch (condition.getOperator()) {
+      case EQ:
+      case IS_NULL:
+        return column.equals(condition.getColumn());
+      case NE:
+      case IS_NOT_NULL:
+        return !column.equals(condition.getColumn());
+      case GT:
+        return column.compareTo((Column<T>) condition.getColumn()) > 0;
+      case GTE:
+        return column.compareTo((Column<T>) condition.getColumn()) >= 0;
+      case LT:
+        return column.compareTo((Column<T>) condition.getColumn()) < 0;
+      case LTE:
+        return column.compareTo((Column<T>) condition.getColumn()) <= 0;
+      default:
+        throw new IllegalArgumentException("unknown operator");
+    }
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -279,12 +279,25 @@ public class Snapshot {
 
   private boolean isWriteSetOverlappedWithRelational(Scan scan) {
     for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
+      // We need to consider three cases here to prevent scan-after-write.
+      //   1) A put operation overlaps the scan range regardless of the update (put) results.
+      //   2) A put operation does not overlap the scan range as a result of the update.
+      //   3) A put operation overlaps the scan range as a result of the update.
+      // See the following examples. Assume that we have a table with two columns whose names are
+      // "key" and "value" and two records in the table: (key=1, value=2) and (key=2, key=3).
+      // Case 2 covers a transaction that puts (1, 4) and then scans "where value < 3". In this
+      // case, there is no overlap, but we intentionally prohibit it due to the consistency and
+      // simplicity of snapshot management. We can find case 2 using the scan results.
+      // Case 3 covers a transaction that puts (2, 2) and then scans "where value < 3". In this
+      // case, we cannot find the overlap using the scan results since the database is not updated
+      // yet. Thus, we need to evaluate if the scan condition potentially matches put operations.
+
+      // Check for cases 1 and 2
       if (scanSet.get(scan).contains(entry.getKey())) {
         return true;
       }
 
-      // the following check prevents scan-after-write even if the update record potentially matches
-      // the scan that can be overlooked above check.
+      // Check for case 3
       Put put = entry.getValue();
       if (!put.forNamespace().equals(scan.forNamespace())
           || !put.forTable().equals(scan.forTable())) {
@@ -317,6 +330,7 @@ public class Snapshot {
     return false;
   }
 
+  @SuppressWarnings("unchecked")
   private <T> boolean match(Column<T> column, ConditionalExpression condition) {
     assert column.getClass() == condition.getColumn().getClass();
     switch (condition.getOperator()) {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -244,4 +244,9 @@ public final class ScalarDbUtils {
         throw new AssertionError();
     }
   }
+
+  public static boolean isRelational(Scan scan) {
+    return scan instanceof ScanAll
+        && (!scan.getOrderings().isEmpty() || !scan.getConjunctions().isEmpty());
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraTest.java
@@ -1,0 +1,81 @@
+package com.scalar.db.storage.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.ResultSet;
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.TableMetadataManager;
+import com.scalar.db.common.checker.OperationChecker;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CassandraTest {
+  private Cassandra cassandra;
+  private StatementHandlerManager handlers;
+  @Mock private DatabaseConfig config;
+  @Mock private ClusterManager clusterManager;
+  @Mock private SelectStatementHandler select;
+  @Mock private InsertStatementHandler insert;
+  @Mock private UpdateStatementHandler update;
+  @Mock private DeleteStatementHandler delete;
+  @Mock private BatchHandler batchHandler;
+  @Mock private TableMetadataManager metadataManager;
+  @Mock private OperationChecker operationChecker;
+  @Mock private ResultSet resultSet;
+  @Mock private TableMetadata tableMetadata;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    handlers =
+        StatementHandlerManager.builder()
+            .select(select)
+            .insert(insert)
+            .update(update)
+            .delete(delete)
+            .build();
+    cassandra =
+        new Cassandra(
+            config, clusterManager, handlers, batchHandler, metadataManager, operationChecker);
+  }
+
+  @Test
+  public void scan_ScanAllWithoutOrderingAndConditionsGiven_ShouldScanHandled()
+      throws ExecutionException {
+    // Arrange
+    Scan scan = Scan.newBuilder().namespace("namespace").table("table").all().build();
+    when(handlers.select().handle(any())).thenReturn(resultSet);
+    when(metadataManager.getTableMetadata(any())).thenReturn(tableMetadata);
+
+    // Act
+    cassandra.scan(scan);
+
+    // Assert
+    verify(handlers.select()).handle(scan);
+  }
+
+  @Test
+  public void scan_ScanAllWithConditionsGiven_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("namespace")
+            .table("table")
+            .all()
+            .where(ConditionBuilder.column("column").isEqualToInt(1))
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> cassandra.scan(scan))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosTest.java
@@ -1,0 +1,60 @@
+package com.scalar.db.storage.cosmos;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import com.azure.cosmos.CosmosClient;
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Scan;
+import com.scalar.db.common.checker.OperationChecker;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CosmosTest {
+  private Cosmos cosmos;
+  @Mock private DatabaseConfig config;
+  @Mock private CosmosClient client;
+  @Mock private SelectStatementHandler select;
+  @Mock private PutStatementHandler put;
+  @Mock private DeleteStatementHandler delete;
+  @Mock private BatchHandler batch;
+  @Mock private OperationChecker operationChecker;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    cosmos = new Cosmos(config, client, select, put, delete, batch, operationChecker);
+  }
+
+  @Test
+  public void scan_ScanAllWithoutOrderingAndConditionsGiven_ShouldScanHandled()
+      throws ExecutionException {
+    // Arrange
+    Scan scan = Scan.newBuilder().namespace("namespace").table("table").all().build();
+
+    // Act
+    cosmos.scan(scan);
+
+    // Assert
+    verify(select).handle(scan);
+  }
+
+  @Test
+  public void scan_ScanAllWithConditionsGiven_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("namespace")
+            .table("table")
+            .all()
+            .where(ConditionBuilder.column("column").isEqualToInt(1))
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.scan(scan)).isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoTest.java
@@ -1,0 +1,60 @@
+package com.scalar.db.storage.dynamo;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Scan;
+import com.scalar.db.common.checker.OperationChecker;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class DynamoTest {
+  private Dynamo dynamo;
+  @Mock private DatabaseConfig config;
+  @Mock private DynamoDbClient client;
+  @Mock private SelectStatementHandler select;
+  @Mock private PutStatementHandler put;
+  @Mock private DeleteStatementHandler delete;
+  @Mock private BatchHandler batch;
+  @Mock private OperationChecker operationChecker;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    dynamo = new Dynamo(config, client, select, put, delete, batch, operationChecker);
+  }
+
+  @Test
+  public void scan_ScanAllWithoutOrderingAndConditionsGiven_ShouldScanHandled()
+      throws ExecutionException {
+    // Arrange
+    Scan scan = Scan.newBuilder().namespace("namespace").table("table").all().build();
+
+    // Act
+    dynamo.scan(scan);
+
+    // Assert
+    verify(select).handle(scan);
+  }
+
+  @Test
+  public void scan_ScanAllWithConditionsGiven_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("namespace")
+            .table("table")
+            .all()
+            .where(ConditionBuilder.column("column").isEqualToInt(1))
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> dynamo.scan(scan)).isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -5,9 +5,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
@@ -153,6 +155,40 @@ public class JdbcServiceTest {
     // Assert
     verify(operationChecker).check(any(ScanAll.class));
     verify(queryBuilder).select(any());
+  }
+
+  @Test
+  public void whenGetScannerExecuted_withRelationalScan_shouldCallQueryBuilder() throws Exception {
+    // Arrange
+    when(queryBuilder.select(any())).thenReturn(selectQueryBuilder);
+
+    when(selectQueryBuilder.from(any(), any(), any())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.where(anySet())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.orderBy(any())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.limit(anyInt())).thenReturn(selectQueryBuilder);
+    when(selectQueryBuilder.build()).thenReturn(selectQuery);
+
+    when(connection.prepareStatement(any())).thenReturn(preparedStatement);
+    when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(false);
+
+    // Act
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .all()
+            .where(ConditionBuilder.column("column").isEqualToInt(10))
+            .build();
+    jdbcService.getScanner(scan, connection);
+
+    // Assert
+    verify(operationChecker).check(any(ScanAll.class));
+    verify(queryBuilder).select(any());
+    verify(queryBuilder.select(any())).from(any(), any(), any());
+    verify(queryBuilder.select(any())).where(anySet());
+    verify(queryBuilder.select(any())).orderBy(anyList());
+    verify(queryBuilder.select(any())).limit(anyInt());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -230,7 +230,7 @@ public class CrudHandlerTest {
     // Assert
     TransactionResult expected = new TransactionResult(result);
     verify(snapshot).put(key, Optional.of(expected));
-    verify(snapshot, never()).verify(any());
+    verify(snapshot).verify(scan);
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -10,11 +10,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
@@ -90,6 +92,15 @@ public class CrudHandlerTest {
   private Scan prepareScan() {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
+  }
+
+  private Scan prepareRelationalScan() {
+    return Scan.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .all()
+        .where(ConditionBuilder.column("column").isEqualToInt(10))
+        .build();
   }
 
   private TransactionResult prepareResult(TransactionState state) {
@@ -219,6 +230,7 @@ public class CrudHandlerTest {
     // Assert
     TransactionResult expected = new TransactionResult(result);
     verify(snapshot).put(key, Optional.of(expected));
+    verify(snapshot, never()).verify(any());
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
@@ -410,5 +422,51 @@ public class CrudHandlerTest {
     Snapshot.Key key2 = new Snapshot.Key(scan, result2);
     assertThat(readSet.get(key2).isPresent()).isTrue();
     assertThat(readSet.get(key2).get()).isEqualTo(new TransactionResult(result2));
+  }
+
+  @Test
+  public void
+      scan_RelationalScanAndResultFromStorageGiven_ShouldUpdateSnapshotAndValidateThenReturn()
+          throws ExecutionException, CrudException {
+    // Arrange
+    Scan scan = prepareRelationalScan();
+    result = prepareResult(TransactionState.COMMITTED);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
+    doNothing()
+        .when(snapshot)
+        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    when(storage.scan(any(ScanAll.class))).thenReturn(scanner);
+
+    // Act
+    List<Result> results = handler.scan(scan);
+
+    // Assert
+    TransactionResult expected = new TransactionResult(result);
+    verify(snapshot).put(key, Optional.of(expected));
+    verify(snapshot).verify(scan);
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0))
+        .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
+  }
+
+  @Test
+  public void
+      scan_RelationalScanAndPreparedResultFromStorageGiven_ShouldNeverUpdateSnapshotNorValidateButThrowUncommittedRecordException()
+          throws ExecutionException {
+    // Arrange
+    Scan scan = prepareRelationalScan();
+    result = prepareResult(TransactionState.PREPARED);
+    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    when(storage.scan(any(ScanAll.class))).thenReturn(scanner);
+
+    // Act
+    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(UncommittedRecordException.class);
+
+    // Assert
+    verify(snapshot, never())
+        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
+    verify(snapshot, never()).verify(any());
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -1100,7 +1100,7 @@ public class SnapshotTest {
 
   @Test
   public void
-      get_ScanGivenAndPutWithSamePartitionKeyWithoutClusteringKeyInWriteSet_ShouldThrowIllegalArgumentException() {
+      get_ScanGivenAndPutWithSamePartitionKeyWithoutClusteringKeyInWriteSet_ShouldNotThrowException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePutWithPartitionKeyOnly();
@@ -1112,12 +1112,29 @@ public class SnapshotTest {
     Throwable thrown = catchThrowable(() -> snapshot.get(scan));
 
     // Assert
+    assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      verify_ScanGivenAndPutWithSamePartitionKeyWithoutClusteringKeyInWriteSet_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePutWithPartitionKeyOnly();
+    Snapshot.Key putKey = new Snapshot.Key(put);
+    snapshot.put(putKey, put);
+    Scan scan = prepareScan();
+
+    // Act Assert
+    Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
+
+    // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   public void
-      get_ScanWithNoRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+      verify_ScanWithNoRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     // "text2"
@@ -1132,7 +1149,7 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME);
 
     // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
+    Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -1140,7 +1157,7 @@ public class SnapshotTest {
 
   @Test
   public void
-      get_ScanWithRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+      verify_ScanWithRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     // "text2"
@@ -1174,11 +1191,11 @@ public class SnapshotTest {
             .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
 
     // Act Assert
-    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
-    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
-    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
-    Throwable thrown4 = catchThrowable(() -> snapshot.get(scan4));
-    Throwable thrown5 = catchThrowable(() -> snapshot.get(scan5));
+    Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
+    Throwable thrown2 = catchThrowable(() -> snapshot.verify(scan2));
+    Throwable thrown3 = catchThrowable(() -> snapshot.verify(scan3));
+    Throwable thrown4 = catchThrowable(() -> snapshot.verify(scan4));
+    Throwable thrown5 = catchThrowable(() -> snapshot.verify(scan5));
 
     // Assert
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
@@ -1190,7 +1207,7 @@ public class SnapshotTest {
 
   @Test
   public void
-      get_ScanWithEndSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+      verify_ScanWithEndSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     // "text2"
@@ -1220,9 +1237,9 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME);
 
     // Act Assert
-    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
-    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
-    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
+    Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
+    Throwable thrown2 = catchThrowable(() -> snapshot.verify(scan2));
+    Throwable thrown3 = catchThrowable(() -> snapshot.verify(scan3));
 
     // Assert
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
@@ -1232,7 +1249,7 @@ public class SnapshotTest {
 
   @Test
   public void
-      get_ScanWithStartSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
+      verify_ScanWithStartSideInfiniteRangeGivenAndPutInWriteSetOverlappedWithScan_ShouldThrowIllegalArgumentException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     // "text2"
@@ -1262,9 +1279,9 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME);
 
     // Act Assert
-    Throwable thrown1 = catchThrowable(() -> snapshot.get(scan1));
-    Throwable thrown2 = catchThrowable(() -> snapshot.get(scan2));
-    Throwable thrown3 = catchThrowable(() -> snapshot.get(scan3));
+    Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
+    Throwable thrown2 = catchThrowable(() -> snapshot.verify(scan2));
+    Throwable thrown3 = catchThrowable(() -> snapshot.verify(scan3));
 
     // Assert
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
@@ -1273,7 +1290,7 @@ public class SnapshotTest {
   }
 
   @Test
-  public void get_ScanAllGivenAndPutInWriteSetInSameTable_ShouldThrowException() {
+  public void verify_ScanAllGivenAndPutInWriteSetInSameTable_ShouldThrowException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     // "text2"
@@ -1287,14 +1304,15 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME);
 
     // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scanAll));
+    Throwable thrown = catchThrowable(() -> snapshot.verify(scanAll));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void get_ScanAllGivenAndPutInWriteSetNotOverlappingWithScanAll_ShouldReturnEmptyList() {
+  public void
+      verify_ScanAllGivenAndPutInWriteSetNotOverlappingWithScanAll_ShouldNotThrowException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     // "text2"
@@ -1308,10 +1326,10 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME_2);
 
     // Act Assert
-    Optional<List<Snapshot.Key>> keys = snapshot.get(scanAll);
+    Throwable thrown = catchThrowable(() -> snapshot.verify(scanAll));
 
     // Assert
-    assertThat(keys).isEmpty();
+    assertThat(thrown).doesNotThrowAnyException();
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageRelationalScanIntegrationTestBase.java
@@ -732,7 +732,6 @@ public abstract class DistributedStorageRelationalScanIntegrationTestBase {
             .namespace(getNamespaceName())
             .table(CONDITION_TEST_TABLE)
             .all()
-            .ordering(Ordering.asc(PARTITION_KEY_NAME))
             .where(
                 prepareOrConditionSet(
                     ImmutableList.of(
@@ -745,6 +744,7 @@ public abstract class DistributedStorageRelationalScanIntegrationTestBase {
             .map(i -> prepareOrConditionSet(ImmutableList.of(columns1.get(i), columns2.get(i))))
             .collect(Collectors.toList());
     orConditionSets.forEach(builder::and);
+    builder.ordering(Ordering.asc(PARTITION_KEY_NAME));
 
     // Act
     List<Result> actual = scanAll(builder.build());

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageRelationalScanIntegrationTestBase.java
@@ -1,0 +1,901 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.scalar.db.api.ConditionalExpression.Operator;
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.ScanBuilder.AndConditionSet;
+import com.scalar.db.api.ScanBuilder.BuildableScanAll;
+import com.scalar.db.api.ScanBuilder.BuildableScanAllWithOngoingWhereAnd;
+import com.scalar.db.api.ScanBuilder.ConditionSetBuilder;
+import com.scalar.db.api.ScanBuilder.OrConditionSet;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.db.util.TestUtils;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DistributedStorageRelationalScanIntegrationTestBase {
+
+  private static final String TEST_NAME = "storage_relational_scan";
+  private static final String NAMESPACE_BASE_NAME = "int_test_" + TEST_NAME + "_";
+  private static final String CONDITION_TEST_TABLE = "condition_test_table";
+  private static final String PARTITION_KEY_NAME = "pk";
+  private static final String COL_NAME1 = "c1";
+  private static final String COL_NAME2 = "c2";
+  private static final String COL_NAME3 = "c3";
+  private static final String COL_NAME4 = "c4";
+  private static final String COL_NAME5 = "c5";
+  private static final String COL_NAME6 = "c6";
+  private static final String COL_NAME7 = "c7";
+  private static final int CONDITION_TEST_TABLE_NUM_ROWS = 3;
+  private static final int CONDITION_TEST_PREDICATE_VALUE = 2;
+  private static final int FIRST_COLUMN_CARDINALITY = 5;
+  private static final int SECOND_COLUMN_CARDINALITY_PER_SAME_FIRST_COLUMN = 20;
+
+  private static final int THREAD_NUM = 10;
+
+  private ExecutorService executorService;
+  private long seed;
+  private ThreadLocal<Random> random;
+
+  private DistributedStorage storage;
+  private DistributedStorageAdmin admin;
+  private String namespaceBaseName;
+
+  // Key: firstColumnType, Value: secondColumnType
+  private ListMultimap<DataType, DataType> columnTypes;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    executorService = Executors.newFixedThreadPool(getThreadNum());
+    StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
+    admin = factory.getStorageAdmin();
+    storage = factory.getStorage();
+    namespaceBaseName = getNamespaceBaseName();
+    columnTypes = getColumnTypes();
+    createTableForConditionTests();
+    createTablesForOrderingTests();
+    seed = System.currentTimeMillis();
+    System.out.println("The seed used in the relational scan integration test is " + seed);
+    random = ThreadLocal.withInitial(Random::new);
+  }
+
+  protected abstract Properties getProperties(String testName);
+
+  protected String getNamespaceBaseName() {
+    return NAMESPACE_BASE_NAME;
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  protected int getThreadNum() {
+    return THREAD_NUM;
+  }
+
+  protected Column<?> getRandomColumn(Random random, String columnName, DataType dataType) {
+    return ScalarDbUtils.toColumn(TestUtils.getRandomValue(random, columnName, dataType));
+  }
+
+  private String getNamespaceName() {
+    return namespaceBaseName;
+  }
+
+  private String getNamespaceName(DataType firstColumnType) {
+    return namespaceBaseName + firstColumnType;
+  }
+
+  private void createTableForConditionTests() throws ExecutionException {
+    Map<String, String> options = getCreationOptions();
+    admin.createNamespace(getNamespaceName(), true, options);
+    admin.createTable(
+        getNamespaceName(),
+        CONDITION_TEST_TABLE,
+        TableMetadata.newBuilder()
+            .addColumn(PARTITION_KEY_NAME, DataType.INT)
+            .addColumn(COL_NAME1, DataType.INT)
+            .addColumn(COL_NAME2, DataType.BIGINT)
+            .addColumn(COL_NAME3, DataType.FLOAT)
+            .addColumn(COL_NAME4, DataType.DOUBLE)
+            .addColumn(COL_NAME5, DataType.TEXT)
+            .addColumn(COL_NAME6, DataType.BOOLEAN)
+            .addColumn(COL_NAME7, DataType.BLOB)
+            .addPartitionKey(PARTITION_KEY_NAME)
+            .build(),
+        true,
+        options);
+  }
+
+  private void createTablesForOrderingTests()
+      throws java.util.concurrent.ExecutionException, InterruptedException {
+    List<Callable<Void>> testCallables = new ArrayList<>();
+
+    Map<String, String> options = getCreationOptions();
+    for (DataType firstColumnType : columnTypes.keySet()) {
+      Callable<Void> testCallable =
+          () -> {
+            admin.createNamespace(getNamespaceName(firstColumnType), true, options);
+            for (DataType secondColumnType : columnTypes.get(firstColumnType)) {
+              createTable(firstColumnType, secondColumnType, options);
+            }
+            return null;
+          };
+      testCallables.add(testCallable);
+    }
+
+    executeInParallel(testCallables);
+  }
+
+  private void createTable(
+      DataType firstColumnType, DataType secondColumnType, Map<String, String> options)
+      throws ExecutionException {
+    admin.createTable(
+        getNamespaceName(firstColumnType),
+        getTableName(firstColumnType, secondColumnType),
+        TableMetadata.newBuilder()
+            .addColumn(PARTITION_KEY_NAME, DataType.INT)
+            .addColumn(COL_NAME1, firstColumnType)
+            .addColumn(COL_NAME2, secondColumnType)
+            .addPartitionKey(PARTITION_KEY_NAME)
+            .build(),
+        true,
+        options);
+  }
+
+  private String getTableName(DataType firstColumnType, DataType secondColumnType) {
+    return String.join("_", firstColumnType.toString(), secondColumnType.toString());
+  }
+
+  private ListMultimap<DataType, DataType> getColumnTypes() {
+    ListMultimap<DataType, DataType> columnTypes = ArrayListMultimap.create();
+    for (DataType firstColumnType : DataType.values()) {
+      for (DataType secondColumnType : DataType.values()) {
+        columnTypes.put(firstColumnType, secondColumnType);
+      }
+    }
+    return columnTypes;
+  }
+
+  private void prepareRecords() {
+    IntStream.range(1, CONDITION_TEST_TABLE_NUM_ROWS + 1)
+        .forEach(
+            i -> {
+              Key key = Key.ofInt(PARTITION_KEY_NAME, i);
+              try {
+                storage.put(preparePut(key, prepareNonKeyColumns(i)));
+              } catch (ExecutionException e) {
+                throw new RuntimeException("put data to database failed", e);
+              }
+            });
+  }
+
+  private void prepareNullRecords() {
+    IntStream.range(1, CONDITION_TEST_TABLE_NUM_ROWS + 1)
+        .forEach(
+            i -> {
+              Key key = Key.ofInt(PARTITION_KEY_NAME, i);
+              try {
+                storage.put(
+                    preparePut(key, i % 2 == 0 ? prepareNullColumns() : prepareNonKeyColumns(i)));
+              } catch (ExecutionException e) {
+                throw new RuntimeException("put data to database failed", e);
+              }
+            });
+  }
+
+  private List<Tuple> prepareRecords(DataType firstColumnType, DataType secondColumnType)
+      throws ExecutionException {
+    List<Tuple> ret = new ArrayList<>();
+    List<Put> puts = new ArrayList<>();
+
+    if (firstColumnType == DataType.BOOLEAN) {
+      TestUtils.booleanValues(COL_NAME1).stream()
+          .map(ScalarDbUtils::toColumn)
+          .forEach(
+              firstColumn ->
+                  prepareRecords(firstColumnType, firstColumn, secondColumnType, puts, ret));
+    } else {
+      Set<Column<?>> columnSet = new HashSet<>();
+      IntStream.range(0, FIRST_COLUMN_CARDINALITY)
+          .forEach(
+              i -> {
+                Column<?> firstColumn;
+                while (true) {
+                  firstColumn = getRandomColumn(random.get(), COL_NAME1, firstColumnType);
+                  // reject duplication
+                  if (!columnSet.contains(firstColumn)) {
+                    columnSet.add(firstColumn);
+                    break;
+                  }
+                }
+
+                prepareRecords(firstColumnType, firstColumn, secondColumnType, puts, ret);
+              });
+    }
+    try {
+      for (Put put : puts) {
+        storage.put(put);
+      }
+    } catch (ExecutionException e) {
+      throw new ExecutionException("put data to database failed", e);
+    }
+    return ret;
+  }
+
+  private void prepareRecords(
+      DataType firstColumnType,
+      Column<?> firstColumn,
+      DataType secondColumnType,
+      List<Put> puts,
+      List<Tuple> ret) {
+    if (secondColumnType == DataType.BOOLEAN) {
+      TestUtils.booleanValues(COL_NAME2).stream()
+          .map(ScalarDbUtils::toColumn)
+          .forEach(
+              secondColumn -> {
+                ret.add(new Tuple(firstColumn, secondColumn));
+                puts.add(
+                    preparePut(
+                        Key.ofInt(PARTITION_KEY_NAME, ret.size()),
+                        firstColumnType,
+                        firstColumn,
+                        secondColumnType,
+                        secondColumn));
+              });
+    } else {
+      Set<Column<?>> columnSet = new HashSet<>();
+      for (int i = 0; i < SECOND_COLUMN_CARDINALITY_PER_SAME_FIRST_COLUMN; i++) {
+        Column<?> secondColumn;
+        while (true) {
+          secondColumn = getRandomColumn(random.get(), COL_NAME2, secondColumnType);
+          // reject duplication
+          if (!columnSet.contains(secondColumn)) {
+            columnSet.add(secondColumn);
+            break;
+          }
+        }
+
+        ret.add(new Tuple(firstColumn, secondColumn));
+        puts.add(
+            preparePut(
+                Key.ofInt(PARTITION_KEY_NAME, ret.size()),
+                firstColumnType,
+                firstColumn,
+                secondColumnType,
+                secondColumn));
+      }
+    }
+  }
+
+  private Put preparePut(Key key, List<Column<?>> columns) {
+    PutBuilder.Buildable builder =
+        Put.newBuilder()
+            .namespace(getNamespaceName())
+            .table(CONDITION_TEST_TABLE)
+            .partitionKey(key);
+    columns.forEach(builder::value);
+    return builder.build();
+  }
+
+  private Put preparePut(
+      Key key,
+      DataType firstColumnType,
+      Column<?> firstColumn,
+      DataType secondColumnType,
+      Column<?> secondColumn) {
+    return Put.newBuilder()
+        .namespace(getNamespaceName(firstColumnType))
+        .table(getTableName(firstColumnType, secondColumnType))
+        .partitionKey(key)
+        .value(firstColumn)
+        .value(secondColumn)
+        .build();
+  }
+
+  private List<Column<?>> prepareNonKeyColumns(int i) {
+    List<Column<?>> columns = new ArrayList<>();
+    columns.add(IntColumn.of(COL_NAME1, i));
+    columns.add(BigIntColumn.of(COL_NAME2, i));
+    columns.add(FloatColumn.of(COL_NAME3, i));
+    columns.add(DoubleColumn.of(COL_NAME4, i));
+    columns.add(TextColumn.of(COL_NAME5, String.valueOf(i)));
+    columns.add(BooleanColumn.of(COL_NAME6, i % 2 == 0));
+    columns.add(BlobColumn.of(COL_NAME7, String.valueOf(i).getBytes(StandardCharsets.UTF_8)));
+    return columns;
+  }
+
+  private List<Column<?>> prepareNullColumns() {
+    List<Column<?>> columns = new ArrayList<>();
+    columns.add(IntColumn.ofNull(COL_NAME1));
+    columns.add(BigIntColumn.ofNull(COL_NAME2));
+    columns.add(FloatColumn.ofNull(COL_NAME3));
+    columns.add(DoubleColumn.ofNull(COL_NAME4));
+    columns.add(TextColumn.ofNull(COL_NAME5));
+    columns.add(BooleanColumn.ofNull(COL_NAME6));
+    columns.add(BlobColumn.ofNull(COL_NAME7));
+    return columns;
+  }
+
+  private List<Column<?>> prepareAllColumns(int value) {
+    List<Column<?>> columns = prepareNonKeyColumns(value);
+    columns.add(0, IntColumn.of(PARTITION_KEY_NAME, value));
+    // columns.add(0, IntColumn.of(COL_NAME1, value));
+    return columns;
+  }
+
+  private OrConditionSet prepareOrConditionSet(List<Column<?>> columns) {
+    return ConditionSetBuilder.orConditionSet(
+            columns.stream()
+                .map(column -> ConditionBuilder.buildConditionalExpression(column, Operator.EQ))
+                .collect(Collectors.toSet()))
+        .build();
+  }
+
+  private AndConditionSet prepareAndConditionSet(List<Column<?>> columns) {
+    return ConditionSetBuilder.andConditionSet(
+            columns.stream()
+                .map(column -> ConditionBuilder.buildConditionalExpression(column, Operator.EQ))
+                .collect(Collectors.toSet()))
+        .build();
+  }
+
+  private List<Integer> getExpectedResults(
+      DataType type, ConditionalExpression.Operator operator, int value) {
+    List<Integer> expected = new ArrayList<>();
+
+    if (type.equals(DataType.BOOLEAN)) {
+      return getExpectedResultsForBoolean(operator, value % 2 == 0);
+    }
+
+    switch (operator) {
+      case EQ:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if (i == value) {
+            expected.add(i);
+          }
+        }
+        break;
+      case NE:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if (i != value) {
+            expected.add(i);
+          }
+        }
+        break;
+      case GT:
+        for (int i = value + 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          expected.add(i);
+        }
+        break;
+      case GTE:
+        for (int i = value; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          expected.add(i);
+        }
+        break;
+      case LT:
+        for (int i = 1; i < value; i++) {
+          expected.add(i);
+        }
+        break;
+      case LTE:
+        for (int i = 1; i <= value; i++) {
+          expected.add(i);
+        }
+        break;
+      default:
+        break;
+    }
+
+    return expected;
+  }
+
+  private List<Integer> getExpectedResultsForBoolean(
+      ConditionalExpression.Operator operator, boolean isEven) {
+    List<Integer> expected = new ArrayList<>();
+
+    switch (operator) {
+      case EQ:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if ((isEven && i % 2 == 0) || (!isEven && i % 2 != 0)) {
+            expected.add(i);
+          }
+        }
+        break;
+      case NE:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if ((isEven && i % 2 != 0) || (!isEven && i % 2 == 0)) {
+            expected.add(i);
+          }
+        }
+        break;
+      case GT:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if (!isEven && i % 2 == 0) {
+            expected.add(i);
+          }
+        }
+        break;
+      case GTE:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if (!isEven || i % 2 == 0) {
+            expected.add(i);
+          }
+        }
+        break;
+      case LT:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if (isEven && i % 2 != 0) {
+            expected.add(i);
+          }
+        }
+        break;
+      case LTE:
+        for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+          if (isEven || i % 2 == 0) {
+            expected.add(i);
+          }
+        }
+        break;
+      default:
+        break;
+    }
+
+    return expected;
+  }
+
+  private List<Integer> getExpectedNullResults(Operator operator) {
+    List<Integer> expected = new ArrayList<>();
+
+    for (int i = 1; i <= CONDITION_TEST_TABLE_NUM_ROWS; i++) {
+      if ((operator.equals(Operator.IS_NULL) && i % 2 == 0)
+          || (operator.equals(Operator.IS_NOT_NULL) && i % 2 != 0)) {
+        expected.add(i);
+      }
+    }
+
+    return expected;
+  }
+
+  private List<Tuple> getExpectedOrderedResults(
+      List<Tuple> tuples, Order firstColumnOrder, Order secondColumnOrder) {
+    List<Tuple> ret = new ArrayList<>(tuples);
+    ret.sort(getTupleComparator(firstColumnOrder, secondColumnOrder));
+    return ret;
+  }
+
+  private int getLimit(boolean withLimit, List<Tuple> expected) {
+    int limit = 0;
+    if (withLimit && !expected.isEmpty()) {
+      if (expected.size() == 1) {
+        limit = 1;
+      } else {
+        limit = random.get().nextInt(expected.size() - 1) + 1;
+      }
+    }
+    return limit;
+  }
+
+  private Ordering prepareOrdering(String column, Ordering.Order order) {
+    return order.equals(Order.ASC) ? Ordering.asc(column) : Ordering.desc(column);
+  }
+
+  private Scan prepareScan(
+      DataType firstColumnType,
+      Order firstColumnOrder,
+      DataType secondColumnType,
+      Order secondColumnOrder,
+      int limit) {
+    BuildableScanAll builder =
+        Scan.newBuilder()
+            .namespace(getNamespaceName(firstColumnType))
+            .table(getTableName(firstColumnType, secondColumnType))
+            .all()
+            .ordering(prepareOrdering(COL_NAME1, firstColumnOrder))
+            .ordering(prepareOrdering(COL_NAME2, secondColumnOrder));
+    if (limit > 0) {
+      builder.limit(limit);
+    }
+    return builder.build();
+  }
+
+  private void assertScanResult(
+      List<Result> actualResults, List<Integer> expected, String description) {
+    List<Integer> actual = new ArrayList<>();
+    for (Result actualResult : actualResults) {
+      actual.add(actualResult.getInt(PARTITION_KEY_NAME));
+    }
+    assertThat(actual).describedAs(description).isEqualTo(expected);
+  }
+
+  private void assertOrderedScanResult(
+      List<Result> actualResults, List<Tuple> expected, String description) {
+    List<Tuple> actual = new ArrayList<>();
+    for (Result actualResult : actualResults) {
+      assertThat(actualResult.getColumns().containsKey(COL_NAME1)).isTrue();
+      assertThat(actualResult.getColumns().containsKey(COL_NAME2)).isTrue();
+      actual.add(
+          new Tuple(
+              actualResult.getColumns().get(COL_NAME1), actualResult.getColumns().get(COL_NAME2)));
+    }
+    assertThat(actual).describedAs(description).isEqualTo(expected);
+  }
+
+  private String description(Column<?> column, Operator operator) {
+    return String.format("failed with column: %s, operator: %s", column, operator);
+  }
+
+  private String description(Column<?> column, Operator operator, int value) {
+    return description(column, operator) + String.format(", value: %s", value);
+  }
+
+  private String description(
+      DataType firstColumnType,
+      Order firstColumnOrder,
+      DataType secondColumnType,
+      Order secondColumnOrder,
+      boolean withLimit) {
+    return String.format(
+        "failed with firstColumnType: %s, firstColumnOrder: %s"
+            + ", secondColumnType: %s, secondColumnOrder: %s, withLimit: %b",
+        firstColumnType, firstColumnOrder, secondColumnType, secondColumnOrder, withLimit);
+  }
+
+  private List<Result> scanAll(Scan scan) throws ExecutionException, IOException {
+    try (Scanner scanner = storage.scan(scan)) {
+      return scanner.all();
+    }
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    truncateTable();
+  }
+
+  private void truncateTable() throws ExecutionException {
+    admin.truncateTable(getNamespaceName(), CONDITION_TEST_TABLE);
+  }
+
+  private void truncateTable(DataType firstColumnType, DataType secondColumnType)
+      throws ExecutionException {
+    admin.truncateTable(
+        getNamespaceName(firstColumnType), getTableName(firstColumnType, secondColumnType));
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    dropTablesForOrderingTests();
+    dropTableForConditionTests();
+    admin.close();
+    storage.close();
+    executorService.shutdown();
+  }
+
+  private void dropTableForConditionTests() throws ExecutionException {
+    admin.dropTable(getNamespaceName(), CONDITION_TEST_TABLE);
+    admin.dropNamespace(getNamespaceName());
+  }
+
+  private void dropTablesForOrderingTests()
+      throws java.util.concurrent.ExecutionException, InterruptedException {
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    for (DataType firstColumnType : columnTypes.keySet()) {
+      Callable<Void> testCallable =
+          () -> {
+            for (DataType secondColumnType : columnTypes.get(firstColumnType)) {
+              admin.dropTable(
+                  getNamespaceName(firstColumnType),
+                  getTableName(firstColumnType, secondColumnType));
+            }
+            admin.dropNamespace(getNamespaceName(firstColumnType));
+            return null;
+          };
+      testCallables.add(testCallable);
+    }
+
+    executeInParallel(testCallables);
+  }
+
+  @Test
+  public void scan_WithCondition_ShouldReturnProperResult()
+      throws java.util.concurrent.ExecutionException, InterruptedException {
+    prepareRecords();
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    for (Operator operator : Operator.values()) {
+      if (!operator.equals(Operator.IS_NULL) && !operator.equals(Operator.IS_NOT_NULL)) {
+        for (Column<?> column : prepareAllColumns(CONDITION_TEST_PREDICATE_VALUE)) {
+          testCallables.add(
+              () -> {
+                scan_WithCondition_ShouldReturnProperResult(
+                    column, operator, CONDITION_TEST_PREDICATE_VALUE);
+                return null;
+              });
+        }
+      }
+    }
+
+    executeInParallel(testCallables);
+  }
+
+  @Test
+  public void scan_WithNullCondition_ShouldReturnProperResult()
+      throws java.util.concurrent.ExecutionException, InterruptedException {
+    prepareNullRecords();
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    for (Operator operator : Operator.values()) {
+      if (operator.equals(Operator.IS_NULL) || operator.equals(Operator.IS_NOT_NULL)) {
+        for (Column<?> column : prepareNullColumns()) {
+          testCallables.add(
+              () -> {
+                scan_WithNullCondition_ShouldReturnProperResult(column, operator);
+                return null;
+              });
+        }
+      }
+    }
+
+    executeInParallel(testCallables);
+  }
+
+  private void scan_WithCondition_ShouldReturnProperResult(
+      Column<?> column, Operator operator, int value) throws IOException, ExecutionException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(getNamespaceName())
+            .table(CONDITION_TEST_TABLE)
+            .all()
+            .where(ConditionBuilder.buildConditionalExpression(column, operator))
+            .build();
+
+    // Act
+    List<Result> actual = scanAll(scan);
+
+    // Assert
+    assertScanResult(
+        actual,
+        getExpectedResults(column.getDataType(), operator, value),
+        description(column, operator, value));
+  }
+
+  private void scan_WithNullCondition_ShouldReturnProperResult(Column<?> column, Operator operator)
+      throws IOException, ExecutionException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(getNamespaceName())
+            .table(CONDITION_TEST_TABLE)
+            .all()
+            .where(ConditionBuilder.buildConditionalExpression(column, operator))
+            .build();
+
+    // Act
+    List<Result> actual = scanAll(scan);
+
+    // Assert
+    assertScanResult(actual, getExpectedNullResults(operator), description(column, operator));
+  }
+
+  @Test
+  public void scan_WithConjunctiveNormalFormConditionsShouldReturnProperResult()
+      throws IOException, ExecutionException {
+    // Arrange
+    prepareRecords();
+    BuildableScanAllWithOngoingWhereAnd builder =
+        Scan.newBuilder()
+            .namespace(getNamespaceName())
+            .table(CONDITION_TEST_TABLE)
+            .all()
+            .where(
+                prepareOrConditionSet(
+                    ImmutableList.of(
+                        IntColumn.of(PARTITION_KEY_NAME, 1), IntColumn.of(PARTITION_KEY_NAME, 2))));
+    List<Column<?>> columns1 = prepareNonKeyColumns(1);
+    List<Column<?>> columns2 = prepareNonKeyColumns(2);
+    List<OrConditionSet> orConditionSets =
+        IntStream.range(0, columns1.size())
+            .boxed()
+            .map(i -> prepareOrConditionSet(ImmutableList.of(columns1.get(i), columns2.get(i))))
+            .collect(Collectors.toList());
+    orConditionSets.forEach(builder::and);
+
+    // Act
+    List<Result> actual = scanAll(builder.build());
+
+    // Assert
+    assertScanResult(
+        actual, getExpectedResults(DataType.INT, Operator.LTE, 2), "failed with CNF conditions");
+  }
+
+  @Test
+  public void scan_WithDisjunctiveNormalFormConditionsShouldReturnProperResult()
+      throws IOException, ExecutionException {
+    // Arrange
+    prepareRecords();
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(getNamespaceName())
+            .table(CONDITION_TEST_TABLE)
+            .all()
+            .where(prepareAndConditionSet(prepareNonKeyColumns(1)))
+            .or(prepareAndConditionSet(prepareNonKeyColumns(2)))
+            .build();
+
+    // Act
+    List<Result> actual = scanAll(scan);
+
+    // Assert
+    assertScanResult(
+        actual, getExpectedResults(DataType.INT, Operator.LTE, 2), "failed with DNF conditions");
+  }
+
+  @Test
+  public void scan_WithOrderingForNonPrimaryColumns_ShouldReturnProperResult()
+      throws java.util.concurrent.ExecutionException, InterruptedException {
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    for (DataType firstColumnType : columnTypes.keySet()) {
+      for (DataType secondColumnType : columnTypes.get(firstColumnType)) {
+        testCallables.add(
+            () -> {
+              random.get().setSeed(seed);
+              truncateTable(firstColumnType, secondColumnType);
+              List<Tuple> tuples = prepareRecords(firstColumnType, secondColumnType);
+              for (Order firstColumnOrder : Order.values()) {
+                for (Order secondColumnOrder : Order.values()) {
+                  for (boolean withLimit : Arrays.asList(false, true)) {
+                    scan_WithOrderingForNonPrimaryColumns_ShouldReturnProperResult(
+                        tuples,
+                        firstColumnType,
+                        firstColumnOrder,
+                        secondColumnType,
+                        secondColumnOrder,
+                        withLimit);
+                  }
+                }
+              }
+              return null;
+            });
+      }
+    }
+
+    executeInParallel(testCallables);
+  }
+
+  private void scan_WithOrderingForNonPrimaryColumns_ShouldReturnProperResult(
+      List<Tuple> tuples,
+      DataType firstColumnType,
+      Order firstColumnOrder,
+      DataType secondColumnType,
+      Order secondColumnOrder,
+      boolean withLimit)
+      throws IOException, ExecutionException {
+    // Arrange
+    List<Tuple> expected = getExpectedOrderedResults(tuples, firstColumnOrder, secondColumnOrder);
+    int limit = getLimit(withLimit, expected);
+    if (limit > 0) {
+      expected = expected.subList(0, limit);
+    }
+    Scan scan =
+        prepareScan(firstColumnType, firstColumnOrder, secondColumnType, secondColumnOrder, limit);
+
+    // Act
+    List<Result> actual = scanAll(scan);
+
+    // Assert
+    assertOrderedScanResult(
+        actual,
+        expected,
+        description(
+            firstColumnType, firstColumnOrder, secondColumnType, secondColumnOrder, withLimit));
+  }
+
+  private void executeInParallel(List<Callable<Void>> testCallables)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    List<Future<Void>> futures = executorService.invokeAll(testCallables);
+    for (Future<Void> future : futures) {
+      future.get();
+    }
+  }
+
+  private Comparator<Tuple> getTupleComparator(Order firstColumnOrder, Order secondColumnOrder) {
+    return (l, r) ->
+        ComparisonChain.start()
+            .compare(
+                l.first,
+                r.first,
+                firstColumnOrder == Order.ASC
+                    ? com.google.common.collect.Ordering.natural()
+                    : com.google.common.collect.Ordering.natural().reverse())
+            .compare(
+                l.second,
+                r.second,
+                secondColumnOrder == Order.ASC
+                    ? com.google.common.collect.Ordering.natural()
+                    : com.google.common.collect.Ordering.natural().reverse())
+            .result();
+  }
+
+  private static class Tuple implements Comparable<Tuple> {
+    @Nonnull public final Column<?> first;
+    @Nonnull public final Column<?> second;
+
+    public Tuple(Column<?> first, Column<?> second) {
+      checkNotNull(first);
+      checkNotNull(second);
+      this.first = first;
+      this.second = second;
+    }
+
+    @Override
+    public int compareTo(Tuple o) {
+      return ComparisonChain.start().compare(first, o.first).compare(second, o.second).result();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Tuple)) {
+        return false;
+      }
+      Tuple other = (Tuple) o;
+      return first.equals(other.first) && second.equals(other.second);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(first, second);
+    }
+
+    @Override
+    public String toString() {
+      return "Tuple{" + "first=" + first + ", second=" + second + '}';
+    }
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageRelationalScanIntegrationTestBase.java
@@ -690,6 +690,7 @@ public abstract class DistributedStorageRelationalScanIntegrationTestBase {
             .table(CONDITION_TEST_TABLE)
             .all()
             .where(ConditionBuilder.buildConditionalExpression(column, operator))
+            .ordering(Ordering.asc(PARTITION_KEY_NAME))
             .build();
 
     // Act
@@ -711,6 +712,7 @@ public abstract class DistributedStorageRelationalScanIntegrationTestBase {
             .table(CONDITION_TEST_TABLE)
             .all()
             .where(ConditionBuilder.buildConditionalExpression(column, operator))
+            .ordering(Ordering.asc(PARTITION_KEY_NAME))
             .build();
 
     // Act
@@ -730,6 +732,7 @@ public abstract class DistributedStorageRelationalScanIntegrationTestBase {
             .namespace(getNamespaceName())
             .table(CONDITION_TEST_TABLE)
             .all()
+            .ordering(Ordering.asc(PARTITION_KEY_NAME))
             .where(
                 prepareOrConditionSet(
                     ImmutableList.of(
@@ -763,6 +766,7 @@ public abstract class DistributedStorageRelationalScanIntegrationTestBase {
             .all()
             .where(prepareAndConditionSet(prepareNonKeyColumns(1)))
             .or(prepareAndConditionSet(prepareNonKeyColumns(2)))
+            .ordering(Ordering.asc(PARTITION_KEY_NAME))
             .build();
 
     // Act


### PR DESCRIPTION
This PR adds the relational scan feature for JDBC storage. For transactions, it only supports the consensus-commit transaction. JDBC and gRPC transactions will be introduced by other PRs.