### PR TITLE
Run `git cherry-pick --abort` after it fails

### DIFF
--- a/ci/auto-pr/create_pull_requests
+++ b/ci/auto-pr/create_pull_requests
@@ -27,9 +27,16 @@ function cherry_pick_and_create_pull_request () {
   local branch=$1
   local new_branch=$2
 
+  # Cleanup just in case
+  git checkout .
+  git clean -f
+
   git checkout $branch
   git checkout -b $new_branch
-  git cherry-pick --no-rerere-autoupdate -m1 $commit_sha
+  if ! git cherry-pick --no-rerere-autoupdate -m1 $commit_sha; then
+      git cherry-pick --abort
+      return 1
+  fi
   git push origin $new_branch
   git status
   gh pr create --assignee $assignee \
@@ -39,6 +46,8 @@ function cherry_pick_and_create_pull_request () {
 }
 
 function create_issue () {
+  local branch=$1
+
   gh issue create --assignee $assignee \
     --title "Backport to branch($branch) failed: $pull_request_title" \
     --body "Backport of $pull_request_url to branch($branch) failed"
@@ -52,6 +61,6 @@ for branch in ${branches[@]}; do
 
   # Create a new temp branch, push it and create a PR for the change.
   # But create an issue if anything fails.
-  cherry_pick_and_create_pull_request $branch $new_branch || create_issue
+  cherry_pick_and_create_pull_request $branch $new_branch || create_issue $branch
 done
 


### PR DESCRIPTION
## Context

The auto-PR backport GHA workflow [failed](https://github.com/scalar-labs/scalardb/actions/runs/5407948409/jobs/9826502966) generated the unexpected large diffs and conflicts (https://github.com/scalar-labs/scalardb/pull/922 and https://github.com/scalar-labs/scalardb/pull/923). But as for branch `3.9`, it succeeds on my local environment with the expected diff. I think the first cherry-pick on branch `3.7` generated dirty changes and the following cherry-picks unexpectedly used it.

## Changes

This PR adds the following improvement to fix the problem.
- Execute `git cherry-pick --abort` when cherry-pick fails
- Cleanup the working dir just in case
