### PR TITLE
Add join() to DistributedTransactionManager

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -197,6 +197,18 @@ public interface DistributedTransactionManager {
       throws TransactionException;
 
   /**
+   * Joins an ongoing transaction associated with the specified transaction ID.
+   *
+   * @param txId the transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction associated with the specified
+   *     transaction ID is not found. You can retry the transaction from the beginning
+   */
+  default DistributedTransaction join(String txId) throws TransactionNotFoundException {
+    return resume(txId);
+  }
+
+  /**
    * Resumes an ongoing transaction associated with the specified transaction ID.
    *
    * @param txId the transaction ID

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -283,6 +283,71 @@ public class ConsensusCommitManagerTest {
   }
 
   @Test
+  public void join_CalledWithBegin_ReturnSameTransactionObject() throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction1 = manager.begin(ANY_TX_ID);
+
+    // Act
+    DistributedTransaction transaction2 = manager.join(ANY_TX_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void join_CalledWithoutBegin_ThrowTransactionNotFoundException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.join(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  public void join_CalledWithBeginAndCommit_ThrowTransactionNotFoundException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID);
+    transaction.commit();
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.join(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
+  public void join_CalledWithBeginAndCommit_CommitExceptionThrown_ReturnSameTransactionObject()
+      throws TransactionException {
+    // Arrange
+    doThrow(CommitException.class).when(commit).commit(any());
+
+    DistributedTransaction transaction1 = manager.begin(ANY_TX_ID);
+    try {
+      transaction1.commit();
+    } catch (CommitException ignored) {
+      // expected
+    }
+
+    // Act
+    DistributedTransaction transaction2 = manager.join(ANY_TX_ID);
+
+    // Assert
+    assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void join_CalledWithBeginAndRollback_ThrowTransactionNotFoundException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin(ANY_TX_ID);
+    transaction.rollback();
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.join(ANY_TX_ID))
+        .isInstanceOf(TransactionNotFoundException.class);
+  }
+
+  @Test
   public void check_StateReturned_ReturnTheState() throws CoordinatorException {
     // Arrange
     TransactionState expected = TransactionState.COMMITTED;

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -305,18 +305,31 @@ DistributedTransaction transaction = transactionManager.start("<transaction ID>"
 
 Note that you must guarantee uniqueness of the transaction ID in this case.
 
+### Join a transaction
+
+You can join an ongoing transaction that has already begun with specifying a transaction ID as follows:
+
+```java
+// Join a transaction
+DistributedTransaction transaction = transactionManager.join("<transaction ID>");
+```
+
+This is particularly useful in a stateful application where a transaction spans across multiple client requests.
+In such a scenario, the application can start a transaction during the first client request.
+Then, in the subsequent client requests, it can join the ongoing transaction using the `join()` method.
+
 ### Resume a transaction
 
-You can resume a transaction you have already begun with specifying a transaction ID as follows:
+You can resume an ongoing transaction you have already begun with specifying a transaction ID as follows:
 
 ```java
 // Resume a transaction
 DistributedTransaction transaction = transactionManager.resume("<transaction ID>");
 ```
 
-It is helpful in a stateful application where a transaction spans multiple client requests.
-In that case, the application can begin a transaction in the first client request.
-And in the following client requests, it can resume the transaction with the `resume()` method.
+This is particularly useful in a stateful application where a transaction spans across multiple client requests.
+In such a scenario, the application can start a transaction during the first client request.
+Then, in the subsequent client requests, it can resume the ongoing transaction using the `resume()` method.
 
 ### CRUD operations
 


### PR DESCRIPTION
This PR adds the `join()` method to `DistributedTransactionManager`. With this method, we can join an ongoing transaction managed by a transaction manager. In fact, this method works in the same way as the `resume()` method.

This method is particularly useful in a stateful application where a transaction spans across multiple client requests. In such a scenario, the application can start a transaction during the first client request. Then, in the subsequent client requests, it can join the ongoing transaction using the `join()` method.

`TwoPhaseCommitTransactionManager` already includes the `join()` method. Therefore, for the sake of consistency, I think we can also add it to `DistributedTransactionManager.`

Please take a look!