### PR TITLE
Fix the wrong argument validations in Auto PR workflow

### DIFF
--- a/ci/auto-pr/create_pull_requests
+++ b/ci/auto-pr/create_pull_requests
@@ -2,7 +2,7 @@
 
 set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
-if [[ $# < 5 ]]; then
+if [[ $# -lt 5 ]]; then
     echo "usage: $0 pull_request_id pull_request_url pull_request_title commit_sha assignee branches"
     exit 1
 fi

--- a/ci/auto-pr/fetch_gh_proj_versions
+++ b/ci/auto-pr/fetch_gh_proj_versions
@@ -2,7 +2,7 @@
 
 set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
-if [[ $# != 3 ]]; then
+if [[ $# -ne 3 ]]; then
     echo "usage: $0 repo_owner repo_name pull_request_id"
     exit 1
 fi

--- a/ci/auto-pr/fetch_gh_user_info
+++ b/ci/auto-pr/fetch_gh_user_info
@@ -2,7 +2,7 @@
 
 set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
-if [[ $# != 3 ]]; then
+if [[ $# -ne 3 ]]; then
     echo "usage: $0 repo_owner repo_name user"
     exit 1
 fi


### PR DESCRIPTION
### Context

https://github.com/scalar-labs/scalardb/actions/runs/5262633849/jobs/9512108324 failed due to the argument validation error of `create_pull_requests` script. But the number of parameters passed to the script was 10, which is enough for the validation. The cause was the script compares "10" and "5" as strings.

### Changes

This PR revises the validation to treat the values as integers.
