### PR TITLE
Backport to branch(3.7) : Should drop namespace only when no tables are in the namespace in Schema Loader

### DIFF
--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -145,7 +145,9 @@ public class SchemaOperator {
   private void dropNamespaces(Set<String> namespaces) throws SchemaLoaderException {
     for (String namespace : namespaces) {
       try {
-        storageAdmin.dropNamespace(namespace, true);
+        if (storageAdmin.getNamespaceTableNames(namespace).isEmpty()) {
+          storageAdmin.dropNamespace(namespace, true);
+        }
       } catch (ExecutionException e) {
         throw new SchemaLoaderException("Deleting the namespace " + namespace + " failed.", e);
       }


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/740