### PR TITLE
Add integration tests for transaction with relational scan

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitRelationalScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitRelationalScanIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitRelationalScanIntegrationTestBase;
+import java.util.Properties;
+
+public class ConsensusCommitRelationalScanIntegrationTestWithJdbcDatabase
+    extends ConsensusCommitRelationalScanIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return JdbcEnv.getProperties(testName);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitRelationalScanIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/TwoPhaseConsensusCommitRelationalScanIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitRelationalScanIntegrationTestBase;
+import java.util.Properties;
+
+public class TwoPhaseConsensusCommitRelationalScanIntegrationTestWithJdbcDatabase
+    extends TwoPhaseConsensusCommitRelationalScanIntegrationTestBase {
+
+  @Override
+  protected Properties getProps1(String testName) {
+    return JdbcEnv.getProperties(testName);
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionRelationalScanIntegrationTestBase.java
@@ -274,9 +274,7 @@ public abstract class DistributedTransactionRelationalScanIntegrationTestBase {
               })
           .doesNotThrowAnyException();
     } finally {
-      if (managerWithDefaultNamespace != null) {
-        managerWithDefaultNamespace.close();
-      }
+      managerWithDefaultNamespace.close();
     }
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionRelationalScanIntegrationTestBase.java
@@ -1,0 +1,369 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.TransactionFactory;
+import com.scalar.db.util.TestUtils;
+import com.scalar.db.util.TestUtils.ExpectedResult;
+import com.scalar.db.util.TestUtils.ExpectedResult.ExpectedResultBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DistributedTransactionRelationalScanIntegrationTestBase {
+
+  protected static final String NAMESPACE_BASE_NAME = "int_test_";
+  protected static final String TABLE = "test_table";
+  protected static final String ACCOUNT_ID = "account_id";
+  protected static final String ACCOUNT_TYPE = "account_type";
+  protected static final String BALANCE = "balance";
+  protected static final String SOME_COLUMN = "some_column";
+  protected static final int INITIAL_BALANCE = 1000;
+  protected static final int NUM_ACCOUNTS = 4;
+  protected static final int NUM_TYPES = 4;
+  protected static final TableMetadata TABLE_METADATA =
+      TableMetadata.newBuilder()
+          .addColumn(ACCOUNT_ID, DataType.INT)
+          .addColumn(ACCOUNT_TYPE, DataType.INT)
+          .addColumn(BALANCE, DataType.INT)
+          .addColumn(SOME_COLUMN, DataType.INT)
+          .addPartitionKey(ACCOUNT_ID)
+          .build();
+  protected DistributedTransactionAdmin admin;
+  protected DistributedTransactionManager manager;
+  protected String namespace;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    String testName = getTestName();
+    initialize(testName);
+    Properties properties = getProperties(testName);
+    TransactionFactory factory = TransactionFactory.create(properties);
+    admin = factory.getTransactionAdmin();
+    namespace = getNamespaceBaseName() + testName;
+    createTables();
+    manager = factory.getTransactionManager();
+  }
+
+  protected void initialize(String testName) throws Exception {}
+
+  protected abstract String getTestName();
+
+  protected abstract Properties getProperties(String testName);
+
+  protected String getNamespaceBaseName() {
+    return NAMESPACE_BASE_NAME;
+  }
+
+  private void createTables() throws ExecutionException {
+    Map<String, String> options = getCreationOptions();
+    admin.createNamespace(namespace, true, options);
+    admin.createTable(namespace, TABLE, TABLE_METADATA, true, options);
+    admin.createCoordinatorTables(true, options);
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    admin.truncateTable(namespace, TABLE);
+    admin.truncateCoordinatorTables();
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    dropTables();
+    admin.close();
+    manager.close();
+  }
+
+  private void dropTables() throws ExecutionException {
+    admin.dropTable(namespace, TABLE);
+    admin.dropNamespace(namespace);
+    admin.dropCoordinatorTables();
+  }
+
+  @Test
+  public void scan_RelationalScanGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Scan scan = prepareRelationalScan(1, 0, 2);
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    TestUtils.assertResultsContainsExactlyInAnyOrder(
+        results, prepareExpectedResults(1, 0, 2, true));
+  }
+
+  @Test
+  public void scan_RelationalScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(1, 0, 2))
+            .projection(ACCOUNT_ID)
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(3);
+    results.forEach(
+        result -> {
+          assertThat(result.getContainedColumnNames())
+              .containsOnly(ACCOUNT_ID, ACCOUNT_TYPE, BALANCE);
+          assertThat(getBalance(result)).isEqualTo(INITIAL_BALANCE);
+        });
+    TestUtils.assertResultsContainsExactlyInAnyOrder(
+        results, prepareExpectedResults(1, 0, 2, false));
+  }
+
+  @Test
+  public void scan_RelationalScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(1, 0, 2))
+            .ordering(Ordering.desc(ACCOUNT_TYPE))
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(12);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(2);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(11);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(1);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(10);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(0);
+  }
+
+  @Test
+  public void scan_RelationalScanWithLimitGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(1, 0, 2))
+            .ordering(Ordering.asc(ACCOUNT_TYPE))
+            .limit(2)
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(10);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(0);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(11);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(1);
+  }
+
+  @Test
+  public void scan_RelationalScanGivenForNonExisting_ShouldReturnEmpty()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Scan scan = prepareRelationalScan(0, 4, 6);
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void
+      scan_RelationalScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+    populateSingleRecord();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(0, 0, 0))
+            .projections(Arrays.asList(BALANCE, SOME_COLUMN))
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    results.forEach(
+        result -> {
+          assertThat(result.getContainedColumnNames()).containsOnly(BALANCE, SOME_COLUMN);
+          assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+          assertThat(result.isNull(SOME_COLUMN)).isTrue();
+        });
+  }
+
+  @Test
+  public void operation_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
+    Properties properties = getProperties(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);
+    final DistributedTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTransactionManager();
+    try {
+      // Arrange
+      populateRecords();
+      Scan scan = Scan.newBuilder().table(TABLE).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                tx.scan(scan);
+                tx.commit();
+              })
+          .doesNotThrowAnyException();
+    } finally {
+      if (managerWithDefaultNamespace != null) {
+        managerWithDefaultNamespace.close();
+      }
+    }
+  }
+
+  protected void populateRecords() throws TransactionException {
+    DistributedTransaction transaction = manager.start();
+    IntStream.range(0, NUM_ACCOUNTS)
+        .forEach(
+            i ->
+                IntStream.range(0, NUM_TYPES)
+                    .forEach(
+                        j -> {
+                          Put put =
+                              Put.newBuilder()
+                                  .namespace(namespace)
+                                  .table(TABLE)
+                                  .partitionKey(Key.ofInt(ACCOUNT_ID, i * 10 + j))
+                                  .value(IntColumn.of(ACCOUNT_TYPE, j))
+                                  .value(IntColumn.of(BALANCE, INITIAL_BALANCE))
+                                  .value(IntColumn.of(SOME_COLUMN, i * j))
+                                  .build();
+                          try {
+                            transaction.put(put);
+                          } catch (CrudException e) {
+                            throw new RuntimeException(e);
+                          }
+                        }));
+    transaction.commit();
+  }
+
+  protected void populateSingleRecord() throws TransactionException {
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .value(IntColumn.of(ACCOUNT_TYPE, 0))
+            .value(IntColumn.of(BALANCE, INITIAL_BALANCE))
+            .build();
+    DistributedTransaction transaction = manager.start();
+    transaction.put(put);
+    transaction.commit();
+  }
+
+  protected Put preparePut(int id, int type) throws TransactionException {
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .partitionKey(Key.ofInt(ACCOUNT_ID, id))
+        .value(IntColumn.of(ACCOUNT_TYPE, type))
+        .build();
+  }
+
+  protected Scan prepareRelationalScan(int offset, int fromType, int toType) {
+    return Scan.newBuilder()
+        .namespace(namespace)
+        .table(TABLE)
+        .all()
+        .where(ConditionBuilder.column(ACCOUNT_ID).isGreaterThanOrEqualToInt(offset * 10))
+        .and(ConditionBuilder.column(ACCOUNT_ID).isLessThanInt((offset + 1) * 10))
+        .and(ConditionBuilder.column(ACCOUNT_TYPE).isGreaterThanOrEqualToInt(fromType))
+        .and(ConditionBuilder.column(ACCOUNT_TYPE).isLessThanOrEqualToInt(toType))
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  protected int getBalance(Result result) {
+    Map<String, Column<?>> columns = result.getColumns();
+    assertThat(columns.containsKey(BALANCE)).isTrue();
+    return columns.get(BALANCE).getIntValue();
+  }
+
+  private List<ExpectedResult> prepareExpectedResults(
+      int offset, int fromType, int toType, boolean withSomeColumn) {
+    List<ExpectedResult> expectedResults = new ArrayList<>();
+    IntStream.range(fromType, toType + 1)
+        .forEach(
+            j -> {
+              ExpectedResultBuilder builder =
+                  new ExpectedResultBuilder()
+                      .column(IntColumn.of(ACCOUNT_ID, offset * 10 + j))
+                      .column(IntColumn.of(ACCOUNT_TYPE, j))
+                      .column(IntColumn.of(BALANCE, INITIAL_BALANCE));
+              if (withSomeColumn) {
+                builder.column(IntColumn.of(SOME_COLUMN, offset * j));
+              }
+              expectedResults.add(builder.build());
+            });
+    return expectedResults;
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionRelationalScanIntegrationTestBase.java
@@ -1,0 +1,357 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.TransactionFactory;
+import com.scalar.db.util.TestUtils;
+import com.scalar.db.util.TestUtils.ExpectedResult;
+import com.scalar.db.util.TestUtils.ExpectedResult.ExpectedResultBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TwoPhaseCommitTransactionRelationalScanIntegrationTestBase {
+
+  protected static final String NAMESPACE_BASE_NAME = "int_test_";
+  protected static final String TABLE_1 = "test_table1";
+  protected static final String TABLE_2 = "test_table2";
+  protected static final String ACCOUNT_ID = "account_id";
+  protected static final String ACCOUNT_TYPE = "account_type";
+  protected static final String BALANCE = "balance";
+  protected static final String SOME_COLUMN = "some_column";
+  protected static final int INITIAL_BALANCE = 1000;
+  protected static final int NUM_ACCOUNTS = 4;
+  protected static final int NUM_TYPES = 4;
+  protected static final TableMetadata TABLE_METADATA =
+      TableMetadata.newBuilder()
+          .addColumn(ACCOUNT_ID, DataType.INT)
+          .addColumn(ACCOUNT_TYPE, DataType.INT)
+          .addColumn(BALANCE, DataType.INT)
+          .addColumn(SOME_COLUMN, DataType.INT)
+          .addPartitionKey(ACCOUNT_ID)
+          .build();
+  protected DistributedTransactionAdmin admin1;
+  protected DistributedTransactionAdmin admin2;
+  protected TwoPhaseCommitTransactionManager manager1;
+  protected TwoPhaseCommitTransactionManager manager2;
+
+  protected String namespace1;
+  protected String namespace2;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    String testName = getTestName();
+    initialize(testName);
+    TransactionFactory factory1 = TransactionFactory.create(getProperties1(testName));
+    admin1 = factory1.getTransactionAdmin();
+    TransactionFactory factory2 = TransactionFactory.create(getProperties2(testName));
+    admin2 = factory2.getTransactionAdmin();
+    namespace1 = getNamespaceBaseName() + testName + "1";
+    namespace2 = getNamespaceBaseName() + testName + "2";
+    createTables();
+    manager1 = factory1.getTwoPhaseCommitTransactionManager();
+    manager2 = factory2.getTwoPhaseCommitTransactionManager();
+  }
+
+  protected void initialize(String testName) throws Exception {}
+
+  protected abstract String getTestName();
+
+  protected abstract Properties getProperties1(String testName);
+
+  protected Properties getProperties2(String testName) {
+    return getProperties1(testName);
+  }
+
+  protected String getNamespaceBaseName() {
+    return NAMESPACE_BASE_NAME;
+  }
+
+  private void createTables() throws ExecutionException {
+    Map<String, String> options = getCreationOptions();
+    admin1.createNamespace(namespace1, true, options);
+    admin1.createTable(namespace1, TABLE_1, TABLE_METADATA, true, options);
+    admin1.createCoordinatorTables(true, options);
+    admin2.createNamespace(namespace2, true, options);
+    admin2.createTable(namespace2, TABLE_2, TABLE_METADATA, true, options);
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    admin1.truncateTable(namespace1, TABLE_1);
+    admin1.truncateCoordinatorTables();
+    admin2.truncateTable(namespace2, TABLE_2);
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    dropTables();
+    admin1.close();
+    admin2.close();
+    manager1.close();
+    manager2.close();
+  }
+
+  private void dropTables() throws ExecutionException {
+    admin1.dropTable(namespace1, TABLE_1);
+    admin1.dropNamespace(namespace1);
+    admin1.dropCoordinatorTables();
+    admin2.dropTable(namespace2, TABLE_2);
+    admin2.dropNamespace(namespace2);
+  }
+
+  @Test
+  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Scan scan = prepareRelationalScan(namespace1, TABLE_1, 1, 0, 2);
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    TestUtils.assertResultsContainsExactlyInAnyOrder(
+        results, prepareExpectedResults(1, 0, 2, true));
+  }
+
+  @Test
+  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(namespace1, TABLE_1, 1, 0, 2))
+            .projection(ACCOUNT_ID)
+            .projection(ACCOUNT_TYPE)
+            .projection(BALANCE)
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    TestUtils.assertResultsContainsExactlyInAnyOrder(
+        results, prepareExpectedResults(1, 0, 2, false));
+  }
+
+  @Test
+  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(namespace1, TABLE_1, 1, 0, 2))
+            .ordering(Ordering.desc(ACCOUNT_TYPE))
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(12);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(2);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(11);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(1);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(10);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(0);
+  }
+
+  @Test
+  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Scan scan =
+        Scan.newBuilder(prepareRelationalScan(namespace1, TABLE_1, 1, 0, 2))
+            .ordering(Ordering.asc(ACCOUNT_TYPE))
+            .limit(2)
+            .build();
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(10);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(0);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(11);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+    assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(1);
+  }
+
+  @Test
+  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Scan scan = prepareRelationalScan(namespace1, TABLE_1, 0, 4, 4);
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void operation_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
+    Properties properties = getProperties1(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
+    final TwoPhaseCommitTransactionManager manager1WithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager();
+    try {
+      // Arrange
+      populateRecords(manager1WithDefaultNamespace, namespace1, TABLE_1);
+      Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TwoPhaseCommitTransaction tx = manager1WithDefaultNamespace.start();
+                tx.scan(scan);
+                tx.prepare();
+                tx.validate();
+                tx.commit();
+              })
+          .doesNotThrowAnyException();
+    } finally {
+      if (manager1WithDefaultNamespace != null) {
+        manager1WithDefaultNamespace.close();
+      }
+    }
+  }
+
+  protected void populateRecords(
+      TwoPhaseCommitTransactionManager manager, String namespaceName, String tableName)
+      throws TransactionException {
+    TwoPhaseCommitTransaction transaction = manager.begin();
+    IntStream.range(0, NUM_ACCOUNTS)
+        .forEach(
+            i ->
+                IntStream.range(0, NUM_TYPES)
+                    .forEach(
+                        j -> {
+                          Put put =
+                              Put.newBuilder()
+                                  .namespace(namespaceName)
+                                  .table(tableName)
+                                  .partitionKey(Key.ofInt(ACCOUNT_ID, i * 10 + j))
+                                  .value(IntColumn.of(ACCOUNT_TYPE, j))
+                                  .value(IntColumn.of(BALANCE, INITIAL_BALANCE))
+                                  .value(IntColumn.of(SOME_COLUMN, i * j))
+                                  .build();
+                          try {
+                            transaction.put(put);
+                          } catch (CrudException e) {
+                            throw new RuntimeException(e);
+                          }
+                        }));
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+  }
+
+  protected Put preparePut(String namespaceName, String tableNam, int id, int type)
+      throws TransactionException {
+    return Put.newBuilder()
+        .namespace(namespaceName)
+        .table(tableNam)
+        .partitionKey(Key.ofInt(ACCOUNT_ID, id))
+        .value(IntColumn.of(ACCOUNT_TYPE, type))
+        .build();
+  }
+
+  protected Scan prepareRelationalScan(
+      String namespaceName, String tableName, int offset, int fromType, int toType) {
+    return Scan.newBuilder()
+        .namespace(namespaceName)
+        .table(tableName)
+        .all()
+        .where(ConditionBuilder.column(ACCOUNT_ID).isGreaterThanOrEqualToInt(offset * 10))
+        .and(ConditionBuilder.column(ACCOUNT_ID).isLessThanInt((offset + 1) * 10))
+        .and(ConditionBuilder.column(ACCOUNT_TYPE).isGreaterThanOrEqualToInt(fromType))
+        .and(ConditionBuilder.column(ACCOUNT_TYPE).isLessThanOrEqualToInt(toType))
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  protected int getBalance(Result result) {
+    Map<String, Column<?>> columns = result.getColumns();
+    assertThat(columns.containsKey(BALANCE)).isTrue();
+    return columns.get(BALANCE).getIntValue();
+  }
+
+  private List<ExpectedResult> prepareExpectedResults(
+      int offset, int fromType, int toType, boolean withSomeColumn) {
+    List<ExpectedResult> expectedResults = new ArrayList<>();
+    IntStream.range(fromType, toType + 1)
+        .forEach(
+            j -> {
+              ExpectedResultBuilder builder =
+                  new ExpectedResultBuilder()
+                      .column(IntColumn.of(ACCOUNT_ID, offset * 10 + j))
+                      .column(IntColumn.of(ACCOUNT_TYPE, j))
+                      .column(IntColumn.of(BALANCE, INITIAL_BALANCE));
+              if (withSomeColumn) {
+                builder.column(IntColumn.of(SOME_COLUMN, offset * j));
+              }
+              expectedResults.add(builder.build());
+            });
+    return expectedResults;
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionRelationalScanIntegrationTestBase.java
@@ -270,9 +270,7 @@ public abstract class TwoPhaseCommitTransactionRelationalScanIntegrationTestBase
               })
           .doesNotThrowAnyException();
     } finally {
-      if (manager1WithDefaultNamespace != null) {
-        manager1WithDefaultNamespace.close();
-      }
+      manager1WithDefaultNamespace.close();
     }
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitRelationalScanIntegrationTestBase.java
@@ -1,0 +1,210 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.google.common.collect.ImmutableSet;
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.DistributedTransactionRelationalScanIntegrationTestBase;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder.BuildableScanOrScanAllFromExisting;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.TransactionFactory;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public abstract class ConsensusCommitRelationalScanIntegrationTestBase
+    extends DistributedTransactionRelationalScanIntegrationTestBase {
+  private DistributedTransactionManager managerWithIncludeMetadataEnabled;
+
+  @BeforeAll
+  @Override
+  public void beforeAll() throws Exception {
+    super.beforeAll();
+
+    Properties includeMetadataEnabledProperties = getPropsWithIncludeMetadataEnabled(getTestName());
+    managerWithIncludeMetadataEnabled =
+        TransactionFactory.create(includeMetadataEnabledProperties).getTransactionManager();
+  }
+
+  @AfterAll
+  @Override
+  public void afterAll() throws Exception {
+    super.afterAll();
+
+    managerWithIncludeMetadataEnabled.close();
+  }
+
+  @Override
+  protected String getTestName() {
+    return "tx_cc";
+  }
+
+  @Override
+  protected final Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(getProps(testName));
+    if (!properties.containsKey(DatabaseConfig.TRANSACTION_MANAGER)) {
+      properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "consensus-commit");
+
+      // Add testName as a coordinator namespace suffix
+      String coordinatorNamespace =
+          properties.getProperty(
+              ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+      properties.setProperty(
+          ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
+    }
+    return properties;
+  }
+
+  protected abstract Properties getProps(String testName);
+
+  protected Properties getPropsWithIncludeMetadataEnabled(String testName) {
+    Properties properties = getProperties(testName);
+    properties.setProperty(ConsensusCommitConfig.INCLUDE_METADATA_ENABLED, "true");
+    return properties;
+  }
+
+  @Test
+  public void scan_PutAndOverlappedRelationalScanGiven_ShouldThrowException()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Put put = preparePut(10, NUM_TYPES + 1);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .all()
+            .where(ConditionBuilder.column(ACCOUNT_ID).isLessThanOrEqualToInt(10))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () -> {
+              transaction.put(put);
+              transaction.scan(scan);
+              transaction.commit();
+            });
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_PutResultNonOverlappedWithRelationalScanGiven_ShouldThrowException()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Put put = preparePut(10, NUM_TYPES);
+    Scan scan = prepareRelationalScan(1, 0, NUM_TYPES - 1);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () -> {
+              transaction.put(put);
+              transaction.scan(scan);
+              transaction.commit();
+            });
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_PutResultOverlappedWithRelationalScanGiven_ShouldThrowException()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Put put = preparePut(10, NUM_TYPES);
+    Scan scan = prepareRelationalScan(1, NUM_TYPES, NUM_TYPES);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () -> {
+              transaction.put(put);
+              transaction.scan(scan);
+              transaction.commit();
+            });
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_WithIncludeMetadataEnabled_ShouldReturnTransactionMetadataColumns()
+      throws TransactionException {
+    scan_WithIncludeMetadataEnabled_ShouldReturnCorrectColumns(false);
+  }
+
+  @Test
+  public void scan_WithIncludeMetadataEnabledAndProjections_ShouldReturnProjectedColumns()
+      throws TransactionException {
+    scan_WithIncludeMetadataEnabled_ShouldReturnCorrectColumns(true);
+  }
+
+  private void scan_WithIncludeMetadataEnabled_ShouldReturnCorrectColumns(boolean hasProjections)
+      throws TransactionException {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .intValue(ACCOUNT_TYPE, 0)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    DistributedTransaction transaction = managerWithIncludeMetadataEnabled.start();
+    transaction.put(put);
+    transaction.commit();
+    transaction = managerWithIncludeMetadataEnabled.start();
+    Set<String> projections =
+        ImmutableSet.of(ACCOUNT_ID, Attribute.BEFORE_PREFIX + BALANCE, Attribute.STATE);
+
+    // Act Assert
+    BuildableScanOrScanAllFromExisting scanBuilder =
+        Scan.newBuilder(prepareRelationalScan(0, 0, 1));
+    if (hasProjections) {
+      scanBuilder.projections(projections);
+    }
+    List<Result> results = transaction.scan(scanBuilder.build());
+    assertThat(results.size()).isOne();
+    Result result = results.get(0);
+    transaction.commit();
+
+    // Assert the actual result
+    TableMetadata transactionTableMetadata =
+        ConsensusCommitUtils.buildTransactionTableMetadata(TABLE_METADATA);
+    if (hasProjections) {
+      assertThat(result.getContainedColumnNames()).isEqualTo(projections);
+    } else {
+      assertThat(result.getContainedColumnNames().size())
+          .isEqualTo(transactionTableMetadata.getColumnNames().size());
+    }
+    for (Column<?> column : result.getColumns().values()) {
+      assertThat(column.getName()).isIn(transactionTableMetadata.getColumnNames());
+      assertThat(column.getDataType())
+          .isEqualTo(transactionTableMetadata.getColumnDataType(column.getName()));
+    }
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitRelationalScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitRelationalScanIntegrationTestBase.java
@@ -1,0 +1,232 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.google.common.collect.ImmutableSet;
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.ScanBuilder.BuildableScanOrScanAllFromExisting;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.api.TwoPhaseCommitTransactionRelationalScanIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.TransactionFactory;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public abstract class TwoPhaseConsensusCommitRelationalScanIntegrationTestBase
+    extends TwoPhaseCommitTransactionRelationalScanIntegrationTestBase {
+  private TwoPhaseCommitTransactionManager managerWithWithIncludeMetadataEnabled;
+
+  @BeforeAll
+  @Override
+  public void beforeAll() throws Exception {
+    super.beforeAll();
+
+    Properties includeMetadataEnabledProperties = getPropsWithIncludeMetadataEnabled(getTestName());
+    managerWithWithIncludeMetadataEnabled =
+        TransactionFactory.create(includeMetadataEnabledProperties)
+            .getTwoPhaseCommitTransactionManager();
+  }
+
+  @AfterAll
+  @Override
+  public void afterAll() throws Exception {
+    super.afterAll();
+
+    managerWithWithIncludeMetadataEnabled.close();
+  }
+
+  @Override
+  protected String getTestName() {
+    return "2pc_cc";
+  }
+
+  @Override
+  protected final Properties getProperties1(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(getProps1(testName));
+    if (!properties.containsKey(DatabaseConfig.TRANSACTION_MANAGER)) {
+      modifyProperties(properties, testName);
+    }
+    return properties;
+  }
+
+  @Override
+  protected final Properties getProperties2(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(getProps2(testName));
+    if (!properties.containsKey(DatabaseConfig.TRANSACTION_MANAGER)) {
+      modifyProperties(properties, testName);
+    }
+    return properties;
+  }
+
+  private void modifyProperties(Properties properties, String testName) {
+    properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "consensus-commit");
+
+    // Add testName as a coordinator namespace suffix
+    String coordinatorNamespace =
+        properties.getProperty(ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+    properties.setProperty(
+        ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
+  }
+
+  protected abstract Properties getProps1(String testName);
+
+  protected Properties getProps2(String testName) {
+    return getProps1(testName);
+  }
+
+  protected Properties getPropsWithIncludeMetadataEnabled(String testName) {
+    Properties properties = getProperties1(testName);
+    properties.setProperty(ConsensusCommitConfig.INCLUDE_METADATA_ENABLED, "true");
+    return properties;
+  }
+
+  @Test
+  public void scan_PutAndOverlappedRelationalScanGiven_ShouldThrowException()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Put put = preparePut(namespace1, TABLE_1, 10, NUM_TYPES + 1);
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .all()
+            .where(ConditionBuilder.column(ACCOUNT_ID).isLessThanOrEqualToInt(10))
+            .consistency(Consistency.LINEARIZABLE)
+            .build();
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () -> {
+              transaction.put(put);
+              transaction.scan(scan);
+              transaction.commit();
+            });
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_PutResultNonOverlappedWithRelationalScanGiven_ShouldThrowException()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Put put = preparePut(namespace1, TABLE_1, 10, NUM_TYPES);
+    Scan scan = prepareRelationalScan(namespace1, TABLE_1, 1, 0, NUM_TYPES - 1);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () -> {
+              transaction.put(put);
+              transaction.scan(scan);
+              transaction.commit();
+            });
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_PutResultOverlappedWithRelationalScanGiven_ShouldThrowException()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Put put = preparePut(namespace1, TABLE_1, 10, NUM_TYPES);
+    Scan scan = prepareRelationalScan(namespace1, TABLE_1, 1, NUM_TYPES, NUM_TYPES);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(
+            () -> {
+              transaction.put(put);
+              transaction.scan(scan);
+              transaction.commit();
+            });
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void scan_WithIncludeMetadataEnabled_ShouldReturnTransactionMetadataColumns()
+      throws TransactionException {
+    scan_WithIncludeMetadataEnabled_ShouldReturnCorrectColumns(false);
+  }
+
+  @Test
+  public void scan_WithIncludeMetadataEnabledAndProjections_ShouldReturnProjectedColumns()
+      throws TransactionException {
+    scan_WithIncludeMetadataEnabled_ShouldReturnCorrectColumns(true);
+  }
+
+  private void scan_WithIncludeMetadataEnabled_ShouldReturnCorrectColumns(boolean hasProjections)
+      throws TransactionException {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .intValue(ACCOUNT_TYPE, 0)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    TwoPhaseCommitTransaction transaction = managerWithWithIncludeMetadataEnabled.start();
+    transaction.put(put);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+    transaction = managerWithWithIncludeMetadataEnabled.start();
+    Set<String> projections =
+        ImmutableSet.of(ACCOUNT_ID, Attribute.BEFORE_PREFIX + BALANCE, Attribute.STATE);
+
+    // Act Assert
+    BuildableScanOrScanAllFromExisting scanBuilder =
+        Scan.newBuilder(prepareRelationalScan(namespace1, TABLE_1, 0, 0, 1));
+    if (hasProjections) {
+      scanBuilder.projections(projections);
+    }
+    List<Result> results = transaction.scan(scanBuilder.build());
+    assertThat(results.size()).isOne();
+    Result result = results.get(0);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert the actual result
+    TableMetadata transactionTableMetadata =
+        ConsensusCommitUtils.buildTransactionTableMetadata(TABLE_METADATA);
+    if (hasProjections) {
+      assertThat(result.getContainedColumnNames()).isEqualTo(projections);
+    } else {
+      assertThat(result.getContainedColumnNames().size())
+          .isEqualTo(transactionTableMetadata.getColumnNames().size());
+    }
+    for (Column<?> column : result.getColumns().values()) {
+      assertThat(column.getName()).isIn(transactionTableMetadata.getColumnNames());
+      assertThat(column.getDataType())
+          .isEqualTo(transactionTableMetadata.getColumnDataType(column.getName()));
+    }
+  }
+}


### PR DESCRIPTION
This PR adds more integration tests for the relational scan, especially from the transaction perspective. DistributedTransactionXX and TwoPhaseCommitTransactionXX cover the basic tests with relational scan. ConsensusCommitTransactionXX and TwoPhaseConsensusCommitTransactionXX include the overlap check to prevent scan-after-writes.