### PR TITLE
Revise the "Add ScalarDB to Your Build" doc

### DIFF
--- a/docs/add-scalardb-to-your-build.md
+++ b/docs/add-scalardb-to-your-build.md
@@ -24,7 +24,7 @@ dependencies {
 </div>
 <div id="Maven" class="tabcontent" markdown="1">
 
-To add the build dependency for ScalarDB by using Maven, add the following to `~/.m2/settings.xml` in your application, replacing `<VERSION>` with the version of ScalarDB that you want to use:
+To add the build dependency for ScalarDB by using Maven, add the following to `pom.xml` in your application, replacing `<VERSION>` with the version of ScalarDB that you want to use:
 
 ```xml
 <dependency>

--- a/docs/add-scalardb-to-your-build.md
+++ b/docs/add-scalardb-to-your-build.md
@@ -1,20 +1,37 @@
-# Add ScalarDB to your build
+# Add ScalarDB to Your Build
 
-The library is available on [maven central repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb).
-You can install it in your application using your build tool such as Gradle and Maven. 
+The ScalarDB library is available on the [Maven Central Repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb). You can add the library as a build dependency to your application by using Gradle or Maven.
 
-To add a dependency on ScalarDB using Gradle, use the following:
+## Configure your application based on your build tool
+
+Select your build tool, and follow the instructions to add the build dependency for ScalarDB to your application.
+
+<div id="tabset-1">
+<div class="tab">
+  <button class="tablinks" onclick="openTab(event, 'Gradle', 'tabset-1')" id="defaultOpen-1">Gradle</button>
+  <button class="tablinks" onclick="openTab(event, 'Maven', 'tabset-1')">Maven</button>
+</div>
+
+<div id="Gradle" class="tabcontent" markdown="1">
+
+To add the build dependency for ScalarDB by using Gradle, add the following to `build.gradle` in your application, replacing `<VERSION>` with the version of ScalarDB that you want to use:
+
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.10.1'
+  implementation 'com.scalar-labs:scalardb:<VERSION>'
 }
 ```
+</div>
+<div id="Maven" class="tabcontent" markdown="1">
 
-To add a dependency using Maven:
+To add the build dependency for ScalarDB by using Maven, add the following to `~/.m2/settings.xml` in your application, replacing `<VERSION>` with the version of ScalarDB that you want to use:
+
 ```xml
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.10.1</version>
+  <version><VERSION></version>
 </dependency>
 ```
+</div>
+</div>


### PR DESCRIPTION
## Description

This PR revises the document that shows users how to add ScalarDB to their application build by using Gradle or Maven. By putting the build tools in content tabs, users can select their preferred build tool to see instructions for how to add ScalarDB to their application.

## Related issues and/or PRs

N/A

## Changes made

- Added content tabs for Gradle and Maven contents.
- Revised the contents, adding headings and providing additional context to the instructions.

## Branches this PR applies to

- `master`
- `3.10`
- `3.9`
- `3.8`
- `3.7`
- `3.6`
- `3.5`

## Testing done

I ran our docs site locally and confirmed that the content tabs for Gradle and Maven in this doc appear and work as expected. The following screenshot shows how the tabs look.

### Content tab for Gradle

![add-scalardb-to-your-build-gradle](https://github.com/scalar-labs/scalardb/assets/23216828/85f4aa95-d6f4-47e8-8bd1-62b699cb7ef9)

### Content tab for Maven

![add-scalardb-to-your-build-maven](https://github.com/scalar-labs/scalardb/assets/23216828/afcc4e99-1da3-46ac-aa46-63dcdccc2f2d)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] The documentation has been updated to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Please see my comment in the doc.