### PR TITLE
Update the ScalarDB dependency version to 3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1'
+    implementation 'com.scalar-labs:scalardb:3.10.0'
 }
 ```
 
@@ -22,7 +22,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.9.1</version>
+  <version>3.10.0</version>
 </dependency>
 ```
 

--- a/docs/add-scalardb-to-your-build.md
+++ b/docs/add-scalardb-to-your-build.md
@@ -6,7 +6,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1'
+    implementation 'com.scalar-labs:scalardb:3.10.0'
 }
 ```
 
@@ -15,6 +15,6 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.9.1</version>
+  <version>3.10.0</version>
 </dependency>
 ```

--- a/docs/getting-started/build.gradle
+++ b/docs/getting-started/build.gradle
@@ -9,7 +9,7 @@ repositories {
 mainClassName = "sample.ElectronicMoneyMain"
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1'
+    implementation 'com.scalar-labs:scalardb:3.10.0'
     implementation 'org.slf4j:slf4j-simple:1.7.30'
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.1'
+    implementation 'com.scalar-labs:scalardb:3.10.0'
 }
 ```
 
@@ -22,7 +22,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.9.1</version>
+  <version>3.10.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Since we have released 3.10.0, this PR update the ScalarDB dependency version. Please take a look!