### PR TITLE
Update the trigger of the GitHub Action to work only on master branch push

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - "[0-9]+"
-      - "[0-9]+.[0-9]+"
 
 jobs:
   release:


### PR DESCRIPTION
## Description

Since we don't use snapshot versions of non-master/main branches, we decided not create and upload packages and containers.

## Related issues and/or PRs

N/A

## Changes made

Update the trigger of the GitHub Action to work only on master branch push.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
