### PR TITLE
Schema Loader `--repair-all` command will also repair namespaces

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraSchemaLoaderIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.scalar.db.storage.cassandra;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -16,6 +19,23 @@ public class CassandraSchemaLoaderIntegrationTest extends SchemaLoaderIntegratio
   @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CassandraAdminTestUtils(getProperties(testName));
+  }
+
+  @Override
+  protected List<String> getCommandArgsForCreation(Path configFilePath, Path schemaFilePath)
+      throws Exception {
+    return ImmutableList.<String>builder()
+        .addAll(super.getCommandArgsForCreation(configFilePath, schemaFilePath))
+        .add("--replication-factor=1")
+        .build();
+  }
+
+  @Override
+  protected List<String> getCommandArgsForReparation(Path configFilePath, Path schemaFilePath) {
+    return ImmutableList.<String>builder()
+        .addAll(super.getCommandArgsForReparation(configFilePath, schemaFilePath))
+        .add("--replication-factor=1")
+        .build();
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoSchemaLoaderIntegrationTest.java
@@ -30,10 +30,9 @@ public class DynamoSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTe
   }
 
   @Override
-  protected List<String> getCommandArgsForTableReparation(
-      Path configFilePath, Path schemaFilePath) {
+  protected List<String> getCommandArgsForReparation(Path configFilePath, Path schemaFilePath) {
     return ImmutableList.<String>builder()
-        .addAll(super.getCommandArgsForTableReparation(configFilePath, schemaFilePath))
+        .addAll(super.getCommandArgsForReparation(configFilePath, schemaFilePath))
         .add("--no-scaling")
         .add("--no-backup")
         .build();

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
@@ -3,8 +3,11 @@ package com.scalar.db.storage.multistorage;
 import static com.datastax.driver.core.Metadata.quoteIfNecessary;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
+import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.cassandra.CassandraAdmin;
+import com.scalar.db.storage.cassandra.CassandraConfig;
 import com.scalar.db.storage.cassandra.ClusterManager;
 import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
@@ -14,15 +17,17 @@ import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import com.scalar.db.util.AdminTestUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.NotImplementedException;
 
 public class MultiStorageAdminTestUtils extends AdminTestUtils {
   // for Cassandra
   private final ClusterManager clusterManager;
+  private final String cassandraMetadataNamespace;
   // for JDBC
   private final String jdbcMetadataSchema;
   private final RdbEngineStrategy rdbEngine;
@@ -31,7 +36,10 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   public MultiStorageAdminTestUtils(Properties cassandraProperties, Properties jdbcProperties) {
     // Cassandra has the coordinator tables
     super(cassandraProperties);
+    CassandraConfig cassandraConfig = new CassandraConfig(new DatabaseConfig(cassandraProperties));
     clusterManager = new ClusterManager(new DatabaseConfig(cassandraProperties));
+    cassandraMetadataNamespace =
+        cassandraConfig.getMetadataKeyspace().orElse(CassandraAdmin.METADATA_KEYSPACE);
 
     // for JDBC
     JdbcConfig jdbcConfig = new JdbcConfig(new DatabaseConfig(jdbcProperties));
@@ -41,8 +49,19 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   }
 
   @Override
-  public void dropNamespacesTable() {
-    throw new UnsupportedOperationException();
+  public void dropNamespacesTable() throws SQLException {
+    // for Cassandra
+    String dropTableQuery =
+        SchemaBuilder.dropTable(
+                quoteIfNecessary(cassandraMetadataNamespace),
+                quoteIfNecessary(CassandraAdmin.NAMESPACES_TABLE))
+            .getQueryString();
+    clusterManager.getSession().execute(dropTableQuery);
+
+    // for JDBC
+    execute(
+        "DROP TABLE "
+            + rdbEngine.encloseFullTableName(jdbcMetadataSchema, JdbcAdmin.NAMESPACES_TABLE));
   }
 
   @Override
@@ -56,8 +75,19 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   }
 
   @Override
-  public void truncateNamespacesTable() {
-    throw new UnsupportedOperationException();
+  public void truncateNamespacesTable() throws SQLException {
+    // for Cassandra
+    String truncateTableQuery =
+        QueryBuilder.truncate(
+                quoteIfNecessary(cassandraMetadataNamespace),
+                quoteIfNecessary(CassandraAdmin.NAMESPACES_TABLE))
+            .getQueryString();
+    clusterManager.getSession().execute(truncateTableQuery);
+
+    // for JDBC
+    String truncateTableStatement =
+        rdbEngine.truncateTableSql(jdbcMetadataSchema, JdbcAdmin.NAMESPACES_TABLE);
+    execute(truncateTableStatement);
   }
 
   @Override
@@ -87,13 +117,72 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
   }
 
   @Override
-  public void dropNamespace(String namespace) {
-    throw new NotImplementedException();
+  public void dropNamespace(String namespace) throws SQLException {
+    boolean existsOnCassandra = namespaceExistsOnCassandra(namespace);
+    boolean existsOnJdbc = namespaceExistsOnJdbc(namespace);
+
+    if (existsOnCassandra && existsOnJdbc) {
+      throw new IllegalStateException(
+          "The " + namespace + " namespace should not exist on both storages");
+    } else if (!(existsOnCassandra || existsOnJdbc)) {
+      throw new IllegalStateException(
+          "The " + namespace + " namespace does not exist on both storages");
+    }
+    if (existsOnCassandra) {
+      String dropKeyspaceQuery =
+          SchemaBuilder.dropKeyspace(quoteIfNecessary(namespace)).getQueryString();
+      clusterManager.getSession().execute(dropKeyspaceQuery);
+    } else {
+      execute(rdbEngine.dropNamespaceSql(namespace));
+    }
   }
 
   @Override
-  public boolean namespaceExists(String namespace) {
-    throw new NotImplementedException();
+  public boolean namespaceExists(String namespace) throws SQLException {
+    boolean existsOnCassandra = namespaceExistsOnCassandra(namespace);
+    boolean existsOnJdbc = namespaceExistsOnJdbc(namespace);
+
+    if (existsOnCassandra && existsOnJdbc) {
+      throw new IllegalStateException(
+          "The " + namespace + " namespace should not exist on both storages");
+    }
+    return existsOnCassandra || existsOnJdbc;
+  }
+
+  private boolean namespaceExistsOnCassandra(String namespace) {
+    return clusterManager.getSession().getCluster().getMetadata().getKeyspace(namespace) != null;
+  }
+
+  private boolean namespaceExistsOnJdbc(String namespace) throws SQLException {
+    String sql;
+    // RdbEngine classes are not publicly exposed, so we test the type using hard coded class name
+    switch (rdbEngine.getClass().getSimpleName()) {
+      case "RdbEngineMysql":
+        sql = "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?";
+        break;
+      case "RdbEngineOracle":
+        sql = "SELECT 1 FROM all_users WHERE username = ?";
+        break;
+      case "RdbEnginePostgresql":
+        sql = "SELECT 1 FROM pg_namespace WHERE nspname = ?";
+        break;
+      case "RdbEngineSqlite":
+        // SQLite has no concept of namespace
+        return true;
+      case "RdbEngineSqlServer":
+        sql = "SELECT 1 FROM sys.schemas WHERE name = ?";
+        break;
+      default:
+        throw new AssertionError("Unsupported engine : " + rdbEngine.getClass().getSimpleName());
+    }
+
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+      preparedStatement.setString(1, namespace);
+      ResultSet resultSet = preparedStatement.executeQuery();
+
+      return resultSet.next();
+    }
   }
 
   private void execute(String sql) throws SQLException {
@@ -105,15 +194,15 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
 
   @Override
   public boolean tableExists(String namespace, String table) throws Exception {
-    boolean existsOnCassandraStorage = tableExistsOnCassandra(namespace, table);
-    boolean existsOnJdbcStorage = tableExistsOnJdbc(namespace, table);
-    if (existsOnCassandraStorage && existsOnJdbcStorage) {
+    boolean existsOnCassandra = tableExistsOnCassandra(namespace, table);
+    boolean existsOnJdbc = tableExistsOnJdbc(namespace, table);
+    if (existsOnCassandra && existsOnJdbc) {
       throw new IllegalStateException(
           String.format(
-              "The %s table should not exists on both storages",
+              "The %s table should not exist on both storages",
               getFullTableName(namespace, table)));
     }
-    return existsOnCassandraStorage || existsOnJdbcStorage;
+    return existsOnCassandra || existsOnJdbc;
   }
 
   private boolean tableExistsOnCassandra(String namespace, String table) {
@@ -142,21 +231,21 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
 
   @Override
   public void dropTable(String namespace, String table) throws Exception {
-    boolean tableExistsOnCassandra = tableExistsOnCassandra(namespace, table);
-    boolean tableExistsOnJdbc = tableExistsOnJdbc(namespace, table);
+    boolean existsOnCassandra = tableExistsOnCassandra(namespace, table);
+    boolean existsOnJdbc = tableExistsOnJdbc(namespace, table);
 
-    if (tableExistsOnCassandra && tableExistsOnJdbc) {
+    if (existsOnCassandra && existsOnJdbc) {
       throw new IllegalStateException(
           String.format(
               "The %s table should not exist on both storages",
               getFullTableName(namespace, table)));
-    } else if (!(tableExistsOnCassandra || tableExistsOnJdbc)) {
+    } else if (!(existsOnCassandra || existsOnJdbc)) {
       throw new IllegalStateException(
           String.format(
               "The %s table does not exist on both storages", getFullTableName(namespace, table)));
     }
 
-    if (tableExistsOnCassandra) {
+    if (existsOnCassandra) {
       String dropTableQuery =
           SchemaBuilder.dropTable(quoteIfNecessary(namespace), quoteIfNecessary(table))
               .getQueryString();

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageSchemaLoaderIntegrationTest.java
@@ -1,10 +1,13 @@
 package com.scalar.db.storage.multistorage;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.db.util.AdminTestUtils;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -60,10 +63,27 @@ public class MultiStorageSchemaLoaderIntegrationTest extends SchemaLoaderIntegra
   }
 
   @Override
+  protected List<String> getCommandArgsForCreation(Path configFilePath, Path schemaFilePath)
+      throws Exception {
+    return ImmutableList.<String>builder()
+        .addAll(super.getCommandArgsForCreation(configFilePath, schemaFilePath))
+        .add("--replication-factor=1")
+        .build();
+  }
+
+  @Override
+  protected List<String> getCommandArgsForReparation(Path configFilePath, Path schemaFilePath) {
+    return ImmutableList.<String>builder()
+        .addAll(super.getCommandArgsForReparation(configFilePath, schemaFilePath))
+        .add("--replication-factor=1")
+        .build();
+  }
+
+  @Override
   protected void waitForCreationIfNecessary() {
     // In some of the tests, we modify metadata in one Cassandra cluster session (via the
     // Schema Loader) and verify if such metadata were updated by using another session (via the
-    // CassandraAdminTestUtils). But it takes some time for metadata change to be propagated from
+    // MultiStorageAdminTestUtils). But it takes some time for metadata change to be propagated from
     // one session to the other, so we need to wait
     Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RdbEngineOracle implements RdbEngineStrategy {
+class RdbEngineOracle implements RdbEngineStrategy {
   private static final Logger logger = LoggerFactory.getLogger(RdbEngineOracle.class);
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -29,7 +29,7 @@ import org.sqlite.SQLiteException;
  * native SQLite library in JAR</a>, we should assure the real error messages in
  * RdbEngineStrategyTest.
  */
-public class RdbEngineSqlite implements RdbEngineStrategy {
+class RdbEngineSqlite implements RdbEngineStrategy {
   private static final String NAMESPACE_SEPARATOR = "$";
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -141,9 +141,6 @@ public abstract class SchemaLoaderIntegrationTestBase {
                         .put("col7", "BOOLEAN")
                         .build())
                 .put("secondary-index", Arrays.asList("col1", "col5"))
-                .put("compaction-strategy", "LCS")
-                .put("network-strategy", "SimpleStrategy")
-                .put("replication-factor", "1")
                 .build(),
         namespace2 + "." + TABLE_2,
             ImmutableMap.<String, Object>builder()
@@ -155,8 +152,6 @@ public abstract class SchemaLoaderIntegrationTestBase {
                     ImmutableMap.of(
                         "pk1", "INT", "ck1", "INT", "col1", "INT", "col2", "BIGINT", "col3",
                         "FLOAT"))
-                .put("network-strategy", "SimpleStrategy")
-                .put("replication-factor", "1")
                 .build());
   }
 
@@ -225,8 +220,7 @@ public abstract class SchemaLoaderIntegrationTestBase {
         .build();
   }
 
-  protected List<String> getCommandArgsForTableReparation(
-      Path configFilePath, Path schemaFilePath) {
+  protected List<String> getCommandArgsForReparation(Path configFilePath, Path schemaFilePath) {
     return ImmutableList.of(
         "--config",
         configFilePath.toString(),
@@ -235,10 +229,10 @@ public abstract class SchemaLoaderIntegrationTestBase {
         "--repair-all");
   }
 
-  protected List<String> getCommandArgsForTableReparationWithCoordinator(
+  protected List<String> getCommandArgsForReparationWithCoordinator(
       Path configFilePath, Path schemaFilePath) {
     return ImmutableList.<String>builder()
-        .addAll(getCommandArgsForTableReparation(configFilePath, schemaFilePath))
+        .addAll(getCommandArgsForReparation(configFilePath, schemaFilePath))
         .add("--coordinator")
         .build();
   }
@@ -322,53 +316,36 @@ public abstract class SchemaLoaderIntegrationTestBase {
   }
 
   @Test
-  public void createTablesThenDropMetadataTableThenRepairTables_ShouldExecuteProperly()
+  public void createTablesThenDropTablesThenRepairAllWithoutCoordinator_ShouldExecuteProperly()
       throws Exception {
     // Arrange
     int exitCodeCreation =
         executeWithArgs(getCommandArgsForCreation(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
     assertThat(exitCodeCreation).isZero();
-    adminTestUtils.dropMetadataTable();
+    adminTestUtils.dropNamespacesTable();
+    adminTestUtils.dropTable(namespace1, TABLE_1);
+    adminTestUtils.dropNamespace(namespace1);
 
     // Act
     int exitCodeReparation =
-        executeWithArgs(getCommandArgsForTableReparation(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
+        executeWithArgs(getCommandArgsForReparation(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
 
     // Assert
     assertThat(exitCodeReparation).isZero();
+    waitForCreationIfNecessary();
+    assertThat(adminTestUtils.namespaceExists(namespace1)).isTrue();
+    assertThat(adminTestUtils.namespaceExists(namespace2)).isTrue();
+    assertThat(transactionAdmin.namespaceExists(namespace1)).isTrue();
+    assertThat(storageAdmin.namespaceExists(namespace2)).isTrue();
     assertThat(adminTestUtils.tableExists(namespace1, TABLE_1)).isTrue();
     assertThat(adminTestUtils.tableExists(namespace2, TABLE_2)).isTrue();
     assertThat(transactionAdmin.getTableMetadata(namespace1, TABLE_1)).isEqualTo(TABLE_1_METADATA);
     assertThat(storageAdmin.getTableMetadata(namespace2, TABLE_2)).isEqualTo(TABLE_2_METADATA);
+    assertThat(adminTestUtils.areTableAndMetadataForCoordinatorTablesPresent()).isFalse();
   }
 
   @Test
-  public void
-      createTablesThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly()
-          throws Exception {
-    // Arrange
-    int exitCodeCreation =
-        executeWithArgs(
-            getCommandArgsForCreationWithCoordinator(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
-    assertThat(exitCodeCreation).isZero();
-    adminTestUtils.dropMetadataTable();
-
-    // Act
-    int exitCodeReparation =
-        executeWithArgs(
-            getCommandArgsForTableReparationWithCoordinator(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
-
-    // Assert
-    assertThat(exitCodeReparation).isZero();
-    assertThat(adminTestUtils.tableExists(namespace1, TABLE_1)).isTrue();
-    assertThat(adminTestUtils.tableExists(namespace2, TABLE_2)).isTrue();
-    assertThat(transactionAdmin.getTableMetadata(namespace1, TABLE_1)).isEqualTo(TABLE_1_METADATA);
-    assertThat(storageAdmin.getTableMetadata(namespace2, TABLE_2)).isEqualTo(TABLE_2_METADATA);
-    assertThat(adminTestUtils.areTableAndMetadataForCoordinatorTablesPresent()).isTrue();
-  }
-
-  @Test
-  public void createTablesThenDropTablesThenRepairTablesWithCoordinator_ShouldExecuteProperly()
+  public void createTablesThenDropTablesThenRepairAllWithCoordinator_ShouldExecuteProperly()
       throws Exception {
     // Arrange
     int exitCodeCreation =
@@ -377,16 +354,20 @@ public abstract class SchemaLoaderIntegrationTestBase {
     assertThat(exitCodeCreation).isZero();
     adminTestUtils.dropMetadataTable();
     adminTestUtils.dropTable(namespace1, TABLE_1);
-    adminTestUtils.dropTable(namespace2, TABLE_2);
+    adminTestUtils.dropNamespace(namespace1);
 
     // Act
     int exitCodeReparation =
         executeWithArgs(
-            getCommandArgsForTableReparationWithCoordinator(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
+            getCommandArgsForReparationWithCoordinator(CONFIG_FILE_PATH, SCHEMA_FILE_PATH));
 
     // Assert
     assertThat(exitCodeReparation).isZero();
     waitForCreationIfNecessary();
+    assertThat(adminTestUtils.namespaceExists(namespace1)).isTrue();
+    assertThat(adminTestUtils.namespaceExists(namespace2)).isTrue();
+    assertThat(transactionAdmin.namespaceExists(namespace1)).isTrue();
+    assertThat(storageAdmin.namespaceExists(namespace2)).isTrue();
     assertThat(adminTestUtils.tableExists(namespace1, TABLE_1)).isTrue();
     assertThat(adminTestUtils.tableExists(namespace2, TABLE_2)).isTrue();
     assertThat(transactionAdmin.getTableMetadata(namespace1, TABLE_1)).isEqualTo(TABLE_1_METADATA);

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -285,15 +285,15 @@ public class SchemaLoader {
   }
 
   /**
-   * Repair tables defined in the schema.
+   * Repair namespaces and tables defined in the schema that are in an unknown state.
    *
    * @param configProperties ScalarDB config properties
    * @param serializedSchemaJson serialized json string schema.
-   * @param options specific options for repairing tables.
+   * @param options specific options for repairing.
    * @param repairCoordinatorTable repair coordinator tables or not.
-   * @throws SchemaLoaderException thrown when repairing tables fails.
+   * @throws SchemaLoaderException thrown when repairing fails.
    */
-  public static void repairTables(
+  public static void repairAll(
       Properties configProperties,
       String serializedSchemaJson,
       Map<String, String> options,
@@ -301,19 +301,19 @@ public class SchemaLoader {
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Right<>(configProperties);
     Either<Path, String> schema = new Right<>(serializedSchemaJson);
-    repairTables(config, schema, options, repairCoordinatorTable);
+    repairAll(config, schema, options, repairCoordinatorTable);
   }
 
   /**
-   * Repair tables defined in the schema file.
+   * Repair namespaces and tables defined in the schema file that are in an unknown state.
    *
    * @param configProperties ScalarDB properties.
    * @param schemaPath path to the schema file.
-   * @param options specific options for repairing tables.
+   * @param options specific options for repairing.
    * @param repairCoordinatorTable repair coordinator tables or not.
-   * @throws SchemaLoaderException thrown when repairing tables fails.
+   * @throws SchemaLoaderException thrown when repairing fails.
    */
-  public static void repairTables(
+  public static void repairAll(
       Properties configProperties,
       Path schemaPath,
       Map<String, String> options,
@@ -321,19 +321,19 @@ public class SchemaLoader {
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Right<>(configProperties);
     Either<Path, String> schema = new Left<>(schemaPath);
-    repairTables(config, schema, options, repairCoordinatorTable);
+    repairAll(config, schema, options, repairCoordinatorTable);
   }
 
   /**
-   * Repair tables defined in the schema.
+   * Repair namespaces and tables defined in the schema that are in an unknown state.
    *
    * @param configPath path to the ScalarDB config.
    * @param serializedSchemaJson serialized json string schema.
-   * @param options specific options for repairing tables.
+   * @param options specific options for repairing.
    * @param repairCoordinatorTable repair coordinator tables or not.
-   * @throws SchemaLoaderException thrown when repairing tables fails.
+   * @throws SchemaLoaderException thrown when repairing fails.
    */
-  public static void repairTables(
+  public static void repairAll(
       Path configPath,
       String serializedSchemaJson,
       Map<String, String> options,
@@ -341,36 +341,36 @@ public class SchemaLoader {
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Left<>(configPath);
     Either<Path, String> schema = new Right<>(serializedSchemaJson);
-    repairTables(config, schema, options, repairCoordinatorTable);
+    repairAll(config, schema, options, repairCoordinatorTable);
   }
 
   /**
-   * Repair tables defined in the schema file.
+   * Repair namespaces and tables defined in the schema file that are in an unknown state.
    *
    * @param configPath path to the ScalarDB config.
    * @param schemaPath path to the schema file.
-   * @param options specific options for repairing tables.
+   * @param options specific options for repairing.
    * @param repairCoordinatorTable repair coordinator tables or not.
-   * @throws SchemaLoaderException thrown when repairing tables fails.
+   * @throws SchemaLoaderException thrown when repairing fails.
    */
-  public static void repairTables(
+  public static void repairAll(
       Path configPath, Path schemaPath, Map<String, String> options, boolean repairCoordinatorTable)
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Left<>(configPath);
     Either<Path, String> schema = new Left<>(schemaPath);
-    repairTables(config, schema, options, repairCoordinatorTable);
+    repairAll(config, schema, options, repairCoordinatorTable);
   }
 
   /**
-   * Repair tables defined in the schema file.
+   * Repair namespaces and tables defined in the schema file.
    *
    * @param config ScalarDB config
    * @param schema schema.
-   * @param options specific options for repairing tables.
+   * @param options specific options for repairing.
    * @param repairCoordinatorTable repair coordinator tables or not.
-   * @throws SchemaLoaderException thrown when repairing tables fails.
+   * @throws SchemaLoaderException thrown when repairing fails.
    */
-  private static void repairTables(
+  private static void repairAll(
       Either<Path, Properties> config,
       Either<Path, String> schema,
       Map<String, String> options,
@@ -381,6 +381,7 @@ public class SchemaLoader {
 
     // Repair tables
     try (SchemaOperator operator = getSchemaOperator(config)) {
+      operator.repairNamespaces(tableSchemaList);
       operator.repairTables(tableSchemaList);
       if (repairCoordinatorTable) {
         operator.repairCoordinatorTables(options);

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -81,7 +81,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
         description =
             "Repair namespaces and tables that are in an unknown state: it recreates namespaces, tables, secondary indexes and their metadata if necessary.",
         defaultValue = "false")
-    boolean repairTables;
+    boolean repairAll;
 
     @Option(
         names = {"-A", "--alter"},
@@ -107,7 +107,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       createTables();
     } else if (mode.deleteTables) {
       SchemaLoader.unload(configPath, schemaFile, coordinator);
-    } else if (mode.repairTables) {
+    } else if (mode.repairAll) {
       repairAll();
     } else if (mode.alterTables) {
       alterTables();

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -79,7 +79,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
     @Option(
         names = {"--repair-all"},
         description =
-            "Repair tables : it repairs the table metadata of existing tables. When using Cosmos DB, it additionally repairs stored procedure attached to each table",
+            "Repair namespaces and tables that are in an unknown state: it recreates namespaces, tables, secondary indexes and their metadata if necessary.",
         defaultValue = "false")
     boolean repairTables;
 
@@ -108,7 +108,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
     } else if (mode.deleteTables) {
       SchemaLoader.unload(configPath, schemaFile, coordinator);
     } else if (mode.repairTables) {
-      repairTables();
+      repairAll();
     } else if (mode.alterTables) {
       alterTables();
     } else if (mode.importTables) {
@@ -122,13 +122,13 @@ public class SchemaLoaderCommand implements Callable<Integer> {
     SchemaLoader.load(configPath, schemaFile, options, coordinator);
   }
 
-  private void repairTables() throws SchemaLoaderException {
+  private void repairAll() throws SchemaLoaderException {
     if (schemaFile == null) {
       throw new IllegalArgumentException(
           "Specifying the '--schema-file' option is required when using the '--repair-all' option");
     }
     Map<String, String> options = prepareAllOptions();
-    SchemaLoader.repairTables(configPath, schemaFile, options, coordinator);
+    SchemaLoader.repairAll(configPath, schemaFile, options, coordinator);
   }
 
   private void alterTables() throws SchemaLoaderException {

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
@@ -540,120 +540,128 @@ public class SchemaLoaderTest {
 
   @Test
   public void
-      repairTable_WithConfigFilePathAndSerializedSchemaAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigFilePathAndSerializedSchemaAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configFilePath, SERIALIZED_SCHEMA_JSON, options, true);
+    SchemaLoader.repairAll(configFilePath, SERIALIZED_SCHEMA_JSON, options, true);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator).repairCoordinatorTables(options);
   }
 
   @Test
   public void
-      repairTable_WithConfigFilePathAndSerializedSchemaAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigFilePathAndSerializedSchemaAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configFilePath, SERIALIZED_SCHEMA_JSON, options, false);
+    SchemaLoader.repairAll(configFilePath, SERIALIZED_SCHEMA_JSON, options, false);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator, never()).repairCoordinatorTables(anyMap());
   }
 
   @Test
   public void
-      repairTable_WithConfigPropertiesAndSerializedSchemaAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigPropertiesAndSerializedSchemaAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configProperties, SERIALIZED_SCHEMA_JSON, options, true);
+    SchemaLoader.repairAll(configProperties, SERIALIZED_SCHEMA_JSON, options, true);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator).repairCoordinatorTables(options);
   }
 
   @Test
   public void
-      repairTable_WithConfigPropertiesAndSerializedSchemaAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigPropertiesAndSerializedSchemaAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configProperties, SERIALIZED_SCHEMA_JSON, options, false);
+    SchemaLoader.repairAll(configProperties, SERIALIZED_SCHEMA_JSON, options, false);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator, never()).repairCoordinatorTables(anyMap());
   }
 
   @Test
   public void
-      repairTable_WithConfigPropertiesAndSchemaFilePathAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigPropertiesAndSchemaFilePathAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configProperties, schemaFilePath, options, true);
+    SchemaLoader.repairAll(configProperties, schemaFilePath, options, true);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator).repairCoordinatorTables(options);
   }
 
   @Test
   public void
-      repairTable_WithConfigPropertiesAndSchemaFilePathAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigPropertiesAndSchemaFilePathAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configProperties, schemaFilePath, options, false);
+    SchemaLoader.repairAll(configProperties, schemaFilePath, options, false);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator, never()).repairCoordinatorTables(anyMap());
   }
 
   @Test
   public void
-      repairTable_WithConfigFilePathAndSchemaFilePathAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigFilePathAndSchemaFilePathAndDoRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configFilePath, schemaFilePath, options, true);
+    SchemaLoader.repairAll(configFilePath, schemaFilePath, options, true);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator).repairCoordinatorTables(options);
   }
 
   @Test
   public void
-      repairTable_WithConfigFilePathAndSchemaFilePathAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
+      repairAll_WithConfigFilePathAndSchemaFilePathAndDoNotRepairCoordinatorTables_ShouldCallParserAndOperatorProperly()
           throws Exception {
     // Arrange
 
     // Act
-    SchemaLoader.repairTables(configFilePath, schemaFilePath, options, false);
+    SchemaLoader.repairAll(configFilePath, schemaFilePath, options, false);
 
     // Assert
     verify(parser).parse();
+    verify(operator).repairNamespaces(anyList());
     verify(operator).repairTables(anyList());
     verify(operator, never()).repairCoordinatorTables(anyMap());
   }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -541,28 +541,43 @@ public class SchemaOperatorTest {
   @Test
   @SuppressWarnings("unchecked")
   public void
-      repairNamespaces_WithSeveralTablesPerNamespace_ShouldRepairWithOptionsFromTheFirstListedTable()
+      repairNamespaces_WithSeveralTablesPerNamespace_ShouldRepairWithOptionsOfTheCorrectTable()
           throws SchemaLoaderException, ExecutionException {
     // Arrange
     Map<String, String> ns1SchemaOptions = mock(Map.class);
     Map<String, String> ns2SchemaOptions = mock(Map.class);
     Map<String, String> ns3SchemaOptions = mock(Map.class);
+    // ns1Schema1, ns2Schema2 and ns3Schema1 will be selected to repair respectively the ns1, ns2
+    // and ns3 namespaces
     TableSchema ns1Schema1 = prepareTableSchemaMock("ns1", true, ns1SchemaOptions);
     TableSchema ns1Schema2 = prepareTableSchemaMock("ns1", true, null);
-    TableSchema ns2Schema1 = prepareTableSchemaMock("ns2", false, ns2SchemaOptions);
-    TableSchema ns2Schema2 = prepareTableSchemaMock("ns2", true, null);
-    TableSchema ns3Schema1 = prepareTableSchemaMock("ns3", true, ns3SchemaOptions);
+    TableSchema ns2Schema1 = prepareTableSchemaMock("ns2", false, null);
+    TableSchema ns2Schema2 = prepareTableSchemaMock("ns2", true, ns2SchemaOptions);
+    TableSchema ns2Schema3 = prepareTableSchemaMock("ns2", true, null);
+    TableSchema ns2Schema4 = prepareTableSchemaMock("ns2", false, null);
+    TableSchema ns3Schema1 = prepareTableSchemaMock("ns3", false, ns3SchemaOptions);
+    TableSchema ns3Schema2 = prepareTableSchemaMock("ns3", false, null);
 
     List<TableSchema> tableSchemaList =
-        Arrays.asList(ns1Schema1, ns1Schema2, ns2Schema1, ns2Schema2, ns3Schema1);
+        Arrays.asList(
+            ns1Schema1,
+            ns1Schema2,
+            ns2Schema1,
+            ns2Schema2,
+            ns2Schema3,
+            ns2Schema4,
+            ns3Schema1,
+            ns3Schema2);
 
     // Act
     operator.repairNamespaces(tableSchemaList);
 
     // Assert
     verify(transactionAdmin).repairNamespace("ns1", ns1SchemaOptions);
-    verify(storageAdmin).repairNamespace("ns2", ns2SchemaOptions);
-    verify(transactionAdmin).repairNamespace("ns3", ns3SchemaOptions);
+    verify(transactionAdmin).repairNamespace("ns2", ns2SchemaOptions);
+    verifyNoMoreInteractions(transactionAdmin);
+    verify(storageAdmin).repairNamespace("ns3", ns3SchemaOptions);
+    verifyNoMoreInteractions(storageAdmin);
   }
 
   private TableSchema prepareTableSchemaMock(

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -535,5 +536,43 @@ public class SchemaOperatorTest {
     // Assert
     verify(storageAdmin, times(3)).importTable("ns", "tb");
     verifyNoInteractions(transactionAdmin);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void
+      repairNamespaces_WithSeveralTablesPerNamespace_ShouldRepairWithOptionsFromTheFirstListedTable()
+          throws SchemaLoaderException, ExecutionException {
+    // Arrange
+    Map<String, String> ns1SchemaOptions = mock(Map.class);
+    Map<String, String> ns2SchemaOptions = mock(Map.class);
+    Map<String, String> ns3SchemaOptions = mock(Map.class);
+    TableSchema ns1Schema1 = prepareTableSchemaMock("ns1", true, ns1SchemaOptions);
+    TableSchema ns1Schema2 = prepareTableSchemaMock("ns1", true, null);
+    TableSchema ns2Schema1 = prepareTableSchemaMock("ns2", false, ns2SchemaOptions);
+    TableSchema ns2Schema2 = prepareTableSchemaMock("ns2", true, null);
+    TableSchema ns3Schema1 = prepareTableSchemaMock("ns3", true, ns3SchemaOptions);
+
+    List<TableSchema> tableSchemaList =
+        Arrays.asList(ns1Schema1, ns1Schema2, ns2Schema1, ns2Schema2, ns3Schema1);
+
+    // Act
+    operator.repairNamespaces(tableSchemaList);
+
+    // Assert
+    verify(transactionAdmin).repairNamespace("ns1", ns1SchemaOptions);
+    verify(storageAdmin).repairNamespace("ns2", ns2SchemaOptions);
+    verify(transactionAdmin).repairNamespace("ns3", ns3SchemaOptions);
+  }
+
+  private TableSchema prepareTableSchemaMock(
+      String namespace, boolean isTransactionTable, @Nullable Map<String, String> options) {
+    TableSchema schema = mock(TableSchema.class);
+    when(schema.getNamespace()).thenReturn(namespace);
+    when(schema.isTransactionTable()).thenReturn(isTransactionTable);
+    if (options != null) {
+      when(schema.getOptions()).thenReturn(options);
+    }
+    return schema;
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
@@ -194,7 +194,7 @@ public class SchemaLoaderCommandTest {
 
   @Test
   public void
-      call_WithProperArgumentsForRepairingTablesWithoutCoordinatorArgument_ShouldCallRepairTableProperly() {
+      call_WithProperArgumentsForRepairingAllWithoutCoordinatorArgument_ShouldCallRepairAllProperly() {
     // Arrange
     String schemaFile = "path_to_file";
     String configFile = "path_to_config_file";
@@ -205,14 +205,12 @@ public class SchemaLoaderCommandTest {
 
     // Assert
     schemaLoaderMockedStatic.verify(
-        () ->
-            SchemaLoader.repairTables(
-                Paths.get(configFile), Paths.get(schemaFile), options, false));
+        () -> SchemaLoader.repairAll(Paths.get(configFile), Paths.get(schemaFile), options, false));
   }
 
   @Test
   public void
-      call_WithProperArgumentsForRepairingTablesWithCoordinatorArgument_ShouldCallRepairTableProperly() {
+      call_WithProperArgumentsForRepairingAllWithCoordinatorArgument_ShouldCallRepairAllProperly() {
     // Arrange
     String schemaFile = "path_to_file";
     String configFile = "path_to_config_file";
@@ -224,12 +222,11 @@ public class SchemaLoaderCommandTest {
 
     // Assert
     schemaLoaderMockedStatic.verify(
-        () ->
-            SchemaLoader.repairTables(Paths.get(configFile), Paths.get(schemaFile), options, true));
+        () -> SchemaLoader.repairAll(Paths.get(configFile), Paths.get(schemaFile), options, true));
   }
 
   @Test
-  public void call_forRepairingTablesWithoutSchemaFile_ShouldThrowIllegalArgumentException() {
+  public void call_forRepairingAllWithoutSchemaFile_ShouldThrowIllegalArgumentException() {
     // Arrange
     String configFile = "path_to_config_file";
 
@@ -351,7 +348,7 @@ public class SchemaLoaderCommandTest {
   }
 
   @Test
-  public void call_ImportOptionGivenWithProperArguments_ShouldCallRepairTableProperly() {
+  public void call_ImportOptionGivenWithProperArguments_ShouldCallImportTableProperly() {
     // Arrange
     String schemaFile = "path_to_file";
     String configFile = "path_to_config_file";

--- a/server/src/integration-test/java/com/scalar/db/server/SchemaLoaderIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/SchemaLoaderIntegrationTestWithServer.java
@@ -2,25 +2,22 @@ package com.scalar.db.server;
 
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
-import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 public class SchemaLoaderIntegrationTestWithServer extends SchemaLoaderIntegrationTestBase {
 
   private ScalarDbServer server;
-  boolean isExternalServerUsed;
 
   @Override
-  protected void initialize(String testName) throws IOException {
+  protected void initialize(String testName) throws Exception {
+    super.initialize(testName);
     Properties properties = ServerEnv.getServer1Properties(testName);
     if (properties != null) {
       server = new ScalarDbServer(properties);
       server.start();
-    } else {
-      isExternalServerUsed = true;
     }
   }
 
@@ -48,37 +45,13 @@ public class SchemaLoaderIntegrationTestWithServer extends SchemaLoaderIntegrati
     }
   }
 
-  /** This test is disabled if {@link #isExternalServerUsed()} return true */
-  @Override
   @Test
-  @DisabledIf("isExternalServerUsed")
-  public void createTablesThenDropMetadataTableThenRepairTables_ShouldExecuteProperly()
-      throws Exception {
-    super.createTablesThenDropMetadataTableThenRepairTables_ShouldExecuteProperly();
-  }
-
-  /** This test is disabled if {@link #isExternalServerUsed()} return true */
+  @Disabled("repairAll is not supported with ScalarDB Server")
   @Override
-  @Test
-  @DisabledIf("isExternalServerUsed")
-  public void
-      createTablesThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly()
-          throws Exception {
-    super.createTablesThenDropMetadataTableThenRepairTablesWithCoordinator_ShouldExecuteProperly();
-  }
+  public void createTablesThenDropTablesThenRepairAllWithoutCoordinator_ShouldExecuteProperly() {}
 
   @Test
-  @DisabledIf("isExternalServerUsed")
+  @Disabled("repairAll is not supported with ScalarDB Server")
   @Override
-  public void createTablesThenDropTablesThenRepairTablesWithCoordinator_ShouldExecuteProperly()
-      throws Exception {
-    super.createTablesThenDropTablesThenRepairTablesWithCoordinator_ShouldExecuteProperly();
-  }
-
-  @SuppressWarnings("unused")
-  private boolean isExternalServerUsed() {
-    // An external server is used, so we don't have access to the configuration to connect to the
-    // underlying storage which makes it impossible to run these tests
-    return isExternalServerUsed;
-  }
+  public void createTablesThenDropTablesThenRepairAllWithCoordinator_ShouldExecuteProperly() {}
 }


### PR DESCRIPTION
## Description
So far, the Schema Loader command `--repair-all` would only to repair the tables in the schema. For now on, this command will additionally repair the namespaces. 

## Related issues and/or PRs
- Related to https://github.com/scalar-labs/scalardb/pull/1107
- Related to https://github.com/scalar-labs/scalardb/pull/989

## Changes made

Update the Schema Loader `--repair-all` command to additionally repair namespaces, besides repairing the tables of the schema.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I will update the documentation in another PR.

## Release notes

Updated the Schema Loader `--repair-all` command to additionally repair namespaces besides repairing the tables of the schema.
