### PR TITLE
Improve some `toString` expressions of Selection Operators

### DIFF
--- a/core/src/main/java/com/scalar/db/api/GetWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/GetWithIndex.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.google.common.base.MoreObjects;
 import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
@@ -96,10 +95,5 @@ public class GetWithIndex extends Get {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode());
-  }
-
-  @Override
-  public String toString() {
-    return super.toString() + MoreObjects.toStringHelper(this);
   }
 }

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -365,16 +365,20 @@ public class Scan extends Selection {
 
   @Override
   public String toString() {
-    return super.toString()
-        + ", "
-        + MoreObjects.toStringHelper(this)
-            .add("startClusteringKey", startClusteringKey)
-            .add("startInclusive", startInclusive)
-            .add("endClusteringKey", endClusteringKey)
-            .add("endInclusive", endInclusive)
-            .add("orderings", orderings)
-            .add("limit", limit)
-            .add("conjunctions", conjunctions);
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", forNamespace())
+        .add("table", forTable())
+        .add("partitionKey", getPartitionKey())
+        .add("projections", getProjections())
+        .add("consistency", getConsistency())
+        .add("startClusteringKey", startClusteringKey)
+        .add("startInclusive", startInclusive)
+        .add("endClusteringKey", endClusteringKey)
+        .add("endInclusive", endInclusive)
+        .add("orderings", orderings)
+        .add("limit", limit)
+        .add("conjunctions", conjunctions)
+        .toString();
   }
 
   /** An optional parameter of {@link Scan} command to specify ordering of returned results. */

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -366,6 +366,7 @@ public class Scan extends Selection {
   @Override
   public String toString() {
     return super.toString()
+        + ", "
         + MoreObjects.toStringHelper(this)
             .add("startClusteringKey", startClusteringKey)
             .add("startInclusive", startInclusive)

--- a/core/src/main/java/com/scalar/db/api/ScanAll.java
+++ b/core/src/main/java/com/scalar/db/api/ScanAll.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.google.common.base.MoreObjects;
 import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
@@ -181,10 +180,5 @@ public class ScanAll extends Scan {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode());
-  }
-
-  @Override
-  public String toString() {
-    return super.toString() + MoreObjects.toStringHelper(this);
   }
 }

--- a/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.google.common.base.MoreObjects;
 import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
@@ -165,10 +164,5 @@ public class ScanWithIndex extends Scan {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode());
-  }
-
-  @Override
-  public String toString() {
-    return super.toString() + MoreObjects.toStringHelper(this);
   }
 }

--- a/core/src/main/java/com/scalar/db/api/Selection.java
+++ b/core/src/main/java/com/scalar/db/api/Selection.java
@@ -1,6 +1,5 @@
 package com.scalar.db.api;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.io.Key;
 import java.util.ArrayList;
@@ -108,17 +107,5 @@ public abstract class Selection extends Operation {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), projections);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("namespace", forNamespace())
-        .add("table", forTable())
-        .add("partitionKey", getPartitionKey())
-        .add("clusteringKey", getClusteringKey())
-        .add("projections", getProjections())
-        .add("consistency", getConsistency())
-        .toString();
   }
 }


### PR DESCRIPTION
## Context

We noticed `ScanAll.toString()` returns a bit weird string https://github.com/scalar-labs/scalardb-analytics-postgresql/pull/18/files#diff-cb027cc25fd71ee28416a31ef37f102db2146445322c88bee5be311a65c60a29R98.

```java
  public static void main(String[] args){
    System.out.println(new GetWithIndex(Key.of()));
    System.out.println(new Scan(Key.of()));
    System.out.println(new ScanWithIndex(Key.of()));
    System.out.println(new ScanAll());
  }
```

```
GetWithIndex{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}GetWithIndex{}
Scan{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}Scan{startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}
ScanWithIndex{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}ScanWithIndex{startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}ScanWithIndex{}
ScanAll{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}ScanAll{startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}ScanAll{}
```

## Changes

This PR updates `ScanAll.toString()` and a few other implementations to remove unnecessary values (e.g., `ScanAll{}`) and avoid concatenation without delimiter (e.g., `... consistency=SEQUENTIAL}Scan{startClusteringKey= ...`).

```
GetWithIndex{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}
Scan{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}, Scan{startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}
ScanWithIndex{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}, ScanWithIndex{startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}
ScanAll{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}, ScanAll{startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}
```

Another option is to add a virtual field for the parent like this.

```
Scan{super=Scan{namespace=Optional.empty, table=Optional.empty, partitionKey=Key{}, clusteringKey=Optional.empty, projections=[], consistency=SEQUENTIAL}, startClusteringKey=Optional.empty, startInclusive=false, endClusteringKey=Optional.empty, endInclusive=false, orderings=[], limit=0, conjunctions=[]}
```
