### PR TITLE
Bump org.eclipse.jetty:jetty-servlet from 9.4.43.v20210629 to 9.4.53.v20231009

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
         scalarAdminVersion = '1.2.0'
         dropwizardMetricsVersion = '4.2.2'
         prometheusVersion = '0.12.0'
-        jettyVersion = '9.4.43.v20210629'
+        jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.8.2'
         commonsLangVersion = '3.12.0'
         assertjVersion = '3.22.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1142