### PR TITLE
Add table importing feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -377,7 +377,7 @@ jobs:
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTestJdbc
+          arguments: integrationTestJdbc -Dscalardb.jdbc.mariadb=true
 
       - name: Upload Gradle test reports
         if: always()

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,53 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminImportTableIntegrationTestBase;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+public class ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
+    extends ConsensusCommitAdminImportTableIntegrationTestBase {
+
+  private JdbcAdminImportTestUtils testUtils;
+
+  @Override
+  protected Properties getProps(String testName) {
+    Properties properties = JdbcEnv.getProperties(testName);
+    testUtils = new JdbcAdminImportTestUtils(properties);
+    return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
+      throws SQLException {
+    return testUtils.createExistingDatabaseWithAllDataTypes(getNamespace());
+  }
+
+  @Override
+  protected void dropNonImportableTable(String table) throws SQLException {
+    testUtils.dropTable(getNamespace(), table);
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSqlite() {
+    return JdbcEnv.isSqlite();
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSqlite")
+  public void importTable_ShouldWorkProperly() throws Exception {
+    super.importTable_ShouldWorkProperly();
+  }
+
+  @Test
+  @Override
+  @EnabledIf("isSqlite")
+  public void importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException() {
+    super.importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.DistributedStorageAdminImportTableIntegrationTestBase;
+import com.scalar.db.api.TableMetadata;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+public class JdbcAdminImportTableIntegrationTest
+    extends DistributedStorageAdminImportTableIntegrationTestBase {
+
+  private JdbcAdminImportTestUtils testUtils;
+
+  @Override
+  protected Properties getProperties(String testName) {
+    Properties properties = JdbcEnv.getProperties(testName);
+    testUtils = new JdbcAdminImportTestUtils(properties);
+    return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
+      throws SQLException {
+    return testUtils.createExistingDatabaseWithAllDataTypes(getNamespace());
+  }
+
+  @Override
+  protected void dropNonImportableTable(String table) throws SQLException {
+    testUtils.dropTable(getNamespace(), table);
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSqlite() {
+    return JdbcEnv.isSqlite();
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSqlite")
+  public void importTable_ShouldWorkProperly() throws Exception {
+    super.importTable_ShouldWorkProperly();
+  }
+
+  @Test
+  @Override
+  @EnabledIf("isSqlite")
+  public void importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException() {
+    super.importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -1,0 +1,426 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.DataType;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import org.apache.commons.dbcp2.BasicDataSource;
+
+public class JdbcAdminImportTestUtils {
+  static final List<String> UNSUPPORTED_DATA_TYPES_MYSQL =
+      Arrays.asList(
+          "BIGINT UNSIGNED",
+          "BIT(8)",
+          "DATE",
+          "DATETIME",
+          "DECIMAL(8,2)",
+          "ENUM('a','b')",
+          "SET('a','b')",
+          "GEOMETRY",
+          "JSON",
+          "NUMERIC",
+          "TIME",
+          "TIMESTAMP",
+          "YEAR");
+  static final List<String> UNSUPPORTED_DATA_TYPES_PGSQL =
+      Arrays.asList(
+          "bigserial",
+          "bit(8)",
+          "bit varying(8)",
+          "box",
+          "cidr",
+          "circle",
+          "date",
+          "inet",
+          "interval",
+          "json",
+          "jsonb",
+          "line",
+          "lseg",
+          "macaddr",
+          "macaddr8",
+          "money",
+          "numeric(8,2)",
+          "path",
+          "pg_lsn",
+          "pg_snapshot", // after v14
+          "point",
+          "polygon",
+          "smallserial",
+          "time",
+          "time with time zone",
+          "timestamp",
+          "timestamp with time zone",
+          "tsquery",
+          "tsvector",
+          "txid_snapshot",
+          "uuid",
+          "xml");
+  static final List<String> UNSUPPORTED_DATA_TYPES_ORACLE =
+      Arrays.asList(
+          "BFILE",
+          "DATE",
+          "FLOAT(54)",
+          "INT",
+          "INTERVAL YEAR(3) TO MONTH",
+          "INTERVAL DAY(2) TO SECOND",
+          "JSON",
+          "NUMBER(16,0)",
+          "ROWID",
+          "TIMESTAMP",
+          "TIMESTAMP WITH TIME ZONE",
+          "TIMESTAMP WITH LOCAL TIME ZONE",
+          "UROWID");
+  static final List<String> UNSUPPORTED_DATA_TYPES_MSSQL =
+      Arrays.asList(
+          "date",
+          "datetime",
+          "datetime2",
+          "datetimeoffset",
+          "decimal(8,2)",
+          "hierarchyid",
+          "money",
+          "numeric(8,2)",
+          "rowversion",
+          "smalldatetime",
+          "smallmoney",
+          "sql_variant",
+          "time",
+          "uniqueidentifier",
+          "xml");
+
+  private final JdbcConfig config;
+  private final RdbEngineStrategy rdbEngine;
+
+  public JdbcAdminImportTestUtils(Properties properties) {
+    config = new JdbcConfig(new DatabaseConfig(properties));
+    rdbEngine = RdbEngineFactory.create(config);
+  }
+
+  public Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes(String namespace)
+      throws SQLException {
+    Map<String, TableMetadata> results = new HashMap<>();
+    List<String> sqls = new ArrayList<>();
+    LinkedHashMap<String, String> goodTableColumns;
+    TableMetadata goodTableMetadata;
+    Map<String, String> badTables;
+    if (rdbEngine instanceof RdbEngineMysql) {
+      goodTableColumns = prepareColumnsForMysql();
+      goodTableMetadata = prepareTableMetadataForMysql();
+      badTables = prepareCreateNonImportableTableSql(namespace, UNSUPPORTED_DATA_TYPES_MYSQL);
+    } else if (rdbEngine instanceof RdbEnginePostgresql) {
+      goodTableColumns = prepareColumnsForPostgresql();
+      goodTableMetadata = prepareTableMetadataForPostgresql();
+      badTables = prepareCreateNonImportableTableSql(namespace, UNSUPPORTED_DATA_TYPES_PGSQL);
+    } else if (rdbEngine instanceof RdbEngineOracle) {
+      goodTableColumns = prepareColumnsForOracle();
+      goodTableMetadata = prepareTableMetadataForOracle();
+      badTables = prepareCreateNonImportableTableSql(namespace, UNSUPPORTED_DATA_TYPES_ORACLE);
+
+      // LONG columns must be tested with separated tables since they cannot be coexisted
+      TableMetadata longRawMetadata = prepareTableMetadataForOracleForLongRaw();
+      sqls.add(
+          prepareCreateTableSql(
+              namespace,
+              "good_table_long_raw",
+              prepareColumnsForOracleLongRaw(),
+              longRawMetadata.getPartitionKeyNames()));
+      results.put("good_table_long_raw", longRawMetadata);
+    } else if (rdbEngine instanceof RdbEngineSqlServer) {
+      goodTableColumns = prepareColumnsForSqlServer();
+      goodTableMetadata = prepareTableMetadataForSqlServer();
+      badTables = prepareCreateNonImportableTableSql(namespace, UNSUPPORTED_DATA_TYPES_MSSQL);
+    } else {
+      throw new RuntimeException();
+    }
+
+    // table with all supported columns
+    sqls.add(
+        prepareCreateTableSql(
+            namespace, "good_table", goodTableColumns, goodTableMetadata.getPartitionKeyNames()));
+    results.put("good_table", goodTableMetadata);
+
+    // tables with an unsupported column
+    badTables.forEach(
+        (table, sql) -> {
+          sqls.add(sql);
+          results.put(table, null);
+        });
+
+    createExistingDatabase(namespace);
+    execute(sqls.toArray(new String[0]));
+    return results;
+  }
+
+  public void createExistingDatabase(String namespace) throws SQLException {
+    execute(rdbEngine.createNamespaceSqls(rdbEngine.enclose(namespace)));
+  }
+
+  public void dropTable(String namespace, String table) throws SQLException {
+    String dropTable = "DROP TABLE " + rdbEngine.encloseFullTableName(namespace, table);
+    execute(dropTable);
+  }
+
+  public void execute(String sql) throws SQLException {
+    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
+        Connection connection = dataSource.getConnection()) {
+      JdbcAdmin.execute(connection, sql);
+    }
+  }
+
+  public void execute(String[] sql) throws SQLException {
+    try (BasicDataSource dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
+        Connection connection = dataSource.getConnection()) {
+      JdbcAdmin.execute(connection, sql);
+    }
+  }
+
+  private LinkedHashMap<String, String> prepareColumnsForMysql() {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk1", "INT");
+    columns.put("pk2", "INT");
+    columns.put("col01", "BOOLEAN");
+    columns.put("col02", "INT");
+    columns.put("col03", "INT UNSIGNED");
+    columns.put("col04", "TINYINT");
+    columns.put("col05", "SMALLINT");
+    columns.put("col06", "MEDIUMINT");
+    columns.put("col07", "BIGINT");
+    columns.put("col08", "FLOAT");
+    columns.put("col09", "DOUBLE");
+    columns.put("col10", "CHAR(8)");
+    columns.put("col11", "VARCHAR(512)");
+    columns.put("col12", "TEXT");
+    columns.put("col13", "TINYTEXT");
+    columns.put("col14", "MEDIUMTEXT");
+    columns.put("col15", "LONGTEXT");
+    columns.put("col16", "VARBINARY(1024)");
+    columns.put("col17", "BLOB");
+    columns.put("col18", "TINYBLOB");
+    columns.put("col19", "MEDIUMBLOB");
+    columns.put("col20", "LONGBLOB");
+    columns.put("col21", "BINARY(255)");
+    return columns;
+  }
+
+  private TableMetadata prepareTableMetadataForMysql() {
+    return TableMetadata.newBuilder()
+        .addColumn("pk1", DataType.INT)
+        .addColumn("pk2", DataType.INT)
+        .addColumn("col01", DataType.BOOLEAN)
+        .addColumn("col02", DataType.INT)
+        .addColumn("col03", DataType.BIGINT)
+        .addColumn("col04", DataType.INT)
+        .addColumn("col05", DataType.INT)
+        .addColumn("col06", DataType.INT)
+        .addColumn("col07", DataType.BIGINT)
+        .addColumn("col08", DataType.FLOAT)
+        .addColumn("col09", DataType.DOUBLE)
+        .addColumn("col10", DataType.TEXT)
+        .addColumn("col11", DataType.TEXT)
+        .addColumn("col12", DataType.TEXT)
+        .addColumn("col13", DataType.TEXT)
+        .addColumn("col14", DataType.TEXT)
+        .addColumn("col15", DataType.TEXT)
+        .addColumn("col16", DataType.BLOB)
+        .addColumn("col17", DataType.BLOB)
+        .addColumn("col18", DataType.BLOB)
+        .addColumn("col19", DataType.BLOB)
+        .addColumn("col20", DataType.BLOB)
+        .addColumn("col21", DataType.BLOB)
+        .addPartitionKey("pk1")
+        .addPartitionKey("pk2")
+        .build();
+  }
+
+  private LinkedHashMap<String, String> prepareColumnsForPostgresql() {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk1", "integer");
+    columns.put("pk2", "integer");
+    columns.put("col01", "boolean");
+    columns.put("col02", "smallint");
+    columns.put("col03", "integer");
+    columns.put("col04", "bigint");
+    columns.put("col05", "real");
+    columns.put("col06", "double precision");
+    columns.put("col07", "char(8)");
+    columns.put("col08", "varchar(512)");
+    columns.put("col09", "text");
+    columns.put("col10", "bytea");
+    return columns;
+  }
+
+  private TableMetadata prepareTableMetadataForPostgresql() {
+    return TableMetadata.newBuilder()
+        .addColumn("pk1", DataType.INT)
+        .addColumn("pk2", DataType.INT)
+        .addColumn("col01", DataType.BOOLEAN)
+        .addColumn("col02", DataType.INT)
+        .addColumn("col03", DataType.INT)
+        .addColumn("col04", DataType.BIGINT)
+        .addColumn("col05", DataType.FLOAT)
+        .addColumn("col06", DataType.DOUBLE)
+        .addColumn("col07", DataType.TEXT)
+        .addColumn("col08", DataType.TEXT)
+        .addColumn("col09", DataType.TEXT)
+        .addColumn("col10", DataType.BLOB)
+        .addPartitionKey("pk1")
+        .addPartitionKey("pk2")
+        .build();
+  }
+
+  private LinkedHashMap<String, String> prepareColumnsForOracle() {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk1", "CHAR(8)");
+    columns.put("pk2", "CHAR(8)");
+    columns.put("col01", "NUMERIC(15,0)");
+    columns.put("col02", "NUMERIC(15,2)");
+    columns.put("col03", "FLOAT(53)");
+    columns.put("col04", "BINARY_FLOAT");
+    columns.put("col05", "BINARY_DOUBLE");
+    columns.put("col06", "CHAR(8)");
+    columns.put("col07", "VARCHAR2(512)");
+    columns.put("col08", "NCHAR(8)");
+    columns.put("col09", "NVARCHAR2(512)");
+    columns.put("col10", "CLOB");
+    columns.put("col11", "NCLOB");
+    columns.put("col12", "LONG");
+    columns.put("col13", "BLOB");
+    columns.put("col14", "RAW(1024)");
+    return columns;
+  }
+
+  private TableMetadata prepareTableMetadataForOracle() {
+    return TableMetadata.newBuilder()
+        .addColumn("pk1", DataType.TEXT)
+        .addColumn("pk2", DataType.TEXT)
+        .addColumn("col01", DataType.BIGINT)
+        .addColumn("col02", DataType.DOUBLE)
+        .addColumn("col03", DataType.DOUBLE)
+        .addColumn("col04", DataType.FLOAT)
+        .addColumn("col05", DataType.DOUBLE)
+        .addColumn("col06", DataType.TEXT)
+        .addColumn("col07", DataType.TEXT)
+        .addColumn("col08", DataType.TEXT)
+        .addColumn("col09", DataType.TEXT)
+        .addColumn("col10", DataType.TEXT)
+        .addColumn("col11", DataType.TEXT)
+        .addColumn("col12", DataType.TEXT)
+        .addColumn("col13", DataType.BLOB)
+        .addColumn("col14", DataType.BLOB)
+        .addPartitionKey("pk1")
+        .addPartitionKey("pk2")
+        .build();
+  }
+
+  private LinkedHashMap<String, String> prepareColumnsForOracleLongRaw() {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk1", "CHAR(8)");
+    columns.put("pk2", "CHAR(8)");
+    columns.put("col", "LONG RAW");
+    return columns;
+  }
+
+  private TableMetadata prepareTableMetadataForOracleForLongRaw() {
+    return TableMetadata.newBuilder()
+        .addColumn("pk1", DataType.TEXT)
+        .addColumn("pk2", DataType.TEXT)
+        .addColumn("col", DataType.BLOB)
+        .addPartitionKey("pk1")
+        .addPartitionKey("pk2")
+        .build();
+  }
+
+  private LinkedHashMap<String, String> prepareColumnsForSqlServer() {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk1", "int");
+    columns.put("pk2", "int");
+    columns.put("col01", "bit");
+    columns.put("col02", "tinyint");
+    columns.put("col03", "smallint");
+    columns.put("col04", "int");
+    columns.put("col05", "bigint");
+    columns.put("col06", "real");
+    columns.put("col07", "float");
+    columns.put("col08", "char(8)");
+    columns.put("col09", "varchar(512)");
+    columns.put("col10", "nchar(8)");
+    columns.put("col11", "nvarchar(512)");
+    columns.put("col12", "text");
+    columns.put("col13", "ntext");
+    columns.put("col14", "binary");
+    columns.put("col15", "varbinary");
+    columns.put("col16", "image");
+    return columns;
+  }
+
+  private TableMetadata prepareTableMetadataForSqlServer() {
+    return TableMetadata.newBuilder()
+        .addColumn("pk1", DataType.INT)
+        .addColumn("pk2", DataType.INT)
+        .addColumn("col01", DataType.BOOLEAN)
+        .addColumn("col02", DataType.INT)
+        .addColumn("col03", DataType.INT)
+        .addColumn("col04", DataType.INT)
+        .addColumn("col05", DataType.BIGINT)
+        .addColumn("col06", DataType.FLOAT)
+        .addColumn("col07", DataType.DOUBLE)
+        .addColumn("col08", DataType.TEXT)
+        .addColumn("col09", DataType.TEXT)
+        .addColumn("col10", DataType.TEXT)
+        .addColumn("col11", DataType.TEXT)
+        .addColumn("col12", DataType.TEXT)
+        .addColumn("col13", DataType.TEXT)
+        .addColumn("col14", DataType.BLOB)
+        .addColumn("col15", DataType.BLOB)
+        .addColumn("col16", DataType.BLOB)
+        .addPartitionKey("pk1")
+        .addPartitionKey("pk2")
+        .build();
+  }
+
+  private Map<String, String> prepareCreateNonImportableTableSql(
+      String namespace, List<String> types) {
+    Map<String, String> tables = new HashMap<>();
+    for (int i = 0; i < types.size(); i++) {
+      String table = "bad_table" + i;
+      tables.put(table, prepareCreateNonImportableTableSql(namespace, table, types.get(i)));
+    }
+    return tables;
+  }
+
+  private String prepareCreateNonImportableTableSql(String namespace, String table, String type) {
+    LinkedHashMap<String, String> columns = new LinkedHashMap<>();
+    columns.put("pk", "CHAR(8)");
+    columns.put("col", type);
+    return prepareCreateTableSql(
+        namespace, table, columns, new LinkedHashSet<>(Collections.singletonList("pk")));
+  }
+
+  private String prepareCreateTableSql(
+      String namespace,
+      String table,
+      LinkedHashMap<String, String> columns,
+      LinkedHashSet<String> primaryKeys) {
+    return "CREATE TABLE "
+        + rdbEngine.encloseFullTableName(namespace, table)
+        + "("
+        + columns.entrySet().stream()
+            .map(entry -> rdbEngine.enclose(entry.getKey()) + " " + entry.getValue())
+            .collect(Collectors.joining(","))
+        + ", PRIMARY KEY("
+        + primaryKeys.stream().map(rdbEngine::enclose).collect(Collectors.joining(","))
+        + "))";
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -57,6 +57,7 @@ public class JdbcAdminImportTestUtils {
           "pg_snapshot", // after v14
           "point",
           "polygon",
+          "serial",
           "smallserial",
           "time",
           "time with time zone",

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
@@ -7,6 +7,7 @@ public final class JdbcEnv {
   private static final String PROP_JDBC_URL = "scalardb.jdbc.url";
   private static final String PROP_JDBC_USERNAME = "scalardb.jdbc.username";
   private static final String PROP_JDBC_PASSWORD = "scalardb.jdbc.password";
+  private static final String PROP_JDBC_MARIADB = "scalardb.jdbc.mariadb";
 
   private static final String DEFAULT_JDBC_URL = "jdbc:mysql://localhost:3306/";
   private static final String DEFAULT_JDBC_USERNAME = "root";
@@ -37,5 +38,9 @@ public final class JdbcEnv {
         DatabaseConfig.CONTACT_POINTS, System.getProperty(PROP_JDBC_URL, DEFAULT_JDBC_URL));
     props.setProperty(DatabaseConfig.STORAGE, "jdbc");
     return JdbcUtils.isSqlite(new JdbcConfig(new DatabaseConfig(props)));
+  }
+
+  public static boolean isMariaDB() {
+    return Boolean.getBoolean(PROP_JDBC_MARIADB);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -1,0 +1,79 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.schemaloader.SchemaLoaderImportIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportIntegrationTestBase {
+
+  private JdbcAdminImportTestUtils testUtils;
+  private RdbEngineStrategy rdbEngine;
+
+  @Override
+  protected Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(JdbcEnv.getProperties(testName));
+    JdbcConfig config = new JdbcConfig(new DatabaseConfig(properties));
+    rdbEngine = RdbEngineFactory.create(config);
+    testUtils = new JdbcAdminImportTestUtils(properties);
+    return properties;
+  }
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new JdbcAdminTestUtils(getProperties(testName));
+  }
+
+  @Override
+  protected void createExistingDatabase(String namespace) throws Exception {
+    testUtils.createExistingDatabase(namespace);
+  }
+
+  @Override
+  protected void createImportableTable(String namespace, String table) throws Exception {
+    testUtils.execute(
+        "CREATE TABLE "
+            + rdbEngine.encloseFullTableName(namespace, table)
+            + "("
+            + rdbEngine.enclose("pk")
+            + " CHAR(8),"
+            + rdbEngine.enclose("col")
+            + " CHAR(8), PRIMARY KEY("
+            + rdbEngine.enclose("pk")
+            + "))");
+  }
+
+  @Override
+  protected void createNonImportableTable(String namespace, String table) throws Exception {
+    testUtils.execute(
+        "CREATE TABLE "
+            + rdbEngine.encloseFullTableName(namespace, table)
+            + "("
+            + rdbEngine.enclose("pk")
+            + " CHAR(8),"
+            + rdbEngine.enclose("col")
+            + " DATE, PRIMARY KEY("
+            + rdbEngine.enclose("pk")
+            + "))");
+  }
+
+  @Override
+  protected void dropNonImportableTable(String namespace, String table) throws Exception {
+    testUtils.dropTable(namespace, table);
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSqlite")
+  public void importTables_ImportableTablesGiven_ShouldImportProperly() throws Exception {
+    super.importTables_ImportableTablesGiven_ShouldImportProperly();
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSqlite() {
+    return JdbcEnv.isSqlite();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.jdbc;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.schemaloader.SchemaLoaderImportIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -32,6 +33,7 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
     testUtils.createExistingDatabase(namespace);
   }
 
+  @SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
   @Override
   protected void createImportableTable(String namespace, String table) throws Exception {
     testUtils.execute(
@@ -46,6 +48,7 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
             + "))");
   }
 
+  @SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
   @Override
   protected void createNonImportableTable(String namespace, String table) throws Exception {
     testUtils.execute(

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminImportTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminImportTableIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.scalar.db.transaction.jdbc;
+
+import com.scalar.db.api.DistributedTransactionAdminImportTableIntegrationTestBase;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcAdminImportTestUtils;
+import com.scalar.db.storage.jdbc.JdbcEnv;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+public class JdbcTransactionAdminImportTableIntegrationTest
+    extends DistributedTransactionAdminImportTableIntegrationTestBase {
+
+  private JdbcAdminImportTestUtils testUtils;
+
+  @Override
+  protected Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(JdbcEnv.getProperties(testName));
+    properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
+    testUtils = new JdbcAdminImportTestUtils(properties);
+    return properties;
+  }
+
+  @Override
+  protected Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
+      throws SQLException {
+    return testUtils.createExistingDatabaseWithAllDataTypes(getNamespace());
+  }
+
+  @Override
+  protected void dropNonImportableTable(String table) throws SQLException {
+    testUtils.dropTable(getNamespace(), table);
+  }
+
+  @SuppressWarnings("unused")
+  private boolean isSqlite() {
+    return JdbcEnv.isSqlite();
+  }
+
+  @Test
+  @Override
+  @DisabledIf("isSqlite")
+  public void importTable_ShouldWorkProperly() throws Exception {
+    super.importTable_ShouldWorkProperly();
+  }
+
+  @Test
+  @Override
+  @EnabledIf("isSqlite")
+  public void importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException() {
+    super.importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException();
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -402,4 +402,15 @@ public interface Admin {
    */
   void addNewColumnToTable(String namespace, String table, String columnName, DataType columnType)
       throws ExecutionException;
+
+  /**
+   * Import an existing table that is not managed by ScalarDB.
+   *
+   * @param namespace an existing namespace
+   * @param table an existing table
+   * @throws IllegalArgumentException if the table is already managed by ScalarDB, if the target
+   *     table does not exist, or if the table does not meet the requirement of ScalarDB table
+   * @throws ExecutionException if the operation fails
+   */
+  void importTable(String namespace, String table) throws ExecutionException;
 }

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -1,5 +1,8 @@
 package com.scalar.db.api;
 
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+
 /**
  * An administrative interface for distributed storage implementations. The user can execute
  * administrative operations with it like createNamespace/createTable/getTableMetadata.
@@ -38,6 +41,28 @@ package com.scalar.db.api;
  * }</pre>
  */
 public interface DistributedStorageAdmin extends Admin {
+
+  /**
+   * Get import table metadata in the ScalarDB format.
+   *
+   * @param namespace namespace name of import table
+   * @param table import table name
+   * @throws IllegalArgumentException if the table does not exist
+   * @throws IllegalStateException if the table does not meet the requirement of ScalarDB table
+   * @throws ExecutionException if the operation fails
+   */
+  TableMetadata getImportTableMetadata(String namespace, String table) throws ExecutionException;
+
+  /**
+   * Add a column in the table without updating the metadata table in ScalarDB.
+   *
+   * @param namespace namespace name of import table
+   * @param table import table name
+   * @throws IllegalArgumentException if the table does not exist
+   * @throws ExecutionException if the operation fails
+   */
+  void addRawColumnToTable(String namespace, String table, String columnName, DataType columnType)
+      throws ExecutionException;
 
   /** Closes connections to the storage. */
   void close();

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.util.ScalarDbUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -23,6 +24,7 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
     this(admin, true);
   }
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CheckedDistributedStorageAdmin(DistributedStorageAdmin admin, boolean checkNamespace) {
     this.admin = admin;
     this.checkNamespace = checkNamespace;
@@ -270,6 +272,49 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
               + ScalarDbUtils.getFullTableName(namespace, table)
               + ", "
               + columnName,
+          e);
+    }
+  }
+
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table)
+      throws ExecutionException {
+    try {
+      return admin.getImportTableMetadata(namespace, table);
+    } catch (ExecutionException e) {
+      throw new ExecutionException(
+          "Getting the table metadata of the importing table failed: "
+              + ScalarDbUtils.getFullTableName(namespace, table),
+          e);
+    }
+  }
+
+  @Override
+  public void importTable(String namespace, String table) throws ExecutionException {
+    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+    if (tableMetadata != null) {
+      throw new IllegalArgumentException(
+          "Table already exists: " + ScalarDbUtils.getFullTableName(namespace, table));
+    }
+
+    try {
+      admin.importTable(namespace, table);
+    } catch (ExecutionException e) {
+      throw new ExecutionException(
+          "Importing the table failed: " + ScalarDbUtils.getFullTableName(namespace, table), e);
+    }
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType)
+      throws ExecutionException {
+    try {
+      admin.addRawColumnToTable(namespace, table, columnName, columnType);
+    } catch (ExecutionException e) {
+      throw new ExecutionException(
+          "Adding the raw column to the table failed: "
+              + ScalarDbUtils.getFullTableName(namespace, table),
           e);
     }
   }

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
@@ -16,6 +17,7 @@ public class AdminService implements DistributedStorageAdmin {
 
   private final DistributedStorageAdmin admin;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Inject
   public AdminService(DistributedStorageAdmin admin) {
     this.admin = admin;
@@ -89,6 +91,24 @@ public class AdminService implements DistributedStorageAdmin {
       String namespace, String table, String columnName, DataType columnType)
       throws ExecutionException {
     admin.addNewColumnToTable(namespace, table, columnName, columnType);
+  }
+
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table)
+      throws ExecutionException {
+    return admin.getImportTableMetadata(namespace, table);
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType)
+      throws ExecutionException {
+    admin.addRawColumnToTable(namespace, table, columnName, columnType);
+  }
+
+  @Override
+  public void importTable(String namespace, String table) throws ExecutionException {
+    admin.importTable(namespace, table);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -187,6 +187,25 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     return builder.build();
   }
 
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in Cassandra");
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in Cassandra");
+  }
+
+  @Override
+  public void importTable(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in Cassandra");
+  }
+
   private Scan.Ordering.Order convertOrder(ClusteringOrder clusteringOrder) {
     switch (clusteringOrder) {
       case ASC:

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -552,6 +552,25 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     }
   }
 
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in Cosmos DB");
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in Cosmos DB");
+  }
+
+  @Override
+  public void importTable(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in Cosmos DB");
+  }
+
   private boolean metadataContainerExists() {
     try {
       client.getDatabase(metadataDatabase).getContainer(METADATA_CONTAINER).read();

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1200,6 +1200,25 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
   }
 
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in DynamoDB");
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in DynamoDB");
+  }
+
+  @Override
+  public void importTable(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in DynamoDB");
+  }
+
   private String getFullTableName(Namespace namespace, String table) {
     return ScalarDbUtils.getFullTableName(namespace.prefixed(), table);
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -1,7 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
+import static com.scalar.db.storage.jdbc.JdbcUtils.getJdbcType;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
-import static com.scalar.db.util.ScalarDbUtils.getJdbcType;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -1,9 +1,11 @@
 package com.scalar.db.storage.jdbc;
 
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
+import static com.scalar.db.util.ScalarDbUtils.getJdbcType;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -17,6 +19,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -47,6 +50,11 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   @VisibleForTesting static final String METADATA_COL_CLUSTERING_ORDER = "clustering_order";
   @VisibleForTesting static final String METADATA_COL_INDEXED = "indexed";
   @VisibleForTesting static final String METADATA_COL_ORDINAL_POSITION = "ordinal_position";
+  @VisibleForTesting static final String JDBC_COL_COLUMN_NAME = "COLUMN_NAME";
+  @VisibleForTesting static final String JDBC_COL_DATA_TYPE = "DATA_TYPE";
+  @VisibleForTesting static final String JDBC_COL_TYPE_NAME = "TYPE_NAME";
+  @VisibleForTesting static final String JDBC_COL_COLUMN_SIZE = "COLUMN_SIZE";
+  @VisibleForTesting static final String JDBC_COL_DECIMAL_DIGITS = "DECIMAL_DIGITS";
   private static final Logger logger = LoggerFactory.getLogger(JdbcAdmin.class);
   private static final String INDEX_NAME_PREFIX = "index";
 
@@ -381,6 +389,10 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     TableMetadata.Builder builder = TableMetadata.newBuilder();
     boolean tableExists = false;
 
+    if (!namespaceExists(metadataSchema)) {
+      return null;
+    }
+
     try (Connection connection = dataSource.getConnection();
         PreparedStatement preparedStatement =
             connection.prepareStatement(getSelectColumnsStatement())) {
@@ -427,6 +439,62 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     return builder.build();
+  }
+
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table)
+      throws ExecutionException {
+    TableMetadata.Builder builder = TableMetadata.newBuilder();
+    boolean primaryKeyExists = false;
+
+    if (!rdbEngine.isImportable()) {
+      throw new UnsupportedOperationException(
+          "Importing table is not allowed in this storage: " + rdbEngine);
+    }
+
+    try (Connection connection = dataSource.getConnection()) {
+      if (!tableExistsInternal(connection, namespace, table)) {
+        throw new IllegalArgumentException(
+            "The table " + getFullTableName(namespace, table) + "  does not exist");
+      }
+
+      DatabaseMetaData metadata = connection.getMetaData();
+      ResultSet resultSet = metadata.getPrimaryKeys(null, namespace, table);
+      while (resultSet.next()) {
+        primaryKeyExists = true;
+        String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
+        builder.addPartitionKey(columnName);
+      }
+
+      if (!primaryKeyExists) {
+        throw new IllegalStateException("The table must have a primary key");
+      }
+
+      resultSet = metadata.getColumns(null, namespace, table, "%");
+      while (resultSet.next()) {
+        String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
+        builder.addColumn(
+            columnName,
+            rdbEngine.getDataTypeForScalarDb(
+                getJdbcType(resultSet.getInt(JDBC_COL_DATA_TYPE)),
+                resultSet.getString(JDBC_COL_TYPE_NAME),
+                resultSet.getInt(JDBC_COL_COLUMN_SIZE),
+                resultSet.getInt(JDBC_COL_DECIMAL_DIGITS),
+                getFullTableName(namespace, table) + " " + columnName));
+      }
+    } catch (SQLException e) {
+      throw new ExecutionException("getting a table metadata failed", e);
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public void importTable(String namespace, String table) throws ExecutionException {
+    TableMetadata tableMetadata = getImportTableMetadata(namespace, table);
+
+    // add ScalarDB metadata
+    repairTable(namespace, table, tableMetadata, ImmutableMap.of());
   }
 
   private String getSelectColumnsStatement() {
@@ -652,6 +720,33 @@ public class JdbcAdmin implements DistributedStorageAdmin {
         execute(connection, getDeleteTableMetadataStatement(namespace, table));
         addTableMetadata(connection, namespace, table, updatedTableMetadata, false);
       }
+    } catch (SQLException e) {
+      throw new ExecutionException(
+          String.format(
+              "Adding the new column %s to the %s.%s table failed", columnName, namespace, table),
+          e);
+    }
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType)
+      throws ExecutionException {
+    try (Connection connection = dataSource.getConnection()) {
+      if (!tableExistsInternal(connection, namespace, table)) {
+        throw new IllegalArgumentException(
+            "The table " + getFullTableName(namespace, table) + "  does not exist");
+      }
+
+      String addNewColumnStatement =
+          "ALTER TABLE "
+              + encloseFullTableName(namespace, table)
+              + " ADD "
+              + enclose(columnName)
+              + " "
+              + rdbEngine.getDataTypeForEngine(columnType);
+
+      execute(connection, addNewColumnStatement);
     } catch (SQLException e) {
       throw new ExecutionException(
           String.format(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -449,7 +449,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
     if (!rdbEngine.isImportable()) {
       throw new UnsupportedOperationException(
-          "Importing table is not allowed in this storage: " + rdbEngine);
+          "Importing table is not allowed in this storage: " + rdbEngine.getClass().getName());
     }
 
     try (Connection connection = dataSource.getConnection()) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import java.sql.Connection;
+import java.sql.JDBCType;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
@@ -105,5 +106,30 @@ public final class JdbcUtils {
 
   public static boolean isSqlite(JdbcConfig config) {
     return config.getJdbcUrl().startsWith("jdbc:sqlite:");
+  }
+
+  /**
+   * Get {@code JDBCType} of the specified {@code sqlType}.
+   *
+   * @param sqlType a type defined in {@code java.sql.Types}
+   * @return a JDBCType
+   */
+  public static JDBCType getJdbcType(int sqlType) {
+    JDBCType type;
+    switch (sqlType) {
+      case 100: // for Oracle BINARY_FLOAT
+        type = JDBCType.REAL;
+        break;
+      case 101: // for Oracle BINARY_DOUBLE
+        type = JDBCType.DOUBLE;
+        break;
+      default:
+        try {
+          type = JDBCType.valueOf(sqlType);
+        } catch (IllegalArgumentException e) {
+          type = JDBCType.OTHER;
+        }
+    }
+    return type;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -8,12 +8,16 @@ import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Driver;
+import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class RdbEngineMysql implements RdbEngineStrategy {
+  private static final Logger logger = LoggerFactory.getLogger(RdbEngineMysql.class);
 
   @Override
   public String[] createNamespaceSqls(String fullNamespace) {
@@ -193,6 +197,84 @@ class RdbEngineMysql implements RdbEngineStrategy {
         return "VARBINARY(64)";
       default:
         return null;
+    }
+  }
+
+  @Override
+  public DataType getDataTypeForScalarDb(
+      JDBCType type, String typeName, int columnSize, int digits, String columnDescription) {
+    switch (type) {
+      case BIT:
+        if (columnSize != 1) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "data type %s(%d) is unsupported: %s", typeName, columnSize, columnDescription));
+        }
+        return DataType.BOOLEAN;
+      case TINYINT:
+      case SMALLINT:
+        logger.info(
+            "data type larger than that of underlying database is assigned: {} ({} to INT)",
+            columnDescription,
+            typeName);
+        return DataType.INT;
+      case INTEGER:
+        if (typeName.toUpperCase().endsWith("UNSIGNED")) {
+          logger.info(
+              "data type larger than that of underlying database is assigned: {} ({} to BIGINT)",
+              columnDescription,
+              typeName);
+          return DataType.BIGINT;
+        }
+        return DataType.INT;
+      case BIGINT:
+        if (typeName.toUpperCase().endsWith("UNSIGNED")) {
+          throw new IllegalArgumentException(
+              String.format("data type %s is unsupported: %s", typeName, columnDescription));
+        }
+        logger.warn(
+            "data type that may be smaller than that of underlying database is assigned: {} (MySQL {} to our BIGINT)",
+            columnDescription,
+            typeName);
+        return DataType.BIGINT;
+      case REAL:
+        return DataType.FLOAT;
+      case DOUBLE:
+        return DataType.DOUBLE;
+      case CHAR:
+      case VARCHAR:
+      case LONGVARCHAR:
+        if (typeName.equalsIgnoreCase("ENUM")
+            || typeName.equalsIgnoreCase("SET")
+            || typeName.equalsIgnoreCase("JSON")) {
+          throw new IllegalArgumentException(
+              String.format("data type %s is unsupported: %s", typeName, columnDescription));
+        }
+        if (!typeName.equalsIgnoreCase("LONGTEXT")) {
+          logger.info(
+              "data type larger than that of underlying database is assigned: {} ({} to TEXT)",
+              columnDescription,
+              typeName);
+        }
+        return DataType.TEXT;
+      case BINARY:
+      case VARBINARY:
+      case LONGVARBINARY:
+        if (!typeName.toUpperCase().endsWith("BINARY")
+            && !typeName.toUpperCase().endsWith("BLOB")) {
+          throw new IllegalArgumentException(
+              String.format("data type %s is unsupported: %s", typeName, columnDescription));
+        }
+        if (!typeName.equalsIgnoreCase("LONGBLOB")) {
+          logger.info(
+              "data type larger than that of underlying database is assigned: {} ({} to BLOB)",
+              columnDescription,
+              typeName);
+        }
+        return DataType.BLOB;
+      default:
+        throw new IllegalArgumentException(
+            String.format("data type %s is unsupported: %s", typeName, columnDescription));
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -233,7 +233,7 @@ class RdbEngineMysql implements RdbEngineStrategy {
               String.format("data type %s is unsupported: %s", typeName, columnDescription));
         }
         logger.warn(
-            "data type that may be smaller than that of underlying database is assigned: {} (MySQL {} to our BIGINT)",
+            "data type that may be smaller than that of underlying database is assigned: {} (MySQL {} to ScalarDB BIGINT)",
             columnDescription,
             typeName);
         return DataType.BIGINT;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -244,6 +244,10 @@ public class RdbEngineOracle implements RdbEngineStrategy {
         }
         return DataType.DOUBLE;
       case DOUBLE:
+        logger.warn(
+            String.format(
+                "data type that may be smaller than that of underlying database is assigned: %s (Oracle %s to our BIGINT)",
+                columnDescription, typeName));
         return DataType.DOUBLE;
       case CHAR:
       case NCHAR:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -244,10 +244,6 @@ public class RdbEngineOracle implements RdbEngineStrategy {
         }
         return DataType.DOUBLE;
       case DOUBLE:
-        logger.warn(
-            String.format(
-                "data type that may be smaller than that of underlying database is assigned: %s (Oracle %s to our BIGINT)",
-                columnDescription, typeName));
         return DataType.DOUBLE;
       case CHAR:
       case NCHAR:
@@ -264,15 +260,15 @@ public class RdbEngineOracle implements RdbEngineStrategy {
         return DataType.TEXT;
       case VARBINARY:
         logger.info(
-            "data type larger than that of underlying database is assigned: {} (Oracle {} to BLOB)",
+            "data type larger than that of underlying database is assigned: {} ({} to BLOB)",
             columnDescription,
             typeName);
         return DataType.BLOB;
       case LONGVARBINARY:
         return DataType.BLOB;
       case BLOB:
-        logger.info(
-            "data type that may be smaller than that of underlying database is assigned: {} ({} to BLOB)",
+        logger.warn(
+            "data type that may be smaller than that of underlying database is assigned: {} (Oracle {} to ScalarDB BLOB)",
             columnDescription,
             typeName);
         return DataType.BLOB;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -229,9 +229,9 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
               String.format("data type %s is unsupported: %s", typeName, columnDescription));
         }
         logger.warn(
-            String.format(
-                "data type that may be smaller than that of underlying database is assigned: %s (PostgreSQL %s to our BIGINT)",
-                columnDescription, typeName));
+            "data type that may be smaller than that of underlying database is assigned: {} (PostgreSQL {} to ScalarDB BIGINT)",
+            columnDescription,
+            typeName);
         return DataType.BIGINT;
       case REAL:
         return DataType.FLOAT;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -10,13 +10,17 @@ import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Driver;
+import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class RdbEnginePostgresql implements RdbEngineStrategy {
+  private static final Logger logger = LoggerFactory.getLogger(RdbEnginePostgresql.class);
 
   @Override
   public String[] createNamespaceSqls(String fullNamespace) {
@@ -188,6 +192,70 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
       return "VARCHAR(10485760)";
     }
     return null;
+  }
+
+  @Override
+  public DataType getDataTypeForScalarDb(
+      JDBCType type, String typeName, int columnSize, int digits, String columnDescription) {
+    switch (type) {
+      case BIT:
+        if (columnSize != 1) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "data type %s(%d) is unsupported: %s", typeName, columnSize, columnDescription));
+        }
+        return DataType.BOOLEAN;
+      case SMALLINT:
+        if (typeName.equalsIgnoreCase("smallserial")) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "data type %s(%d) is unsupported: %s", typeName, columnSize, columnDescription));
+        }
+        logger.info(
+            "data type larger than that of underlying database is assigned: {} ({} to INT)",
+            columnDescription,
+            typeName);
+        return DataType.INT;
+      case INTEGER:
+        if (typeName.equalsIgnoreCase("serial")) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "data type %s(%d) is unsupported: %s", typeName, columnSize, columnDescription));
+        }
+        return DataType.INT;
+      case BIGINT:
+        if (typeName.equalsIgnoreCase("bigserial")) {
+          throw new IllegalArgumentException(
+              String.format("data type %s is unsupported: %s", typeName, columnDescription));
+        }
+        logger.warn(
+            String.format(
+                "data type that may be smaller than that of underlying database is assigned: %s (PostgreSQL %s to our BIGINT)",
+                columnDescription, typeName));
+        return DataType.BIGINT;
+      case REAL:
+        return DataType.FLOAT;
+      case DOUBLE:
+        if (!typeName.equalsIgnoreCase("float8")) {
+          throw new IllegalArgumentException(
+              String.format("data type %s is unsupported: %s", typeName, columnDescription));
+        }
+        return DataType.DOUBLE;
+      case CHAR:
+      case VARCHAR:
+        if (!typeName.equalsIgnoreCase("text")) {
+          logger.info(
+              "data type larger than that of underlying database is assigned: {} ({} to TEXT)",
+              columnDescription,
+              typeName);
+        }
+        return DataType.TEXT;
+      case BINARY:
+        return DataType.BLOB;
+      default:
+        throw new IllegalArgumentException(
+            String.format("data type %s is unsupported: %s", typeName, columnDescription));
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -202,9 +202,9 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
         return DataType.INT;
       case BIGINT:
         logger.warn(
-            String.format(
-                "data type that may be smaller than that of underlying database is assigned: %s (SQL Server %s to our BIGINT)",
-                columnDescription, typeName));
+            "data type that may be smaller than that of underlying database is assigned: {} (SQL Server {} to ScalarDB BIGINT)",
+            columnDescription,
+            typeName);
         return DataType.BIGINT;
       case REAL:
         return DataType.FLOAT;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -8,6 +8,7 @@ import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Driver;
+import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
@@ -122,6 +123,12 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
   @Override
   public String getTextType(int charLength) {
     return "TEXT";
+  }
+
+  @Override
+  public DataType getDataTypeForScalarDb(
+      JDBCType type, String typeName, int columnSize, int digits, String columnDescription) {
+    throw new UnsupportedOperationException("SQLite is not supported");
   }
 
   @Override
@@ -258,5 +265,10 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
   @Override
   public Driver getDriver() {
     return new org.sqlite.JDBC();
+  }
+
+  @Override
+  public boolean isImportable() {
+    return false;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -6,6 +6,7 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import java.sql.Driver;
+import java.sql.JDBCType;
 import java.sql.SQLException;
 
 /**
@@ -25,6 +26,9 @@ public interface RdbEngineStrategy {
   String getDataTypeForEngine(DataType dataType);
 
   String getDataTypeForKey(DataType dataType);
+
+  DataType getDataTypeForScalarDb(
+      JDBCType type, String typeName, int columnSize, int digits, String columnDescription);
 
   int getSqlTypes(DataType dataType);
 
@@ -90,4 +94,8 @@ public interface RdbEngineStrategy {
   UpsertQuery buildUpsertQuery(UpsertQuery.Builder builder);
 
   Driver getDriver();
+
+  default boolean isImportable() {
+    return true;
+  }
 }

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -182,6 +182,24 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
     getAdmin(namespace, table).addNewColumnToTable(namespace, table, columnName, columnType);
   }
 
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table)
+      throws ExecutionException {
+    return getAdmin(namespace, table).getImportTableMetadata(namespace, table);
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType)
+      throws ExecutionException {
+    getAdmin(namespace, table).addRawColumnToTable(namespace, table, columnName, columnType);
+  }
+
+  @Override
+  public void importTable(String namespace, String table) throws ExecutionException {
+    getAdmin(namespace, table).importTable(namespace, table);
+  }
+
   private DistributedStorageAdmin getAdmin(String namespace) {
     DistributedStorageAdmin admin = namespaceAdminMap.get(namespace);
     return admin != null ? admin : defaultAdmin;

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
@@ -326,6 +326,25 @@ public class GrpcAdmin implements DistributedStorageAdmin {
                                 .build())));
   }
 
+  @Override
+  public TableMetadata getImportTableMetadata(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in ScalarDB Server");
+  }
+
+  @Override
+  public void addRawColumnToTable(
+      String namespace, String table, String columnName, DataType columnType) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in ScalarDB Server");
+  }
+
+  @Override
+  public void importTable(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in ScalarDB Server");
+  }
+
   private static <T> T execute(ThrowableSupplier<T, ExecutionException> supplier)
       throws ExecutionException {
     try {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -1,6 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.TRANSACTION_META_COLUMNS;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.buildTransactionTableMetadata;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getBeforeImageColumnName;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getNonPrimaryKeyColumns;
@@ -203,7 +202,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     tableMetadata = admin.getImportTableMetadata(namespace, table);
 
     // add transaction metadata columns
-    for (Map.Entry<String, DataType> entry : TRANSACTION_META_COLUMNS.entrySet()) {
+    for (Map.Entry<String, DataType> entry :
+        ConsensusCommitUtils.getTransactionMetaColumns().entrySet()) {
       admin.addRawColumnToTable(namespace, table, entry.getKey(), entry.getValue());
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -1,10 +1,13 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.TRANSACTION_META_COLUMNS;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.buildTransactionTableMetadata;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getBeforeImageColumnName;
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getNonPrimaryKeyColumns;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.removeTransactionMetaColumns;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
@@ -14,6 +17,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.util.ScalarDbUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +30,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   private final String coordinatorNamespace;
   private final boolean isIncludeMetadataEnabled;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   @Inject
   public ConsensusCommitAdmin(DistributedStorageAdmin admin, DatabaseConfig databaseConfig) {
     this.admin = admin;
@@ -186,6 +191,33 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
 
     admin.addNewColumnToTable(namespace, table, columnName, columnType);
     admin.addNewColumnToTable(namespace, table, beforeColumnName, columnType);
+  }
+
+  @Override
+  public void importTable(String namespace, String table) throws ExecutionException {
+    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+    if (tableMetadata != null) {
+      throw new IllegalArgumentException(
+          "Table already exists: " + ScalarDbUtils.getFullTableName(namespace, table));
+    }
+    tableMetadata = admin.getImportTableMetadata(namespace, table);
+
+    // add transaction metadata columns
+    for (Map.Entry<String, DataType> entry : TRANSACTION_META_COLUMNS.entrySet()) {
+      admin.addRawColumnToTable(namespace, table, entry.getKey(), entry.getValue());
+    }
+
+    // add before image columns
+    Set<String> nonPrimaryKeyColumns = getNonPrimaryKeyColumns(tableMetadata);
+    for (String columnName : nonPrimaryKeyColumns) {
+      String beforeColumnName = getBeforeImageColumnName(columnName, tableMetadata);
+      DataType columnType = tableMetadata.getColumnDataType(columnName);
+      admin.addRawColumnToTable(namespace, table, beforeColumnName, columnType);
+    }
+
+    // add ScalarDB metadata
+    admin.repairTable(
+        namespace, table, buildTransactionTableMetadata(tableMetadata), ImmutableMap.of());
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -28,7 +29,7 @@ public final class ConsensusCommitUtils {
           .put(Attribute.COMMITTED_AT, DataType.BIGINT)
           .build();
 
-  static final ImmutableMap<String, DataType> TRANSACTION_META_COLUMNS =
+  private static final ImmutableMap<String, DataType> TRANSACTION_META_COLUMNS =
       ImmutableMap.<String, DataType>builder()
           .putAll(AFTER_IMAGE_META_COLUMNS)
           .putAll(BEFORE_IMAGE_META_COLUMNS)
@@ -127,11 +128,25 @@ public final class ConsensusCommitUtils {
     return true;
   }
 
-  static Set<String> getNonPrimaryKeyColumns(TableMetadata tableMetadata) {
+  /**
+   * Get non-primary key columns from the specified table metadata.
+   *
+   * @return a set of non-primary key column names
+   */
+  public static Set<String> getNonPrimaryKeyColumns(TableMetadata tableMetadata) {
     return tableMetadata.getColumnNames().stream()
         .filter(c -> !tableMetadata.getPartitionKeyNames().contains(c))
         .filter(c -> !tableMetadata.getClusteringKeyNames().contains(c))
         .collect(Collectors.toSet());
+  }
+
+  /**
+   * Get transaction meta columns.
+   *
+   * @return a map of transaction meta columns
+   */
+  public static Map<String, DataType> getTransactionMetaColumns() {
+    return TRANSACTION_META_COLUMNS;
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -28,7 +28,7 @@ public final class ConsensusCommitUtils {
           .put(Attribute.COMMITTED_AT, DataType.BIGINT)
           .build();
 
-  private static final ImmutableMap<String, DataType> TRANSACTION_META_COLUMNS =
+  static final ImmutableMap<String, DataType> TRANSACTION_META_COLUMNS =
       ImmutableMap.<String, DataType>builder()
           .putAll(AFTER_IMAGE_META_COLUMNS)
           .putAll(BEFORE_IMAGE_META_COLUMNS)
@@ -127,7 +127,7 @@ public final class ConsensusCommitUtils {
     return true;
   }
 
-  private static Set<String> getNonPrimaryKeyColumns(TableMetadata tableMetadata) {
+  static Set<String> getNonPrimaryKeyColumns(TableMetadata tableMetadata) {
     return tableMetadata.getColumnNames().stream()
         .filter(c -> !tableMetadata.getPartitionKeyNames().contains(c))
         .filter(c -> !tableMetadata.getClusteringKeyNames().contains(c))

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -1,7 +1,6 @@
 package com.scalar.db.transaction.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
@@ -93,10 +92,7 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
 
   @Override
   public void importTable(String namespace, String table) throws ExecutionException {
-    TableMetadata tableMetadata = jdbcAdmin.getImportTableMetadata(namespace, table);
-
-    // add ScalarDB metadata
-    jdbcAdmin.repairTable(namespace, table, tableMetadata, ImmutableMap.of());
+    jdbcAdmin.importTable(namespace, table);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -1,6 +1,7 @@
 package com.scalar.db.transaction.jdbc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
@@ -88,6 +89,14 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
   @Override
   public boolean namespaceExists(String namespace) throws ExecutionException {
     return jdbcAdmin.namespaceExists(namespace);
+  }
+
+  @Override
+  public void importTable(String namespace, String table) throws ExecutionException {
+    TableMetadata tableMetadata = jdbcAdmin.getImportTableMetadata(namespace, table);
+
+    // add ScalarDB metadata
+    jdbcAdmin.repairTable(namespace, table, tableMetadata, ImmutableMap.of());
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
@@ -394,6 +394,12 @@ public class GrpcTransactionAdmin implements DistributedTransactionAdmin {
                         .build()));
   }
 
+  @Override
+  public void importTable(String namespace, String table) {
+    throw new UnsupportedOperationException(
+        "import-related functionality is not supported in ScalarDB Server");
+  }
+
   private static <T> T execute(ThrowableSupplier<T, ExecutionException> supplier)
       throws ExecutionException {
     try {

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -251,18 +251,24 @@ public final class ScalarDbUtils {
         && (!scan.getOrderings().isEmpty() || !scan.getConjunctions().isEmpty());
   }
 
-  public static JDBCType getJdbcType(int sqlTypes) {
+  /**
+   * Get {@code JDBCType} of the specified {@code sqlType}.
+   *
+   * @param sqlType a type defined in {@code java.sql.Types}
+   * @return a JDBCType
+   */
+  public static JDBCType getJdbcType(int sqlType) {
     JDBCType type;
-    switch (sqlTypes) {
-      case 100:
+    switch (sqlType) {
+      case 100: // for Oracle BINARY_FLOAT
         type = JDBCType.REAL;
         break;
-      case 101:
+      case 101: // for Oracle BINARY_DOUBLE
         type = JDBCType.DOUBLE;
         break;
       default:
         try {
-          type = JDBCType.valueOf(sqlTypes);
+          type = JDBCType.valueOf(sqlType);
         } catch (IllegalArgumentException e) {
           type = JDBCType.OTHER;
         }

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -28,6 +28,7 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
+import java.sql.JDBCType;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
@@ -248,5 +249,24 @@ public final class ScalarDbUtils {
   public static boolean isRelational(Scan scan) {
     return scan instanceof ScanAll
         && (!scan.getOrderings().isEmpty() || !scan.getConjunctions().isEmpty());
+  }
+
+  public static JDBCType getJdbcType(int sqlTypes) {
+    JDBCType type;
+    switch (sqlTypes) {
+      case 100:
+        type = JDBCType.REAL;
+        break;
+      case 101:
+        type = JDBCType.DOUBLE;
+        break;
+      default:
+        try {
+          type = JDBCType.valueOf(sqlTypes);
+        } catch (IllegalArgumentException e) {
+          type = JDBCType.OTHER;
+        }
+    }
+    return type;
   }
 }

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -28,7 +28,6 @@ import com.scalar.db.io.IntValue;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.io.TextValue;
 import com.scalar.db.io.Value;
-import java.sql.JDBCType;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
@@ -249,30 +248,5 @@ public final class ScalarDbUtils {
   public static boolean isRelational(Scan scan) {
     return scan instanceof ScanAll
         && (!scan.getOrderings().isEmpty() || !scan.getConjunctions().isEmpty());
-  }
-
-  /**
-   * Get {@code JDBCType} of the specified {@code sqlType}.
-   *
-   * @param sqlType a type defined in {@code java.sql.Types}
-   * @return a JDBCType
-   */
-  public static JDBCType getJdbcType(int sqlType) {
-    JDBCType type;
-    switch (sqlType) {
-      case 100: // for Oracle BINARY_FLOAT
-        type = JDBCType.REAL;
-        break;
-      case 101: // for Oracle BINARY_DOUBLE
-        type = JDBCType.DOUBLE;
-        break;
-      default:
-        try {
-          type = JDBCType.valueOf(sqlType);
-        } catch (IllegalArgumentException e) {
-          type = JDBCType.OTHER;
-        }
-    }
-    return type;
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -4,6 +4,7 @@ import static com.datastax.driver.core.Metadata.quote;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -590,5 +591,26 @@ public class CassandraAdminTest {
             .type(com.datastax.driver.core.DataType.text())
             .getQueryString();
     verify(cassandraSession).execute(alterTableQuery);
+  }
+
+  @Test
+  public void unsupportedOperations_ShouldThrowUnsupportedException() {
+    // Arrange
+    String namespace = "sample_ns";
+    String table = "tbl";
+    String column = "col";
+
+    // Act
+    Throwable thrown1 =
+        catchThrowable(() -> cassandraAdmin.getImportTableMetadata(namespace, table));
+    Throwable thrown2 =
+        catchThrowable(
+            () -> cassandraAdmin.addRawColumnToTable(namespace, table, column, DataType.INT));
+    Throwable thrown3 = catchThrowable(() -> cassandraAdmin.importTable(namespace, table));
+
+    // Assert
+    assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cosmos;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -846,5 +847,24 @@ public abstract class CosmosAdminTestBase {
         ImmutableMap.of(currentColumn, "text", newColumn, "int"));
 
     verify(container).upsertItem(expectedCosmosTableMetadata);
+  }
+
+  @Test
+  public void unsupportedOperations_ShouldThrowUnsupportedException() {
+    // Arrange
+    String namespace = "sample_ns";
+    String table = "tbl";
+    String column = "col";
+
+    // Act
+    Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(namespace, table));
+    Throwable thrown2 =
+        catchThrowable(() -> admin.addRawColumnToTable(namespace, table, column, DataType.INT));
+    Throwable thrown3 = catchThrowable(() -> admin.importTable(namespace, table));
+
+    // Assert
+    assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.dynamo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -1174,5 +1175,19 @@ public abstract class DynamoAdminTestBase {
                 .tableName(getFullMetadataTableName())
                 .item(itemValues)
                 .build());
+  }
+
+  @Test
+  public void unsupportedOperations_ShouldThrowUnsupportedException() {
+    // Arrange Act
+    Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(NAMESPACE, TABLE));
+    Throwable thrown2 =
+        catchThrowable(() -> admin.addRawColumnToTable(NAMESPACE, TABLE, "c1", DataType.INT));
+    Throwable thrown3 = catchThrowable(() -> admin.importTable(NAMESPACE, TABLE));
+
+    // Assert
+    assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -1,17 +1,29 @@
 package com.scalar.db.storage.jdbc;
 
+import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_COLUMN_NAME;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_COLUMN_SIZE;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_DATA_TYPE;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_DECIMAL_DIGITS;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_TYPE_NAME;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.description;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.mysql.cj.jdbc.exceptions.CommunicationsException;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
@@ -19,15 +31,19 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.jdbc.JdbcAdminTestBase.GetColumnsResultSetMocker.Row;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -38,6 +54,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.sqlite.SQLiteErrorCode;
@@ -49,6 +66,16 @@ import org.sqlite.SQLiteException;
  * {@link JdbcConfig#TABLE_METADATA_SCHEMA}.
  */
 public abstract class JdbcAdminTestBase {
+  private static final String NAMESPACE = "namespace";
+  private static final String TABLE = "table";
+  private static final String COLUMN_1 = "c1";
+  private static final ImmutableMap<RdbEngine, RdbEngineStrategy> RDB_ENGINES =
+      ImmutableMap.of(
+          RdbEngine.MYSQL, RdbEngineFactory.create("jdbc:mysql:"),
+          RdbEngine.ORACLE, RdbEngineFactory.create("jdbc:oracle:"),
+          RdbEngine.POSTGRESQL, RdbEngineFactory.create("jdbc:postgresql:"),
+          RdbEngine.SQL_SERVER, RdbEngineFactory.create("jdbc:sqlserver:"),
+          RdbEngine.SQLITE, RdbEngineFactory.create("jdbc:sqlite:"));
 
   @Mock private BasicDataSource dataSource;
   @Mock private Connection connection;
@@ -161,6 +188,7 @@ public abstract class JdbcAdminTestBase {
     String namespace = "ns";
     String table = "table";
 
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -179,7 +207,7 @@ public abstract class JdbcAdminTestBase {
                 new GetColumnsResultSetMocker.Row(
                     "c7", DataType.FLOAT.toString(), null, null, false)));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
     when(dataSource.getConnection()).thenReturn(connection);
 
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
@@ -212,6 +240,32 @@ public abstract class JdbcAdminTestBase {
     // mocked to return the current row data
     doAnswer(new GetColumnsResultSetMocker(rows)).when(resultSet).next();
     return resultSet;
+  }
+
+  @Test
+  public void getTableMetadata_MetadataSchemaNotExistsForX_ShouldReturnNull()
+      throws SQLException, ExecutionException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      getTableMetadata_MetadataSchemaNotExistsForX_ShouldReturnNull(rdbEngine);
+    }
+  }
+
+  private void getTableMetadata_MetadataSchemaNotExistsForX_ShouldReturnNull(RdbEngine rdbEngine)
+      throws SQLException, ExecutionException {
+    // Arrange
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    Connection connection = mock(Connection.class);
+    PreparedStatement selectStatement = prepareStatementForNamespaceCheck(false);
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+
+    // Act
+    TableMetadata actual = admin.getTableMetadata("my_ns", "my_tbl");
+
+    // Assert
+    assertThat(actual).isNull();
   }
 
   @Test
@@ -1377,6 +1431,7 @@ public abstract class JdbcAdminTestBase {
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -1386,7 +1441,7 @@ public abstract class JdbcAdminTestBase {
                 new GetColumnsResultSetMocker.Row(
                     indexColumn, DataType.BOOLEAN.toString(), null, null, false)));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
     Statement statement = mock(Statement.class);
 
     when(dataSource.getConnection()).thenReturn(connection);
@@ -1474,6 +1529,7 @@ public abstract class JdbcAdminTestBase {
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -1483,7 +1539,7 @@ public abstract class JdbcAdminTestBase {
                 new GetColumnsResultSetMocker.Row(
                     indexColumn, DataType.TEXT.toString(), null, null, false)));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
 
     Statement statement = mock(Statement.class);
 
@@ -1587,6 +1643,7 @@ public abstract class JdbcAdminTestBase {
     String table = "my_tbl";
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -1596,7 +1653,7 @@ public abstract class JdbcAdminTestBase {
                 new GetColumnsResultSetMocker.Row(
                     indexColumn, DataType.BOOLEAN.toString(), null, null, false)));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
 
     Statement statement = mock(Statement.class);
 
@@ -1679,6 +1736,7 @@ public abstract class JdbcAdminTestBase {
     String table = "my_tbl";
     String indexColumn = "my_column";
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -1688,7 +1746,7 @@ public abstract class JdbcAdminTestBase {
                 new GetColumnsResultSetMocker.Row(
                     indexColumn, DataType.TEXT.toString(), null, null, false)));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
 
     Statement statement = mock(Statement.class);
 
@@ -2111,6 +2169,7 @@ public abstract class JdbcAdminTestBase {
     String currentColumn = "c1";
     String newColumn = "c2";
 
+    PreparedStatement checkStatement = prepareStatementForNamespaceCheck();
     PreparedStatement selectStatement = mock(PreparedStatement.class);
     ResultSet resultSet =
         mockResultSet(
@@ -2118,7 +2177,7 @@ public abstract class JdbcAdminTestBase {
                 new Row(currentColumn, DataType.TEXT.toString(), "PARTITION", null, false)));
     when(selectStatement.executeQuery()).thenReturn(resultSet);
 
-    when(connection.prepareStatement(any())).thenReturn(selectStatement);
+    when(connection.prepareStatement(any())).thenReturn(checkStatement).thenReturn(selectStatement);
     List<Statement> expectedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       Statement expectedStatement = mock(Statement.class);
@@ -2141,6 +2200,527 @@ public abstract class JdbcAdminTestBase {
     for (int i = 0; i < expectedSqlStatements.length; i++) {
       verify(expectedStatements.get(i)).execute(expectedSqlStatements[i]);
     }
+  }
+
+  @Test
+  public void getImportTableMetadata_ForX_ShouldWorkProperly()
+      throws SQLException, ExecutionException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      if (rdbEngine.equals(RdbEngine.SQLITE)) {
+        getImportTableMetadata_ForSQLite_ShouldThrowUnsupportedOperationException(rdbEngine);
+      } else {
+        getImportTableMetadata_ForOtherThanSQLite_ShouldWorkProperly(
+            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+      }
+    }
+  }
+
+  private void getImportTableMetadata_ForOtherThanSQLite_ShouldWorkProperly(
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement)
+      throws SQLException, ExecutionException {
+    // Arrange
+    Statement checkTableExistStatement = mock(Statement.class);
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    ResultSet primaryKeyResults = mock(ResultSet.class);
+    ResultSet columnResults = mock(ResultSet.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(connection.getMetaData()).thenReturn(metadata);
+    when(primaryKeyResults.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(primaryKeyResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn("pk1").thenReturn("pk2");
+    when(columnResults.next())
+        .thenAnswer(
+            new Answer<Boolean>() {
+              private int i = 0;
+
+              @Override
+              public Boolean answer(InvocationOnMock invocation) {
+                // two primary key columns + one regular column
+                return i++ < 3;
+              }
+            });
+    when(columnResults.getString(JDBC_COL_COLUMN_NAME))
+        .thenReturn("pk1")
+        .thenReturn("pk2")
+        .thenReturn("col");
+    when(columnResults.getInt(JDBC_COL_DATA_TYPE))
+        .thenReturn(Types.VARCHAR)
+        .thenReturn(Types.VARCHAR)
+        .thenReturn(Types.REAL);
+    when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("").thenReturn("").thenReturn("");
+    when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0).thenReturn(0).thenReturn(0);
+    when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0).thenReturn(0).thenReturn(0);
+    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+
+    Map<String, DataType> expectedColumns = new LinkedHashMap<>();
+    expectedColumns.put("pk1", DataType.TEXT);
+    expectedColumns.put("pk2", DataType.TEXT);
+    expectedColumns.put("col", DataType.FLOAT);
+
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    String description = "database engine specific test failed: " + rdbEngine;
+
+    // Act
+    TableMetadata actual = admin.getImportTableMetadata(NAMESPACE, TABLE);
+
+    // Assert
+    verify(checkTableExistStatement, description(description))
+        .execute(expectedCheckTableExistStatement);
+    assertThat(actual.getPartitionKeyNames()).hasSameElementsAs(ImmutableSet.of("pk1", "pk2"));
+    assertThat(actual.getColumnDataTypes()).containsExactlyEntriesOf(expectedColumns);
+  }
+
+  private void getImportTableMetadata_ForSQLite_ShouldThrowUnsupportedOperationException(
+      RdbEngine rdbEngine) {
+    // Arrange
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.getImportTableMetadata(NAMESPACE, TABLE))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void getImportTableMetadata_PrimaryKeyNotExistsForX_ShouldThrowExecutionException()
+      throws SQLException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      if (!rdbEngine.equals(RdbEngine.SQLITE)) {
+        getImportTableMetadata_PrimaryKeyNotExistsForX_ShouldThrowIllegalStateException(
+            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+      }
+    }
+  }
+
+  @Test
+  public void getImportTableMetadata_WithNonExistingTableForX_ShouldThrowIllegalArgumentException()
+      throws SQLException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      if (!rdbEngine.equals(RdbEngine.SQLITE)) {
+        getImportTableMetadata_WithNonExistingTableForX_ShouldThrowIllegalArgumentException(
+            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+      }
+    }
+  }
+
+  private void getImportTableMetadata_WithNonExistingTableForX_ShouldThrowIllegalArgumentException(
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
+    // Arrange
+    Statement checkTableExistStatement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    SQLException sqlException = mock(SQLException.class);
+    mockUndefinedTableError(rdbEngine, sqlException);
+    when(checkTableExistStatement.execute(any())).thenThrow(sqlException);
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.getImportTableMetadata(NAMESPACE, TABLE))
+        .isInstanceOf(IllegalArgumentException.class);
+    verify(
+            checkTableExistStatement,
+            description("database engine specific test failed: " + rdbEngine))
+        .execute(expectedCheckTableExistStatement);
+  }
+
+  private void getImportTableMetadata_PrimaryKeyNotExistsForX_ShouldThrowIllegalStateException(
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
+    // Arrange
+    Statement checkTableExistStatement = mock(Statement.class);
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    ResultSet primaryKeyResults = mock(ResultSet.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(connection.getMetaData()).thenReturn(metadata);
+    when(primaryKeyResults.next()).thenReturn(false);
+    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    String description = "database engine specific test failed: " + rdbEngine;
+
+    // Act
+    Throwable thrown = catchThrowable(() -> admin.getImportTableMetadata(NAMESPACE, TABLE));
+
+    // Assert
+    verify(checkTableExistStatement, description(description))
+        .execute(expectedCheckTableExistStatement);
+    assertThat(thrown).as(description).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getImportTableMetadata_UnsupportedDataTypeGivenForX_ShouldThrowExecutionException()
+      throws SQLException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      if (!rdbEngine.equals(RdbEngine.SQLITE)) {
+        getImportTableMetadata_UnsupportedDataTypeGivenForX_ShouldThrowExecutionException(
+            rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+      }
+    }
+  }
+
+  private void getImportTableMetadata_UnsupportedDataTypeGivenForX_ShouldThrowExecutionException(
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
+    // Arrange
+    Statement checkTableExistStatement = mock(Statement.class);
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    ResultSet primaryKeyResults = mock(ResultSet.class);
+    ResultSet columnResults = mock(ResultSet.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(connection.getMetaData()).thenReturn(metadata);
+    when(primaryKeyResults.next()).thenReturn(true).thenReturn(false);
+    when(primaryKeyResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn("pk1");
+    when(columnResults.next()).thenReturn(true).thenReturn(false);
+    when(columnResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn("pk1");
+    when(columnResults.getInt(JDBC_COL_DATA_TYPE)).thenReturn(Types.TIMESTAMP);
+    when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("timestamp");
+    when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0);
+    when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0);
+    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    String description = "database engine specific test failed: " + rdbEngine;
+
+    // Act
+    Throwable thrown = catchThrowable(() -> admin.getImportTableMetadata(NAMESPACE, TABLE));
+
+    // Assert
+    verify(checkTableExistStatement, description(description))
+        .execute(expectedCheckTableExistStatement);
+    assertThat(thrown).as(description).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void addRawColumnToTable_ForX_ShouldWorkProperly()
+      throws SQLException, ExecutionException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      addRawColumnToTable_ForX_ShouldWorkProperly(
+          rdbEngine,
+          prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE),
+          prepareSqlForAlterTableAddColumn(rdbEngine, COLUMN_1));
+    }
+  }
+
+  private void addRawColumnToTable_ForX_ShouldWorkProperly(
+      RdbEngine rdbEngine, String... expectedSqlStatements)
+      throws SQLException, ExecutionException {
+    // Arrange
+    List<Statement> expectedStatements = new ArrayList<>();
+    for (int i = 0; i < expectedSqlStatements.length; i++) {
+      Statement expectedStatement = mock(Statement.class);
+      expectedStatements.add(expectedStatement);
+    }
+    when(connection.createStatement())
+        .thenReturn(
+            expectedStatements.get(0),
+            expectedStatements.subList(1, expectedStatements.size()).toArray(new Statement[0]));
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    // Act
+    admin.addRawColumnToTable(NAMESPACE, TABLE, COLUMN_1, DataType.INT);
+
+    // Assert
+    for (int i = 0; i < expectedSqlStatements.length; i++) {
+      verify(
+              expectedStatements.get(i),
+              description("database engine specific test failed: " + rdbEngine))
+          .execute(expectedSqlStatements[i]);
+    }
+  }
+
+  @Test
+  public void addRawColumnToTable_WithNonExistingTableForX_ShouldThrowIllegalArgumentException()
+      throws SQLException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      addRawColumnToTable_WithNonExistingTableForX_ShouldThrowIllegalArgumentException(
+          rdbEngine, prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+    }
+  }
+
+  private void addRawColumnToTable_WithNonExistingTableForX_ShouldThrowIllegalArgumentException(
+      RdbEngine rdbEngine, String expectedCheckTableExistStatement) throws SQLException {
+    // Arrange
+    Statement checkTableExistStatement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(checkTableExistStatement);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+    SQLException sqlException = mock(SQLException.class);
+    mockUndefinedTableError(rdbEngine, sqlException);
+    when(checkTableExistStatement.execute(any())).thenThrow(sqlException);
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.addRawColumnToTable(NAMESPACE, TABLE, COLUMN_1, DataType.INT))
+        .isInstanceOf(IllegalArgumentException.class);
+    verify(
+            checkTableExistStatement,
+            description("database engine specific test failed: " + rdbEngine))
+        .execute(expectedCheckTableExistStatement);
+  }
+
+  @Test
+  public void importTable_ForX_ShouldWorkProperly() throws SQLException, ExecutionException {
+    for (RdbEngine rdbEngine : RDB_ENGINES.keySet()) {
+      if (!rdbEngine.equals(RdbEngine.SQLITE)) {
+        List<String> statements = new ArrayList<>();
+        statements.add(prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+        statements.add(prepareSqlForTableCheck(rdbEngine, NAMESPACE, TABLE));
+        statements.add(prepareSqlForMetadataTableCheck(rdbEngine));
+        statements.addAll(prepareSqlForCreateSchemaStatements(rdbEngine));
+        statements.add(prepareSqlForCreateMetadataTable(rdbEngine));
+        statements.add(
+            prepareSqlForInsertMetadata(
+                rdbEngine, COLUMN_1, "TEXT", "PARTITION", "NULL", false, 1));
+        importTable_ForX_ShouldWorkProperly(rdbEngine, statements);
+      }
+    }
+  }
+
+  private void importTable_ForX_ShouldWorkProperly(
+      RdbEngine rdbEngine, List<String> expectedSqlStatements)
+      throws SQLException, ExecutionException {
+    // Arrange
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    ResultSet primaryKeyResults = mock(ResultSet.class);
+    ResultSet columnResults = mock(ResultSet.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.getMetaData()).thenReturn(metadata);
+    when(primaryKeyResults.next()).thenReturn(true).thenReturn(false);
+    when(primaryKeyResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn(COLUMN_1);
+    when(columnResults.next()).thenReturn(true).thenReturn(false);
+    when(columnResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn(COLUMN_1);
+    when(columnResults.getInt(JDBC_COL_DATA_TYPE)).thenReturn(Types.VARCHAR);
+    when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("");
+    when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0);
+    when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0);
+    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    List<Statement> expectedStatements = new ArrayList<>();
+    for (int i = 0; i < expectedSqlStatements.size(); i++) {
+      Statement expectedStatement = mock(Statement.class);
+      expectedStatements.add(expectedStatement);
+    }
+    when(connection.createStatement())
+        .thenReturn(
+            expectedStatements.get(0),
+            expectedStatements.subList(1, expectedStatements.size()).toArray(new Statement[0]));
+
+    // prepare the situation where metadata table does not exist
+    SQLException sqlException = mock(SQLException.class);
+    mockUndefinedTableError(rdbEngine, sqlException);
+    when(expectedStatements.get(2).execute(any())).thenThrow(sqlException);
+
+    when(dataSource.getConnection()).thenReturn(connection);
+    JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
+
+    // Act
+    admin.importTable(NAMESPACE, TABLE);
+
+    // Assert
+    for (int i = 0; i < expectedSqlStatements.size(); i++) {
+      verify(
+              expectedStatements.get(i),
+              description("database engine specific test failed: " + rdbEngine))
+          .execute(expectedSqlStatements.get(i));
+    }
+  }
+
+  @Test
+  public void importTable_ForSQLite_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    JdbcAdmin admin = createJdbcAdminFor(RdbEngine.SQLITE);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> admin.importTable(NAMESPACE, TABLE));
+
+    // Assert
+    assertThat(thrown).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private PreparedStatement prepareStatementForNamespaceCheck() throws SQLException {
+    return prepareStatementForNamespaceCheck(true);
+  }
+
+  private PreparedStatement prepareStatementForNamespaceCheck(boolean exists) throws SQLException {
+    PreparedStatement statement = mock(PreparedStatement.class);
+    ResultSet results = mock(ResultSet.class);
+    doNothing().when(statement).setString(anyInt(), anyString());
+    when(statement.executeQuery()).thenReturn(results);
+    when(results.next()).thenReturn(exists);
+    return statement;
+  }
+
+  private String prepareSqlForMetadataTableCheck(RdbEngine rdbEngine) {
+    return prepareSqlForTableCheck(rdbEngine, tableMetadataSchemaName, "metadata");
+  }
+
+  private String prepareSqlForTableCheck(RdbEngine rdbEngine, String namespace, String table) {
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    StringBuilder sql =
+        new StringBuilder("SELECT ")
+            .append(rdbEngine.equals(RdbEngine.SQL_SERVER) ? "TOP 1 1" : "1")
+            .append(" FROM ")
+            .append(rdbEngineStrategy.encloseFullTableName(namespace, table));
+
+    switch (rdbEngine) {
+      case ORACLE:
+        sql.append(" FETCH FIRST 1 ROWS ONLY");
+        break;
+      case SQL_SERVER:
+        break;
+      default:
+        sql.append(" LIMIT 1");
+    }
+
+    return sql.toString();
+  }
+
+  private String prepareSqlForAlterTableAddColumn(RdbEngine rdbEngine, String column) {
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    return "ALTER TABLE "
+        + rdbEngineStrategy.encloseFullTableName(NAMESPACE, TABLE)
+        + " ADD "
+        + rdbEngineStrategy.enclose(column)
+        + " INT";
+  }
+
+  private List<String> prepareSqlForCreateSchemaStatements(RdbEngine rdbEngine) {
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    List<String> statements = new ArrayList<>();
+
+    switch (rdbEngine) {
+      case MYSQL:
+      case POSTGRESQL:
+      case SQL_SERVER:
+        statements.add(
+            "CREATE SCHEMA "
+                + (rdbEngine.equals(RdbEngine.SQL_SERVER) ? "" : "IF NOT EXISTS ")
+                + rdbEngineStrategy.enclose(tableMetadataSchemaName));
+        break;
+      case ORACLE:
+        statements.add(
+            "CREATE USER "
+                + rdbEngineStrategy.enclose(tableMetadataSchemaName)
+                + " IDENTIFIED BY "
+                + rdbEngineStrategy.enclose("oracle"));
+        statements.add(
+            "ALTER USER "
+                + rdbEngineStrategy.enclose(tableMetadataSchemaName)
+                + " quota unlimited on USERS");
+        break;
+      default:
+        break;
+    }
+
+    return statements;
+  }
+
+  private String prepareSqlForCreateMetadataTable(RdbEngine rdbEngine) {
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    StringBuilder sql = new StringBuilder("CREATE TABLE ");
+    if (!rdbEngine.equals(RdbEngine.ORACLE) && !rdbEngine.equals(RdbEngine.SQL_SERVER)) {
+      sql.append("IF NOT EXISTS ");
+    }
+
+    sql.append(rdbEngineStrategy.encloseFullTableName(tableMetadataSchemaName, "metadata"))
+        .append("(")
+        .append(rdbEngineStrategy.enclose("full_table_name"))
+        .append(" ")
+        .append(getVarcharString(rdbEngine, 128))
+        .append(",")
+        .append(rdbEngineStrategy.enclose("column_name"))
+        .append(" ")
+        .append(getVarcharString(rdbEngine, 128))
+        .append(",")
+        .append(rdbEngineStrategy.enclose("data_type"))
+        .append(" ")
+        .append(getVarcharString(rdbEngine, 20))
+        .append(" NOT NULL,")
+        .append(rdbEngineStrategy.enclose("key_type"))
+        .append(" ")
+        .append(getVarcharString(rdbEngine, 20))
+        .append(",")
+        .append(rdbEngineStrategy.enclose("clustering_order"))
+        .append(" ")
+        .append(getVarcharString(rdbEngine, 10))
+        .append(",")
+        .append(rdbEngineStrategy.enclose("indexed"));
+
+    switch (rdbEngine) {
+      case ORACLE:
+        sql.append(" NUMBER(1) NOT NULL,");
+        break;
+      case SQL_SERVER:
+        sql.append(" BIT NOT NULL,");
+        break;
+      default:
+        sql.append(" BOOLEAN NOT NULL,");
+        break;
+    }
+
+    sql.append(rdbEngineStrategy.enclose("ordinal_position"))
+        .append(" INTEGER NOT NULL,PRIMARY KEY (")
+        .append(rdbEngineStrategy.enclose("full_table_name"))
+        .append(", ")
+        .append(rdbEngineStrategy.enclose("column_name"))
+        .append("))");
+
+    return sql.toString();
+  }
+
+  private String getVarcharString(RdbEngine rdbEngine, int size) {
+    switch (rdbEngine) {
+      case ORACLE:
+        return "VARCHAR2(" + size + ")";
+      case SQLITE:
+        return "TEXT";
+      default:
+        return "VARCHAR(" + size + ")";
+    }
+  }
+
+  private String prepareSqlForInsertMetadata(
+      RdbEngine rdbEngine,
+      String column,
+      String dataType,
+      String keyType,
+      String clusteringOrder,
+      boolean indexed,
+      int ordinal) {
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    List<String> values =
+        ImmutableList.of(
+            "'" + NAMESPACE + "." + TABLE + "'",
+            "'" + column + "'",
+            "'" + dataType + "'",
+            "'" + keyType + "'",
+            clusteringOrder,
+            getBooleanString(rdbEngine, indexed),
+            Integer.toString(ordinal));
+
+    return "INSERT INTO "
+        + rdbEngineStrategy.encloseFullTableName(tableMetadataSchemaName, "metadata")
+        + " VALUES ("
+        + String.join(",", values)
+        + ")";
+  }
+
+  private String getBooleanString(RdbEngine rdbEngine, boolean value) {
+    switch (rdbEngine) {
+      case ORACLE:
+      case SQL_SERVER:
+        return value ? "1" : "0";
+      case SQLITE:
+        return value ? "TRUE" : "FALSE";
+      default:
+        return value ? "true" : "false";
+    }
+  }
+
+  private RdbEngineStrategy getRdbEngineStrategy(RdbEngine rdbEngine) {
+    return RDB_ENGINES.getOrDefault(rdbEngine, RdbEngineFactory.create("jdbc:mysql:"));
   }
 
   // Utility class used to mock ResultSet for getTableMetadata test

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineTest.java
@@ -1,0 +1,228 @@
+package com.scalar.db.storage.jdbc;
+
+import static com.scalar.db.storage.jdbc.RdbEngine.MYSQL;
+import static com.scalar.db.storage.jdbc.RdbEngine.ORACLE;
+import static com.scalar.db.storage.jdbc.RdbEngine.POSTGRESQL;
+import static com.scalar.db.storage.jdbc.RdbEngine.SQL_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.scalar.db.io.DataType;
+import java.sql.JDBCType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class RdbEngineTest {
+  private static final Map<RdbEngine, Map<Column, DataType>> DATA_TYPE_MAP = new HashMap<>();
+
+  @BeforeAll
+  public static void beforeAll() {
+    prepareDataTypeMap();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = RdbEngine.class,
+      names = {"SQLITE"},
+      mode = EnumSource.Mode.EXCLUDE)
+  public void getDataTypeForScalarDbTest(RdbEngine rdbEngineType) {
+    RdbEngineStrategy rdbEngine = RdbEngine.createRdbEngineStrategy(rdbEngineType);
+
+    DATA_TYPE_MAP
+        .get(rdbEngineType)
+        .forEach(
+            (given, expected) -> {
+              String description =
+                  String.format(
+                      "database engine specific test failed: "
+                          + "%s, JDBCType = %s, type name = %s, column size = %d, digits = %dp",
+                      rdbEngineType, given.type, given.typeName, given.columnSize, given.digits);
+              if (expected != null) {
+                DataType actual =
+                    rdbEngine.getDataTypeForScalarDb(
+                        given.type, given.typeName, given.columnSize, given.digits, "");
+                assertThat(actual).as(description).isEqualTo(expected);
+              } else {
+                Throwable thrown =
+                    catchThrowable(
+                        () ->
+                            rdbEngine.getDataTypeForScalarDb(
+                                given.type, given.typeName, given.columnSize, given.digits, ""));
+                assertThat(thrown).as(description).isInstanceOf(IllegalArgumentException.class);
+              }
+            });
+  }
+
+  private static void prepareDataTypeMap() {
+    // init
+    for (RdbEngine rdbEngine : RdbEngine.values()) {
+      DATA_TYPE_MAP.put(rdbEngine, new HashMap<>());
+    }
+
+    // BOOLEAN
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BIT, "BIT", 1, 0), DataType.BOOLEAN);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.BIT, "bool", 1, 0), DataType.BOOLEAN);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.BIT, "bit", 1, 0), DataType.BOOLEAN);
+
+    // INT
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.TINYINT, "TINYINT"), DataType.INT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.SMALLINT, "SMALLINT"), DataType.INT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.INTEGER, "INT"), DataType.INT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.INTEGER, "INT UNSIGNED"), DataType.BIGINT);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.SMALLINT, "int2"), DataType.INT);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.SMALLINT, "smallserial"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.INTEGER, "int4"), DataType.INT);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.INTEGER, "serial"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.INTEGER, "INT"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.SMALLINT, "smallint"), DataType.INT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.INTEGER, "int"), DataType.INT);
+
+    // BIGINT
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BIGINT, "BIGINT"), DataType.BIGINT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BIGINT, "BIGINT UNSIGNED"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.BIGINT, "bigint"), DataType.BIGINT);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.BIGINT, "bigserial"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.BIGINT, "BIGINT"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.BIGINT, "bigint"), DataType.BIGINT);
+
+    // FLOAT
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.REAL, "FLOAT"), DataType.FLOAT);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.REAL, "float4"), DataType.FLOAT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.REAL, "BINARY_FLOAT"), DataType.FLOAT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.REAL, "real"), DataType.FLOAT);
+
+    // DOUBLE
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.DOUBLE, "DOUBLE"), DataType.DOUBLE);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.DOUBLE, "float8"), DataType.DOUBLE);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.DOUBLE, "money"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.DOUBLE, "BINARY_DOUBLE"), DataType.DOUBLE);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.FLOAT, "FLOAT", 53, 0), DataType.DOUBLE);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.FLOAT, "FLOAT", 54, 0), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.DOUBLE, "real"), DataType.DOUBLE);
+
+    // TEXT
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.CHAR, "CHAR"), DataType.TEXT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.CHAR, "ENUM"), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.CHAR, "SET"), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.VARCHAR, "VARCHAR"), DataType.TEXT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.VARCHAR, "TINYTEXT"), DataType.TEXT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.LONGVARCHAR, "TEXT"), DataType.TEXT);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.LONGVARCHAR, "JSON"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.CHAR, "bpchar"), DataType.TEXT);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.VARCHAR, "varchar"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.CHAR, "CHAR"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.CLOB, "CLOB"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.VARCHAR, "VARCHAR2"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.NCHAR, "NCHAR"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.NCLOB, "NCLOB"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.NVARCHAR, "NVARCHAR"), DataType.TEXT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.LONGVARCHAR, "LONG"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.CHAR, "char"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.CHAR, "uniqueidentifier"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.VARCHAR, "varchar"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.NCHAR, "nchar"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.NVARCHAR, "nvarchar"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.LONGVARCHAR, "text"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.LONGNVARCHAR, "ntext"), DataType.TEXT);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.LONGNVARCHAR, "xml"), null);
+
+    // BLOB
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BINARY, "BINARY"), DataType.BLOB);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BINARY, "GEOMETRY"), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.LONGVARBINARY, "BLOB"), DataType.BLOB);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.BINARY, "bytea"), DataType.BLOB);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.BLOB, "BLOB"), DataType.BLOB);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.VARBINARY, "RAW"), DataType.BLOB);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.LONGVARBINARY, "LONG RAW"), DataType.BLOB);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.BINARY, "binary"), DataType.BLOB);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.BINARY, "timestamp"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.VARBINARY, "varbinary"), DataType.BLOB);
+
+    // NUMERIC/DECIMAL
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.NUMERIC, "NUMERIC"), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.DECIMAL, "DECIMAL"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.NUMERIC, "numeric"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.DECIMAL, "decimal"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.NUMERIC, "NUMBER", 15, 0), DataType.BIGINT);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.NUMERIC, "NUMBER", 15, 2), DataType.DOUBLE);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.NUMERIC, "NUMBER", 16, 0), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.NUMERIC, "numeric"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.DECIMAL, "decimal"), null);
+
+    // DATE/TIME/TIMESTAMP
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.DATE, "DATE"), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.TIME, "TIME"), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.TIMESTAMP, "TIMESTAMP"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.DATE, "date"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.TIME, "time"), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.TIMESTAMP, "timestamp"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.DATE, "DATE"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.TIME, "TIME"), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.TIMESTAMP, "TIMESTAMP"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.DATE, "date"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.TIME, "time"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.TIMESTAMP, "datetime"), null);
+
+    // Other unsupported data types
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.BIT, "BIT", 8, 0), null);
+    DATA_TYPE_MAP.get(MYSQL).put(new Column(JDBCType.OTHER, ""), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.BIT, "bit", 8, 0), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.SQLXML, ""), null);
+    DATA_TYPE_MAP.get(POSTGRESQL).put(new Column(JDBCType.OTHER, ""), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.OTHER, ""), null);
+    DATA_TYPE_MAP.get(ORACLE).put(new Column(JDBCType.ROWID, "ROWID"), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.BIT, "BIT", 8, 0), null);
+    DATA_TYPE_MAP.get(SQL_SERVER).put(new Column(JDBCType.OTHER, ""), null);
+  }
+
+  @Immutable
+  private static class Column {
+    final JDBCType type;
+    final String typeName;
+    final int columnSize;
+    final int digits;
+
+    Column(JDBCType type, String typeName) {
+      this(type, typeName, 0, 0);
+    }
+
+    Column(JDBCType type, String typeName, int columnSize, int digits) {
+      this.type = type;
+      this.typeName = typeName;
+      this.columnSize = columnSize;
+      this.digits = digits;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (!(o instanceof Column)) {
+        return false;
+      }
+      Column other = (Column) o;
+      return (type.equals(other.type)
+          && typeName.equals(other.typeName)
+          && columnSize == other.columnSize
+          && digits == other.digits);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(type, typeName, columnSize, digits);
+    }
+
+    @Override
+    public String toString() {
+      return String.format(
+          "ColumnMetadata { JDBCType: %s typeName: %s columnSize: %d digits: %s }",
+          type, typeName, columnSize, digits);
+    }
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.rpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -330,5 +331,24 @@ public class GrpcAdminTest {
                 .setColumnName(columnName)
                 .setColumnType(com.scalar.db.rpc.DataType.DATA_TYPE_TEXT)
                 .build());
+  }
+
+  @Test
+  public void unsupportedOperations_ShouldThrowUnsupportedException() {
+    // Arrange
+    String namespace = "sample_ns";
+    String table = "tbl";
+    String column = "col";
+
+    // Act
+    Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(namespace, table));
+    Throwable thrown2 =
+        catchThrowable(() -> admin.addRawColumnToTable(namespace, table, column, DataType.INT));
+    Throwable thrown3 = catchThrowable(() -> admin.importTable(namespace, table));
+
+    // Assert
+    assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -1,6 +1,5 @@
 package com.scalar.db.transaction.consensuscommit;
 
