### PR TITLE
Unify styles of the exception messages of Storage Admin implementations

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -196,7 +196,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(
-              "Dropping the secondary index on the %s column  of the %s table failed",
+              "Dropping the secondary index on the %s column of the %s table failed",
               columnName, getFullTableName(namespace, table)),
           e);
     }
@@ -341,7 +341,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(
-              "Adding the new %s column  to the %s table failed",
+              "Adding the new %s column to the %s table failed",
               columnName, getFullTableName(namespace, table)),
           e);
     }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -78,7 +78,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       // thrown by ReplicationStrategy.fromString() when the given replication strategy is unknown
       throw e;
     } catch (RuntimeException e) {
-      throw new ExecutionException(String.format("Creating the keyspace %s failed", namespace), e);
+      throw new ExecutionException(String.format("Creating the %s keyspace failed", namespace), e);
     }
   }
 
@@ -180,7 +180,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(
-              "Creating the secondary index for %s.%s.%s failed", namespace, table, columnName),
+              "Creating the secondary index on the %s column of the %s table failed",
+              columnName, getFullTableName(namespace, table)),
           e);
     }
   }
@@ -195,7 +196,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(
-              "Dropping the secondary index for %s.%s.%s failed", namespace, table, columnName),
+              "Dropping the secondary index on the %s column  of the %s table failed",
+              columnName, getFullTableName(namespace, table)),
           e);
     }
   }
@@ -214,7 +216,11 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       }
       return createTableMetadata(metadata);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Getting a table metadata failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Getting a table metadata for the %s table failed",
+              getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -280,7 +286,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
           .map(com.datastax.driver.core.TableMetadata::getName)
           .collect(Collectors.toSet());
     } catch (RuntimeException e) {
-      throw new ExecutionException("Retrieving the table names of the namespace failed", e);
+      throw new ExecutionException(
+          String.format("Retrieving the table names of the %s keyspace failed", namespace), e);
     }
   }
 
@@ -300,7 +307,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
       return resultSet.one() != null;
     } catch (RuntimeException e) {
-      throw new ExecutionException("Checking if the namespace exists failed", e);
+      throw new ExecutionException(
+          String.format("Checking if the %s keyspace exists failed", namespace), e);
     }
   }
 
@@ -311,7 +319,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     // We have this check to stay consistent with the behavior of the other admins classes
     if (!tableExists(namespace, table)) {
       throw new IllegalArgumentException(
-          "The table " + getFullTableName(namespace, table) + "  does not exist");
+          "The " + getFullTableName(namespace, table) + " table does not exist");
     }
     // The table metadata are not managed by ScalarDB, so we don't need to do anything here
   }
@@ -333,7 +341,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(
-              "Adding the new column %s to the %s.%s table failed", columnName, namespace, table),
+              "Adding the new %s column  to the %s table failed",
+              columnName, getFullTableName(namespace, table)),
           e);
     }
   }
@@ -356,7 +365,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
       return keyspaceNames;
     } catch (RuntimeException e) {
-      throw new ExecutionException("Retrieving the existing namespace names failed", e);
+      throw new ExecutionException("Retrieving the existing keyspace names failed", e);
     }
   }
 
@@ -440,7 +449,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       clusterManager.getSession().execute(createTableWithOptions.getQueryString());
     } catch (RuntimeException e) {
       throw new ExecutionException(
-          String.format("Creating the table %s.%s failed", keyspace, table), e);
+          String.format("Creating the %s table failed", getFullTableName(keyspace, table)), e);
     }
   }
 
@@ -535,7 +544,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
         }
       }
       throw new IllegalArgumentException(
-          String.format("The network strategy %s does not exist", text));
+          String.format("The %s network strategy does not exist", text));
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -579,7 +579,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     } catch (ExecutionException e) {
       throw new ExecutionException(
           String.format(
-              "Adding the new %s column  to the %s container failed",
+              "Adding the new %s column to the %s container failed",
               columnName, getFullTableName(namespace, table)),
           e);
     }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -95,7 +95,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       createContainer(namespace, table, metadata);
       putTableMetadata(namespace, table, metadata);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Creating the container failed", e);
