### PR TITLE
Backport to branch(3.10) : Fix to ignore empty condition set when building Scan object

### DIFF
--- a/core/src/main/java/com/scalar/db/api/ScanBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ScanBuilder.java
@@ -1395,10 +1395,15 @@ public class ScanBuilder {
     } else if (conjunctions.isEmpty()) {
       scan.withConjunctions(
           Sets.cartesianProduct(new ArrayList<>(disjunctions)).stream()
+              .filter(conditions -> conditions.size() > 0)
               .map(Scan.Conjunction::of)
               .collect(Collectors.toSet()));
     } else {
-      scan.withConjunctions(conjunctions.stream().map(Conjunction::of).collect(Collectors.toSet()));
+      scan.withConjunctions(
+          conjunctions.stream()
+              .filter(conditions -> conditions.size() > 0)
+              .map(Conjunction::of)
+              .collect(Collectors.toSet()));
     }
 
     if (!projections.isEmpty()) {

--- a/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
@@ -886,38 +886,6 @@ public class ScanBuilderTest {
 
   @Test
   public void
-      buildScanAll_ScanWithEmptyOrConditionSets_ShouldBuildScanWithoutConjunctionCorrectly() {
-    // Arrange Act
-    Scan scan =
-        Scan.newBuilder()
-            .namespace(NAMESPACE_1)
-            .table(TABLE_1)
-            .all()
-            .whereAnd(ImmutableSet.of())
-            .build();
-
-    // Assert
-    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
-  }
-
-  @Test
-  public void
-      buildScanAll_ScanWithEmptyAndConditionSets_ShouldBuildScanWithoutConjunctionCorrectly() {
-    // Arrange Act
-    Scan scan =
-        Scan.newBuilder()
-            .namespace(NAMESPACE_1)
-            .table(TABLE_1)
-            .all()
-            .whereOr(ImmutableSet.of())
-            .build();
-
-    // Assert
-    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
-  }
-
-  @Test
-  public void
       buildScanAll_FromExistingWithConditionsAndUpdateAllParameters_ShouldBuildScanWithUpdatedParameters() {
     // Arrange
     Scan scan =

--- a/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ScanBuilderTest.java
@@ -852,6 +852,72 @@ public class ScanBuilderTest {
 
   @Test
   public void
+      buildScanAll_ScanWithEmptyOrConditionSet_ShouldBuildScanWithoutConjunctionCorrectly() {
+    // Arrange Act
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .all()
+            .where(ConditionSetBuilder.orConditionSet(ImmutableSet.of()).build())
+            .and(ConditionSetBuilder.orConditionSet(ImmutableSet.of()).build())
+            .build();
+
+    // Assert
+    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void
+      buildScanAll_ScanWithEmptyAndConditionSet_ShouldBuildScanWithoutConjunctionCorrectly() {
+    // Arrange Act
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .all()
+            .where(ConditionSetBuilder.andConditionSet(ImmutableSet.of()).build())
+            .or(ConditionSetBuilder.andConditionSet(ImmutableSet.of()).build())
+            .build();
+
+    // Assert
+    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void
+      buildScanAll_ScanWithEmptyOrConditionSets_ShouldBuildScanWithoutConjunctionCorrectly() {
+    // Arrange Act
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .all()
+            .whereAnd(ImmutableSet.of())
+            .build();
+
+    // Assert
+    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void
+      buildScanAll_ScanWithEmptyAndConditionSets_ShouldBuildScanWithoutConjunctionCorrectly() {
+    // Arrange Act
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .all()
+            .whereOr(ImmutableSet.of())
+            .build();
+
+    // Assert
+    assertThat(scan).isEqualTo(new ScanAll().forNamespace(NAMESPACE_1).forTable(TABLE_1));
+  }
+
+  @Test
+  public void
       buildScanAll_FromExistingWithConditionsAndUpdateAllParameters_ShouldBuildScanWithUpdatedParameters() {
     // Arrange
     Scan scan =


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1006