### PR TITLE
Add "Exception and log message guideline" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ pre-commit install
 
 The code formatter is automatically executed when commiting files. A commit will fail and be formatted by the formatter when any invalid code format is detected. Try to commit the change again.
 
-### Exception and log message guideline
+### Exception and log message guidelines
 
 All the exception and log messages in this project are consistent with the following guidelines:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ $ pre-commit install
 
 The code formatter is automatically executed when commiting files. A commit will fail and be formatted by the formatter when any invalid code format is detected. Try to commit the change again.
 
+### Exception and log message guideline
+
+All the exception and log messages in this project are consistent with the following guideline.
+
+- The first character is capitalized
+- The message should not end with punctuation
+
+Follow the guideline when you contribute to this project.
+
 ## License
 ScalarDB is dual-licensed under both the Apache 2.0 License (found in the LICENSE file in the root directory) and a commercial license.
 You may select, at your option, one of the above-listed licenses.

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ The code formatter is automatically executed when commiting files. A commit will
 
 ### Exception and log message guideline
 
-All the exception and log messages in this project are consistent with the following guideline.
+All the exception and log messages in this project are consistent with the following guidelines:
 
-- The first character is capitalized
-- The message should not end with punctuation
+- The first character is capitalized.
+- The message does not end with a punctuation mark.
 
-Follow the guideline when you contribute to this project.
+When contributing to this project, please follow these guidelines.
 
 ## License
 ScalarDB is dual-licensed under both the Apache 2.0 License (found in the LICENSE file in the root directory) and a commercial license.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Here are the contributors we are especially thankful for:
 - [Toshihiro Suzuki](https://github.com/brfrn169) - created [Phoenix adapter](https://github.com/scalar-labs/scalardb-phoenix) for ScalarDB
 - [Yonezawa-T2](https://github.com/Yonezawa-T2) - reported bugs around Serializable and proposed a new Serializable strategy (now named Extra-Read)
 
-## Development
-
 ### Pre-commit hook
 
 This project uses [pre-commit](https://pre-commit.com/) to automate code format and so on as much as possible. If you're interested in the development of ScalarDB, please [install pre-commit](https://pre-commit.com/#installation) and the git hook script as follows.


### PR DESCRIPTION
## Context

We've [updated](https://github.com/scalar-labs/scalardb/pull/985) all the exception and log messages in this project to apply the consistent message style. But no rule or guideline on it is written down yet.

## Changes

This PR adds "Exception and log message guideline" section to README so that contributors to this project know the message style.