### PR TITLE
Backport to branch(3.10) : Clarify the supported Oracle JDK and OpenJDK versions; add a note about other JDKs and versions

### DIFF
--- a/docs/getting-started-with-scalardb-by-using-kotlin.md
+++ b/docs/getting-started-with-scalardb-by-using-kotlin.md
@@ -12,11 +12,20 @@ The electronic money application is simplified for this tutorial and isn't suita
 
 ## Install a JDK
 
-Because ScalarDB is written in Java, you must have one of the following Java Development Kits (JDKs) installed in your environment.
+Because ScalarDB is written in Java, you must have one of the following Java Development Kits (JDKs) installed in your environment:
 
-* [Oracle JDK 8](https://www.oracle.com/java/technologies/downloads/#java8)
-* [Oracle JDK 11](https://www.oracle.com/java/technologies/downloads/#java11)
-* [OpenJDK 8](https://openjdk.org/install/)
+- [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) LTS version (8, 11, or 17)
+- [OpenJDK](https://openjdk.org/install/) LTS version (8, 11, or 17)
+
+{% capture notice--info %}
+**Note**
+
+We recommend using the LTS versions mentioned above, but other non-LTS versions may work.
+
+In addition, other JDKs should work with ScalarDB, but we haven't tested them.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 ## Clone the `scalardb` repository
  
@@ -305,4 +314,3 @@ The balance for merchant1 is 100
 ## Reference
 
 To see the source code for the electronic money application used in this tutorial, see [`ElectronicMoney.kt`](./getting-started-kotlin/src/main/kotlin/sample/ElectronicMoney.kt).
-

--- a/docs/getting-started-with-scalardb.md
+++ b/docs/getting-started-with-scalardb.md
@@ -12,11 +12,20 @@ The electronic money application is simplified for this tutorial and isn't suita
 
 ## Install a JDK
 
-Because ScalarDB is written in Java, you must have one of the following Java Development Kits (JDKs) installed in your environment.
+Because ScalarDB is written in Java, you must have one of the following Java Development Kits (JDKs) installed in your environment:
 
-* [Oracle JDK 8](https://www.oracle.com/java/technologies/downloads/#java8)
-* [Oracle JDK 11](https://www.oracle.com/java/technologies/downloads/#java11)
-* [OpenJDK 8](https://openjdk.org/install/)
+- [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) LTS version (8, 11, or 17)
+- [OpenJDK](https://openjdk.org/install/) LTS version (8, 11, or 17)
+
+{% capture notice--info %}
+**Note**
+
+We recommend using the LTS versions mentioned above, but other non-LTS versions may work.
+
+In addition, other JDKs should work with ScalarDB, but we haven't tested them.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 ## Clone the `scalardb` repository
  


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1085