-import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.TRANSACTION_META_COLUMNS;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getBeforeImageColumnName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -615,7 +614,8 @@ public abstract class ConsensusCommitAdminTestBase {
     // Assert
     verify(distributedStorageAdmin).getTableMetadata(NAMESPACE, TABLE);
     verify(distributedStorageAdmin).getImportTableMetadata(NAMESPACE, TABLE);
-    for (Entry<String, DataType> entry : TRANSACTION_META_COLUMNS.entrySet()) {
+    for (Entry<String, DataType> entry :
+        ConsensusCommitUtils.getTransactionMetaColumns().entrySet()) {
       verify(distributedStorageAdmin)
           .addRawColumnToTable(NAMESPACE, TABLE, entry.getKey(), entry.getValue());
     }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -227,4 +227,21 @@ public class JdbcTransactionAdminTest {
     // Assert
     verify(jdbcAdmin).addNewColumnToTable(namespace, table, column, dataType);
   }
+
+  @Test
+  public void importTable_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
+    when(jdbcAdmin.getImportTableMetadata(namespace, table)).thenReturn(metadata);
+
+    // Act
+    admin.importTable(namespace, table);
+
+    // Assert
+    verify(jdbcAdmin).getImportTableMetadata(namespace, table);
+    verify(jdbcAdmin).repairTable(namespace, table, metadata, ImmutableMap.of());
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -233,15 +233,11 @@ public class JdbcTransactionAdminTest {
     // Arrange
     String namespace = "ns";
     String table = "tbl";
-    TableMetadata metadata =
-        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
-    when(jdbcAdmin.getImportTableMetadata(namespace, table)).thenReturn(metadata);
 
     // Act
     admin.importTable(namespace, table);
 
     // Assert
-    verify(jdbcAdmin).getImportTableMetadata(namespace, table);
-    verify(jdbcAdmin).repairTable(namespace, table, metadata, ImmutableMap.of());
+    verify(jdbcAdmin).importTable(namespace, table);
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
@@ -113,7 +113,9 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
 
   private void importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(String table) {
     // Act Assert
-    assertThatThrownBy(() -> admin.importTable(getNamespace(), table))
+    assertThatThrownBy(
+            () -> admin.importTable(getNamespace(), table),
+            "non-importable data type test failed: " + table)
         .isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
@@ -1,0 +1,125 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.service.StorageFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
+
+  private static final String TEST_NAME = "storage_admin_import_table";
+  private static final String NAMESPACE = "int_test_" + TEST_NAME;
+  private final Map<String, TableMetadata> tables = new HashMap<>();
+
+  protected DistributedStorageAdmin admin;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    initialize(TEST_NAME);
+  }
+
+  protected void initialize(String testName) throws Exception {}
+
+  protected abstract Properties getProperties(String testName);
+
+  protected String getNamespace() {
+    return NAMESPACE;
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  private void dropTable() throws Exception {
+    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
+      String table = entry.getKey();
+      TableMetadata metadata = entry.getValue();
+      if (metadata == null) {
+        dropNonImportableTable(table);
+      } else {
+        admin.dropTable(getNamespace(), table);
+      }
+    }
+    admin.dropNamespace(getNamespace());
+  }
+
+  @BeforeEach
+  protected void setUp() throws Exception {
+    StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
+    admin = factory.getStorageAdmin();
+  }
+
+  @AfterEach
+  protected void afterEach() throws Exception {
+    dropTable();
+    admin.close();
+  }
+
+  @AfterAll
+  protected void afterAll() throws Exception {}
+
+  protected abstract Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
+      throws Exception;
+
+  protected abstract void dropNonImportableTable(String table) throws Exception;
+
+  @Test
+  public void importTable_ShouldWorkProperly() throws Exception {
+    // Arrange
+    tables.putAll(createExistingDatabaseWithAllDataTypes());
+
+    // Act Assert
+    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
+      String table = entry.getKey();
+      TableMetadata metadata = entry.getValue();
+      if (metadata == null) {
+        importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(table);
+      } else {
+        importTable_ForImportableTable_ShouldImportProperly(table, metadata);
+      }
+    }
+    importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException();
+  }
+
+  @Test
+  public void importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException() {
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), "unsupported_db"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private void importTable_ForImportableTable_ShouldImportProperly(
+      String table, TableMetadata metadata) throws ExecutionException {
+    // Act
+    admin.importTable(getNamespace(), table);
+
+    // Assert
+    assertThat(admin.tableExists(getNamespace(), table)).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), table)).isEqualTo(metadata);
+  }
+
+  private void importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(String table) {
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), table))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private void importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), "non-existing-table"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
@@ -1,0 +1,125 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.service.TransactionFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DistributedTransactionAdminImportTableIntegrationTestBase {
+
+  private static final String TEST_NAME = "tx_admin_import_table";
+  private static final String NAMESPACE = "int_test_" + TEST_NAME;
+  private final Map<String, TableMetadata> tables = new HashMap<>();
+
+  protected DistributedTransactionAdmin admin;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    initialize(TEST_NAME);
+  }
+
+  protected void initialize(String testName) throws Exception {}
+
+  protected abstract Properties getProperties(String testName);
+
+  protected String getNamespace() {
+    return NAMESPACE;
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  private void dropTable() throws Exception {
+    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
+      String table = entry.getKey();
+      TableMetadata metadata = entry.getValue();
+      if (metadata == null) {
+        dropNonImportableTable(table);
+      } else {
+        admin.dropTable(getNamespace(), table);
+      }
+    }
+    admin.dropNamespace(getNamespace());
+  }
+
+  @BeforeEach
+  protected void setUp() throws Exception {
+    TransactionFactory factory = TransactionFactory.create(getProperties(TEST_NAME));
+    admin = factory.getTransactionAdmin();
+  }
+
+  @AfterEach
+  protected void afterEach() throws Exception {
+    dropTable();
+    admin.close();
+  }
+
+  @AfterAll
+  protected void afterAll() throws Exception {}
+
+  protected abstract Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
+      throws Exception;
+
+  protected abstract void dropNonImportableTable(String table) throws Exception;
+
+  @Test
+  public void importTable_ShouldWorkProperly() throws Exception {
+    // Arrange
+    tables.putAll(createExistingDatabaseWithAllDataTypes());
+
+    // Act Assert
+    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
+      String table = entry.getKey();
+      TableMetadata metadata = entry.getValue();
+      if (metadata == null) {
+        importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(table);
+      } else {
+        importTable_ForImportableTable_ShouldImportProperly(table, metadata);
+      }
+    }
+    importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException();
+  }
+
+  @Test
+  public void importTable_ForUnsupportedDatabase_ShouldThrowUnsupportedOperationException() {
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), "unsupported_db"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private void importTable_ForImportableTable_ShouldImportProperly(
+      String table, TableMetadata metadata) throws ExecutionException {
+    // Act
+    admin.importTable(getNamespace(), table);
+
+    // Assert
+    assertThat(admin.tableExists(getNamespace(), table)).isTrue();
+    assertThat(admin.getTableMetadata(getNamespace(), table)).isEqualTo(metadata);
+  }
+
+  private void importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(String table) {
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), table))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private void importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), "non-existing-table"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -1,0 +1,176 @@
+package com.scalar.db.schemaloader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
+import com.scalar.db.util.AdminTestUtils;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class SchemaLoaderImportIntegrationTestBase {
+  private static final String TEST_NAME = "schema_loader_import";
+  private static final Path CONFIG_FILE_PATH = Paths.get("config.properties").toAbsolutePath();
+  private static final Path IMPORT_SCHEMA_FILE_PATH =
+      Paths.get("import_schema.json").toAbsolutePath();
+
+  private static final String NAMESPACE_1 = "int_test_" + TEST_NAME + "1";
+  private static final String TABLE_1 = "test_table1";
+  private static final String NAMESPACE_2 = "int_test_" + TEST_NAME + "2";
+  private static final String TABLE_2 = "test_table2";
+
+  private DistributedStorageAdmin storageAdmin;
+  private DistributedTransactionAdmin transactionAdmin;
+  private String namespace1;
+  private String namespace2;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    initialize(TEST_NAME);
+    Properties properties = getProperties(TEST_NAME);
+    namespace1 = getNamespace1();
+    namespace2 = getNamespace2();
+    writeConfigFile(properties);
+    writeSchemaFile(IMPORT_SCHEMA_FILE_PATH, getImportSchemaJsonMap());
+    StorageFactory factory = StorageFactory.create(properties);
+    storageAdmin = factory.getStorageAdmin();
+    TransactionFactory transactionFactory = TransactionFactory.create(properties);
+    transactionAdmin = transactionFactory.getTransactionAdmin();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    dropTablesIfExist();
+  }
+
+  protected void initialize(String testName) throws Exception {}
+
+  protected abstract Properties getProperties(String testName);
+
+  protected void writeConfigFile(Properties properties) throws IOException {
+    try (OutputStream outputStream = Files.newOutputStream(CONFIG_FILE_PATH)) {
+      properties.store(outputStream, null);
+    }
+  }
+
+  protected String getNamespace1() {
+    return NAMESPACE_1;
+  }
+
+  protected String getNamespace2() {
+    return NAMESPACE_2;
+  }
+
+  protected abstract AdminTestUtils getAdminTestUtils(String testName);
+
+  protected Map<String, Object> getImportSchemaJsonMap() {
+    return ImmutableMap.of(
+        namespace1 + "." + TABLE_1,
+        ImmutableMap.<String, Object>builder().put("transaction", true).build(),
+        namespace2 + "." + TABLE_2,
+        ImmutableMap.<String, Object>builder().put("transaction", false).build());
+  }
+
+  protected void writeSchemaFile(Path schemaFilePath, Map<String, Object> schemaJsonMap)
+      throws IOException {
+    Gson gson = new Gson();
+    try (Writer writer = Files.newBufferedWriter(schemaFilePath)) {
+      gson.toJson(schemaJsonMap, writer);
+    }
+  }
+
+  protected List<String> getCommandArgsForImport(Path configFilePath, Path schemaFilePath) {
+    return ImmutableList.of(
+        "--config",
+        configFilePath.toString(),
+        "--schema-file",
+        schemaFilePath.toString(),
+        "--import");
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    dropTablesIfExist();
+    transactionAdmin.close();
+    storageAdmin.close();
+
+    // Delete the files
+    Files.delete(CONFIG_FILE_PATH);
+    Files.delete(IMPORT_SCHEMA_FILE_PATH);
+  }
+
+  private void dropTablesIfExist() throws Exception {
+    transactionAdmin.dropTable(namespace1, TABLE_1, true);
+    transactionAdmin.dropNamespace(namespace1, true);
+    storageAdmin.dropTable(namespace2, TABLE_2, true);
+    storageAdmin.dropNamespace(namespace2, true);
+  }
+
+  protected abstract void createExistingDatabase(String namespace) throws Exception;
+
+  protected abstract void createImportableTable(String namespace, String table) throws Exception;
+
+  protected abstract void createNonImportableTable(String namespace, String table) throws Exception;
+
+  protected abstract void dropNonImportableTable(String namespace, String table) throws Exception;
+
+  @Test
+  public void importTables_ImportableTablesGiven_ShouldImportProperly() throws Exception {
+    // Arrange
+    createExistingDatabase(namespace1);
+    createExistingDatabase(namespace2);
+    createImportableTable(namespace1, TABLE_1);
+    createImportableTable(namespace2, TABLE_2);
+
+    // Act
+    int exitCode =
+        executeWithArgs(getCommandArgsForImport(CONFIG_FILE_PATH, IMPORT_SCHEMA_FILE_PATH));
+
+    // Assert
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(transactionAdmin.tableExists(namespace1, TABLE_1)).isTrue();
+    assertThat(storageAdmin.tableExists(namespace2, TABLE_2)).isTrue();
+    assertThat(transactionAdmin.coordinatorTablesExist()).isFalse();
+  }
+
+  @Test
+  public void importTables_NonImportableTablesGiven_ShouldThrowIllegalArgumentException()
+      throws Exception {
+    // Arrange
+    createExistingDatabase(namespace1);
+    createExistingDatabase(namespace2);
+    createNonImportableTable(namespace1, TABLE_1);
+    createNonImportableTable(namespace2, TABLE_2);
+
+    // Act
+    int exitCode =
+        executeWithArgs(getCommandArgsForImport(CONFIG_FILE_PATH, IMPORT_SCHEMA_FILE_PATH));
+
+    // Assert
+    assertThat(exitCode).isEqualTo(1);
+    dropNonImportableTable(namespace1, TABLE_1);
+    dropNonImportableTable(namespace2, TABLE_2);
+  }
+
+  protected int executeWithArgs(List<String> args) {
+    return SchemaLoader.mainInternal(args.toArray(new String[0]));
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminImportTableIntegrationTestBase.java
@@ -1,0 +1,28 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import com.scalar.db.api.DistributedTransactionAdminImportTableIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+
+public abstract class ConsensusCommitAdminImportTableIntegrationTestBase
+    extends DistributedTransactionAdminImportTableIntegrationTestBase {
+
+  @Override
+  protected final Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(getProps(testName));
+    if (!properties.containsKey(DatabaseConfig.TRANSACTION_MANAGER)) {
+      properties.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "consensus-commit");
+
+      // Add testName as a coordinator namespace suffix
+      String coordinatorNamespace =
+          properties.getProperty(
+              ConsensusCommitConfig.COORDINATOR_NAMESPACE, Coordinator.NAMESPACE);
+      properties.setProperty(
+          ConsensusCommitConfig.COORDINATOR_NAMESPACE, coordinatorNamespace + "_" + testName);
+    }
+    return properties;
+  }
+
+  protected abstract Properties getProps(String testName);
+}

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
@@ -1,0 +1,44 @@
+package com.scalar.db.schemaloader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class ImportSchemaParser {
+  private final JsonObject schemaJson;
+
+  public ImportSchemaParser(Path jsonFilePath) throws SchemaLoaderException {
+    try (Reader reader = Files.newBufferedReader(jsonFilePath)) {
+      schemaJson = JsonParser.parseReader(reader).getAsJsonObject();
+    } catch (IOException | JsonParseException e) {
+      throw new SchemaLoaderException("Parsing the schema JSON failed", e);
+    }
+  }
+
+  public ImportSchemaParser(String serializedSchemaJson) throws SchemaLoaderException {
+    try {
+      schemaJson = JsonParser.parseString(serializedSchemaJson).getAsJsonObject();
+    } catch (JsonParseException e) {
+      throw new SchemaLoaderException("Parsing the schema JSON failed", e);
+    }
+  }
+
+  public List<ImportTableSchema> parse() throws SchemaLoaderException {
+    ArrayList<ImportTableSchema> tableSchemaList = new ArrayList<>();
+    for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {
+      tableSchemaList.add(
+          new ImportTableSchema(entry.getKey(), entry.getValue().getAsJsonObject()));
+    }
+    return tableSchemaList;
+  }
+}

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
@@ -34,7 +34,7 @@ public class ImportSchemaParser {
   }
 
   public List<ImportTableSchema> parse() throws SchemaLoaderException {
-    ArrayList<ImportTableSchema> tableSchemaList = new ArrayList<>();
+    List<ImportTableSchema> tableSchemaList = new ArrayList<>();
     for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {
       tableSchemaList.add(
           new ImportTableSchema(entry.getKey(), entry.getValue().getAsJsonObject()));

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
@@ -13,9 +13,10 @@ public class ImportTableSchema {
   public ImportTableSchema(String tableFullName, JsonObject tableDefinition)
       throws SchemaLoaderException {
     String[] fullName = tableFullName.split("\\.", -1);
-    if (fullName.length < 2) {
+    if (fullName.length != 2) {
       throw new SchemaLoaderException(
-          "Parsing the schema JSON failed. Table full name must contains table name and namespace");
+          "Parsing the schema JSON failed. Table full name must contains namespace and table: "
+              + tableFullName);
     }
     namespace = fullName[0];
     tableName = fullName[1];

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
@@ -1,0 +1,40 @@
+package com.scalar.db.schemaloader;
+
+import com.google.gson.JsonObject;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class ImportTableSchema {
+  private static final String TRANSACTION = "transaction";
+  private final String namespace;
+  private final String tableName;
+  private final boolean isTransactionTable;
+
+  public ImportTableSchema(String tableFullName, JsonObject tableDefinition)
+      throws SchemaLoaderException {
+    String[] fullName = tableFullName.split("\\.", -1);
+    if (fullName.length < 2) {
+      throw new SchemaLoaderException(
+          "Parsing the schema JSON failed. Table full name must contains table name and namespace");
+    }
+    namespace = fullName[0];
+    tableName = fullName[1];
+    if (tableDefinition.keySet().contains(TRANSACTION)) {
+      isTransactionTable = tableDefinition.get(TRANSACTION).getAsBoolean();
+    } else {
+      isTransactionTable = true;
+    }
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getTable() {
+    return tableName;
+  }
+
+  public boolean isTransactionTable() {
+    return isTransactionTable;
+  }
+}

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -508,6 +508,72 @@ public class SchemaLoader {
     }
   }
 
+  /**
+   * Import tables defined in the schema.
+   *
+   * @param configProperties ScalarDB config properties
+   * @param serializedSchemaJson serialized json string schema.
+   * @throws SchemaLoaderException thrown when importing tables fails.
+   */
+  public static void importTables(Properties configProperties, String serializedSchemaJson)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Right<>(configProperties);
+    Either<Path, String> schema = new Right<>(serializedSchemaJson);
+    importTables(config, schema);
+  }
+
+  /**
+   * Import tables defined in the schema file.
+   *
+   * @param configProperties ScalarDB properties.
+   * @param schemaPath path to the schema file.
+   * @throws SchemaLoaderException thrown when importing tables fails.
+   */
+  public static void importTables(Properties configProperties, Path schemaPath)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Right<>(configProperties);
+    Either<Path, String> schema = new Left<>(schemaPath);
+    importTables(config, schema);
+  }
+
+  /**
+   * Import tables defined in the schema.
+   *
+   * @param configPath path to the ScalarDB config.
+   * @param serializedSchemaJson serialized json string schema.
+   * @throws SchemaLoaderException thrown when importing tables fails.
+   */
+  public static void importTables(Path configPath, String serializedSchemaJson)
+      throws SchemaLoaderException {
+    Either<Path, Properties> config = new Left<>(configPath);
+    Either<Path, String> schema = new Right<>(serializedSchemaJson);
+    importTables(config, schema);
+  }
+
+  /**
+   * Import tables defined in the schema file.
+   *
+   * @param configPath path to the ScalarDB config.
+   * @param schemaPath path to the schema file.
+   * @throws SchemaLoaderException thrown when importing tables fails.
+   */
+  public static void importTables(Path configPath, Path schemaPath) throws SchemaLoaderException {
+    Either<Path, Properties> config = new Left<>(configPath);
+    Either<Path, String> schema = new Left<>(schemaPath);
+    importTables(config, schema);
+  }
+
+  private static void importTables(Either<Path, Properties> config, Either<Path, String> schema)
+      throws SchemaLoaderException {
+    // Parse the schema
+    List<ImportTableSchema> tableSchemaList = getImportTableSchemaList(schema);
+
+    // Import tables
+    try (SchemaOperator operator = getSchemaOperator(config)) {
+      operator.importTables(tableSchemaList);
+    }
+  }
+
   @VisibleForTesting
   static SchemaOperator getSchemaOperator(Either<Path, Properties> config)
       throws SchemaLoaderException {
@@ -543,6 +609,28 @@ public class SchemaLoader {
       return new SchemaParser(schema.getLeft(), options);
     } else {
       return new SchemaParser(schema.getRight(), options);
+    }
+  }
+
+  private static List<ImportTableSchema> getImportTableSchemaList(Either<Path, String> schema)
+      throws SchemaLoaderException {
+    if ((schema.isLeft() && schema.getLeft() != null)
+        || (schema.isRight() && schema.getRight() != null)) {
+      ImportSchemaParser schemaParser = getImportSchemaParser(schema);
+      return schemaParser.parse();
+    }
+    return Collections.emptyList();
+  }
+
+  @VisibleForTesting
+  static ImportSchemaParser getImportSchemaParser(Either<Path, String> schema)
+      throws SchemaLoaderException {
+    assert (schema.isLeft() && schema.getLeft() != null)
+        || (schema.isRight() && schema.getRight() != null);
+    if (schema.isLeft()) {
+      return new ImportSchemaParser(schema.getLeft());
+    } else {
+      return new ImportSchemaParser(schema.getRight());
     }
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -364,6 +364,24 @@ public class SchemaOperator implements AutoCloseable {
     }
   }
 
+  public void importTables(List<ImportTableSchema> tableSchemaList) throws SchemaLoaderException {
+    for (ImportTableSchema tableSchema : tableSchemaList) {
+      String namespace = tableSchema.getNamespace();
+      String table = tableSchema.getTable();
+      try {
+        if (tableSchema.isTransactionTable()) {
+          transactionAdmin.get().importTable(namespace, table);
+        } else {
+          storageAdmin.get().importTable(namespace, table);
+        }
+        logger.info("Importing the table {} in the namespace {} succeeded.", table, namespace);
+      } catch (ExecutionException e) {
+        throw new SchemaLoaderException(
+            String.format("Importing the table %s.%s failed.", namespace, table), e);
+      }
+    }
+  }
+
   @Override
   public void close() {
     if (storageAdminLoaded.get()) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -93,8 +93,8 @@ public class SchemaLoaderCommand implements Callable<Integer> {
 
     @Option(
         names = {"-I", "--import"},
-        description = "",
-        defaultValue = "")
+        description = "Import tables : it will import existing non-ScalarDB tables to ScalarDB.",
+        defaultValue = "false")
     boolean importTables;
   }
 

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -90,6 +90,12 @@ public class SchemaLoaderCommand implements Callable<Integer> {
                 + "It compares the provided table schema to the existing schema to decide which columns need to be added and which indexes need to be created or deleted",
         defaultValue = "false")
     boolean alterTables;
+
+    @Option(
+        names = {"-I", "--import"},
+        description = "",
+        defaultValue = "")
+    boolean importTables;
   }
 
   @Override
@@ -105,6 +111,8 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       repairTables();
     } else if (mode.alterTables) {
       alterTables();
+    } else if (mode.importTables) {
+      importTables();
     }
     return 0;
   }
