### PR TITLE
Fix CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext {
         guiceVersion = '5.1.0'
-        guavaVersion = '31.1-jre'
+        guavaVersion = '32.1.1-jre'
         slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.11.3'
         azureCosmosVersion = '4.47.0'


### PR DESCRIPTION
This PR fixes CVE-2023-2976 by upgrading the Guava library to version `32.1.1-jre`. Please take a look!