+      throw new ExecutionException(
+          String.format("Creating the %s container failed", getFullTableName(namespace, table)), e);
     }
   }
 
@@ -225,7 +226,11 @@ public class CosmosAdmin implements DistributedStorageAdmin {
           convertToCosmosTableMetadata(getFullTableName(namespace, table), metadata);
       getTableMetadataContainer().upsertItem(cosmosTableMetadata);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Putting the table metadata failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Putting the table metadata for the %s contained failed",
+              getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -272,7 +277,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       createMetadataDatabaseAndNamespaceContainerIfNotExists();
       getNamespacesContainer().createItem(new CosmosNamespace(namespace));
     } catch (RuntimeException e) {
-      throw new ExecutionException("Creating the database failed", e);
+      throw new ExecutionException(String.format("Creating the %s database failed", namespace), e);
     }
   }
 
@@ -283,7 +288,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       database.getContainer(table).delete();
       deleteTableMetadata(namespace, table);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Deleting the container failed", e);
+      throw new ExecutionException(
+          String.format("Deleting the %s container failed", getFullTableName(namespace, table)), e);
     }
   }
 
@@ -305,7 +311,11 @@ public class CosmosAdmin implements DistributedStorageAdmin {
         getTableMetadataContainer().delete();
       }
     } catch (RuntimeException e) {
-      throw new ExecutionException("Deleting the table metadata failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Deleting the table metadata for the %s container failed",
+              getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -330,7 +340,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
         client.getDatabase(metadataDatabase).delete();
       }
     } catch (RuntimeException e) {
-      throw new ExecutionException("Deleting the database failed", e);
+      throw new ExecutionException(String.format("Deleting the %s database failed", namespace), e);
     }
   }
 
@@ -352,7 +362,9 @@ public class CosmosAdmin implements DistributedStorageAdmin {
                   new PartitionKey(record.getConcatenatedPartitionKey()),
                   new CosmosItemRequestOptions()));
     } catch (RuntimeException e) {
-      throw new ExecutionException("Truncating the container failed", e);
+      throw new ExecutionException(
+          String.format("Truncating the %s container failed", getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -399,7 +411,11 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       // update the container properties
       database.getContainer(containerName).replace(properties);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Updating the indexing policy failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Updating the indexing policy for the %s table failed",
+              getFullTableName(databaseName, containerName)),
+          e);
     }
   }
 
@@ -413,7 +429,11 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       }
       return convertToTableMetadata(cosmosTableMetadata);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Getting the container metadata failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Getting the table metadata for the %s container failed",
+              getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -493,7 +513,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
           && ((CosmosException) e).getStatusCode() == CosmosErrorCode.NOT_FOUND.get()) {
         return false;
       }
-      throw new ExecutionException("Checking if the namespace exists failed", e);
+      throw new ExecutionException(
+          String.format("Checking if the %s database exists failed", namespace), e);
     }
   }
 
@@ -513,7 +534,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       }
     } catch (ExecutionException | CosmosException e) {
       throw new ExecutionException(
-          String.format("Repairing the table %s.%s failed", namespace, table), e);
+          String.format("Repairing the %s container failed", getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -540,7 +562,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
           .map(tableMetadata -> tableMetadata.getId().replaceFirst("^" + namespace + ".", ""))
           .collect(Collectors.toSet());
     } catch (RuntimeException e) {
-      throw new ExecutionException("Retrieving the container names of the database failed", e);
+      throw new ExecutionException(
+          String.format("Retrieving the container names of the %s database failed", namespace), e);
     }
   }
 
@@ -556,7 +579,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
     } catch (ExecutionException e) {
       throw new ExecutionException(
           String.format(
-              "Adding the new column %s to the %s.%s table failed", columnName, namespace, table),
+              "Adding the new %s column  to the %s container failed",
+              columnName, getFullTableName(namespace, table)),
           e);
     }
   }
