### PR TITLE
Bump org.eclipse.jetty:jetty-servlet from 9.4.51.v20230217 to 9.4.53.v20231009

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
         dropwizardMetricsVersion = '4.2.19'
         prometheusVersion = '0.16.0'
         commonsTextVersion = '1.10.0'
-        jettyVersion = '9.4.51.v20230217'
+        jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.9.3'
         commonsLangVersion = '3.12.0'
         assertjVersion = '3.24.2'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1142