### PR TITLE
Fix tla+/consensus-commit

### DIFF
--- a/tla+/consensus-commit/CC.tla
+++ b/tla+/consensus-commit/CC.tla
@@ -132,3 +132,4 @@ CCS == INSTANCE CCSpec
 THEOREM Spec => CCS!Spec
 \* Put "CCS!Spec" into the Properties section of the model to check it
 
+=============================================================================

--- a/tla+/consensus-commit/CCSpec.tla
+++ b/tla+/consensus-commit/CCSpec.tla
@@ -51,3 +51,4 @@ Spec == Init /\ [][Next]_<<rState, cState>>
 
 THEOREM Spec => [](TypeOK /\ Consistent)
 
+=============================================================================

--- a/tla+/consensus-commit/README.md
+++ b/tla+/consensus-commit/README.md
@@ -51,7 +51,7 @@ The implementation is done in message passing style. All messages are sent on th
 2. In "What is the behavior spec?" select "Temporal formula" and enter "Spec".
 3. In "What is the model?" enter "R <- r1, r2, r3" and select "Set of model values" and also "Symmetry set". This means that r1, r2, and r3 are interchangable and will make model checking much faster.
 4. Make sure "Deadlock" is _not_ selected.
-5. Under "Invariants" you can enter "TypeOK" and "Consistent".
+5. Under "Invariants" you can enter "TypeOK".
 6. Under "Properties" enter "Spec".
 7. Now you should be able to run the model checker. Push the little green arrow at the top.
 8. The number in "States Found" and "Distinct States" should give you a good idea if the model checker is working correctly or not.


### PR DESCRIPTION
I ran into some errors when I tried to run `tla+/consensus-commit` on TLA+ Toolbox v1.8.0. This PR fixed the following issues:
1. `CC.tla` and `CCSpec.tla` don't have module-end line (`======`) which is required in the specification. See `2.2 The TLA+ Module` in https://lamport.azurewebsites.net/tla/p-manual.pdf for details
2. The README says `Consistent` invariant can be used with `Spec`. But it doesn't work

---

BTW, the following error still happens. I'll look into it later when I have a time

```
The subscript of the next-state relation specified by the specification
does not seem to contain the state variable msgs
The subscript of the next-state relation specified by the specification
does not seem to contain the state variable rPrepared
current state is not a legal state
While working on the initial state:
/\ msgs = null
/\ rState = (r1 :> "initialized" @@ r2 :> "initialized" @@ r3 :> "initialized")
/\ cState = "initialized"
/\ rPrepared = null
```