### PR TITLE
Use PAT that has `workflows` permission in auto-pr

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -20,6 +20,8 @@ jobs:
         with:
           # This is necessary to avoid unexpected auto-merge in git cherry-pick
           fetch-depth: 0
+          # This is necessary for git-push
+          token: ${{ secrets.GH_PR_PAT }}
 
       - name: Create pull requests
         run: |


### PR DESCRIPTION
## Context

An Auto-PR workflow job failed https://github.com/scalar-labs/scalardb/actions/runs/5606662051/jobs/10257033504 due to a failure of git-push for GHA workflow files.

```
To https://github.com/scalar-labs/scalardb
 ! [remote rejected]   3-pull-931 -> 3-pull-931 (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yaml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/scalar-labs/scalardb'
```

It seems the git-push attempt doesn't use the PAT which has `workflows` permission.

## Changes

This PR sets `token` parameter of `actions/checkout` to make subsequent git-push succeed.

```markdown
    # Personal access token (PAT) used to fetch the repository. The PAT is configured
    # with the local git config, which enables your scripts to run authenticated git
    # commands. The post-job step removes the PAT.
```
https://github.com/actions/checkout#usage