@@ -596,7 +620,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
 
       return allNamespaces.stream().map(CosmosNamespace::getId).collect(Collectors.toSet());
     } catch (RuntimeException e) {
-      throw new ExecutionException("Retrieving the namespaces names failed", e);
+      throw new ExecutionException("Retrieving the database names failed", e);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -226,7 +226,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       createNamespacesTableIfNotExists(noBackup);
       insertIntoNamespacesTable(namespace);
     } catch (ExecutionException e) {
-      throw new ExecutionException("Creating the namespace " + namespace + " failed", e);
+      throw new ExecutionException("Creating the " + namespace + " namespace failed", e);
     }
   }
 
@@ -241,7 +241,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
               .build());
     } catch (Exception e) {
       throw new ExecutionException(
-          "Inserting the namespace " + namespace + " into the namespaces table failed", e);
+          "Inserting the " + namespace + " namespace into the namespaces table failed", e);
     }
   }
 
@@ -268,7 +268,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     try {
       client.createTable(requestBuilder.build());
     } catch (Exception e) {
-      throw new ExecutionException("Creating the table failed", e);
+      throw new ExecutionException(
+          "Creating the " + getFullTableName(namespace, table) + " table failed", e);
     }
     waitForTableCreation(namespace, table);
 
@@ -450,7 +451,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
               .build());
     } catch (Exception e) {
       throw new ExecutionException(
-          "Adding the meta data for table " + getFullTableName(namespace, table) + " failed", e);
+          "Adding the metadata for the " + getFullTableName(namespace, table) + " table failed", e);
     }
   }
 
@@ -508,7 +509,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       return false;
     } catch (Exception e) {
       throw new ExecutionException(
-          "Checking the table " + getFullTableName(namespace, table) + " existence failed", e);
+          "Checking the " + getFullTableName(namespace, table) + " table existence failed", e);
     }
   }
 
@@ -526,7 +527,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         }
       }
     } catch (Exception e) {
-      throw new ExecutionException("Waiting for the table creation failed", e);
+      throw new ExecutionException(
+          "Waiting for the " + getFullTableName(namespace, table) + " table creation failed", e);
     }
   }
 
@@ -639,7 +641,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         }
       }
     } catch (Exception e) {
-      throw new ExecutionException("Waiting for the table backup enabled at creation failed", e);
+      throw new ExecutionException(
+          "Waiting for enabling the "
+              + getFullTableName(namespace, table)
+              + " table backup at creation failed",
+          e);
     }
   }
 
@@ -664,7 +670,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     try {
       client.deleteTable(DeleteTableRequest.builder().tableName(fullTableName).build());
     } catch (Exception e) {
-      throw new ExecutionException("Deleting table " + fullTableName + " failed", e);
+      throw new ExecutionException("Deleting the " + fullTableName + " table failed", e);
     }
     waitForTableDeletion(namespace, table);
     deleteTableMetadata(namespace, table);
@@ -734,7 +740,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       client.deleteItem(
           DeleteItemRequest.builder().tableName(metadataTable).key(keyToDelete).build());
     } catch (Exception e) {
-      throw new ExecutionException("Deleting the metadata failed", e);
+      throw new ExecutionException(
+          "Deleting the metadata for the " + getFullTableName(namespace, table) + " table failed",
+          e);
     }
 
     ScanResponse scanResponse;
@@ -765,7 +773,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         }
       }
     } catch (Exception e) {
-      throw new ExecutionException("Waiting for the table deletion failed", e);
+      throw new ExecutionException(
+          "Waiting for the " + getFullTableName(namespace, tableName) + " table deletion failed",
+          e);
     }
   }
 
@@ -776,11 +786,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       deleteFromNamespacesTable(namespace);
       dropNamespacesTableIfEmpty();
     } catch (Exception e) {
-      throw new ExecutionException(
-          "Dropping the namespace "
-              + Namespace.of(namespacePrefix, nonPrefixedNamespace)
-              + " failed",
-          e);
+      throw new ExecutionException("Dropping the " + namespace + " namespace failed", e);
     }
   }
 
@@ -805,7 +811,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
           DeleteItemRequest.builder().tableName(namespacesTableFullName).key(keyToDelete).build());
     } catch (Exception e) {
       throw new ExecutionException(
-          "Deleting the namespace " + namespace + " from the namespaces table failed", e);
+          "Deleting the " + namespace + " namespace from the namespaces table failed", e);
     }
   }
 
