### PR TITLE
Add DistributedTransactionDecoratorAddable and TwoPhaseCommitTransactionDecoratorAddable

### DIFF
--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 
 public abstract class AbstractDistributedTransactionManager
-    implements DistributedTransactionManager {
+    implements DistributedTransactionManager, DistributedTransactionDecoratorAddable {
 
   private Optional<String> namespace;
   private Optional<String> tableName;
@@ -83,6 +83,7 @@ public abstract class AbstractDistributedTransactionManager
     return decorated;
   }
 
+  @Override
   public void addTransactionDecorator(DistributedTransactionDecorator transactionDecorator) {
     transactionDecorators.add(transactionDecorator);
   }

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 
 public abstract class AbstractTwoPhaseCommitTransactionManager
-    implements TwoPhaseCommitTransactionManager {
+    implements TwoPhaseCommitTransactionManager, TwoPhaseCommitTransactionDecoratorAddable {
 
   private Optional<String> namespace;
   private Optional<String> tableName;
@@ -85,6 +85,7 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
     return decorated;
   }
 
+  @Override
   public void addTransactionDecorator(TwoPhaseCommitTransactionDecorator transactionDecorator) {
     transactionDecorators.add(transactionDecorator);
   }

--- a/core/src/main/java/com/scalar/db/common/DistributedTransactionDecoratorAddable.java
+++ b/core/src/main/java/com/scalar/db/common/DistributedTransactionDecoratorAddable.java
@@ -1,0 +1,6 @@
+package com.scalar.db.common;
+
+public interface DistributedTransactionDecoratorAddable {
+
+  void addTransactionDecorator(DistributedTransactionDecorator transactionDecorator);
+}

--- a/core/src/main/java/com/scalar/db/common/TwoPhaseCommitTransactionDecoratorAddable.java
+++ b/core/src/main/java/com/scalar/db/common/TwoPhaseCommitTransactionDecoratorAddable.java
@@ -1,0 +1,6 @@
+package com.scalar.db.common;
+
+public interface TwoPhaseCommitTransactionDecoratorAddable {
+
+  void addTransactionDecorator(TwoPhaseCommitTransactionDecorator transactionDecorator);
+}


### PR DESCRIPTION
## Description

This PR introduces `DistributedTransactionDecoratorAddable` and `TwoPhaseCommitTransactionDecoratorAddable`, which serve as abstractions for holders of transaction decorators.

## Related issues and/or PRs

N/A

## Changes made

- Add `DistributedTransactionDecoratorAddable` and `TwoPhaseCommitTransactionDecoratorAddable`
- Make `AbstractDistributedTransactionManager` implement `DistributedTransactionDecoratorAddable`
- Make `AbstractTwoPhaseCommitTransactionManager` implement `TwoPhaseCommitTransactionDecoratorAddable`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
