### PR TITLE
Fix Oracle 23 CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -560,7 +560,7 @@ jobs:
           password: ${{ secrets.CR_PAT }}
 
       - name: Start Oracle 23 container
-        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23.2.0-free
+        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23
 
       - name: Wait for the container to be ready
         timeout-minutes: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -542,23 +542,35 @@ jobs:
     name: Oracle 23 integration test
     runs-on: ubuntu-latest
 
-    services:
-      oracle:
-        image: ghcr.io/scalar-labs/oracle/db-prebuilt:23
-        credentials:
+    steps:
+      - name: Free up ~14GB of disk space by removing the Android SDK
+        run: |
+          echo "Storage available before deletion"
+          df -h /
+          echo 
+          sudo rm -r /usr/local/lib/android
+          echo "Storage available after deletion"
+          df -h /
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
-        ports:
-          - 1521:1521
-        options: >-
-          --health-cmd "/opt/oracle/checkDBStatus.sh"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 120
-    steps:
-      - name: Free up ~2GB of disk space by removing .NET runtime and libraries.
-        run: |
-          sudo rm -r /usr/share/dotnet
+
+      - name: Start Oracle 23 container
+        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23.2.0-free
+
+      - name: Wait for the container to be ready
+        timeout-minutes: 5
+        run : |
+          while [ "`docker inspect -f {{.State.Health.Status}} oracle-23`" != "healthy" ] 
+          do 
+            sleep 10
+            echo "Container is not yet ready" 
+          done
+          echo "Container is ready"
 
       - uses: actions/checkout@v4
 
@@ -572,6 +584,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
+
+      - name: Stop Oracle 23 container
+        if: always()
+        run: docker stop oracle-23 | xargs docker rm
 
       - name: Upload Gradle test reports
         if: always()


### PR DESCRIPTION
## Description
Yesterday's fix made in https://github.com/scalar-labs/scalardb/pull/1126 was eventually too optimistic and we need to implement the option 2 I mentioned in the PR description.

Oracle 23 CI is failing because of a lack of storage space to run the job. 14GB of storage is at least provided, while the job requires about 16 GB. 
The solution is to free up storage space by removing unused tooling in the runner machine before the Oracle container is started.


## Related issues and/or PRs
https://github.com/scalar-labs/scalardb/pull/1126

## Changes made
Rewrite the Oracle 23 job to free up storage space (~14GB) before starting the Oracle 23 container.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Oracle 18 and 21 images weigh 10.2 GB and 11.8 GB, respectively, so the allocated 14GB of runner storage is enough to run the integration test. So we don't need to port these changes to the Oracle 18 and 21 jobs.

## Release notes

N/A