### PR TITLE
Backport to branch(3.10) : Free up storage space in CI for Oracle 23 job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -556,6 +556,10 @@ jobs:
           --health-timeout 5s
           --health-retries 120
     steps:
+      - name: Free up ~2GB of disk space by removing .NET runtime and libraries.
+        run: |
+          sudo rm -r /usr/share/dotnet
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1126