@@ -155,5 +163,20 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       options.put(DynamoAdmin.NO_SCALING, noScaling.toString());
     }
     SchemaLoader.alterTables(configPath, schemaFile, options);
+  }
+
+  private void importTables() throws SchemaLoaderException {
+    if (schemaFile == null) {
+      throw new IllegalArgumentException(
+          "Specifying the '--schema-file' option is required when using the '--import' option");
+    }
+
+    if (coordinator) {
+      throw new IllegalArgumentException(
+          "Specifying the '--coordinator' option with the '--import' option is not allowed."
+              + " Create coordinator tables separately.");
+    }
+
+    SchemaLoader.importTables(configPath, schemaFile);
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/ImportSchemaParserTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/ImportSchemaParserTest.java
@@ -1,0 +1,68 @@
+package com.scalar.db.schemaloader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ImportSchemaParserTest {
+
+  @Test
+  public void parse_ProperSerializedSchemaJsonAndOptionsGiven_ShouldParseCorrectly()
+      throws SchemaLoaderException {
+    // Arrange
+    String serializedSchemaJson =
+        "{"
+            + "  \"sample_db.sample_table1\": {"
+            + "    \"transaction\": true"
+            + "  },"
+            + "  \"sample_db.sample_table2\": {"
+            + "    \"transaction\": false"
+            + "  },"
+            + "  \"sample_db.sample_table3\": {" // unrelated options are expected to be ignored
+            + "    \"partition-key\": ["
+            + "      \"c1\","
+            + "      \"c2\""
+            + "    ],"
+            + "    \"clustering-key\": ["
+            + "      \"c3 ASC\","
+            + "      \"c4 DESC\""
+            + "    ],"
+            + "    \"columns\": {"
+            + "      \"c1\": \"INT\","
+            + "      \"c2\": \"TEXT\","
+            + "      \"c3\": \"BLOB\","
+            + "      \"c4\": \"FLOAT\","
+            + "      \"c5\": \"BOOLEAN\","
+            + "      \"c6\": \"DOUBLE\","
+            + "      \"c7\": \"BIGINT\""
+            + "    },"
+            + "    \"secondary-index\": ["
+            + "      \"c5\","
+            + "      \"c6\""
+            + "    ],"
+            + "    \"ru\": 5000,"
+            + "    \"compaction-strategy\": \"LCS\""
+            + "  }"
+            + "}";
+    ImportSchemaParser parser = new ImportSchemaParser(serializedSchemaJson);
+
+    // Act
+    List<ImportTableSchema> actual = parser.parse();
+
+    // Assert
+    assertThat(actual.size()).isEqualTo(3);
+
+    assertThat(actual.get(0).getNamespace()).isEqualTo("sample_db");
+    assertThat(actual.get(0).getTable()).isEqualTo("sample_table1");
+    assertThat(actual.get(0).isTransactionTable()).isTrue();
+
+    assertThat(actual.get(1).getNamespace()).isEqualTo("sample_db");
+    assertThat(actual.get(1).getTable()).isEqualTo("sample_table2");
+    assertThat(actual.get(1).isTransactionTable()).isFalse();
+
+    assertThat(actual.get(2).getNamespace()).isEqualTo("sample_db");
+    assertThat(actual.get(2).getTable()).isEqualTo("sample_table3");
+    assertThat(actual.get(2).isTransactionTable()).isTrue();
+  }
+}

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/ImportTableSchemaTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/ImportTableSchemaTest.java
@@ -1,0 +1,74 @@
+package com.scalar.db.schemaloader;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ImportTableSchemaTest {
+
+  @Mock private JsonObject tableDefinition;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void constructor_DefinitionWithTransactionTrueGiven_ShouldConstructProperTableSchema()
+      throws SchemaLoaderException {
+    String tableDefinitionJson = "{\"transaction\": true}";
+    JsonObject tableDefinition = JsonParser.parseString(tableDefinitionJson).getAsJsonObject();
+
+    // Act
+    ImportTableSchema tableSchema = new ImportTableSchema("ns.tbl", tableDefinition);
+
+    // Assert
+    Assertions.assertThat(tableSchema.getNamespace()).isEqualTo("ns");
+    Assertions.assertThat(tableSchema.getTable()).isEqualTo("tbl");
+    Assertions.assertThat(tableSchema.isTransactionTable()).isEqualTo(true);
+  }
+
+  @Test
+  public void constructor_DefinitionWithTransactionFalseGiven_ShouldConstructProperTableSchema()
+      throws SchemaLoaderException {
+    String tableDefinitionJson = "{\"transaction\": false}";
+    JsonObject tableDefinition = JsonParser.parseString(tableDefinitionJson).getAsJsonObject();
+
+    // Act
+    ImportTableSchema tableSchema = new ImportTableSchema("ns.tbl", tableDefinition);
+
+    // Assert
+    Assertions.assertThat(tableSchema.getNamespace()).isEqualTo("ns");
+    Assertions.assertThat(tableSchema.getTable()).isEqualTo("tbl");
+    Assertions.assertThat(tableSchema.isTransactionTable()).isEqualTo(false);
+  }
+
+  @Test
+  public void constructor_WrongFormatTableFullNameGiven_ShouldThrowSchemaLoaderException() {
+    // Arrange
+    String tableFullName = "namespace_and_table_without_dot_separator";
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> new ImportTableSchema(tableFullName, tableDefinition))
+        .isInstanceOf(SchemaLoaderException.class);
+  }
+
+  @Test
+  public void constructor_DefinitionWithoutTransactionGiven_ShouldConstructProperTableSchema()
+      throws SchemaLoaderException {
+    String tableDefinitionJson = "{}";
+    JsonObject tableDefinition = JsonParser.parseString(tableDefinitionJson).getAsJsonObject();
+
+    // Act
+    ImportTableSchema tableSchema = new ImportTableSchema("ns.tbl", tableDefinition);
+
+    // Assert
+    Assertions.assertThat(tableSchema.getNamespace()).isEqualTo("ns");
+    Assertions.assertThat(tableSchema.getTable()).isEqualTo("tbl");
+    Assertions.assertThat(tableSchema.isTransactionTable()).isEqualTo(true);
+  }
+}

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
@@ -27,6 +27,7 @@ public class SchemaLoaderTest {
 
   @Mock private SchemaOperator operator;
   @Mock private SchemaParser parser;
+  @Mock private ImportSchemaParser importSchemaParser;
 
   @Mock private Path configFilePath;
   @Mock private Properties configProperties;
@@ -44,8 +45,11 @@ public class SchemaLoaderTest {
     schemaLoaderMockedStatic
         .when(() -> SchemaLoader.getSchemaParser(any(), anyMap()))
         .thenReturn(parser);
-
+    schemaLoaderMockedStatic
+        .when(() -> SchemaLoader.getImportSchemaParser(any()))
+        .thenReturn(importSchemaParser);
     when(parser.parse()).thenReturn(Collections.emptyList());
+    when(importSchemaParser.parse()).thenReturn(Collections.emptyList());
   }
 
   @AfterEach
@@ -706,5 +710,60 @@ public class SchemaLoaderTest {
     // Assert
     verify(parser).parse();
     verify(operator).alterTables(anyList(), anyMap());
+  }
+
+  @Test
+  public void
+      importTable_WithConfigPropertiesAndSerializedSchema_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.importTables(configProperties, SERIALIZED_SCHEMA_JSON);
+
+    // Assert
+    verify(importSchemaParser).parse();
+    verify(operator).importTables(anyList());
+  }
+
+  @Test
+  public void
+      importTable_WithConfigFilePathAndSerializedSchema_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.importTables(configFilePath, SERIALIZED_SCHEMA_JSON);
+
+    // Assert
+    verify(importSchemaParser).parse();
+    verify(operator).importTables(anyList());
+  }
+
+  @Test
+  public void
+      importTable_WithConfigPropertiesAndSchemaFilePath_ShouldCallParserAndOperatorProperly()
+          throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.importTables(configProperties, schemaFilePath);
+
+    // Assert
+    verify(importSchemaParser).parse();
+    verify(operator).importTables(anyList());
+  }
+
+  @Test
+  public void importTable_WithConfigFilePathAndSchemaFilePath_ShouldCallParserAndOperatorProperly()
+      throws Exception {
+    // Arrange
+
+    // Act
+    SchemaLoader.importTables(configFilePath, schemaFilePath);
+
+    // Assert
+    verify(importSchemaParser).parse();
+    verify(operator).importTables(anyList());
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
@@ -349,4 +349,46 @@ public class SchemaLoaderCommandTest {
     Assertions.assertThat(exitCode).isEqualTo(1);
     schemaLoaderMockedStatic.verifyNoInteractions();
   }
+
+  @Test
+  public void call_ImportOptionGivenWithProperArguments_ShouldCallRepairTableProperly() {
+    // Arrange
+    String schemaFile = "path_to_file";
+    String configFile = "path_to_config_file";
+
+    // Act
+    commandLine.execute("-f", schemaFile, "--import", "--config", configFile);
+
+    // Assert
+    schemaLoaderMockedStatic.verify(
+        () -> SchemaLoader.importTables(Paths.get(configFile), Paths.get(schemaFile)));
+  }
+
+  @Test
+  public void call_ImportOptionGivenWithoutSchemaFile_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    String configFile = "path_to_config_file";
+
+    // Act
+    int exitCode = commandLine.execute("--import", "--config", configFile);
+
+    // Assert
+    Assertions.assertThat(exitCode).isEqualTo(1);
+    schemaLoaderMockedStatic.verifyNoInteractions();
+  }
+
+  @Test
+  public void call_ImportOptionGivenWithCoordinatorArgument_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    String schemaFile = "path_to_file";
+    String configFile = "path_to_config_file";
+
+    // Act
+    int exitCode =
+        commandLine.execute("-f", schemaFile, "--import", "--config", configFile, "--coordinator");
+
+    // Assert
+    Assertions.assertThat(exitCode).isEqualTo(1);
+    schemaLoaderMockedStatic.verifyNoInteractions();
+  }
 }

