### PR TITLE
Fix to handle supported data types properly when importing tables in MySQL and SQL Server

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -103,7 +103,9 @@ public class JdbcAdminImportTestUtils {
           "sql_variant",
           "time",
           "uniqueidentifier",
-          "xml");
+          "xml",
+          "geometry",
+          "geography");
 
   private final JdbcConfig config;
   private final RdbEngineStrategy rdbEngine;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -235,9 +235,8 @@ class RdbEngineMysql implements RdbEngineStrategy {
       case CHAR:
       case VARCHAR:
       case LONGVARCHAR:
-        if (typeName.equalsIgnoreCase("ENUM")
-            || typeName.equalsIgnoreCase("SET")
-            || typeName.equalsIgnoreCase("JSON")) {
+        if (!typeName.toUpperCase().endsWith("CHAR") && !typeName.toUpperCase().endsWith("TEXT")) {
+          // to exclude ENUM, SET, JSON, etc.
           throw new IllegalArgumentException(
               String.format("Data type %s is unsupported: %s", typeName, columnDescription));
         }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -223,14 +223,16 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
         return DataType.TEXT;
       case BINARY:
       case VARBINARY:
-        if (typeName.equalsIgnoreCase("timestamp") || typeName.equalsIgnoreCase("hierarchyid")) {
+        if (!typeName.equalsIgnoreCase("binary") && !typeName.equalsIgnoreCase("varbinary")) {
           throw new IllegalArgumentException(
               String.format("Data type %s is unsupported: %s", typeName, columnDescription));
         }
-        logger.info(
-            "Data type larger than that of underlying database is assigned: {} ({} to BLOB)",
-            columnDescription,
-            typeName);
+        if (columnSize < Integer.MAX_VALUE) {
+          logger.info(
+              "Data type larger than that of underlying database is assigned: {} ({} to BLOB)",
+              columnDescription,
+              typeName);
+        }
         return DataType.BLOB;
       case LONGVARBINARY:
         return DataType.BLOB;

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -2517,7 +2517,10 @@ public abstract class JdbcAdminTestBase {
         .thenReturn(Types.VARCHAR)
         .thenReturn(Types.VARCHAR)
         .thenReturn(Types.REAL);
-    when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("").thenReturn("").thenReturn("");
+    when(columnResults.getString(JDBC_COL_TYPE_NAME))
+        .thenReturn("VARCHAR")
+        .thenReturn("VARCHAR")
+        .thenReturn("");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0).thenReturn(0).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0).thenReturn(0).thenReturn(0);
     when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
@@ -2762,7 +2765,7 @@ public abstract class JdbcAdminTestBase {
     when(columnResults.next()).thenReturn(true).thenReturn(false);
     when(columnResults.getString(JDBC_COL_COLUMN_NAME)).thenReturn(COLUMN_1);
     when(columnResults.getInt(JDBC_COL_DATA_TYPE)).thenReturn(Types.VARCHAR);
-    when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("");
+    when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("VARCHAR");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0);
     when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);


### PR DESCRIPTION
This PR fixes handling supported data types correctly. Without this fix, users can accidentally import some minor unsupported data types like "geometry" as the blob type in ScalarDB.