### PR TITLE
Should call abort() when aborting transaction in transaction wrapper classes

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -10,6 +10,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
@@ -178,6 +179,18 @@ public abstract class AbstractDistributedTransactionManager
       }
       try {
         transaction.rollback();
+      } finally {
+        status = Status.ROLLED_BACK;
+      }
+    }
+
+    @Override
+    public void abort() throws AbortException {
+      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+        throw new IllegalStateException("The transaction has already been committed or aborted");
+      }
+      try {
+        transaction.abort();
       } finally {
         status = Status.ROLLED_BACK;
       }

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -10,6 +10,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
@@ -209,6 +210,18 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
       }
       try {
         transaction.rollback();
+      } finally {
+        status = Status.ROLLED_BACK;
+      }
+    }
+
+    @Override
+    public void abort() throws AbortException {
+      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+        throw new IllegalStateException("The transaction has already been committed or aborted");
+      }
+      try {
+        transaction.abort();
       } finally {
         status = Status.ROLLED_BACK;
       }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -8,6 +8,7 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
@@ -137,6 +138,15 @@ public abstract class ActiveTransactionManagedDistributedTransactionManager
     public synchronized void rollback() throws RollbackException {
       try {
         transaction.rollback();
+      } finally {
+        remove(getId());
+      }
+    }
+
+    @Override
+    public void abort() throws AbortException {
+      try {
+        transaction.abort();
       } finally {
         remove(getId());
       }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -8,6 +8,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
@@ -149,6 +150,15 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     public synchronized void rollback() throws RollbackException {
       try {
         transaction.rollback();
+      } finally {
+        remove(getId());
+      }
+    }
+
+    @Override
+    public void abort() throws AbortException {
+      try {
+        transaction.abort();
       } finally {
         remove(getId());
       }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionOnBidirectionalStream.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransactionOnBidirectionalStream.java
@@ -417,7 +417,7 @@ public class GrpcTwoPhaseCommitTransactionOnBidirectionalStream
     ResponseOrError responseOrError =
         sendRequest(
             TwoPhaseCommitTransactionRequest.newBuilder()
-                .setRollbackRequest(RollbackRequest.getDefaultInstance())
+                .setAbortRequest(TwoPhaseCommitTransactionRequest.AbortRequest.getDefaultInstance())
                 .build());
     finished.set(true);
     throwIfErrorForAbort(responseOrError);


### PR DESCRIPTION
Currently, some transaction wrapper classes do not implement the `abort()` method. As a result, when a transaction is aborted, the `abort()` method of the wrapped transaction class is not called; instead, the `rollback()` method is called. To address this issue, this PR implements the `abort()` method in the transaction wrapper classes.

Please take a look!