### PR TITLE
Add out-of-support banner to docs to show that ScalarDB 3.4 is no longer supported on the docs site

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # A Guide on How to Back up and Restore Databases Integrated with Scalar DB
 
 Since Scalar DB provides transaction capability on top of non-transactional (possibly transactional) databases non-invasively, you need to take special care of backing up and restoring the databases in a transactionally-consistent way.

--- a/docs/getting-started-with-scalardb-on-cassandra.md
+++ b/docs/getting-started-with-scalardb-on-cassandra.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on Cassandra
     
 ## Overview

--- a/docs/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/getting-started-with-scalardb-on-cosmosdb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on Cosmos DB
 
 ## Overview

--- a/docs/getting-started-with-scalardb-on-dynamodb.md
+++ b/docs/getting-started-with-scalardb-on-dynamodb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on DynamoDB
 
 ## Overview

--- a/docs/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/getting-started-with-scalardb-on-jdbc.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on JDBC databases
 
 ## Overview

--- a/docs/getting-started-with-scalardb.md
+++ b/docs/getting-started-with-scalardb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB
 
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB
 
 ## Overview

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 ## Scalar DB
 
 [![CI](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Requirements in the Underlining Databases of Scalar DB
 
 This document explains the requirements in the underlining databases of Scalar DB to make Scalar DB applications work correctly.

--- a/docs/scalardb-server.md
+++ b/docs/scalardb-server.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Scalar DB server
 
 Scalar DB server is a gRPC server that implements Scalar DB interface. 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Database schema in Scalar DB
 
 Scalar DB has its own data model and schema, that maps to the implementation specific data model and schema.

--- a/docs/two-phase-commit-transactions.md
+++ b/docs/two-phase-commit-transactions.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Two-phase Commit Transactions
 
 Scalar DB also supports two-phase commit style transactions called *Two-phase Commit Transactions*.


### PR DESCRIPTION
This PR adds an "include" that contains a banner to the top of ScalarDB 3.4 docs. The banner states version 3.4 is no longer supported. 

> **Note**
> 
> The banner is displayed on ScalarDB 3.4 pages on only our docs site. Visitors to the Markdown files in this repository will only see `{% include end-of-support.html %}` at the top of the document. That line will then be displayed as expected when the docs are rendered in Jekyll, the static site generator for our docs site.
> 
> **Reference:** The include file on the docs site: [`end-of-support.html`](https://github.com/scalar-labs/docs-scalardb/blob/main/_includes/end-of-support.html).