### PR TITLE
Support release/support branches in auto-pr

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
     types:
       - closed
 


### PR DESCRIPTION
## Description

We've already installed `auto-pr.yaml` which automatically creates PRs based on specified Projects. But it only supports the default branches (`main`/`master`.) We'll need to manage the backports from branch `3` to branch `3.x` after releasing version 4. `auto-pr` needs to support the release/support branches not only the default branches.

## Related issues and/or PRs

N/A

## Changes made

Add regex pattern for the release/support branches to `pull_request.branches` in `auto-pr.yaml`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This change isn't tested, but it doesn't affect current operations.
- I'll backport this change to other ScalarDB projects once confirming it works.

## Release notes

N/A