@@ -825,7 +831,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
                     .exclusiveStartKey(lastKeyEvaluated)
                     .build());
       } catch (Exception e) {
-        throw new ExecutionException("Scanning items from table " + fullTableName + " failed", e);
+        throw new ExecutionException(
+            "Scanning items from the " + fullTableName + " table failed", e);
       }
 
       for (Map<String, AttributeValue> item : scanResponse.items()) {
@@ -838,7 +845,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
           client.deleteItem(
               DeleteItemRequest.builder().tableName(fullTableName).key(keyToDelete).build());
         } catch (Exception e) {
-          throw new ExecutionException("Deleting item from table " + fullTableName + " failed", e);
+          throw new ExecutionException(
+              "Deleting item from the " + fullTableName + " table failed", e);
         }
       }
       lastKeyEvaluated = scanResponse.lastEvaluatedKey();
@@ -854,7 +862,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
     if (metadata == null) {
       throw new IllegalArgumentException(
-          "Table " + getFullTableName(namespace, table) + " does not exist");
+          "The " + getFullTableName(namespace, table) + " table does not exist");
     }
 
     if (metadata.getColumnDataType(columnName) == DataType.BOOLEAN) {
@@ -896,7 +904,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
                       .build())
               .build());
     } catch (Exception e) {
-      throw new ExecutionException("Creating the secondary index failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Creating the secondary index for the %s column of the %s table failed",
+              columnName, getFullTableName(namespace, table)),
+          e);
     }
 
     waitForIndexCreation(namespace, table, columnName);
@@ -950,7 +962,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         }
       }
     } catch (Exception e) {
-      throw new ExecutionException("Waiting for the secondary index creation failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Waiting for the secondary index creation on the %s column of the %s table failed",
+              columnName, getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -998,7 +1014,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
                       .build())
               .build());
     } catch (Exception e) {
-      throw new ExecutionException("Dropping the secondary index failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Dropping the secondary index on the %s column of the %s table failed",
+              columnName, getFullTableName(namespace, table)),
+          e);
     }
 
     waitForIndexDeletion(namespace, table, columnName);
@@ -1051,7 +1071,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         }
       }
     } catch (Exception e) {
-      throw new ExecutionException("Waiting for the secondary index deletion failed", e);
+      throw new ExecutionException(
+          String.format(
+              "Waiting for the secondary index deletion on the %s column for the %s table failed",
+              columnName, getFullTableName(namespace, table)),
+          e);
     }
   }
 
@@ -1095,12 +1119,12 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   @Override
   public TableMetadata getTableMetadata(String nonPrefixedNamespace, String table)
       throws ExecutionException {
+    String fullName = getFullTableName(Namespace.of(namespacePrefix, nonPrefixedNamespace), table);
     try {
-      String fullName =
-          getFullTableName(Namespace.of(namespacePrefix, nonPrefixedNamespace), table);
       return readMetadata(fullName);
     } catch (RuntimeException e) {
-      throw new ExecutionException("Getting a table metadata failed", e);
+      throw new ExecutionException(
+          "Getting a table metadata for the " + fullName + " table failed", e);
     }
   }
 
@@ -1124,7 +1148,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       }
       return createTableMetadata(metadata);
     } catch (Exception e) {
-      throw new ExecutionException("Failed to read the table metadata", e);
+      throw new ExecutionException(
+          "Failed to read the table metadata for the " + fullName + " table", e);
     }
   }
 
