### PR TITLE
Fix broken links to the "Getting Started" doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To add a dependency using Maven:
 ```
 
 ## Docs
-* [Getting started](docs/getting-started.md)
+* [Getting started](docs/getting-started-with-scalardb.md)
 * [Java API Guide](docs/api-guide.md)
 * [ScalarDB Samples](https://github.com/scalar-labs/scalardb-samples)
 * [ScalarDB Server](docs/scalardb-server.md)

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -930,7 +930,7 @@ scalar.db.consensus_commit.include_metadata.enabled=true
 ## References
 
 * [Design document](design.md)
-* [Getting started](getting-started.md)
+* [Getting started](getting-started-with-scalardb.md)
 * [Multi-storage Transactions](multi-storage-transactions.md)
 * [Two-phase Commit Transactions](two-phase-commit-transactions.md)
 * [ScalarDB Server](scalardb-server.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ To add a dependency using Maven:
 ```
 
 ## Docs
-* [Getting started](getting-started.md)
+* [Getting started](getting-started-with-scalardb.md)
 * [Java API Guide](api-guide.md)
 * [ScalarDB Samples](https://github.com/scalar-labs/scalardb-samples)
 * [ScalarDB Server](scalardb-server.md)

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -21,7 +21,7 @@ This section explains how the Storage API can be used in a simple electronic mon
 ### ScalarDB configuration
 
 The configuration is the same as when you use the ACID transaction manager.
-Please see [Getting Started](getting-started.md) for the details of the configuration.
+Please see [Getting Started](getting-started-with-scalardb.md) for the details of the configuration.
 
 From here, we assume that the configuration file **scalardb.properties** exists.
 
@@ -773,6 +773,6 @@ Scan scanUsingSpecifiedNamespace =
 
 * [Java API Guide](api-guide.md)
 * [Design document](design.md)
-* [Getting started](getting-started.md)
+* [Getting started](getting-started-with-scalardb.md)
 * [ScalarDB Server](scalardb-server.md)
 * [Schema Loader](schema-loader.md)


### PR DESCRIPTION
This PR fixes broken links that were not updated in the https://github.com/scalar-labs/scalardb/pull/990.

I've replaced the broken link with the link that points to [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).