### PR TITLE
Split release.yaml to two sub workflows

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,93 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      GH_PROJECT_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK 8 and 11 (default 8)
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: |
+            11
+            8
+
+      - name: Checkout release note scripts
+        uses: actions/checkout@v4
+        with:
+          repository: scalar-labs/actions
+          # TODO: Delete the below line when add-releasenote-script branch is merged on scalar-labs/actions repository
+          ref: add-releasenote-script
+          token: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+          path: ${{ github.workspace }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            release-note-script/src/main/java
+
+      - name: Move scripts to the working directory
+        run: cp ${{ github.workspace }}/release-note-script/src/main/java/* ${{ github.workspace }}
+
+      - name: Create release note body
+        id: rn_body
+        env:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        run: |
+          $JAVA_HOME_11_X64/bin/java --source 11 ReleaseNoteCreation.java ${{ github.repository_owner }} ScalarDB ${{ steps.version.outputs.version }} ${{ github.event.repository.name }} > rnbody.md
+          cat rnbody.md # For debug
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          # TODO: Remove '#' and enable "body_path: rnbody" when every PR becomes including the release note section.
+          # Until that, the release note body is created by actions/create-release automatically.
+          # body_path: rnbody.md
+          draft: true
+          prerelease: false
+
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+
+      - name: Build scalardb-server zip
+        run: ./gradlew :server:distZip
+
+      - name: Upload scalardb-server zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: server/build/distributions/scalardb-server-${{ steps.version.outputs.version }}.zip
+          asset_name: scalardb-server-${{ steps.version.outputs.version }}.zip
+          asset_content_type: application/zip
+
+      - name: Build scalardb-schema-loader jar
+        run: ./gradlew :schema-loader:shadowJar
+
+      - name: Upload scalardb-schema-loader jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: schema-loader/build/libs/scalardb-schema-loader-${{ steps.version.outputs.version }}.jar
+          asset_name: scalardb-schema-loader-${{ steps.version.outputs.version }}.jar
+          asset_content_type: application/java-archive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,134 +10,24 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  upload-artifacts:
+    uses: ./.github/workflows/upload-artifacts.yaml
+    secrets:
+      CR_PAT: ${{ secrets.CR_PAT }}
+      ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+      ACR_USER: ${{ secrets.ACR_USER }}
+      ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
+      AWS_MARKETPLACE_ROLE_OIDC: ${{ secrets.AWS_MARKETPLACE_ROLE_OIDC }}
+      AWS_MARKETPLACE_ECR_ID: ${{ secrets.AWS_MARKETPLACE_ECR_ID }}
+      SIGNING_SECRET_KEY_RING: ${{ secrets.SIGNING_SECRET_KEY_RING }}
+      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      OSSRH_USERNAMAE: ${{ secrets.OSSRH_USERNAMAE }}
+      OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
-    steps:
-      - name: Set version
-        id: version
-        run: |
-          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          MINOR_VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g" | grep -o -E "^[0-9]+\.[0-9]+")
-          echo "minor_version=${MINOR_VERSION}" >> $GITHUB_OUTPUT
-          LATEST_VERSION=$(curl -s -u "${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/scalar-labs/scalardb/tags | jq -r .[].name | sort --version-sort -r | head -n 1 | sed -e "s#v##g")
-          echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Login to Azure Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.ACR_LOGIN_SERVER }}
-          username: ${{ secrets.ACR_USER }}
-          password: ${{ secrets.ACR_PASSWORD }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_MARKETPLACE_ROLE_OIDC }}
-          aws-region: us-east-1
-
-      - name: Login to Amazon Elastic Container Registry
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registries: ${{ secrets.AWS_MARKETPLACE_ECR_ID }}
-
-      - name: Create containers
-        run: ./gradlew docker
-
-      - name: Push containers
-        run: |
-          docker push ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
-          docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
-
-      - name: Push containers to Azure Container Registry
-        run: |
-          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.version }}
-          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.minor_version }}
-          docker push ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.version }}
-          docker push ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.minor_version }}
-
-      # Push the latest tag image since it is required from the perspective of the specification of Azure Marketplace.
-      - name: Push latest tag to Azure Container Registry
-        if: ${{ steps.version.outputs.version == steps.version.outputs.latest_version }}
-        run: |
-          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:latest
-          docker push ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:latest
-
-      # Push the patch version image only since AWS Marketplace restricts using the latest tag.
-      - name: Push containers to Amazon Elastic Container Registry
-        run: |
-          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.AWS_MARKETPLACE_ECR_ID }}.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server:${{ steps.version.outputs.version }}
-          docker push ${{ secrets.AWS_MARKETPLACE_ECR_ID }}.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server:${{ steps.version.outputs.version }}
-
-      - name: Upload scalardb, scalardb-server, scalardb-rpc, scalardb-schema-loader, and scalardb-integration-test to Maven Central Repository
-        run: |
-          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publish \
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
-          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
-
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: true
-          prerelease: false
-
-      - name: Build scalardb-server zip
-        run: ./gradlew :server:distZip
-
-      - name: Upload scalardb-server zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: server/build/distributions/scalardb-server-${{ steps.version.outputs.version }}.zip
-          asset_name: scalardb-server-${{ steps.version.outputs.version }}.zip
-          asset_content_type: application/zip
-
-      - name: Build scalardb-schema-loader jar
-        run: ./gradlew :schema-loader:shadowJar
-
-      - name: Upload scalardb-schema-loader jar
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: schema-loader/build/libs/scalardb-schema-loader-${{ steps.version.outputs.version }}.jar
-          asset_name: scalardb-schema-loader-${{ steps.version.outputs.version }}.jar
-          asset_content_type: application/java-archive
+  create-release:
+    needs: upload-artifacts
+    if: ${{ success() }}
+    uses: ./.github/workflows/create-release.yaml
+    secrets:
+      GH_PROJECT_ACCESS_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -1,0 +1,124 @@
+name: Upload artifacts
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      CR_PAT:
+        required: true
+      ACR_LOGIN_SERVER:
+        required: true
+      ACR_USER:
+        required: true
+      ACR_PASSWORD:
+        required: true
+      AWS_MARKETPLACE_ROLE_OIDC:
+        required: true
+      AWS_MARKETPLACE_ECR_ID:
+        required: true
+      SIGNING_SECRET_KEY_RING:
+        required: true
+      SIGNING_KEY_ID:
+        required: true
+      SIGNING_PASSWORD:
+        required: true
+      OSSRH_USERNAMAE:
+        required: true
+      OSSRH_PASSWORD:
+        required: true
+
+jobs:
+  upload-artifacts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          MINOR_VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g" | grep -o -E "^[0-9]+\.[0-9]+")
+          echo "minor_version=${MINOR_VERSION}" >> $GITHUB_OUTPUT
+          LATEST_VERSION=$(curl -s -u "${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/scalar-labs/scalardb/tags | jq -r .[].name | sort --version-sort -r | head -n 1 | sed -e "s#v##g")
+          echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Login to Azure Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.ACR_LOGIN_SERVER }}
+          username: ${{ secrets.ACR_USER }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_MARKETPLACE_ROLE_OIDC }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon Elastic Container Registry
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.AWS_MARKETPLACE_ECR_ID }}
+
+      - name: Create containers
+        run: ./gradlew docker
+
+      - name: Push containers
+        run: |
+          docker push ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
+
+      - name: Push containers to Azure Container Registry
+        run: |
+          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.version }}
+          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.minor_version }}
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.version }}
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:${{ steps.version.outputs.minor_version }}
+
+      # Push the latest tag image since it is required from the perspective of the specification of Azure Marketplace.
+      - name: Push latest tag to Azure Container Registry
+        if: ${{ steps.version.outputs.version == steps.version.outputs.latest_version }}
+        run: |
+          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:latest
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/scalardb-server:latest
+
+      # Push the patch version image only since AWS Marketplace restricts using the latest tag.
+      - name: Push containers to Amazon Elastic Container Registry
+        run: |
+          docker tag ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }} ${{ secrets.AWS_MARKETPLACE_ECR_ID }}.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server:${{ steps.version.outputs.version }}
+          docker push ${{ secrets.AWS_MARKETPLACE_ECR_ID }}.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server:${{ steps.version.outputs.version }}
+
+      - name: Upload scalardb, scalardb-server, scalardb-rpc, scalardb-schema-loader, and scalardb-integration-test to Maven Central Repository
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > ~/.gradle/secring.gpg
+          ./gradlew publish \
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
+          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
+          -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
+          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
+          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"


### PR DESCRIPTION
The changes made by this PR are as follows:

1. Splits `release.yaml` into two sub workflow files: `upload-artifacts.yaml` and `create-release.yaml`.
   - `upload-artifacts.yaml` creates container images, registers them to the container registries, and registers Jar files in the Maven central.
   - `create-release.yaml` generates release notes and uploads release assets.
2. Uses the [release-note-scritp](https://github.com/scalar-labs/actions/tree/add-releasenote-script) to create the main release note body.

By this separation, the release workflow executed  as follows:

`release.yaml  ->  upload-artifacts.yaml  -(if succeeded)->  create-release.yaml`

`create-release.yaml` is invoked only if `upload-artifacts.yaml` succeeds.  If `upload-artifacts.yaml` fails, `create-release.yaml` will not be executed.  In that case, create-release.yaml can be executed manually.


***NOTE:*** I'll create another PR on the workflow to generate merged release notes for ScalarDB.