@@ -1173,6 +1198,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   @Override
   public Set<String> getNamespaceTableNames(String nonPrefixedNamespace) throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     try {
       Set<String> tableSet = new HashSet<>();
       String lastEvaluatedTableName = null;
@@ -1182,7 +1208,6 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         ListTablesResponse listTablesResponse = client.listTables(listTablesRequest);
         lastEvaluatedTableName = listTablesResponse.lastEvaluatedTableName();
         List<String> tableNames = listTablesResponse.tableNames();
-        Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
         String prefix = namespace.prefixed() + ".";
         for (String tableName : tableNames) {
           if (tableName.startsWith(prefix)) {
@@ -1193,19 +1218,18 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
       return tableSet;
     } catch (Exception e) {
-      throw new ExecutionException("Getting list of tables failed", e);
+      throw new ExecutionException(
+          "Getting the list of tables of the " + namespace + " namespace failed", e);
     }
   }
 
   @Override
   public boolean namespaceExists(String nonPrefixedNamespace) throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     try {
       Map<String, AttributeValue> key =
           ImmutableMap.of(
-              NAMESPACES_ATTR_NAME,
-              AttributeValue.builder()
-                  .s(Namespace.of(namespacePrefix, nonPrefixedNamespace).prefixed())
-                  .build());
+              NAMESPACES_ATTR_NAME, AttributeValue.builder().s(namespace.prefixed()).build());
       GetItemResponse response =
           client.getItem(
               GetItemRequest.builder()
@@ -1217,11 +1241,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     } catch (ResourceNotFoundException e) {
       return false;
     } catch (Exception e) {
-      throw new ExecutionException(
-          "Checking the namespace "
-              + Namespace.of(namespacePrefix, nonPrefixedNamespace)
-              + " existence failed",
-          e);
+      throw new ExecutionException("Checking the " + namespace + " namespace existence failed", e);
     }
   }
 
@@ -1236,7 +1256,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     try {
       if (!tableExists(nonPrefixedNamespace, table)) {
         throw new IllegalArgumentException(
-            "The table " + getFullTableName(namespace, table) + "  does not exist");
+            "The " + getFullTableName(namespace, table) + " table does not exist");
       }
       boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
       createMetadataTableIfNotExists(noBackup);
@@ -1245,7 +1265,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       throw e;
     } catch (RuntimeException e) {
       throw new ExecutionException(
-          String.format("Repairing the table %s.%s failed", namespace, table), e);
+          String.format("Repairing the %s table failed", getFullTableName(namespace, table)), e);
     }
   }
 
@@ -1253,17 +1273,18 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   public void addNewColumnToTable(
       String nonPrefixedNamespace, String table, String columnName, DataType columnType)
       throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     try {
       TableMetadata currentTableMetadata = getTableMetadata(nonPrefixedNamespace, table);
       TableMetadata updatedTableMetadata =
           TableMetadata.newBuilder(currentTableMetadata).addColumn(columnName, columnType).build();
-      Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+
       putTableMetadata(namespace, table, updatedTableMetadata);
     } catch (ExecutionException e) {
       throw new ExecutionException(
           String.format(
-              "Adding the new column %s to the %s.%s table failed",
-              columnName, nonPrefixedNamespace, table),
+              "Adding the new %s column to the %s table failed",
+              columnName, getFullTableName(namespace, table)),
           e);
     }
   }


### PR DESCRIPTION
**Context** 
Storage Admin implementations (CassandraAdmin, CosmosAdmin...) are wrapped by the [CheckedDistributedStorageAdmin](https://github.com/scalar-labs/scalardb/blob/b858fe12ec9d6d496cf4825662c0d9426d2e675b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java#L23-L34). 
The Storage Admin implementations use storage-specific synonyms instead of `namespace` and `table` : 
  * the `CassandraAdmin` uses `keyspace` and `table`
  * the `DynamoAdmin` uses `namespace` and `table`
  * the `CosmosAdmin` uses `database` and `container`
  * the `JdbcAdmin` uses `schema` and `table` 

This wording is also used in exception messages. Though, all exceptions thrown by the Storage Admin implementations will be ultimately caught and rethrown by the `CheckedDistributedStorageAdmin` which will use the ScalarDB-specific `namespace` and `table` to provide a standard ScalarDB vocabulary for the end user.
 
 **Changes**
 * The exception messages of the Storage Admin implementations were not systematically using the storage-specific wording for `namespace` and `table`. This PRs fixes that.
 
* Error messages are made more dynamic by mentioning the error context, such as the targeted namespace or table name (as suggested by @komamitsu [here](https://github.com/scalar-labs/scalardb/pull/989#discussion_r1285699051))
