### PR TITLE
Escape PR title in `auto-pr` workflow

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_PR_PAT }}
+      # Escape the PR title. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable for details
+      PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -49,7 +51,7 @@ jobs:
           ci/auto-pr/create_pull_requests \
             "${{ github.event.number }}" \
             "${{ github.event.pull_request.html_url }}" \
-            "${{ github.event.pull_request.title }}" \
+            "$PR_TITLE" \
             "${{ github.sha }}" \
             "$new_pr_assignee" \
             $branches


### PR DESCRIPTION
## Context

The `auto-pr` workflow failed in https://github.com/scalar-labs/scalardb/actions/runs/5850991695. The cause was the PR title contained double quotes.

## Changes

This PR escapes quotes in PR title using [a recommended way](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).
