### PR TITLE
Revise supported databases

### DIFF
--- a/docs/scalardb-supported-databases.md
+++ b/docs/scalardb-supported-databases.md
@@ -4,8 +4,8 @@ ScalarDB supports the following databases and their versions.
 
 ## Amazon DynamoDB
 
-| Version           | DynamoDB |
-|:------------------|:---------|
+| Version           | DynamoDB  |
+|:------------------|:----------|
 | **ScalarDB 3.10** | ✅        |
 | **ScalarDB 3.9**  | ✅        |
 | **ScalarDB 3.8**  | ✅        |
@@ -24,8 +24,8 @@ For requirements when using Cassandra or Cassandra-compatible databases, see [Ca
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
 
-| Version           | Cassandra 4.1 | Cassandra 4.0 | Cassandra 3.11 | Cassandra 3.0 | Cassandra 2.2 |
-|:------------------|:--------------|:--------------|:---------------|:--------------|:--------------|
+| Version           | Cassandra 4.1  | Cassandra 4.0  | Cassandra 3.11  | Cassandra 3.0  | Cassandra 2.2  |
+|:------------------|:---------------|:---------------|:----------------|:---------------|:---------------|
 | **ScalarDB 3.10** | ❌             | ❌             | ✅              | ✅             | ❌             |
 | **ScalarDB 3.9**  | ❌             | ❌             | ✅              | ✅             | ❌             |
 | **ScalarDB 3.8**  | ❌             | ❌             | ✅              | ✅             | ❌             |
@@ -36,8 +36,8 @@ For requirements when using Cassandra or Cassandra-compatible databases, see [Ca
 
 ## Azure Cosmos DB for NoSQL
 
-| Version           | Cosmos DB for NoSQL |
-|:------------------|:--------------------|
+| Version           | Cosmos DB for NoSQL  |
+|:------------------|:---------------------|
 | **ScalarDB 3.10** | ✅                   |
 | **ScalarDB 3.9**  | ✅                   |
 | **ScalarDB 3.8**  | ✅                   |
@@ -58,8 +58,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### Amazon Aurora MySQL
 
-| Version           | Aurora MySQL 3 | Aurora MySQL 2 |
-|:------------------|:---------------|:---------------|
+| Version           | Aurora MySQL 3  | Aurora MySQL 2  |
+|:------------------|:----------------|:----------------|
 | **ScalarDB 3.10** | ✅              | ✅              |
 | **ScalarDB 3.9**  | ✅              | ✅              |
 | **ScalarDB 3.8**  | ✅              | ✅              |
@@ -70,8 +70,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### Amazon Aurora PostgreSQL
 
-| Version           | Aurora PostgreSQL 15 | Aurora PostgreSQL 14 | Aurora PostgreSQL 13 | Aurora PostgreSQL 12 |
-|:------------------|:---------------------|:---------------------|:---------------------|:---------------------|
+| Version           | Aurora PostgreSQL 15  | Aurora PostgreSQL 14  | Aurora PostgreSQL 13  | Aurora PostgreSQL 12  |
+|:------------------|:----------------------|:----------------------|:----------------------|:----------------------|
 | **ScalarDB 3.10** | ✅                    | ✅                    | ✅                    | ✅                    |
 | **ScalarDB 3.9**  | ✅                    | ✅                    | ✅                    | ✅                    |
 | **ScalarDB 3.8**  | ✅                    | ✅                    | ✅                    | ✅                    |
@@ -82,8 +82,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### Microsoft SQL Server
 
-| Version           | SQL Server 2022 | SQL Server 2019 | SQL Server 2017 |
-|:------------------|:----------------|:----------------|:----------------|
+| Version           | SQL Server 2022  | SQL Server 2019  | SQL Server 2017  |
+|:------------------|:-----------------|:-----------------|:-----------------|
 | **ScalarDB 3.10** | ✅               | ✅               | ✅               |
 | **ScalarDB 3.9**  | ✅               | ✅               | ✅               |
 | **ScalarDB 3.8**  | ✅               | ✅               | ✅               |
@@ -94,8 +94,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### MySQL
 
-| Version           | MySQL 8.1 | MySQL 8.0 | MySQL 5.7 |
-|:------------------|:----------|:----------|:----------|
+| Version           | MySQL 8.1  | MySQL 8.0  | MySQL 5.7  |
+|:------------------|:-----------|:-----------|:-----------|
 | **ScalarDB 3.10** | ✅         | ✅         | ✅         |
 | **ScalarDB 3.9**  | ✅         | ✅         | ✅         |
 | **ScalarDB 3.8**  | ✅         | ✅         | ✅         |
@@ -106,8 +106,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### Oracle
 
-| Version           | Oracle 23.2.0-free | Oracle 21.3.0-xe | Oracle 18.4.0-xe |
-|:------------------|:-------------------|:-----------------|:-----------------|
+| Version           | Oracle 23.2.0-free  | Oracle 21.3.0-xe  | Oracle 18.4.0-xe  |
+|:------------------|:--------------------|:------------------|:------------------|
 | **ScalarDB 3.10** | ✅                  | ✅                | ✅                |
 | **ScalarDB 3.9**  | ✅                  | ✅                | ✅                |
 | **ScalarDB 3.8**  | ✅                  | ✅                | ✅                |
@@ -118,8 +118,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### PostgreSQL
 
-| Version           | PostgreSQL 15 | PostgreSQL 14 | PostgreSQL 13 | PostgreSQL 12 |
-|:------------------|:--------------|:--------------|:--------------|:--------------|
+| Version           | PostgreSQL 15  | PostgreSQL 14  | PostgreSQL 13  | PostgreSQL 12  |
+|:------------------|:---------------|:---------------|:---------------|:---------------|
 | **ScalarDB 3.10** | ✅             | ✅             | ✅             | ✅             |
 | **ScalarDB 3.9**  | ✅             | ✅             | ✅             | ✅             |
 | **ScalarDB 3.8**  | ✅             | ✅             | ✅             | ✅             |
@@ -130,8 +130,8 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### SQLite
 
-| Version           | SQLite 3 |
-|:------------------|:---------|
+| Version           | SQLite 3  |
+|:------------------|:----------|
 | **ScalarDB 3.10** | ✅        |
 | **ScalarDB 3.9**  | ✅        |
 | **ScalarDB 3.8**  | ❌        |

--- a/docs/scalardb-supported-databases.md
+++ b/docs/scalardb-supported-databases.md
@@ -4,15 +4,15 @@ ScalarDB supports the following databases and their versions.
 
 ## Amazon DynamoDB
 
-| Version | DynamoDB |
-|:------------------|:---------------|
-| **ScalarDB 3.10** | ✅ |
-| **ScalarDB 3.9** | ✅ |
-| **ScalarDB 3.8** | ✅ |
-| **ScalarDB 3.7** | ✅ |
-| **ScalarDB 3.6** | ✅ |
-| **ScalarDB 3.5** | ✅ |
-| **ScalarDB 3.4** | ✅ |
+| Version           | DynamoDB |
+|:------------------|:---------|
+| **ScalarDB 3.10** | ✅        |
+| **ScalarDB 3.9**  | ✅        |
+| **ScalarDB 3.8**  | ✅        |
+| **ScalarDB 3.7**  | ✅        |
+| **ScalarDB 3.6**  | ✅        |
+| **ScalarDB 3.5**  | ✅        |
+| **ScalarDB 3.4**  | ✅        |
 
 ## Apache Cassandra
 
@@ -24,27 +24,27 @@ For requirements when using Cassandra or Cassandra-compatible databases, see [Ca
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
 
-| Version | Cassandra 4.1 | Cassandra 4.0 | Cassandra 3.11 | Cassandra 3.0 | Cassandra 2.2 |
-|:------------------|:---------------|:-----------------|:----------------|:-----------------|:----------------|
-| **ScalarDB 3.10** | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **ScalarDB 3.9** | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **ScalarDB 3.8** | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **ScalarDB 3.7** | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **ScalarDB 3.6** | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **ScalarDB 3.5** | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **ScalarDB 3.4** | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Version           | Cassandra 4.1 | Cassandra 4.0 | Cassandra 3.11 | Cassandra 3.0 | Cassandra 2.2 |
+|:------------------|:--------------|:--------------|:---------------|:--------------|:--------------|
+| **ScalarDB 3.10** | ❌             | ❌             | ✅              | ✅             | ❌             |
+| **ScalarDB 3.9**  | ❌             | ❌             | ✅              | ✅             | ❌             |
+| **ScalarDB 3.8**  | ❌             | ❌             | ✅              | ✅             | ❌             |
+| **ScalarDB 3.7**  | ❌             | ❌             | ✅              | ✅             | ❌             |
+| **ScalarDB 3.6**  | ❌             | ❌             | ✅              | ✅             | ❌             |
+| **ScalarDB 3.5**  | ❌             | ❌             | ✅              | ✅             | ❌             |
+| **ScalarDB 3.4**  | ❌             | ❌             | ✅              | ✅             | ❌             |
 
 ## Azure Cosmos DB for NoSQL
 
-| Version | Cosmos DB for NoSQL |
-|:------------------|:---------------|
-| **ScalarDB 3.10** | ✅ |
-| **ScalarDB 3.9** | ✅ |
-| **ScalarDB 3.8** | ✅ |
-| **ScalarDB 3.7** | ✅ |
-| **ScalarDB 3.6** | ✅ |
-| **ScalarDB 3.5** | ✅ |
-| **ScalarDB 3.4** | ✅ |
+| Version           | Cosmos DB for NoSQL |
+|:------------------|:--------------------|
+| **ScalarDB 3.10** | ✅                   |
+| **ScalarDB 3.9**  | ✅                   |
+| **ScalarDB 3.8**  | ✅                   |
+| **ScalarDB 3.7**  | ✅                   |
+| **ScalarDB 3.6**  | ✅                   |
+| **ScalarDB 3.5**  | ✅                   |
+| **ScalarDB 3.4**  | ✅                   |
 
 ## JDBC databases
 
@@ -58,84 +58,84 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 
 ### Amazon Aurora MySQL
 
-| Version | Aurora MySQL 3 | Aurora MySQL 2 |
-:---------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ | ✅ |
-| **ScalarDB 3.9** | ✅ | ✅ |
-| **ScalarDB 3.8** | ✅ | ✅ |
-| **ScalarDB 3.7** | ✅ | ✅ |
-| **ScalarDB 3.6** | ✅ | ✅ |
-| **ScalarDB 3.5** | ✅ | ✅ |
-| **ScalarDB 3.4** | ✅ | ✅ |
+| Version           | Aurora MySQL 3 | Aurora MySQL 2 |
+|:------------------|:---------------|:---------------|
+| **ScalarDB 3.10** | ✅              | ✅              |
+| **ScalarDB 3.9**  | ✅              | ✅              |
+| **ScalarDB 3.8**  | ✅              | ✅              |
+| **ScalarDB 3.7**  | ✅              | ✅              |
+| **ScalarDB 3.6**  | ✅              | ✅              |
+| **ScalarDB 3.5**  | ✅              | ✅              |
+| **ScalarDB 3.4**  | ✅              | ✅              |
 
 ### Amazon Aurora PostgreSQL
 
-| Version | Aurora PostgreSQL 14 | Aurora PostgreSQL 13 | Aurora PostgreSQL 12 |
-:---------------|:---------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.9** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.8** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.7** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.6** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.5** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.4** | ✅ | ✅ | ✅ |
+| Version           | Aurora PostgreSQL 15 | Aurora PostgreSQL 14 | Aurora PostgreSQL 13 | Aurora PostgreSQL 12 |
+|:------------------|:---------------------|:---------------------|:---------------------|:---------------------|
+| **ScalarDB 3.10** | ✅                    | ✅                    | ✅                    | ✅                    |
+| **ScalarDB 3.9**  | ✅                    | ✅                    | ✅                    | ✅                    |
+| **ScalarDB 3.8**  | ✅                    | ✅                    | ✅                    | ✅                    |
+| **ScalarDB 3.7**  | ✅                    | ✅                    | ✅                    | ✅                    |
+| **ScalarDB 3.6**  | ✅                    | ✅                    | ✅                    | ✅                    |
+| **ScalarDB 3.5**  | ✅                    | ✅                    | ✅                    | ✅                    |
+| **ScalarDB 3.4**  | ✅                    | ✅                    | ✅                    | ✅                    |
 
 ### Microsoft SQL Server
 
-| Version | SQL Server 2022 | SQL Server 2019 | SQL Server 2017 |
-:---------------|:---------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.9** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.8** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.7** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.6** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.5** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.4** | ✅ | ✅ | ✅ |
+| Version           | SQL Server 2022 | SQL Server 2019 | SQL Server 2017 |
+|:------------------|:----------------|:----------------|:----------------|
+| **ScalarDB 3.10** | ✅               | ✅               | ✅               |
+| **ScalarDB 3.9**  | ✅               | ✅               | ✅               |
+| **ScalarDB 3.8**  | ✅               | ✅               | ✅               |
+| **ScalarDB 3.7**  | ✅               | ✅               | ✅               |
+| **ScalarDB 3.6**  | ✅               | ✅               | ✅               |
+| **ScalarDB 3.5**  | ✅               | ✅               | ✅               |
+| **ScalarDB 3.4**  | ✅               | ✅               | ✅               |
 
 ### MySQL
 
-| Version | MySQL 8.0 | MySQL 5.7 |
-|:---------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ | ✅ |
-| **ScalarDB 3.9** | ✅ | ✅ |
-| **ScalarDB 3.8** | ✅ | ✅ |
-| **ScalarDB 3.7** | ✅ | ✅ |
-| **ScalarDB 3.6** | ✅ | ✅ |
-| **ScalarDB 3.5** | ✅ | ✅ |
-| **ScalarDB 3.4** | ✅ | ✅ |
+| Version           | MySQL 8.1 | MySQL 8.0 | MySQL 5.7 |
+|:------------------|:----------|:----------|:----------|
+| **ScalarDB 3.10** | ✅         | ✅         | ✅         |
+| **ScalarDB 3.9**  | ✅         | ✅         | ✅         |
+| **ScalarDB 3.8**  | ✅         | ✅         | ✅         |
+| **ScalarDB 3.7**  | ✅         | ✅         | ✅         |
+| **ScalarDB 3.6**  | ✅         | ✅         | ✅         |
+| **ScalarDB 3.5**  | ✅         | ✅         | ✅         |
+| **ScalarDB 3.4**  | ✅         | ✅         | ✅         |
 
 ### Oracle
 
-| Version | Oracle 21.3.0-xe | Oracle 18.4.0-xe |
-:---------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ | ✅ |
-| **ScalarDB 3.9** | ✅ | ✅ |
-| **ScalarDB 3.8** | ✅ | ✅ |
-| **ScalarDB 3.7** | ✅ | ✅ |
-| **ScalarDB 3.6** | ✅ | ✅ |
-| **ScalarDB 3.5** | ✅ | ✅ |
-| **ScalarDB 3.4** | ✅ | ✅ |
+| Version           | Oracle 23.2.0-free | Oracle 21.3.0-xe | Oracle 18.4.0-xe |
+|:------------------|:-------------------|:-----------------|:-----------------|
+| **ScalarDB 3.10** | ✅                  | ✅                | ✅                |
+| **ScalarDB 3.9**  | ✅                  | ✅                | ✅                |
+| **ScalarDB 3.8**  | ✅                  | ✅                | ✅                |
+| **ScalarDB 3.7**  | ✅                  | ✅                | ✅                |
+| **ScalarDB 3.6**  | ✅                  | ✅                | ✅                |
+| **ScalarDB 3.5**  | ✅                  | ✅                | ✅                |
+| **ScalarDB 3.4**  | ✅                  | ✅                | ✅                |
 
 ### PostgreSQL
 
-| Version | PostgreSQL 14 | PostgreSQL 13 | PostgreSQL 12 |
-|:---------------|:---------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.9** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.8** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.7** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.6** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.5** | ✅ | ✅ | ✅ |
-| **ScalarDB 3.4** | ✅ | ✅ | ✅ |
+| Version           | PostgreSQL 15 | PostgreSQL 14 | PostgreSQL 13 | PostgreSQL 12 |
+|:------------------|:--------------|:--------------|:--------------|:--------------|
+| **ScalarDB 3.10** | ✅             | ✅             | ✅             | ✅             |
+| **ScalarDB 3.9**  | ✅             | ✅             | ✅             | ✅             |
+| **ScalarDB 3.8**  | ✅             | ✅             | ✅             | ✅             |
+| **ScalarDB 3.7**  | ✅             | ✅             | ✅             | ✅             |
+| **ScalarDB 3.6**  | ✅             | ✅             | ✅             | ✅             |
+| **ScalarDB 3.5**  | ✅             | ✅             | ✅             | ✅             |
+| **ScalarDB 3.4**  | ✅             | ✅             | ✅             | ✅             |
 
 ### SQLite
 
-| Version | SQLite 3 |
-:---------------|:---------------|
-| **ScalarDB 3.10** | ✅ |
-| **ScalarDB 3.9** | ✅ |
-| **ScalarDB 3.8** | ❌ |
-| **ScalarDB 3.7** | ❌ |
-| **ScalarDB 3.6** | ❌ |
-| **ScalarDB 3.5** | ❌ |
-| **ScalarDB 3.4** | ❌ |
+| Version           | SQLite 3 |
+|:------------------|:---------|
+| **ScalarDB 3.10** | ✅        |
+| **ScalarDB 3.9**  | ✅        |
+| **ScalarDB 3.8**  | ❌        |
+| **ScalarDB 3.7**  | ❌        |
+| **ScalarDB 3.6**  | ❌        |
+| **ScalarDB 3.5**  | ❌        |
+| **ScalarDB 3.4**  | ❌        |

--- a/docs/scalardb-supported-databases.md
+++ b/docs/scalardb-supported-databases.md
@@ -80,6 +80,18 @@ For recommendations when using JDBC databases, see [JDBC database recommendation
 | **ScalarDB 3.5**  | ✅                    | ✅                    | ✅                    | ✅                    |
 | **ScalarDB 3.4**  | ✅                    | ✅                    | ✅                    | ✅                    |
 
+### MariaDB
+
+| Version           | MariaDB 10.11 |
+|:------------------|:--------------|
+| **ScalarDB 3.10** | ✅            |
+| **ScalarDB 3.9**  | ✅            |
+| **ScalarDB 3.8**  | ✅            |
+| **ScalarDB 3.7**  | ✅            |
+| **ScalarDB 3.6**  | ✅            |
+| **ScalarDB 3.5**  | ✅            |
+| **ScalarDB 3.4**  | ✅            |
+
 ### Microsoft SQL Server
 
 | Version           | SQL Server 2022  | SQL Server 2019  | SQL Server 2017  |

--- a/docs/scalardb-supported-databases.md
+++ b/docs/scalardb-supported-databases.md
@@ -24,15 +24,15 @@ For requirements when using Cassandra or Cassandra-compatible databases, see [Ca
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
 
-| Version           | Cassandra 4.1  | Cassandra 4.0  | Cassandra 3.11  | Cassandra 3.0  | Cassandra 2.2  |
-|:------------------|:---------------|:---------------|:----------------|:---------------|:---------------|
-| **ScalarDB 3.10** | ❌             | ❌             | ✅              | ✅             | ❌             |
-| **ScalarDB 3.9**  | ❌             | ❌             | ✅              | ✅             | ❌             |
-| **ScalarDB 3.8**  | ❌             | ❌             | ✅              | ✅             | ❌             |
-| **ScalarDB 3.7**  | ❌             | ❌             | ✅              | ✅             | ❌             |
-| **ScalarDB 3.6**  | ❌             | ❌             | ✅              | ✅             | ❌             |
-| **ScalarDB 3.5**  | ❌             | ❌             | ✅              | ✅             | ❌             |
-| **ScalarDB 3.4**  | ❌             | ❌             | ✅              | ✅             | ❌             |
+| Version           | Cassandra 4.1  | Cassandra 4.0  | Cassandra 3.11  | Cassandra 3.0  |
+|:------------------|:---------------|:---------------|:----------------|:---------------|
+| **ScalarDB 3.10** | ❌             | ❌             | ✅              | ✅             |
+| **ScalarDB 3.9**  | ❌             | ❌             | ✅              | ✅             |
+| **ScalarDB 3.8**  | ❌             | ❌             | ✅              | ✅             |
+| **ScalarDB 3.7**  | ❌             | ❌             | ✅              | ✅             |
+| **ScalarDB 3.6**  | ❌             | ❌             | ✅              | ✅             |
+| **ScalarDB 3.5**  | ❌             | ❌             | ✅              | ✅             |
+| **ScalarDB 3.4**  | ❌             | ❌             | ✅              | ✅             |
 
 ## Azure Cosmos DB for NoSQL
 


### PR DESCRIPTION
**Context**
We completed verifying the support for new database versions in https://github.com/scalar-labs/scalardb/pull/1005

**Changes**
This updates the supported databases document by 
* Adding support for:
    * Aurora PostgreSQL 15
    * MySQL 8.1
    * Oracle 23.2.0-free
    * PostgreSQL 15
* Removing support for Cassandra 2.2 since this version has reached end-of-life
