### PR TITLE
v.3.5 - Check storages compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ env:
   TERM: dumb
 jobs:
   check:
+    name: Gradle check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -53,7 +54,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_test_reports
+          name: gradle_check_reports
           path: /tmp/gradle_test_reports
 
       - name: Upload Spotbugs reports
@@ -64,6 +65,7 @@ jobs:
           path: /tmp/gradle_spotbugs_reports
 
   docker:
+    name: Docker
     runs-on: ubuntu-latest
 
     steps:
@@ -127,12 +129,13 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
 
-  integration-test-for-cassandra:
+  integration-test-for-cassandra-3-0:
+    name: Cassandra 3.0 integration test
     runs-on: ubuntu-latest
 
     services:
       cassandra:
-        image: cassandra:3.11.11
+        image: cassandra:3.0
         env:
           MAX_HEAP_SIZE: 2048m
           HEAP_NEWSIZE: 512m
@@ -165,10 +168,53 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_cassandra_integration_test_reports
+          name: cassandra_3.0_integration_test_reports
+          path: core/build/reports/tests/integrationTestCassandra
+
+  integration-test-for-cassandra-3-11:
+    name: Cassandra 3.11 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      cassandra:
+        image: cassandra:3.11
+        env:
+          MAX_HEAP_SIZE: 2048m
+          HEAP_NEWSIZE: 512m
+        ports:
+          - 9042:9042
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestCassandra' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestCassandra
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestCassandra /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestCassandra /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cassandra_3.11_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
   integration-test-for-cosmos:
+    name: Cosmos DB integration test
     runs-on: self-hosted
 
     steps:
@@ -201,10 +247,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_cosmos_integration_test_reports
+          name: cosmos_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
   integration-test-for-dynamo:
+    name: DynamoDB integration test
     runs-on: ubuntu-latest
 
     services:
@@ -239,15 +286,57 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_dynamo_integration_test_reports
+          name: dynamo_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
-  integration-test-for-jdbc-mysql:
+  integration-test-for-jdbc-mysql-5-7:
+    name: MySQL 5.7 integration test
     runs-on: ubuntu-latest
 
     services:
       mysql:
-        image: mysql:8
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+        ports:
+          - 3306:3306
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mysql_5.7_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-mysql-8-0:
+    name: MySQL 8.0 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: mysql
         ports:
@@ -279,15 +368,57 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_jdbc_mysql_integration_test_reports
+          name: mysql_8.0_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
-  integration-test-for-jdbc-postgresql:
+  integration-test-for-jdbc-mysql-8-1:
+    name: MySQL 8.1 integration test
     runs-on: ubuntu-latest
 
     services:
       mysql:
-        image: postgres:14.1-alpine
+        image: mysql:8.1
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+        ports:
+          - 3306:3306
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mysql_8.1_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-12:
+    name: PostgreSQL 12 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:12-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -320,20 +451,147 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_jdbc_postgresql_integration_test_reports
+          name: postgresql_12_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
-  integration-test-for-jdbc-oracle:
+  integration-test-for-jdbc-postgresql-13:
+    name: PostgreSQL 13 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: postgresql_13_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-14:
+    name: PostgreSQL 14 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: postgresql_14_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-15:
+    name: PostgreSQL 15 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: postgresql_15_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-oracle-18:
+    name: Oracle 18 integration test
     runs-on: ubuntu-latest
 
     services:
       oracle:
-        image: ghcr.io/scalar-labs/oracle/database:21.3.0-xe
+        image: ghcr.io/scalar-labs/oracle/db-prebuilt:18
         credentials:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
         env:
-          ORACLE_PWD: Oracle21
+          ORACLE_PWD: Oracle
         ports:
           - 1521:1521
         options: >-
@@ -350,15 +608,10 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
-      - name: Retrieve then store the oracle container ip address in an environment variable.
-        run: |
-          echo "oracle_db_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'  $(docker ps -aq))" >> $GITHUB_ENV
-
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v2
-        #       Addressing the Oracle container with "@localhost" in the JDBC url cause the JDBC connection to fail for an unknown reason. As a workaround, using instead the container ip address is working.
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@${{ env.oracle_db_ip }}:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle21
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
 
       - name: Save Gradle test reports
         if: always()
@@ -372,10 +625,148 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_jdbc_oracle_integration_test_reports
+          name: oracle_18_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-oracle-21:
+    name: Oracle 21 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      oracle:
+        image: ghcr.io/scalar-labs/oracle/db-prebuilt:21
+        credentials:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+        env:
+          ORACLE_PWD: Oracle
+        ports:
+          - 1521:1521
+        options: >-
+          --health-cmd "/opt/oracle/checkDBStatus.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: oracle_21_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-oracle-23:
+    name: Oracle 23 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      oracle:
+        image: ghcr.io/scalar-labs/oracle/db-prebuilt:23
+        credentials:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+        ports:
+          - 1521:1521
+        options: >-
+          --health-cmd "/opt/oracle/checkDBStatus.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: oracle_23_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-sqlserver-2017:
+    name: SQL Server 2017 integration test
+    runs-on: ubuntu-latest
+
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2017-latest
+        env:
+          MSSQL_PID: "Express"
+          SA_PASSWORD: "SqlServer17"
+          ACCEPT_EULA: "Y"
+        ports:
+          - 1433:1433
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer17
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlserver_2017_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
-  integration-test-for-jdbc-sqlserver:
+  integration-test-for-jdbc-sqlserver-2019:
+    name: SQL Server 2019 integration test
     runs-on: ubuntu-latest
 
     services:
@@ -410,19 +801,60 @@ jobs:
           cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
           cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
 
+      - name: Save Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlserver_2019_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-mariadb:
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+        ports:
+          - 3306:3306
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integrationTestJdbc
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_integration_test_reports/core
+          mkdir -p /tmp/gradle_integration_test_reports/schema-loader
+          cp -a core/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/core/
+          cp -a schema-loader/build/reports/tests/integrationTestJdbc /tmp/gradle_integration_test_reports/schema-loader/
+
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle_jdbc_sqlserver_integration_test_reports
-          path: /tmp/gradle_integration_test_reports
+          name: mariadb_10_integration_test_reports
+          path: core/build/reports/tests/integrationTestJdbc
 
   integration-test-for-multi-storage:
+    name: Multi-storage integration test
     runs-on: ubuntu-latest
 
     services:
       cassandra:
-        image: cassandra:3.11.11
+        image: cassandra:3.11
         env:
           MAX_HEAP_SIZE: 2048m
           HEAP_NEWSIZE: 512m
@@ -461,10 +893,11 @@ jobs:
         uses: actions/upload-artifact@v3
         if : always()
         with:
-          name: gradle_multi_storage_integration_test_reports
+          name: multi_storage_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
   integration-test-for-scalardb-server:
+    name: ScalarDB Server integration test
     runs-on: ubuntu-latest
 
     services:
@@ -501,7 +934,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if : always()
         with:
-          name: gradle_scalardb_server_integration_test_reports
+          name: scalardb_server_integration_test_reports
           path: /tmp/gradle_integration_test_reports
 
   integration-test-for-two-phase-consensus-commit:


### PR DESCRIPTION
PR only used to check the storages compatibility of ScalarDB v3.5. 
**This won't be merged**