### PR TITLE
Backport to branch(3) : Fix utility method to check transactional table metadata

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -117,10 +117,10 @@ public final class ConsensusCommitUtils {
       //   - the column name without the "before_" prefix
       // if both columns don't exist, the table metadata is not transactional
       if (!tableMetadata.getColumnNames().contains(Attribute.BEFORE_PREFIX + nonPrimaryKeyColumn)
-          && !nonPrimaryKeyColumn.startsWith(Attribute.BEFORE_PREFIX)
-          && !tableMetadata
-              .getColumnNames()
-              .contains(nonPrimaryKeyColumn.substring(Attribute.BEFORE_PREFIX.length()))) {
+          && !(nonPrimaryKeyColumn.startsWith(Attribute.BEFORE_PREFIX)
+              && tableMetadata
+                  .getColumnNames()
+                  .contains(nonPrimaryKeyColumn.substring(Attribute.BEFORE_PREFIX.length())))) {
         return false;
       }
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtilsTest.java
@@ -192,7 +192,7 @@ public class ConsensusCommitUtilsTest {
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
     final String BALANCE = "balance";
-
+    // the 'Attribute.ID' column is missing
     TableMetadata metadata =
         TableMetadata.newBuilder()
             .addColumn(ACCOUNT_ID, DataType.INT)
@@ -221,12 +221,48 @@ public class ConsensusCommitUtilsTest {
 
   @Test
   public void
+      isTransactionTableMetadata_TransactionTableMetadataWithoutProperAfterColumnGiven_shouldReturnFalse() {
+    // Arrange
+    final String ACCOUNT_ID = "account_id";
+    final String ACCOUNT_TYPE = "account_type";
+    final String FOO = "foo";
+
+    // the 'before_foo' column exists but the 'foo' column is missing
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREFIX + FOO, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_ID, DataType.TEXT)
+            .addColumn(Attribute.BEFORE_STATE, DataType.INT)
+            .addColumn(Attribute.BEFORE_VERSION, DataType.INT)
+            .addColumn(Attribute.BEFORE_PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.BEFORE_COMMITTED_AT, DataType.BIGINT)
+            .addColumn(Attribute.ID, DataType.TEXT)
+            .addColumn(Attribute.STATE, DataType.INT)
+            .addColumn(Attribute.VERSION, DataType.INT)
+            .addColumn(Attribute.PREPARED_AT, DataType.BIGINT)
+            .addColumn(Attribute.COMMITTED_AT, DataType.BIGINT)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .build();
+
+    // Act
+    boolean actual = ConsensusCommitUtils.isTransactionTableMetadata(metadata);
+
+    // Assert
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  public void
       isTransactionTableMetadata_TransactionTableMetadataWithoutProperBeforeColumnGiven_shouldReturnFalse() {
     // Arrange
     final String ACCOUNT_ID = "account_id";
     final String ACCOUNT_TYPE = "account_type";
     final String BALANCE = "balance";
 
+    // the 'balance' column exists but the 'before_balance' column is missing
     TableMetadata metadata =
         TableMetadata.newBuilder()
             .addColumn(ACCOUNT_ID, DataType.INT)


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/950