--- a/server/src/main/java/com/scalar/db/server/DistributedStorageAdminService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedStorageAdminService.java
@@ -21,6 +21,7 @@ import com.scalar.db.rpc.RepairTableRequest;
 import com.scalar.db.rpc.TruncateTableRequest;
 import com.scalar.db.util.ProtoUtils;
 import com.scalar.db.util.ThrowableRunnable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.util.Set;
@@ -38,6 +39,7 @@ public class DistributedStorageAdminService
   private final DistributedStorageAdmin admin;
   private final Metrics metrics;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public DistributedStorageAdminService(DistributedStorageAdmin admin, Metrics metrics) {
     this.admin = admin;
     this.metrics = metrics;


### PR DESCRIPTION
This PR adds a table-importing feature to enable users to import their existing databases to ScalarDB. Sorry for the big PR.

You can import your existing databases using schema-loader with the `--import` option. For the `--import` option, you need to specify a schema JSON file with `-f`. The grammar of the schema file is basically the same as the usual loading, but it only requires a namespace, table, and transactional flag. Other items are ignored, and you don't have to specify columns since the import function automatically reads table metadata and recognizes columns.

Note that we do not support SQLite at this moment.  Rough policies of supported data types are as follows.

- We do not support data types that are larger or have higher precision than any of the ScalarDB data types.
  - The only exception is BIGINT. Our BIGINT is a little smaller than a regular 8-byte BIGINT due to the DynamoDB support, but I left BIGINT supported with a warning because we plan to remove this limitation (w/o DynamoDB).
- We notify users when we use a ScalarDB data type for an underlying data type that is smaller or has lower precision than ScalarDB's one.
- NUMERIC and DECIMAL are currently not supported.
- See inline comments for all supported (mapped data types) and unsupported data types, respectively.
