### PR TITLE
Free up storage space in CI for Oracle 23 job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -556,6 +556,10 @@ jobs:
           --health-timeout 5s
           --health-retries 120
     steps:
+      - name: Free up ~2GB of disk space by removing .NET runtime and libraries.
+        run: |
+          sudo rm -r /usr/share/dotnet
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8


### PR DESCRIPTION
## Description

The CI job running the integration test on Oracle 23 has been failing consistently for a few days. The reason is a lack of storage space.
The Github runner only [guarantees 14GB of available disk space](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), but practically, about 16 GB is allocated. This leaves enough room to start the Oracle container, which requires 15GB, but not enough to run the integration test, which requires about 1GB.
To free up storage, we can delete unused tooling provided in the runner, such as .NET libraries weighting about 2GB.

To fix the issues, I considered two options:
1. Free up storage after the Oracle container is started and before the integration test are run. 
This requires adding a step to delete .NET libraries. However, this job will fail if the storage allocated to the runner falls under the 15GB required to start the Oracle container. This could happen anytime since only 14GB of storage is guaranteed. 
2. Free up storage before the Oracle container is started. 
This requires implementing option 1 and modifying the current job to start the container without using the [built-in syntax](https://github.com/scalar-labs/scalardb/blob/499799e5225161ce170fa27d9f81c77f8763f6f5/.github/workflows/ci.yaml#L545-L557) but in one of the steps of the job. Doing so could have some pitfalls since this is not documented.

Since option 2 could have some pitfalls, I prefered option 1. If, at some point, the storage allocated to the Github runner is not enough to start the Oracle container, we can consider implementing option 2.
 
## Related issues and/or PRs

https://github.com/scalar-labs/scalardb/pull/1106

## Changes made

In the CI job for Oracle 23, deletes .NET libraries to free up ~2GB of storage which leaves enough storage space to run the integration test.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
