### PR TITLE
Update busybox version in dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/busybox:1.32 AS tools
+FROM docker.io/busybox:latest AS tools
 
 ENV GRPC_HEALTH_PROBE_VERSION v0.4.17
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/busybox:latest AS tools
+FROM docker.io/busybox:1.36 AS tools
 
 ENV GRPC_HEALTH_PROBE_VERSION v0.4.17
 


### PR DESCRIPTION
## Description

In the following PR, we found an issue about busybox. This issue prevents the building container images. So, I fix it in this PR.
https://github.com/scalar-labs/scalardb-cluster/pull/178#discussion_r1346053889

## Related issues and/or PRs

https://github.com/scalar-labs/scalardb-cluster/pull/178#discussion_r1346053889

## Changes made

* Update the busybox version.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I reproduced the issue with `1.32` and confirmed that we can resolve this issue by using `1.36` as follows.

```console
$ docker run -it --rm busybox:1.32
/ #
/ # wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.17/grpc_health_probe-linux-amd64"
wget: note: TLS certificate validation not implemented
wget: TLS error from peer (alert code 80): 80
wget: error getting response: Connection reset by peer
/ #
```

```console
$ docker run -it --rm busybox:1.36
/ #
/ # wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.17/grpc_health_probe-linux-amd64"
wget: note: TLS certificate validation not implemented
/ #
/ # ls -l ./grpc_health_probe
-rw-r--r--    1 root     root      11351042 Oct  6 06:57 ./grpc_health_probe
/ #
```

## Release notes

N/A
