### PR TITLE
Backport to branch(3.8) : Revise the contents of the Java API guide

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -357,19 +357,21 @@ public interface Admin {
    * Add a new column to an existing table. The new column cannot be a partition or clustering key.
    * <br>
    * <br>
-   * <strong>Warning :</strong> this should be executed with significant consideration as the
-   * execution time may vary greatly depending on the underlying storage. Please plan accordingly
-   * especially if the database runs in production:
+   * <strong>Attention:</strong> You should carefully consider adding a new column to a table
+   * because the execution time may vary greatly depending on the underlying storage. Please plan
+   * accordingly and consider the following, especially if the database runs in production:
    *
    * <ul>
-   *   <li>for Cosmos and Dynamo DB: this operation is almost instantaneous as the table schema is
-   *       not modified. Only the table metadata stored in a separated table are updated.
-   *   <li>for Cassandra: adding a column will only update the schema metadata and do not modify
-   *       existing schema records. The cluster topology is the main factor for the execution time.
-   *       Since the schema metadata change propagates to each cluster node via a gossip protocol,
-   *       the larger the cluster, the longer it will take for all nodes to be updated.
-   *   <li>for relational databases (MySQL, Oracle, etc.): it may take a very long time to execute
-   *       and a table-lock may be performed.
+   *   <li><strong>For Cosmos DB for noSQL and DynamoDB:</strong> Adding a column is almost
+   *       instantaneous as the table schema is not modified. Only the table metadata stored in a
+   *       separate table is updated.
+   *   <li><strong>For Cassandra:</strong> Adding a column will only update the schema metadata and
+   *       will not modify the existing schema records. The cluster topology is the main factor for
+   *       the execution time. Changes to the schema metadata are shared to each cluster node via a
+   *       gossip protocol. Because of this, the larger the cluster, the longer it will take for all
+   *       nodes to be updated.
+   *   <li><strong>For relational databases (MySQL, Oracle, etc.):</strong> Adding a column
+   *       shouldn't take a long time to execute.
    * </ul>
    *
    * @param namespace the table namespace

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1,29 +1,33 @@
-# Java API Guide
+# ScalarDB Java API Guide
 
-ScalarDB Java API is mainly composed of Administrative API and Transactional API.
-This guide briefly explains what kind of APIs exist and how to use them.
-
-* [Administrative API](#administrative-api)
-* [Transactional API](#transactional-api)
+The ScalarDB Java API is mainly composed of the Administrative API and Transactional API. This guide briefly explains what kinds of APIs exist, how to use them, and related topics like how to handle exceptions.
 
 ## Administrative API
 
-This section explains how to execute administrative operations with Administrative API in ScalarDB.
-You can execute administrative operations programmatically as follows, but you can also execute those operations through [Schema Loader](schema-loader.md).
+This section explains how to execute administrative operations programmatically by using the Administrative API in ScalarDB.
 
-### Get a DistributedTransactionAdmin instance
+{% capture notice--info %}
+**Note**
 
-To execute administrative operations, you first need to get a `DistributedTransactionAdmin` instance.
-The `DistributedTransactionAdmin` instance can be obtained from `TransactionFactory` as follows:
+Another method for executing administrative operations is to use [Schema Loader](schema-loader.md).
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+### Get a `DistributedTransactionAdmin` instance
+
+You first need to get a `DistributedTransactionAdmin` instance to execute administrative operations.
+
+To get a `DistributedTransactionAdmin` instance, you can use `TransactionFactory` as follows:
 
 ```java
-TransactionFactory transactionFactory = TransactionFactory.create("<configuration file path>");
+TransactionFactory transactionFactory = TransactionFactory.create("<CONFIGURATION_FILE_PATH>");
 DistributedTransactionAdmin admin = transactionFactory.getTransactionAdmin();
 ```
 
-Please see [Getting Started](getting-started.md) for the details of the configuration file.
+For details about configurations, see [ScalarDB Configurations](configurations.md).
 
-Once you have executed all administrative operations, you should close the `DistributedTransactionAdmin` instance as follows:
+After you have executed all administrative operations, you should close the `DistributedTransactionAdmin` instance as follows:
 
 ```java
 admin.close();
@@ -32,60 +36,77 @@ admin.close();
 ### Create a namespace
 
 Before creating tables, namespaces must be created since a table belongs to one namespace.
+
 You can create a namespace as follows:
 
 ```java
-// Create a namespace "ns". It will throw an exception if the namespace already exists
+// Create the namespace "ns". If the namespace already exists, an exception will be thrown.
 admin.createNamespace("ns");
 
-// Create a namespace only if it does not already exist
+// Create the namespace only if it does not already exist.
 boolean ifNotExists = true;
 admin.createNamespace("ns", ifNotExists);
 
-// Create a namespace with options
+// Create the namespace with options.
 Map<String, String> options = ...;
 admin.createNamespace("ns", options);
 ```
 
-#### Creation Options
+#### Creation options
 
-In the creation operations (creating a namespace, creating a table, etc.), you can specify options that are maps of option names and values (`Map<String, String>`).
-With the options, we can set storage adapter specific configurations.
+In the creation operations, like creating a namespace and creating a table, you can specify options that are maps of option names and values (`Map<String, String>`). By using the options, you can set storage adapter–specific configurations.
 
-Currently, we can set the following options for the storage adapters:
+Select your database to see the options available:
 
-For Cosmos DB:
+<div id="tabset-1">
+<div class="tab">
+  <button class="tablinks" onclick="openTab(event, 'Cassandra', 'tabset-1')" id="defaultOpen-1">Cassandra</button>
+  <button class="tablinks" onclick="openTab(event, 'Cosmos_DB_for_NoSQL', 'tabset-1')">Cosmos DB for NoSQL</button>
+  <button class="tablinks" onclick="openTab(event, 'DynamoDB', 'tabset-1')">DynamoDB</button>
+  <button class="tablinks" onclick="openTab(event, 'JDBC_databases', 'tabset-1')">JDBC databases</button>
+</div>
 
-| name       | value                              | default |
-|------------|------------------------------------|---------|
-| ru         | Base resource unit                 | 400     |
-| no-scaling | Disable auto-scaling for Cosmos DB | false   |
+<div id="Cassandra" class="tabcontent" markdown="1">
 
-For DynamoDB:
+| Name                 | Description                                                                            | Default          |
+|----------------------|----------------------------------------------------------------------------------------|------------------|
+| replication-strategy | Cassandra replication strategy. Must be `SimpleStrategy` or `NetworkTopologyStrategy`. | `SimpleStrategy` |
+| compaction-strategy  | Cassandra compaction strategy, Must be `LCS`, `STCS` or `TWCS`.                        | `STCS`           |
+| replication-factor   | Cassandra replication factor.                                                          | 1                |
 
-| name       | value                                  | default |
-|------------|----------------------------------------|---------|
-| no-scaling | Disable auto-scaling for DynamoDB      | false   |
-| no-backup  | Disable continuous backup for DynamoDB | false   |
-| ru         | Base resource unit                     | 10      |
+</div>
+<div id="Cosmos_DB_for_NoSQL" class="tabcontent" markdown="1">
 
-For Cassandra:
+| Name       | Description                                         | Default |
+|------------|-----------------------------------------------------|---------|
+| ru         | Base resource unit.                                 | 400     |
+| no-scaling | Disable auto-scaling for Cosmos DB for NoSQL.       | false   |
 
-| name                 | value                                                                                 | default          |
-|----------------------|---------------------------------------------------------------------------------------|------------------|
-| replication-strategy | Cassandra replication strategy, must be `SimpleStrategy` or `NetworkTopologyStrategy` | `SimpleStrategy` |
-| compaction-strategy  | Cassandra compaction strategy, must be `LCS`, `STCS` or `TWCS`                        | `STCS`           |
-| replication-factor   | Cassandra replication factor                                                          | 1                |
+</div>
+<div id="DynamoDB" class="tabcontent" markdown="1">
 
+| Name       | Description                             | Default |
+|------------|-----------------------------------------|---------|
+| no-scaling | Disable auto-scaling for DynamoDB.      | false   |
+| no-backup  | Disable continuous backup for DynamoDB. | false   |
+| ru         | Base resource unit.                     | 10      |
+
+</div>
+<div id="JDBC_databases" class="tabcontent" markdown="1">
+
+No options are available for JDBC databases.
+
+</div>
+</div>
 
 ### Create a table
 
-Next, we will discuss table creation.
+When creating a table, you should define the table metadata and then create the table.
 
-You firstly need to create the TaleMetadata as follows:
+To define the table metadata, you can use `TableMetadata`. The following shows how to define the columns, partition key, clustering key including clustering orders, and secondary indexes of a table:
 
 ```java
-// Define a table metadata
+// Define the table metadata.
 TableMetadata tableMetadata =
     TableMetadata.newBuilder()
         .addColumn("c1", DataType.INT)
@@ -100,21 +121,19 @@ TableMetadata tableMetadata =
         .build();
 ```
 
-Here you define columns, a partition key, a clustering key including clustering orders, and secondary indexes of a table.
+For details about the data model of ScalarDB, see [Data Model](design.md#data-model).
 
-Please see [ScalarDB design document - Data Model](design.md#data-model) for the details of the ScalarDB Data Model.
-
-And then, you can create a table as follows: 
+Then, create a table as follows:
 
 ```java
-// Create a table "ns.tbl". It will throw an exception if the table already exists
+// Create the table "ns.tbl". If the table already exists, an exception will be thrown.
 admin.createTable("ns", "tbl", tableMetadata);
 
-// Create a table only if it does not already exist
+// Create the table only if it does not already exist.
 boolean ifNotExists = true;
 admin.createTable("ns", "tbl", tableMetadata, ifNotExists);
 
-// Create a table with options
+// Create the table with options.
 Map<String, String> options = ...;
 admin.createTable("ns", "tbl", tableMetadata, options);
 ```
@@ -124,43 +143,45 @@ admin.createTable("ns", "tbl", tableMetadata, options);
 You can create a secondary index as follows:
 
 ```java
-// Create a secondary index on a column "c5" of a table "ns.tbl". It will throw an exception if the secondary index already exists
+// Create a secondary index on column "c5" for table "ns.tbl". If a secondary index already exists, an exception will be thrown.
 admin.createIndex("ns", "tbl", "c5");
 
-// Create a secondary index only if it does not already exist
+// Create the secondary index only if it does not already exist.
 boolean ifNotExists = true;
 admin.createIndex("ns", "tbl", "c5", ifNotExists);
 
-// Create a secondary index with options
+// Create the secondary index with options.
 Map<String, String> options = ...;
 admin.createIndex("ns", "tbl", "c5", options);
 ```
 
 ### Add a new column to a table
 
-You can add a new non-partition key column to a table as follows:  
+You can add a new, non-partition key column to a table as follows:
+
 ```java
-// Add the new column "c6" of type INT to the table "ns.tbl"  
+// Add a new column "c6" with the INT data type to the table "ns.tbl".
 admin.addNewColumnToTable("ns", "tbl", "c6", DataType.INT)
 ```
 
-This should be executed with significant consideration as the execution time may vary greatly
-depending on the underlying storage. Please plan accordingly especially if the database runs in production:
-- For Cosmos and Dynamo DB: this operation is almost instantaneous as the table
-     schema is not modified. Only the table metadata stored in a separated table are updated.
-- For Cassandra: adding a column will only update the schema metadata and do not modify existing 
-  schema records. The cluster topology is the main factor for the execution time. Since the schema 
-  metadata change propagates to each cluster node via a gossip protocol, the larger the cluster, the
-  longer it will take for all nodes to be updated.
-- For relational databases (MySQL, Oracle, etc.): it may take a very long time to execute and a 
-      table-lock may be performed.
+{% capture notice--warning %}
+**Attention**
+
+You should carefully consider adding a new column to a table because the execution time may vary greatly depending on the underlying storage. Please plan accordingly and consider the following, especially if the database runs in production:
+
+- **For Cosmos DB for NoSQL and DynamoDB:** Adding a column is almost instantaneous as the table schema is not modified. Only the table metadata stored in a separate table is updated.
+- **For Cassandra:** Adding a column will only update the schema metadata and will not modify the existing schema records. The cluster topology is the main factor for the execution time. Changes to the schema metadata are shared to each cluster node via a gossip protocol. Because of this, the larger the cluster, the longer it will take for all nodes to be updated.
+- **For relational databases (MySQL, Oracle, etc.):** Adding a column shouldn't take a long time to execute.
+{% endcapture %}
+
+<div class="notice--warning">{{ notice--warning | markdownify }}</div>
 
 ### Truncate a table
 
 You can truncate a table as follows:
 
 ```java
-// Truncate a table "ns.tbl"
+// Truncate the table "ns.tbl".
 admin.truncateTable("ns", "tbl");
 ```
 
@@ -169,10 +190,10 @@ admin.truncateTable("ns", "tbl");
 You can drop a secondary index as follows:
 
 ```java
-// Drop a secondary index on a column "c5" of a table "ns.tbl". It will throw an exception if the secondary index does not exist
+// Drop the secondary index on column "c5" from table "ns.tbl". If the secondary index does not exist, an exception will be thrown.
 admin.dropIndex("ns", "tbl", "c5");
 
-// Drop a secondary index only if it exists
+// Drop the secondary index only if it exists.
 boolean ifExists = true;
 admin.dropIndex("ns", "tbl", "c5", ifExists);
 ```
@@ -182,10 +203,10 @@ admin.dropIndex("ns", "tbl", "c5", ifExists);
 You can drop a table as follows:
 
 ```java
-// Drop a table "ns.tbl". It will throw an exception if the table does not exist
+// Drop the table "ns.tbl". If the table does not exist, an exception will be thrown.
 admin.dropTable("ns", "tbl");
 
-// Drop a table only if it exists
+// Drop the table only if it exists.
 boolean ifExists = true;
 admin.dropTable("ns", "tbl", ifExists);
 ```
@@ -195,168 +216,211 @@ admin.dropTable("ns", "tbl", ifExists);
 You can drop a namespace as follows:
 
 ```java
-// Drop a namespace "ns". It will throw an exception if the namespace does not exist
+// Drop the namespace "ns". If the namespace does not exist, an exception will be thrown.
 admin.dropNamespace("ns");
 
-// Drop a namespace only if it exists
+// Drop the namespace only if it exists.
 boolean ifExists = true;
 admin.dropNamespace("ns", ifExists);
 ```
 
-### Get a table metadata
+### Get the tables of a namespace
 
-You can get a table metadata as follows:
+You can get the tables of a namespace as follows:
 
 ```java
-// Get a table metadata of "ns.tbl"
+// Get the tables of the namespace "ns".
+Set<String> tables = admin.getNamespaceTableNames("ns");
+```
+
+### Get table metadata
+
+You can get table metadata as follows:
+
+```java
+// Get the table metadata for "ns.tbl".
 TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 ```
 
-### Operations for Coordinator tables
+### Specify operations for the Coordinator table
 
-Depending on the transaction manager type, you need to create coordinator tables to execute transactions. 
-The following items describe the operations for the coordinator table.
+The Coordinator table is used by the [Transactional API](#transactional-api) to track the statuses of transactions.
 
-#### Create Coordinator tables
+When using a transaction manager, you must create the Coordinator table to execute transactions. In addition to creating the table, you can truncate and drop the Coordinator table.
 
-You can create coordinator tables as follows:
+#### Create the Coordinator table
+
+You can create the Coordinator table as follows:
 
 ```java
-// Create coordinator tables
+// Create the Coordinator table.
 admin.createCoordinatorTables();
 
-// Create coordinator tables only if they do not already exist
+// Create the Coordinator table only if one does not already exist.
 boolean ifNotExist = true;
 admin.createCoordinatorTables(ifNotExist);
 
-// Create coordinator tables with options
+// Create the Coordinator table with options.
 Map<String, String> options = ...;
 admin.createCoordinatorTables(options);
 ```
 
-#### Truncate Coordinator tables
+#### Truncate the Coordinator table
 
-You can truncate coordinator tables as follows:
+You can truncate the Coordinator table as follows:
 
 ```java
-// Truncate coordinator tables
+// Truncate the Coordinator table.
 admin.truncateCoordinatorTables();
 ```
 
-#### Drop Coordinator tables
+#### Drop the Coordinator table
 
-You can drop coordinator tables as follows:
+You can drop the Coordinator table as follows:
 
 ```java
-// Drop coordinator tables
+// Drop the Coordinator table.
 admin.dropCoordinatorTables();
 
-// Drop coordinator tables if they exist
+// Drop the Coordinator table if one exist.
 boolean ifExist = true;
 admin.dropCoordinatorTables(ifExist);
 ```
 
 ## Transactional API
 
-This section explains how to execute transactional operations with Transactional API in ScalarDB.
+This section explains how to execute transactional operations by using the Transactional API in ScalarDB.
 
-### Get a DistributedTransactionManager instance
+### Get a `DistributedTransactionManager` instance
 
-You need to get a `DistributedTransactionManager` instance to execute transactional operations.
-You can get it in the following way:
+You first need to get a `DistributedTransactionManager` instance to execute transactional operations.
+
+To get a `DistributedTransactionManager` instance, you can use `TransactionFactory` as follows:
 
 ```java
-TransactionFactory transactionFactory = TransactionFactory.create("<configuration file path>");
+TransactionFactory transactionFactory = TransactionFactory.create("<CONFIGURATION_FILE_PATH>");
 DistributedTransactionManager manager = transactionFactory.getTransactionManager();
 ```
 
-Once you have executed all transactional operations, you should close the `DistributedTransactionManager` instance as follows:
+After you have executed all transactional operations, you should close the `DistributedTransactionManager` instance as follows:
 
 ```java
 manager.close();
 ```
 
-### Begin/Start a transaction
+### Begin or start a transaction
 
-You need to begin/start a transaction before executing transactional CRUD operations.
-You can begin/start a transaction as follows:
+Before executing transactional CRUD operations, you need to begin or start a transaction.
+
+You can begin a transaction as follows:
 
 ```java
-// Begin a transaction
+// Begin a transaction.
 DistributedTransaction transaction = manager.begin();
+```
 
-Or
+Or, you can start a transaction as follows:
 
-// Start a transaction
+```java
+// Start a transaction.
 DistributedTransaction transaction = manager.start();
 ```
 
-You can also begin/start a transaction with specifying a transaction ID as follows:
+Alternatively, you can use the `begin` method for a transaction by specifying a transaction ID as follows:
 
 ```java
-// Begin a transaction with specifying a transaction ID
-DistributedTransaction transaction = manager.begin("<transaction ID>");
-
-Or
-
-// Start a transaction with specifying a transaction ID
-DistributedTransaction transaction = manager.start("<transaction ID>");
+// Begin a transaction with specifying a transaction ID.
+DistributedTransaction transaction = manager.begin("<TRANSACTION_ID>");
 ```
 
-Note that you must guarantee uniqueness of the transaction ID in this case.
+Or, you can use the `start` method for a transaction by specifying a transaction ID as follows:
+
+```java
+// Start a transaction with specifying a transaction ID.
+DistributedTransaction transaction = manager.start("<TRANSACTION_ID>");
+```
+
+{% capture notice--info %}
+**Note**
+
+Specifying a transaction ID is useful when you want to link external systems to ScalarDB. Otherwise, you should use the `begin()` method or the `start()` method.
+
+When you specify a transaction ID, make sure you specify a unique ID (for example, UUID v4) throughout the system since ScalarDB depends on the uniqueness of transaction IDs for correctness.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 ### Resume a transaction
 
-You can resume a transaction you have already begun with specifying a transaction ID as follows:
+Resuming a transaction is particularly useful in a stateful application where a transaction spans multiple client requests. In such a scenario, the application can start a transaction during the first client request. Then, in subsequent client requests, the application can resume the ongoing transaction by using the `resume()` method.
+
+You can resume an ongoing transaction that you have already begun by specifying a transaction ID as follows:
 
 ```java
-// Resume a transaction
-DistributedTransaction transaction = manager.resume("<transaction ID>");
+// Resume a transaction.
+DistributedTransaction transaction = manager.resume("<TRANSACTION_ID>");
 ```
 
-It is helpful in a stateful application where a transaction spans multiple client requests.
-In that case, the application can begin a transaction in the first client request.
-And in the following client requests, it can resume the transaction with the `resume()` method.
+{% capture notice--info %}
+**Note**
 
-### CRUD operations
+To get the transaction ID with `getId()`, you can specify the following:
+
+```java
+tx.getId();
+```
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+### Implement CRUD operations
+
+The following sections describe key construction and CRUD operations.
+
+{% capture notice--info %}
+**Note**
+
+Although all the builders of the CRUD operations can specify consistency by using the `consistency()` methods, those methods are ignored. Instead, the `LINEARIZABLE` consistency level is always used in transactions.
+
+In addition, although the builders of the mutation operations (`Put` and `Delete` operations) can specify a condition by using the `condition()` methods, those methods are also ignored. Instead, if you want to implement conditional mutation, please program such conditions for transactions.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 #### Key construction
 
-Most CRUD operations need to specify `Key` objects (partition-key, clustering-key, etc.).
-So, before moving on to CRUD operations, the following explains how to construct a `Key` object.
+Most CRUD operations need to specify `Key` objects (partition-key, clustering-key, etc.). So, before moving on to CRUD operations, the following explains how to construct a `Key` object.
 
-For a single column key, you can use the `Key.ofXXX()` methods (XXX is a type name) to construct it as follows:
+For a single column key, you can use `Key.of<TYPE_NAME>()` methods to construct the key as follows:
 
 ```java
-// for a key that consists of a single column of Int
+// For a key that consists of a single column of INT.
 Key key1 = Key.ofInt("col1", 1);
 
-// for a key that consists of a single column of BigInt
+// For a key that consists of a single column of BIGINT.
 Key key2 = Key.ofBigInt("col1", 100L);
 
-// for a key that consists of a single column of Double
+// For a key that consists of a single column of DOUBLE.
 Key key3 = Key.ofDouble("col1", 1.3d);
 
-// for a key that consists of a single column of Text
+// For a key that consists of a single column of TEXT.
 Key key4 = Key.ofText("col1", "value");
 ```
 
-For a key that consists of 2 - 5 columns, you can use the `Key.of()` methods to construct it as follows:
+For a key that consists of two to five columns, you can use the `Key.of()` method to construct the key as follows. Similar to `ImmutableMap.of()` in Guava, you need to specify column names and values in turns:
 
 ```java
-// for a key that consists of 2 - 5 columns
+// For a key that consists of two to five columns.
 Key key1 = Key.of("col1", 1, "col2", 100L);
 Key key2 = Key.of("col1", 1, "col2", 100L, "col3", 1.3d);
 Key key3 = Key.of("col1", 1, "col2", 100L, "col3", 1.3d, "col4", "value");
 Key key4 = Key.of("col1", 1, "col2", 100L, "col3", 1.3d, "col4", "value", "col5", false);
 ```
 
-Similar to `ImmutableMap.of()` in Guava, you need to specify column names and values in turns.
-
-For a key that consists of more than 5 columns, we can use the builder to construct it as follows:
+For a key that consists of more than five columns, we can use the builder to construct the key as follows:
 
 ```java
-// for a key that consists of more than 5 columns
+// For a key that consists of more than five columns.
 Key key = Key.newBuilder()
     .addInt("col1", 1)
     .addBigInt("col2", 100L)
@@ -367,14 +431,14 @@ Key key = Key.newBuilder()
     .build();
 ```
 
-#### Get operation
+#### `Get` operation
 
 `Get` is an operation to retrieve a single record specified by a primary key.
 
-You need to create a Get object first, and then you can execute it with the `transaction.get()` method as follows:
+You need to create a `Get` object first, and then you can execute the object by using the `transaction.get()` method as follows:
 
 ```java
-// Create a Get operation
+// Create a `Get` operation.
 Key partitionKey = Key.ofInt("c1", 10);
 Key clusteringKey = Key.of("c2", "aaa", "c3", 100L);
 
@@ -387,62 +451,61 @@ Get get =
         .projections("c1", "c2", "c3", "c4")
         .build();
 
-// Execute the Get operation
+// Execute the `Get` operation.
 Optional<Result> result = transaction.get(get);
 ```
 
 You can also specify projections to choose which columns are returned.
 
-##### Handle Result objects
+##### Handle `Result` objects
 
-The Get operation and Scan operation return `Result` objects.
-So the following shows how to handle `Result` objects.
+The `Get` operation and `Scan` operation return `Result` objects. The following shows how to handle `Result` objects.
 
-You can get a column value of a result with `getXXX("<column name>")` methods (XXX is a type name) as follows:
+You can get a column value of a result by using `get<TYPE_NAME>("<COLUMN_NAME>")` methods as follows:
 
 ```java
-// Get a Boolean value of a column
-boolean booleanValue = result.getBoolean("<column name>");
+// Get the BOOLEAN value of a column.
+boolean booleanValue = result.getBoolean("<COLUMN_NAME>");
 
-// Get an Int value of a column
-int intValue = result.getInt("<column name>");
+// Get the INT value of a column.
+int intValue = result.getInt("<COLUMN_NAME>");
 
-// Get a BigInt value of a column
-long bigIntValue = result.getBigInt("<column name>");
+// Get the BIGINT value of a column.
+long bigIntValue = result.getBigInt("<COLUMN_NAME>");
 
-// Get a Float value of a column
-float floatValue = result.getFloat("<column name>");
+// Get the FLOAT value of a column.
+float floatValue = result.getFloat("<COLUMN_NAME>");
 
-// Get a Double value of a column
-double doubleValue = result.getDouble("<column name>");
+// Get the DOUBLE value of a column.
+double doubleValue = result.getDouble("<COLUMN_NAME>");
 
-// Get a Text value of a column
-String textValue = result.getText("<column name>");
+// Get the TEXT value of a column.
+String textValue = result.getText("<COLUMN_NAME>");
 
-// Get a Blob value of a column (as a ByteBuffer)
-ByteBuffer blobValue = result.getBlob("<column name>");
+// Get the BLOB value of a column as a `ByteBuffer`.
+ByteBuffer blobValue = result.getBlob("<COLUMN_NAME>");
 
-// Get a Blob value of a column as a byte array
-byte[] blobValueAsBytes = result.getBlobAsBytes("<column name>");
+// Get the BLOB value of a column as a `byte` array.
+byte[] blobValueAsBytes = result.getBlobAsBytes("<COLUMN_NAME>");
 ```
 
-And if you need to check if a value of a column is null, you can use the `isNull("<column name>")` method.
+And if you need to check if a value of a column is null, you can use the `isNull("<COLUMN_NAME>")` method.
 
 ``` java
-// Check if a value of a column is null
-boolean isNull = result.isNull("<column name>");
+// Check if a value of a column is null.
+boolean isNull = result.isNull("<COLUMN_NAME>");
 ```
 
-Please see also [Javadoc of `Result`](https://javadoc.io/static/com.scalar-labs/scalardb/3.6.0/com/scalar/db/api/Result.html) for more details.
+For more details, see the `Result` page in the [Javadoc](https://javadoc.io/doc/com.scalar-labs/scalardb/latest/index.html) of the version of ScalarDB that you're using.
 
-##### Get with a secondary index
+##### Execute `Get` by using a secondary index
 
-You can also execute a Get operation with a secondary index. 
+You can execute a `Get` operation by using a secondary index.
 
-Instead of specifying a partition key, you can specify an index key (specifying an indexed column) to use a secondary index as follows:
+Instead of specifying a partition key, you can specify an index key (indexed column) to use a secondary index as follows:
 
 ```java
-// Create a Get operation with a secondary index
+// Create a `Get` operation by using a secondary index.
 Key indexKey = Key.ofFloat("c4", 1.23F);
 
 Get get =
@@ -453,22 +516,27 @@ Get get =
         .projections("c1", "c2", "c3", "c4")
         .build();
 
-// Execute the Get operation
+// Execute the `Get` operation.
 Optional<Result> result = transaction.get(get);
 ```
 
-Note that if the result has more than one record, the `transaction.get()` throws an exception.
-If you want to handle multiple results, use [Scan with a secondary index](#scan-with-a-secondary-index).
+{% capture notice--info %}
+**Note**
 
-#### Scan operation
+If the result has more than one record, `transaction.get()` will throw an exception. If you want to handle multiple results, see [Execute `Scan` by using a secondary index](#execute-scan-by-using-a-secondary-index).
 
-`Scan` is an operation to retrieve multiple records within a partition.
-You can specify clustering key boundaries and orderings for clustering key columns in Scan operations.
+{% endcapture %}
 
-You need to create a Scan object first, and then you can execute it with the `transaction.scan()` method as follows:
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+#### `Scan` operation
+
+`Scan` is an operation to retrieve multiple records within a partition. You can specify clustering-key boundaries and orderings for clustering-key columns in `Scan` operations.
+
+You need to create a `Scan` object first, and then you can execute the object by using the `transaction.scan()` method as follows:
 
 ```java
-// Create a Scan operation
+// Create a `Scan` operation.
 Key partitionKey = Key.ofInt("c1", 10);
 Key startClusteringKey = Key.of("c2", "aaa", "c3", 100L);
 Key endClusteringKey = Key.of("c2", "aaa", "c3", 300L);
@@ -485,23 +553,22 @@ Scan scan =
         .limit(10)
         .build();
 
-// Execute the Scan operation
+// Execute the `Scan` operation.
 List<Result> results = transaction.scan(scan);
 ```
 
-You can omit the clustering key boundaries, or you can specify either a start boundary or an end boundary.
-If you don't specify orderings, you get results ordered by clustering order you defined when creating the table.
+You can omit the clustering-key boundaries or specify either a `start` boundary or an `end` boundary. If you don't specify `orderings`, you will get results ordered by the clustering order that you defined when creating the table.
 
-Also, you can specify projections to choose which columns are returned, and limit to specify the number of records to return in Scan operations.
+In addition, you can specify `projections` to choose which columns are returned and use `limit` to specify the number of records to return in `Scan` operations.
 
-##### Scan with a secondary index
+##### Execute `Scan` by using a secondary index
 
-You can also execute a Scan operation with a secondary index.
+You can execute a `Scan` operation by using a secondary index.
 
-Instead of specifying a partition key, you can specify an index key (specifying an indexed column) to use a secondary index as follows:
+Instead of specifying a partition key, you can specify an index key (indexed column) to use a secondary index as follows:
 
 ```java
-// Create a Scan operation with a secondary index
+// Create a `Scan` operation by using a secondary index.
 Key indexKey = Key.ofFloat("c4", 1.23F);
 
 Scan scan =
@@ -513,20 +580,26 @@ Scan scan =
         .limit(10)
         .build();
 
-// Execute the Scan operation
+// Execute the `Scan` operation.
 List<Result> results = transaction.scan(scan);
 ```
 
-Note that you can't specify clustering key boundaries and orderings in Scan with a secondary index.
+{% capture notice--info %}
+**Note**
 
-##### Scan without a partition key to retrieve all the records of a table
+You can't specify clustering-key boundaries and orderings in `Scan` by using a secondary index.
+{% endcapture %}
 
-You can also execute a Scan operation without specifying a partition key.
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+##### Execute `Scan` without specifying a partition key to retrieve all the records of a table
+
+You can execute a `Scan` operation without specifying a partition key.
 
 Instead of calling the `partitionKey()` method in the builder, you can call the `all()` method to scan a table without specifying a partition key as follows:
 
 ```java
-// Create a Scan operation without a partition key
+// Create a `Scan` operation without specifying a partition key.
 Scan scan =
     Scan.newBuilder()
         .namespace("ns")
@@ -536,22 +609,34 @@ Scan scan =
         .limit(10)
         .build();
 
-// Execute the Scan operation
+// Execute the `Scan` operation.
 List<Result> results = transaction.scan(scan);
 ```
 
-Note that you can't specify clustering key boundaries and orderings in Scan without a partition key.
+{% capture notice--info %}
+**Note**
 
-#### Put operation
+You can't specify clustering-key boundaries and orderings in `Scan` without specifying a partition key.
+{% endcapture %}
 
-`Put` is an operation to put a record specified by a primary key.
-It behaves as an upsert operation for a record, i.e., updating the record if the record exists; otherwise, inserting the record.
-Note that when you update an existing record, you need to read it using a `Get` or a `Scan` before a `Put` operation.
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
-You need to create a Put object first, and then you can execute it with the `transaction.put()` method as follows:
+#### `Put` operation
+
+`Put` is an operation to put a record specified by a primary key. The operation behaves as an upsert operation for a record, in which the operation updates the record if the record exists or inserts the record if the record does not exist.
+
+{% capture notice--info %}
+**Note**
+
+When you update an existing record, you need to read the record by using `Get` or `Scan` before using a `Put` operation.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+You need to create a `Put` object first, and then you can execute the object by using the `transaction.put()` method as follows:
 
 ```java
-// Create a Put operation
+// Create a `Put` operation.
 Key partitionKey = Key.ofInt("c1", 10);
 Key clusteringKey = Key.of("c2", "aaa", "c3", 100L);
 
@@ -565,11 +650,11 @@ Put put =
         .doubleValue("c5", 4.56)
         .build();
 
-// Execute the Put operation
+// Execute the `Put` operation.
 transaction.put(put);
 ```
 
-You can also put a record with null values as follows:
+You can also put a record with `null` values as follows:
 
 ```java
 Put put =
@@ -583,15 +668,22 @@ Put put =
         .build();
 ```
 
-#### Delete operation
+#### `Delete` operation
 
 `Delete` is an operation to delete a record specified by a primary key.
-Note that when you delete a record, you need to read it using a `Get` or a `Scan` before a `Delete` operation.
 
-You need to create a Delete object first, and then you can execute it with the `transaction.delete()` method as follows:
+{% capture notice--info %}
+**Note**
+
+When you delete a record, you need to read the record by using `Get` or `Scan` before using a `Delete` operation.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+You need to create a `Delete` object first, and then you can execute the object by using the `transaction.delete()` method as follows:
 
 ```java
-// Create a Delete operation
+// Create a `Delete` operation.
 Key partitionKey = Key.ofInt("c1", 10);
 Key clusteringKey = Key.of("c2", "aaa", "c3", 100L);
 
@@ -603,18 +695,18 @@ Delete delete =
         .clusteringKey(clusteringKey)
         .build();
 
-// Execute the Delete operation
+// Execute the `Delete` operation.
 transaction.delete(delete);
 ```
 
 #### Mutate operation
 
-Mutate is an operation to execute multiple mutations (Put and Delete operations).
+Mutate is an operation to execute multiple mutations (`Put` and `Delete` operations).
 
-You need to create mutation objects first, and then you can execute them with the `transaction.mutate()` method as follows:
+You need to create mutation objects first, and then you can execute the objects by using the `transaction.mutate()` method as follows:
 
 ```java
-// Create Put and Delete operations
+// Create `Put` and `Delete` operations.
 Key partitionKey = Key.ofInt("c1", 10);
 
 Key clusteringKeyForPut = Key.of("c2", "aaa", "c3", 100L);
@@ -639,72 +731,70 @@ Delete delete =
         .clusteringKey(clusteringKeyForDelete)
         .build();
 
-// Execute the operations
+// Execute the operations.
 transaction.mutate(Arrays.asList(put, delete));
 ```
-
-#### Notes
-
-- All the builders of the CRUD operations can specify consistency with the `consistency()` methods, but it's ignored, and the `LINEARIZABLE` consistency level is always used in transactions.
-- Also, the builders of the mutation operations (Put and Delete operations) can specify a condition with the `condition()` methods, but it's ignored, too. 
-Please program such conditions in a transaction if you want to implement conditional mutation.
 
 ### Commit a transaction
 
 After executing CRUD operations, you need to commit a transaction to finish it.
 
-You can commit a transaction as follows;
+You can commit a transaction as follows:
 
 ```java
-// Commit a transaction
+// Commit a transaction.
 transaction.commit();
 ```
 
-### Rollback/Abort a transaction
+### Roll back or abort a transaction
 
-If you want to rollback/abort a transaction or an error happens during the execution, you can rollback/abort a transaction.
+If an error occurs when executing a transaction, you can roll back or abort the transaction.
 
-You can rollback/abort a transaction as follows;
+You can roll back a transaction as follows:
 
 ```java
-// Rollback a transaction
+// Roll back a transaction.
 transaction.rollback();
+```
 
-Or
+Or, you can abort a transaction as follows:
 
-// Abort a transaction
+```java
+// Abort a transaction.
 transaction.abort();
 ```
 
-Please see [Handle Exceptions](#handle-exceptions) for the details of how to handle exceptions in ScalarDB.
+For details about how to handle exceptions in ScalarDB, see [How to handle exceptions](#how-to-handle-exceptions).
 
-## Transactional operations for Two-phase Commit Transaction
+## How to handle exceptions
 
-Please see [Two-phase Commit Transactions](two-phase-commit-transactions.md).
+When executing a transaction, you will also need to handle exceptions properly.
 
-## Handle Exceptions
+{% capture notice--warning %}
+**Attention**
 
-Handling exceptions correctly in ScalarDB is very important.
-If you mishandle exceptions, your data could become inconsistent.
-This document explains how to handle exceptions properly in ScalarDB.
+If you don't handle exceptions properly, you may face anomalies or data inconsistency.
+{% endcapture %}
 
-Let's look at the following example code to see how to handle exceptions in ScalarDB.
+<div class="notice--warning">{{ notice--warning | markdownify }}</div>
+
+The following sample code shows how to handle exceptions:
 
 ```java
 public class Sample {
   public static void main(String[] args) throws IOException, InterruptedException {
-    TransactionFactory factory = TransactionFactory.create("<configuration file path>");
+    TransactionFactory factory = TransactionFactory.create("<CONFIGURATION_FILE_PATH>");
     DistributedTransactionManager manager = factory.getTransactionManager();
 
     int retryCount = 0;
 
     while (true) {
       if (retryCount > 0) {
-        // Retry the transaction three times maximum in this sample code
+        // Retry the transaction three times maximum in this sample code.
         if (retryCount == 3) {
           return;
         }
-        // Sleep 100 milliseconds before retrying the transaction in this sample code
+        // Sleep 100 milliseconds before retrying the transaction in this sample code.
         TimeUnit.MILLISECONDS.sleep(100);
       }
 
@@ -713,44 +803,43 @@ public class Sample {
       try {
         tx = manager.start();
       } catch (TransactionException e) {
-        // If starting a transaction fails, it indicates some failure happens during a transaction,
-        // so you should cancel the transaction or retry the transaction after the failure/error is
-        // fixed
+        // If starting a transaction fails, it indicates some failure has happened during the transaction,
+        // so you should cancel the transaction or retry the transaction after fixing the failure/error.
         return;
       }
 
       try {
-        // Execute CRUD operations in the transaction
+        // Execute CRUD operations in the transaction.
         Optional<Result> result = tx.get(...);
         List<Result> results = tx.scan(...);
         tx.put(...);
         tx.delete(...);
 
-        // Commit the transaction
+        // Commit the transaction.
         tx.commit();
       } catch (CrudConflictException | CommitConflictException e) {
-        // If you catch CrudConflictException or CommitConflictException, it indicates conflicts 
-        // happen during a transaction so that you can retry the transaction
+        // If you catch `CrudConflictException` or `CommitConflictException`, it indicates conflicts 
+        // happened during a transaction, so you should retry the transaction.
         try {
           tx.abort();
         } catch (AbortException ex) {
-          // Aborting the transaction fails. You can log it here
+          // Aborting the transaction fails. You can log it here.
         }
         retryCount++;
       } catch (CrudException | CommitException e) {
-        // If you catch CrudException or CommitException, it indicates some failure happens, so you
-        // should cancel the transaction or retry the transaction after the failure/error is fixed
+        // If you catch `CrudException` or `CommitException`, it indicates some failure has happened, so you
+        // should cancel the transaction or retry the transaction after fixing the failure/error.
         try {
           tx.abort();
         } catch (AbortException ex) {
-          // Aborting the transaction fails. You can log it here
+          // Aborting the transaction fails. You can log it here.
         }
         return;
       } catch (UnknownTransactionStatusException e) {
         // If you catch `UnknownTransactionStatusException` when committing the transaction, you are
         // not sure if the transaction succeeds or not. In such a case, you need to check if the
         // transaction is committed successfully or not and retry it if it failed. How to identify a
-        // transaction status is delegated to users
+        // transaction status is delegated to users.
         return;
       }
     }
@@ -758,46 +847,30 @@ public class Sample {
 }
 ```
 
-The APIs for CRUD operations (`get()`/`scan()`/`put()`/`delete()`/`mutate()`) could throw `CrudException` and `CrudConflictException`.
-If you catch `CrudException`, it indicates some failure (e.g., database failure and network error) happens during a transaction, so you should cancel the transaction or retry the transaction after the failure/error is fixed.
-If you catch `CrudConflictException`, it indicates conflicts happen during a transaction so that you can retry the transaction, preferably with well-adjusted exponential backoff based on your application and environment.
-The sample code retries three times maximum and sleeps 100 milliseconds before retrying the transaction.
+### `CrudException` and `CrudConflictException`
 
-Also, the `commit()` API could throw `CommitException`, `CommitConflictException`, and `UnknownTransactionStatusException`.
-If you catch `CommitException`, like the `CrudException` case, you should cancel the transaction or retry the transaction after the failure/error is fixed.
-If you catch `CommitConflictException`, like the `CrudConflictException` case, you can retry the transaction.
-If you catch `UnknownTransactionStatusException`, you are not sure if the transaction succeeds or not.
-In such a case, you need to check if the transaction is committed successfully or not and retry it if it fails.
-How to identify a transaction status is delegated to users.
-You may want to create a transaction status table and update it transactionally with other application data so that you can get the status of a transaction from the status table.
+The APIs for CRUD operations (`get()`, `scan()`, `put()`, `delete()`, and `mutate()`) could throw `CrudException` or `CrudConflictException`:
 
-### For Two-phase Commit Transactions
+- If you catch `CrudException`, this exception indicates that the transaction CRUD operation has failed due to transient or non-transient faults. You can try retrying the transaction from the beginning, but the transaction may still fail if the cause is non-transient.
+- If you catch `CrudConflictException`, this exception indicates that the transaction CRUD operation has failed due to transient faults (for example, a conflict error). In this case, you can retry the transaction from the beginning.
 
-You need to handle more exceptions when you use [Two-phase Commit Transactions](two-phase-commit-transactions.md) because you additionally need to call the `prepare()` API (and the `validate()` API when required).
+### `CommitException`, `CommitConflictException`, and `UnknownTransactionStatusException`
 
-The `prepare()` API could throw `PreparationException` and `PreparationConflictException`.
-If you catch `PreparationException`, like the `CrudException` case, you should cancel the transaction or retry the transaction after the failure/error is fixed.
-If you catch `PreparationConflictException`, like the `CrudConflictException` case, you can retry the transaction.
+The `commit()` API could throw `CommitException`, `CommitConflictException`, or `UnknownTransactionStatusException`:
 
-Also, the `validate()` API could throw `ValidationException` and `ValidationConflictException`.
-If you catch `ValidationException`, like the `CrudException` case, you should cancel the transaction or retry the transaction after the failure/error is fixed.
-If you catch `ValidationConflictException`, like the `CrudConflictException` case, you can retry the transaction.
+- If you catch `CommitException`, this exception indicates that committing the transaction fails due to transient or non-transient faults. You can try retrying the transaction from the beginning, but the transaction may still fail if the cause is non-transient.
+- If you catch `CommitConflictException`, this exception indicates that committing the transaction has failed due to transient faults (for example, a conflict error). In this case, you can retry the transaction from the beginning.
+- If you catch `UnknownTransactionStatusException`, this exception indicates that the status of the transaction, whether it was successful or not, is unknown. In this case, you need to check if the transaction is committed successfully and retry the transaction if it has failed.
 
-## Investigate Consensus Commit transactions errors
+How to identify a transaction status is delegated to users. You may want to create a transaction status table and update it transactionally with other application data so that you can get the status of a transaction from the status table.
 
-This configuration is only available to troubleshoot Consensus Commit transactions. By adding the following configuration, `Get` and `Scan` operations results will contain [transaction metadata](schema-loader.md#internal-metadata-for-consensus-commit).
-To see the transaction metadata columns details for a given table, you can use the `DistributedTransactionAdmin.getTableMetadata()` method which will return the table metadata augmented with the transaction metadata columns. 
-All in all, using this configuration can be useful to investigate transaction related issues.
+## Investigating Consensus Commit transaction manager errors
+
+To investigate errors when using the Consensus Commit transaction manager, you can enable a configuration that will return table metadata augmented with transaction metadata columns, which can be helpful when investigating transaction-related issues. This configuration, which is only available when troubleshooting the Consensus Commit transaction manager, enables you to see transaction metadata column details for a given table by using the `DistributedTransactionAdmin.getTableMetadata()` method.
+
+By adding the following configuration, `Get` and `Scan` operations results will contain [transaction metadata](schema-loader.md#internal-metadata-for-consensus-commit):
 
 ```properties
-# By default, it is set to "false".
+# By default, this configuration is set to `false`.
 scalar.db.consensus_commit.include_metadata.enabled=true
 ```
-
-## References
-
-* [Design document](design.md)
-* [Getting started](getting-started-with-scalardb.md)
-* [Multi-storage Transactions](multi-storage-transactions.md)
-* [Two-phase Commit Transactions](two-phase-commit-transactions.md)
-* [ScalarDB Server](scalardb-server.md)


### PR DESCRIPTION
Backport of #1084

> **Note**
> 
> Reviewed and modified the contents of this doc for the `3.8` branch to check alignment with the changes we made on the `master` branch in #1084.
> 
> - Added the **Get the tables of namespace** section. (ref: [discussion](https://scalar-labs.slack.com/archives/CDSFWGSTZ/p1694584184946279?thread_ts=1694583285.025399&cid=CDSFWGSTZ))