### PR TITLE
Avoid decrementing outstanding requests counter duplicately

### DIFF
--- a/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
+++ b/server/src/main/java/com/scalar/db/server/DistributedTransactionService.java
@@ -176,6 +176,7 @@ public class DistributedTransactionService
     private final Function<StreamObserver<?>, Boolean> preProcessor;
     private final Runnable postProcessor;
     private final AtomicBoolean preProcessed = new AtomicBoolean();
+    private final AtomicBoolean postProcessed = new AtomicBoolean();
 
     private DistributedTransaction transaction;
 
@@ -320,6 +321,13 @@ public class DistributedTransactionService
       responseObserver.onNext(responseBuilder.build());
       if (completed) {
         responseObserver.onCompleted();
+        postProcess();
+      }
+    }
+
+    private void postProcess() {
+      // postProcessor is executed only once after preProcessor is executed
+      if (preProcessed.get() && postProcessed.compareAndSet(false, true)) {
         postProcessor.run();
       }
     }
@@ -441,7 +449,7 @@ public class DistributedTransactionService
         }
       }
 
-      postProcessor.run();
+      postProcess();
     }
 
     private void respondInternalError(String message) {


### PR DESCRIPTION
Currently, there is a chance that the outgoing requests counter could be decremented twice when a transaction is being committed or rolled back, and an error occurs simultaneously. To prevent this, this PR introduces a safety measure to ensure the counter is only decremented once. Please take a look!