### PR TITLE
Make Cosmos DTO objects immutable

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminTestUtils.java
@@ -12,10 +12,10 @@ import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.util.CosmosPagedIterable;
-import com.google.common.collect.ImmutableList;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
+import org.assertj.core.util.Sets;
 
 public class CosmosAdminTestUtils extends AdminTestUtils {
 
@@ -65,9 +65,11 @@ public class CosmosAdminTestUtils extends AdminTestUtils {
 
   @Override
   public void corruptMetadata(String namespace, String table) {
-    CosmosTableMetadata corruptedMetadata = new CosmosTableMetadata();
-    corruptedMetadata.setId(getFullTableName(namespace, table));
-    corruptedMetadata.setPartitionKeyNames(ImmutableList.of("corrupted"));
+    CosmosTableMetadata corruptedMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("corrupted"))
+            .build();
 
     CosmosContainer container =
         client.getDatabase(metadataDatabase).getContainer(CosmosAdmin.METADATA_CONTAINER);

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -243,15 +243,9 @@ public class CosmosAdmin implements DistributedStorageAdmin {
 
   private CosmosTableMetadata convertToCosmosTableMetadata(
       String fullTableName, TableMetadata tableMetadata) {
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setId(fullTableName);
-    cosmosTableMetadata.setPartitionKeyNames(new ArrayList<>(tableMetadata.getPartitionKeyNames()));
-    cosmosTableMetadata.setClusteringKeyNames(
-        new ArrayList<>(tableMetadata.getClusteringKeyNames()));
-    cosmosTableMetadata.setClusteringOrders(
+    Map<String, String> clusteringOrders =
         tableMetadata.getClusteringKeyNames().stream()
-            .collect(Collectors.toMap(c -> c, c -> tableMetadata.getClusteringOrder(c).name())));
-    cosmosTableMetadata.setSecondaryIndexNames(tableMetadata.getSecondaryIndexNames());
+            .collect(Collectors.toMap(c -> c, c -> tableMetadata.getClusteringOrder(c).name()));
     Map<String, String> columnTypeByName = new HashMap<>();
     tableMetadata
         .getColumnNames()
@@ -259,8 +253,14 @@ public class CosmosAdmin implements DistributedStorageAdmin {
             columnName ->
                 columnTypeByName.put(
                     columnName, tableMetadata.getColumnDataType(columnName).name().toLowerCase()));
-    cosmosTableMetadata.setColumns(columnTypeByName);
-    return cosmosTableMetadata;
+    return CosmosTableMetadata.newBuilder()
+        .id(fullTableName)
+        .partitionKeyNames(tableMetadata.getPartitionKeyNames())
+        .clusteringKeyNames(tableMetadata.getClusteringKeyNames())
+        .clusteringOrders(clusteringOrders)
+        .secondaryIndexNames(tableMetadata.getSecondaryIndexNames())
+        .columns(columnTypeByName)
+        .build();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosMutation.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosMutation.java
@@ -14,6 +14,7 @@ import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.Column;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
@@ -53,20 +54,18 @@ public class CosmosMutation extends CosmosOperation {
   @Nonnull
   public Record makeRecord() {
     Mutation mutation = (Mutation) getOperation();
-    Record record = new Record();
 
     if (mutation instanceof Delete) {
-      return record;
+      return new Record();
     }
     Put put = (Put) mutation;
 
-    record.setId(getId());
-    record.setConcatenatedPartitionKey(getConcatenatedPartitionKey());
-    record.setPartitionKey(toMap(put.getPartitionKey().getColumns()));
-    put.getClusteringKey().ifPresent(k -> record.setClusteringKey(toMap(k.getColumns())));
-    record.setValues(toMapForPut(put));
-
-    return record;
+    return new Record(
+        getId(),
+        getConcatenatedPartitionKey(),
+        toMap(put.getPartitionKey().getColumns()),
+        put.getClusteringKey().map(k -> toMap(k.getColumns())).orElse(Collections.emptyMap()),
+        toMapForPut(put));
   }
 
   @Nonnull

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
@@ -2,12 +2,13 @@ package com.scalar.db.storage.cosmos;
 
 import com.google.common.base.MoreObjects;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A metadata class for a table of ScalarDB to know the type of each column
@@ -15,39 +16,44 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @author Yuji Ito
  */
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
-@NotThreadSafe
+@ThreadSafe
 public class CosmosTableMetadata {
-  private String id;
-  private LinkedHashSet<String> partitionKeyNames;
-  private LinkedHashSet<String> clusteringKeyNames;
-  private Map<String, String> clusteringOrders;
-  private Set<String> secondaryIndexNames;
-  private Map<String, String> columns;
+  private final String id;
+  private final LinkedHashSet<String> partitionKeyNames;
+  private final LinkedHashSet<String> clusteringKeyNames;
+  private final Map<String, String> clusteringOrders;
+  private final Set<String> secondaryIndexNames;
+  private final Map<String, String> columns;
 
-  public CosmosTableMetadata() {}
-
-  public void setId(String id) {
-    this.id = id;
+  public CosmosTableMetadata() {
+    this(null, null, null, null, null, null);
   }
 
-  public void setPartitionKeyNames(List<String> partitionKeyNames) {
-    this.partitionKeyNames = new LinkedHashSet<>(partitionKeyNames);
+  public CosmosTableMetadata(
+      @Nullable String id,
+      @Nullable LinkedHashSet<String> partitionKeyNames,
+      @Nullable LinkedHashSet<String> clusteringKeyNames,
+      @Nullable Map<String, String> clusteringOrders,
+      @Nullable Set<String> secondaryIndexNames,
+      @Nullable Map<String, String> columns) {
+    this.id = id != null ? id : "";
+    this.partitionKeyNames = partitionKeyNames != null ? partitionKeyNames : new LinkedHashSet<>();
+    this.clusteringKeyNames =
+        clusteringKeyNames != null ? clusteringKeyNames : new LinkedHashSet<>();
+    this.clusteringOrders = clusteringOrders != null ? clusteringOrders : Collections.emptyMap();
+    this.secondaryIndexNames =
+        secondaryIndexNames != null ? secondaryIndexNames : Collections.emptySet();
+    this.columns = columns != null ? columns : Collections.emptyMap();
   }
 
-  public void setClusteringKeyNames(List<String> clusteringKeyNames) {
-    this.clusteringKeyNames = new LinkedHashSet<>(clusteringKeyNames);
-  }
-
-  public void setClusteringOrders(Map<String, String> clusteringOrders) {
-    this.clusteringOrders = clusteringOrders;
-  }
-
-  public void setSecondaryIndexNames(Set<String> secondaryIndexNames) {
-    this.secondaryIndexNames = secondaryIndexNames;
-  }
-
-  public void setColumns(Map<String, String> columns) {
-    this.columns = columns;
+  private CosmosTableMetadata(Builder builder) {
+    this(
+        builder.id,
+        builder.partitionKeyNames,
+        builder.clusteringKeyNames,
+        builder.clusteringOrders,
+        builder.secondaryIndexNames,
+        builder.columns);
   }
 
   public String getId() {
@@ -107,5 +113,55 @@ public class CosmosTableMetadata {
         .add("secondaryIndexNames", secondaryIndexNames)
         .add("columns", columns)
         .toString();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private String id;
+    private LinkedHashSet<String> partitionKeyNames;
+    private LinkedHashSet<String> clusteringKeyNames;
+    private Map<String, String> clusteringOrders;
+    private Set<String> secondaryIndexNames;
+    private Map<String, String> columns;
+
+    private Builder() {}
+
+    public Builder id(String val) {
+      id = val;
+      return this;
+    }
+
+    public Builder partitionKeyNames(LinkedHashSet<String> val) {
+      partitionKeyNames = val;
+      return this;
+    }
+
+    public Builder clusteringKeyNames(LinkedHashSet<String> val) {
+      clusteringKeyNames = val;
+      return this;
+    }
+
+    public Builder clusteringOrders(Map<String, String> val) {
+      clusteringOrders = val;
+      return this;
+    }
+
+    public Builder secondaryIndexNames(Set<String> val) {
+      secondaryIndexNames = val;
+      return this;
+    }
+
+    public Builder columns(Map<String, String> val) {
+      columns = val;
+      return this;
+    }
+
+    public CosmosTableMetadata build() {
+      return new CosmosTableMetadata(this);
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
@@ -24,7 +24,8 @@ public class CosmosTableMetadata {
   private final Map<String, String> clusteringOrders;
   private final Set<String> secondaryIndexNames;
   private final Map<String, String> columns;
-
+  // The default constructor  is required by the Cosmos SDK which uses Jackson to deserialize JSON
+  // object
   public CosmosTableMetadata() {
     this(null, null, null, null, null, null);
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosTableMetadata.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * A metadata class for a table of ScalarDB to know the type of each column
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @author Yuji Ito
  */
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
-@ThreadSafe
+@Immutable
 public class CosmosTableMetadata {
   private final String id;
   private final LinkedHashSet<String> partitionKeyNames;

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
@@ -21,6 +21,8 @@ public class Record {
   private final Map<String, Object> clusteringKey;
   private final Map<String, Object> values;
 
+  // The default constructor  is required by the Cosmos SDK which uses Jackson to deserialize JSON
+  // object
   public Record() {
     this(null, null, null, null, null);
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
@@ -4,7 +4,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A record class that Cosmos DB uses for storing a document based on ScalarDB data model.
@@ -12,34 +13,30 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @author Yuji Ito
  */
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
-@NotThreadSafe
+@ThreadSafe
 public class Record {
-  private String id = "";
-  private String concatenatedPartitionKey = "";
-  private Map<String, Object> partitionKey = Collections.emptyMap();
-  private Map<String, Object> clusteringKey = Collections.emptyMap();
-  private Map<String, Object> values = Collections.emptyMap();
+  private final String id;
+  private final String concatenatedPartitionKey;
+  private final Map<String, Object> partitionKey;
+  private final Map<String, Object> clusteringKey;
+  private final Map<String, Object> values;
 
-  public Record() {}
-
-  public void setId(String id) {
-    this.id = id;
+  public Record() {
+    this(null, null, null, null, null);
   }
 
-  public void setConcatenatedPartitionKey(String concatenatedPartitionKey) {
-    this.concatenatedPartitionKey = concatenatedPartitionKey;
-  }
-
-  public void setPartitionKey(Map<String, Object> partitionKey) {
-    this.partitionKey = partitionKey;
-  }
-
-  public void setClusteringKey(Map<String, Object> clusteringKey) {
-    this.clusteringKey = clusteringKey;
-  }
-
-  public void setValues(Map<String, Object> values) {
-    this.values = values;
+  public Record(
+      @Nullable String id,
+      @Nullable String concatenatedPartitionKey,
+      @Nullable Map<String, Object> partitionKey,
+      @Nullable Map<String, Object> clusteringKey,
+      @Nullable Map<String, Object> values) {
+    this.id = id != null ? id : "";
+    this.concatenatedPartitionKey =
+        concatenatedPartitionKey != null ? concatenatedPartitionKey : "";
+    this.partitionKey = partitionKey != null ? partitionKey : Collections.emptyMap();
+    this.clusteringKey = clusteringKey != null ? clusteringKey : Collections.emptyMap();
+    this.values = values != null ? values : Collections.emptyMap();
   }
 
   public String getId() {

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Record.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * A record class that Cosmos DB uses for storing a document based on ScalarDB data model.
@@ -13,7 +13,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @author Yuji Ito
  */
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
-@ThreadSafe
+@Immutable
 public class Record {
   private final String id;
   private final String concatenatedPartitionKey;

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -33,20 +33,19 @@ import com.azure.cosmos.models.IndexingPolicy;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.ThroughputProperties;
 import com.azure.cosmos.util.CosmosPagedIterable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -105,11 +104,11 @@ public abstract class CosmosAdminTestBase {
             ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
         .thenReturn(response);
 
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c1"));
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    cosmosTableMetadata.setSecondaryIndexNames(Collections.emptySet());
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
 
     when(response.getItem()).thenReturn(cosmosTableMetadata);
 
@@ -264,22 +263,24 @@ public abstract class CosmosAdminTestBase {
         .isEqualTo(CosmosAdmin.METADATA_CONTAINER);
     assertThat(containerPropertiesCaptor.getValue().getPartitionKeyDefinition().getPaths())
         .containsExactly("/id");
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setId(getFullTableName(namespace, table));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c3"));
-    cosmosTableMetadata.setClusteringKeyNames(Arrays.asList("c1", "c2"));
-    cosmosTableMetadata.setClusteringOrders(ImmutableMap.of("c1", "DESC", "c2", "ASC"));
-    cosmosTableMetadata.setColumns(
-        new ImmutableMap.Builder<String, String>()
-            .put("c1", "text")
-            .put("c2", "bigint")
-            .put("c3", "boolean")
-            .put("c4", "blob")
-            .put("c5", "int")
-            .put("c6", "double")
-            .put("c7", "float")
-            .build());
-    cosmosTableMetadata.setSecondaryIndexNames(ImmutableSet.of("c4"));
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c3"))
+            .clusteringKeyNames(Sets.newLinkedHashSet("c1", "c2"))
+            .clusteringOrders(ImmutableMap.of("c1", "DESC", "c2", "ASC"))
+            .columns(
+                new ImmutableMap.Builder<String, String>()
+                    .put("c1", "text")
+                    .put("c2", "bigint")
+                    .put("c3", "boolean")
+                    .put("c4", "blob")
+                    .put("c5", "int")
+                    .put("c6", "double")
+                    .put("c7", "float")
+                    .build())
+            .secondaryIndexNames(ImmutableSet.of("c4"))
+            .build();
     verify(metadataContainer).upsertItem(cosmosTableMetadata);
   }
 
@@ -346,22 +347,22 @@ public abstract class CosmosAdminTestBase {
         .isEqualTo(CosmosAdmin.METADATA_CONTAINER);
     assertThat(containerPropertiesCaptor.getValue().getPartitionKeyDefinition().getPaths())
         .containsExactly("/id");
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setId(getFullTableName(namespace, table));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c3"));
-    cosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    cosmosTableMetadata.setColumns(
-        new ImmutableMap.Builder<String, String>()
-            .put("c1", "text")
-            .put("c2", "bigint")
-            .put("c3", "boolean")
-            .put("c4", "blob")
-            .put("c5", "int")
-            .put("c6", "double")
-            .put("c7", "float")
-            .build());
-    cosmosTableMetadata.setSecondaryIndexNames(ImmutableSet.of("c4"));
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c3"))
+            .secondaryIndexNames(ImmutableSet.of("c4"))
+            .columns(
+                new ImmutableMap.Builder<String, String>()
+                    .put("c1", "text")
+                    .put("c2", "bigint")
+                    .put("c3", "boolean")
+                    .put("c4", "blob")
+                    .put("c5", "int")
+                    .put("c6", "double")
+                    .put("c7", "float")
+                    .build())
+            .build();
     verify(metadataContainer).upsertItem(cosmosTableMetadata);
   }
 
@@ -519,10 +520,10 @@ public abstract class CosmosAdminTestBase {
     // Arrange
     String namespace = "ns";
 
-    CosmosTableMetadata t1 = new CosmosTableMetadata();
-    t1.setId(getFullTableName(namespace, "t1"));
-    CosmosTableMetadata t2 = new CosmosTableMetadata();
-    t2.setId(getFullTableName(namespace, "t2"));
+    CosmosTableMetadata t1 =
+        CosmosTableMetadata.newBuilder().id(getFullTableName(namespace, "t1")).build();
+    CosmosTableMetadata t2 =
+        CosmosTableMetadata.newBuilder().id(getFullTableName(namespace, "t2")).build();
 
     when(client.getDatabase(metadataDatabaseName)).thenReturn(database);
     when(database.getContainer(CosmosAdmin.METADATA_CONTAINER)).thenReturn(container);
@@ -574,13 +575,13 @@ public abstract class CosmosAdminTestBase {
             ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
         .thenReturn(itemResponse);
 
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setId(getFullTableName(namespace, table));
-    cosmosTableMetadata.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c1"));
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    cosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
-    cosmosTableMetadata.setSecondaryIndexNames(ImmutableSet.of("c2"));
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .secondaryIndexNames(ImmutableSet.of("c2"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
     when(itemResponse.getItem()).thenReturn(cosmosTableMetadata);
 
     // Act
@@ -605,13 +606,13 @@ public abstract class CosmosAdminTestBase {
     verify(container).replace(properties);
 
     // for metadata table
-    CosmosTableMetadata expected = new CosmosTableMetadata();
-    expected.setId(getFullTableName(namespace, table));
-    expected.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    expected.setPartitionKeyNames(Collections.singletonList("c1"));
-    expected.setClusteringKeyNames(Collections.emptyList());
-    expected.setClusteringOrders(Collections.emptyMap());
-    expected.setSecondaryIndexNames(ImmutableSet.of("c2", "c3"));
+    CosmosTableMetadata expected =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .secondaryIndexNames(ImmutableSet.of("c2", "c3"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
     verify(metadataContainer).upsertItem(expected);
   }
 
@@ -643,13 +644,13 @@ public abstract class CosmosAdminTestBase {
             ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
         .thenReturn(itemResponse);
 
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setId(getFullTableName(namespace, table));
-    cosmosTableMetadata.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c1"));
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    cosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
-    cosmosTableMetadata.setSecondaryIndexNames(ImmutableSet.of("c2", "c3"));
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .secondaryIndexNames(ImmutableSet.of("c2", "c3"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
     when(itemResponse.getItem()).thenReturn(cosmosTableMetadata);
 
     // Act
@@ -673,13 +674,13 @@ public abstract class CosmosAdminTestBase {
     verify(container).replace(properties);
 
     // for metadata table
-    CosmosTableMetadata expected = new CosmosTableMetadata();
-    expected.setId(getFullTableName(namespace, table));
-    expected.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    expected.setPartitionKeyNames(Collections.singletonList("c1"));
-    expected.setClusteringKeyNames(Collections.emptyList());
-    expected.setClusteringOrders(Collections.emptyMap());
-    expected.setSecondaryIndexNames(ImmutableSet.of("c3"));
+    CosmosTableMetadata expected =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .secondaryIndexNames(ImmutableSet.of("c3"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
     verify(metadataContainer).upsertItem(expected);
   }
 
@@ -705,7 +706,6 @@ public abstract class CosmosAdminTestBase {
     // Arrange
     String namespace = "ns";
     String table = "tbl";
-    String fullTableName = getFullTableName(namespace, table);
     TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn("c1", DataType.INT)
@@ -713,13 +713,12 @@ public abstract class CosmosAdminTestBase {
             .addColumn("c3", DataType.BIGINT)
             .addPartitionKey("c1")
             .build();
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c1"));
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    cosmosTableMetadata.setSecondaryIndexNames(Collections.emptySet());
-    cosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
-    cosmosTableMetadata.setId(fullTableName);
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
 
     when(client.getDatabase(namespace)).thenReturn(database);
     when(database.getContainer(table)).thenReturn(container);
@@ -754,7 +753,6 @@ public abstract class CosmosAdminTestBase {
     // Arrange
     String namespace = "ns";
     String table = "tbl";
-    String fullTableName = getFullTableName(namespace, table);
     TableMetadata tableMetadata =
         TableMetadata.newBuilder()
             .addColumn("c1", DataType.INT)
@@ -762,13 +760,12 @@ public abstract class CosmosAdminTestBase {
             .addColumn("c3", DataType.BIGINT)
             .addPartitionKey("c1")
             .build();
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setColumns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList("c1"));
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    cosmosTableMetadata.setSecondaryIndexNames(Collections.emptySet());
-    cosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
-    cosmosTableMetadata.setId(fullTableName);
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(getFullTableName(namespace, table))
+            .partitionKeyNames(Sets.newLinkedHashSet("c1"))
+            .columns(ImmutableMap.of("c1", "int", "c2", "text", "c3", "bigint"))
+            .build();
 
     when(client.getDatabase(namespace)).thenReturn(database);
     when(database.getContainer(table)).thenReturn(container);
@@ -822,11 +819,11 @@ public abstract class CosmosAdminTestBase {
             ArgumentMatchers.<Class<CosmosTableMetadata>>any()))
         .thenReturn(response);
 
-    CosmosTableMetadata cosmosTableMetadata = new CosmosTableMetadata();
-    cosmosTableMetadata.setColumns(ImmutableMap.of(currentColumn, "text"));
-    cosmosTableMetadata.setPartitionKeyNames(Collections.singletonList(currentColumn));
-    cosmosTableMetadata.setSecondaryIndexNames(Collections.emptySet());
-    cosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
+    CosmosTableMetadata cosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .partitionKeyNames(Sets.newLinkedHashSet(currentColumn))
+            .columns(ImmutableMap.of(currentColumn, "text"))
+            .build();
 
     when(response.getItem()).thenReturn(cosmosTableMetadata);
 
@@ -837,15 +834,12 @@ public abstract class CosmosAdminTestBase {
     verify(container)
         .readItem(fullTableName, new PartitionKey(fullTableName), CosmosTableMetadata.class);
 
-    CosmosTableMetadata expectedCosmosTableMetadata = new CosmosTableMetadata();
-    expectedCosmosTableMetadata.setId(fullTableName);
-    expectedCosmosTableMetadata.setPartitionKeyNames(ImmutableList.of(currentColumn));
-    expectedCosmosTableMetadata.setClusteringKeyNames(Collections.emptyList());
-    expectedCosmosTableMetadata.setClusteringOrders(Collections.emptyMap());
-    expectedCosmosTableMetadata.setSecondaryIndexNames(Collections.emptySet());
-    expectedCosmosTableMetadata.setColumns(
-        ImmutableMap.of(currentColumn, "text", newColumn, "int"));
-
+    CosmosTableMetadata expectedCosmosTableMetadata =
+        CosmosTableMetadata.newBuilder()
+            .id(fullTableName)
+            .partitionKeyNames(Sets.newLinkedHashSet(currentColumn))
+            .columns(ImmutableMap.of(currentColumn, "text", newColumn, "int"))
+            .build();
     verify(container).upsertItem(expectedCosmosTableMetadata);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ResultInterpreterTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ResultInterpreterTest.java
@@ -50,12 +50,7 @@ public class ResultInterpreterTest {
   @Test
   public void interpret_ShouldReturnWhatsSet() {
     // Arrange
-    Record record = new Record();
-    record.setId(ANY_ID_1);
-    record.setConcatenatedPartitionKey(ANY_TEXT_1);
-    record.setPartitionKey(ImmutableMap.of(ANY_NAME_1, ANY_TEXT_1));
-    record.setClusteringKey(ImmutableMap.of(ANY_NAME_2, ANY_TEXT_2));
-    record.setValues(
+    Map<String, Object> recordValues =
         ImmutableMap.<String, Object>builder()
             .put(ANY_COLUMN_NAME_1, true)
             .put(ANY_COLUMN_NAME_2, Integer.MAX_VALUE)
@@ -66,8 +61,14 @@ public class ResultInterpreterTest {
             .put(
                 ANY_COLUMN_NAME_7,
                 Base64.getEncoder().encodeToString("bytes".getBytes(StandardCharsets.UTF_8)))
-            .build());
-
+            .build();
+    Record record =
+        new Record(
+            ANY_ID_1,
+            ANY_TEXT_1,
+            ImmutableMap.of(ANY_NAME_1, ANY_TEXT_1),
+            ImmutableMap.of(ANY_NAME_2, ANY_TEXT_2),
+            recordValues);
     List<String> projections = Collections.emptyList();
     ResultInterpreter spy = spy(new ResultInterpreter(projections, TABLE_METADATA));
 
@@ -151,20 +152,21 @@ public class ResultInterpreterTest {
   @Test
   public void interpret_ShouldReturnWhatsSetWithNullValues() {
     // Arrange
-    Record record = new Record();
-    record.setId(ANY_ID_1);
-    record.setConcatenatedPartitionKey(ANY_TEXT_1);
-    record.setPartitionKey(ImmutableMap.of(ANY_NAME_1, ANY_TEXT_1));
-    record.setClusteringKey(ImmutableMap.of(ANY_NAME_2, ANY_TEXT_2));
-    Map<String, Object> v = new HashMap<>();
-    v.put(ANY_COLUMN_NAME_1, null);
-    v.put(ANY_COLUMN_NAME_2, null);
-    v.put(ANY_COLUMN_NAME_3, null);
-    v.put(ANY_COLUMN_NAME_4, null);
-    v.put(ANY_COLUMN_NAME_5, null);
-    v.put(ANY_COLUMN_NAME_6, null);
-    v.put(ANY_COLUMN_NAME_7, null);
-    record.setValues(v);
+    Map<String, Object> recordValues = new HashMap<>();
+    recordValues.put(ANY_COLUMN_NAME_1, null);
+    recordValues.put(ANY_COLUMN_NAME_2, null);
+    recordValues.put(ANY_COLUMN_NAME_3, null);
+    recordValues.put(ANY_COLUMN_NAME_4, null);
+    recordValues.put(ANY_COLUMN_NAME_5, null);
+    recordValues.put(ANY_COLUMN_NAME_6, null);
+    recordValues.put(ANY_COLUMN_NAME_7, null);
+    Record record =
+        new Record(
+            ANY_ID_1,
+            ANY_TEXT_1,
+            ImmutableMap.of(ANY_NAME_1, ANY_TEXT_1),
+            ImmutableMap.of(ANY_NAME_2, ANY_TEXT_2),
+            recordValues);
 
     List<String> projections = Collections.emptyList();
 


### PR DESCRIPTION
**Changes**
This PR makes the `CosmosMetadata` and `Record` objects immutable. These DTO (Data Transfer Object) are used by the Cosmos SDK which uses Jackson.

**Note**
This PR originated thanks to this discussion https://github.com/scalar-labs/scalardb/pull/989#discussion_r1285761870