### PR TITLE
Add `upgrade()` to Admin API

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
@@ -14,5 +15,10 @@ public class CassandraAdminIntegrationTest extends DistributedStorageAdminIntegr
   @Override
   protected Map<String, String> getCreationOptions() {
     return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new CassandraAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -18,6 +18,7 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
     return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CassandraAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
@@ -15,5 +16,9 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
   @Override
   protected Map<String, String> getCreationOptions() {
     return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new CassandraAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -36,5 +37,9 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new CosmosAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -39,6 +39,7 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
     return CosmosEnv.getCreationOptions();
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -35,5 +36,9 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new CosmosAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -38,6 +38,7 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
     return CosmosEnv.getCreationOptions();
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new CosmosAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -23,6 +23,7 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
     return false;
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new DynamoAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
 
@@ -20,5 +21,9 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   @Override
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new DynamoAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
 import java.util.Properties;
 
@@ -19,5 +20,9 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
   @Override
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new DynamoAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -22,6 +22,7 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
     return false;
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new DynamoAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 
 public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
@@ -9,5 +10,9 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
   @Override
   protected Properties getProps(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new JdbcAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -12,6 +12,7 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     return JdbcEnv.getProperties(testName);
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new JdbcAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -11,6 +11,7 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
     return JdbcEnv.getProperties(testName);
   }
 
+  @Override
   protected AdminTestUtils getAdminTestUtils(String testName) {
     return new JdbcAdminTestUtils(getProperties(testName));
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 
 public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
@@ -8,5 +9,9 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   @Override
   protected Properties getProperties(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new JdbcAdminTestUtils(getProperties(testName));
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -4,6 +4,7 @@ import com.scalar.db.api.DistributedTransactionAdminIntegrationTestBase;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.storage.jdbc.JdbcEnv;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -70,5 +71,16 @@ public class JdbcTransactionAdminIntegrationTest
   public void dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException()
       throws ExecutionException {
     super.dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException();
+  }
+
+  @Test
+  @Disabled("JDBC Transaction Admin does not support upgrade()")
+  @Override
+  public void
+      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -431,4 +431,14 @@ public interface Admin {
    * @throws ExecutionException if the operation fails
    */
   Set<String> getNamespaceNames() throws ExecutionException;
+
+  /**
+   * Upgrades the Scalar DB environment to support the latest version of the Scalar DB API.
+   * Typically, you will be requested, as indicated on the release notes, to run this method after
+   * updating the Scalar DB version of your application environment.
+   *
+   * @param options options to upgrade
+   * @throws ExecutionException if the operation fails
+   */
+  void upgrade(Map<String, String> options) throws ExecutionException;
 }

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -433,9 +433,9 @@ public interface Admin {
   Set<String> getNamespaceNames() throws ExecutionException;
 
   /**
-   * Upgrades the Scalar DB environment to support the latest version of the Scalar DB API.
+   * Upgrades the ScalarDB environment to support the latest version of the ScalarDB API.
    * Typically, you will be requested, as indicated on the release notes, to run this method after
-   * updating the Scalar DB version of your application environment.
+   * updating the ScalarDB version of your application environment.
    *
    * @param options options to upgrade
    * @throws ExecutionException if the operation fails

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -433,9 +433,9 @@ public interface Admin {
   Set<String> getNamespaceNames() throws ExecutionException;
 
   /**
-   * Upgrades the ScalarDB environment to support the latest version of the ScalarDB API.
-   * Typically, you will be requested, as indicated on the release notes, to run this method after
-   * updating the ScalarDB version of your application environment.
+   * Upgrades the ScalarDB environment to support the latest version of the ScalarDB API. Typically,
+   * you will be requested, as indicated on the release notes, to run this method after updating the
+   * ScalarDB version of your application environment.
    *
    * @param options options to upgrade
    * @throws ExecutionException if the operation fails

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -328,6 +328,15 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    try {
+      admin.upgrade(options);
+    } catch (ExecutionException e) {
+      throw new ExecutionException("Upgrading the ScalarDB environment failed", e);
+    }
+  }
+
+  @Override
   public void close() {
     admin.close();
   }

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -123,6 +123,11 @@ public class AdminService implements DistributedStorageAdmin {
   }
 
   @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    admin.upgrade(options);
+  }
+
+  @Override
   public void close() {
     admin.close();
   }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -412,7 +412,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       createKeyspace(metadataKeyspace, options, true);
       createNamespacesTableIfNotExists();
       // Retrieve user keyspace and filter out system ones. A downside is that this may include
-      // keyspace not created by Scalar DB.
+      // keyspace not created by ScalarDB.
       Set<String> userKeyspaces =
           clusterManager.getSession().getCluster().getMetadata().getKeyspaces().stream()
               .map(KeyspaceMetadata::getName)

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -406,6 +406,26 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     }
   }
 
+  @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    try {
+      createKeyspace(metadataKeyspace, options, true);
+      createNamespacesTableIfNotExists();
+      // Retrieve user keyspace and filter out system ones. A downside is that this may include
+      // keyspace not created by Scalar DB.
+      Set<String> userKeyspaces =
+          clusterManager.getSession().getCluster().getMetadata().getKeyspaces().stream()
+              .map(KeyspaceMetadata::getName)
+              .filter(name -> !name.startsWith("system") && !name.equals(metadataKeyspace))
+              .collect(Collectors.toSet());
+      for (String userKeyspace : userKeyspaces) {
+        upsertIntoNamespacesTable(userKeyspace);
+      }
+    } catch (RuntimeException e) {
+      throw new ExecutionException("Upgrading the ScalarDB environment failed", e);
+    }
+  }
+
   private void createNamespacesTableIfNotExists() {
     String createTableQuery =
         SchemaBuilder.createTable(

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1393,7 +1393,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
                     .build());
       } catch (RuntimeException e) {
         throw new ExecutionException(
-            "failed to retrieve the namespaces names of existing tables", e);
+            "Failed to retrieve the namespaces names of existing tables", e);
       }
       lastEvaluatedKey = scanResponse.lastEvaluatedKey();
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1363,6 +1363,50 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     }
   }
 
+  @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    if (!metadataTableExists()) {
+      return;
+    }
+    boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
+    createNamespacesTableIfNotExists(noBackup);
+    try {
+      for (Namespace namespace : getNamespacesOfExistingTables()) {
+        upsertIntoNamespacesTable(namespace);
+      }
+    } catch (ExecutionException e) {
+      throw new ExecutionException("Upgrading the ScalarDB environment failed", e);
+    }
+  }
+
+  private Set<Namespace> getNamespacesOfExistingTables() throws ExecutionException {
+    Set<Namespace> namespaceNames = new HashSet<>();
+    Map<String, AttributeValue> lastEvaluatedKey = null;
+    do {
+      ScanResponse scanResponse;
+      try {
+        scanResponse =
+            client.scan(
+                ScanRequest.builder()
+                    .tableName(ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE))
+                    .exclusiveStartKey(lastEvaluatedKey)
+                    .build());
+      } catch (RuntimeException e) {
+        throw new ExecutionException(
+            "failed to retrieve the namespaces names of existing tables", e);
+      }
+      lastEvaluatedKey = scanResponse.lastEvaluatedKey();
+
+      for (Map<String, AttributeValue> tableMetadata : scanResponse.items()) {
+        String fullTableName = tableMetadata.get(METADATA_ATTR_TABLE).s();
+        String namespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
+        namespaceNames.add(Namespace.of(namespaceName));
+      }
+    } while (!lastEvaluatedKey.isEmpty());
+
+    return namespaceNames;
+  }
+
   private void createNamespacesTableIfNotExists(boolean noBackup) throws ExecutionException {
     try {
       if (!namespacesTableExists()) {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Namespace.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Namespace.java
@@ -1,5 +1,7 @@
 package com.scalar.db.storage.dynamo;
 
+import java.util.Objects;
+
 public class Namespace {
   private final String prefix;
   private final String name;
@@ -34,5 +36,22 @@ public class Namespace {
   @Override
   public String toString() {
     return prefixed();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Namespace)) {
+      return false;
+    }
+    Namespace namespace = (Namespace) o;
+    return Objects.equals(prefix, namespace.prefix) && Objects.equals(name, namespace.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(prefix, name);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -255,6 +255,13 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
     return namespaceNames;
   }
 
+  @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    for (DistributedStorageAdmin admin : namespaceAdminMap.values()) {
+      admin.upgrade(options);
+    }
+  }
+
   private DistributedStorageAdmin getAdmin(String namespace) {
     DistributedStorageAdmin admin = namespaceAdminMap.get(namespace);
     return admin != null ? admin : defaultAdmin;

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
@@ -364,6 +364,12 @@ public class GrpcAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    throw new UnsupportedOperationException(
+        "Upgrading the ScalarDB environment is not supported in ScalarDB Server");
+  }
+
+  @Override
   public void close() {
     try {
       channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -236,6 +236,11 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    admin.upgrade(options);
+  }
+
+  @Override
   public void close() {
     admin.close();
   }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -143,6 +143,12 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    throw new UnsupportedOperationException(
+        "Upgrading the ScalarDB environment is not supported with the JDBC transaction admin");
+  }
+
+  @Override
   public void close() {
     jdbcAdmin.close();
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
@@ -412,6 +412,12 @@ public class GrpcTransactionAdmin implements DistributedTransactionAdmin {
         "Repairing a namespace is not supported in ScalarDB Server");
   }
 
+  @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    throw new UnsupportedOperationException(
+        "Upgrading the ScalarDB environment is not supported in ScalarDB Server");
+  }
+
   private static <T> T execute(ThrowableSupplier<T, ExecutionException> supplier)
       throws ExecutionException {
     try {

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -599,4 +599,22 @@ public class MultiStorageAdminTest {
     // Assert
     verify(admin3).repairNamespace(namespace, options);
   }
+
+  @Test
+  public void upgrade_ShouldCallNamespaceAndDefaultAdmins() throws ExecutionException {
+    // Arrange
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+    Map<String, DistributedStorageAdmin> namespaceAdminMap =
+        ImmutableMap.of("ns1", admin1, "ns2", admin2);
+    DistributedStorageAdmin defaultAdmin = admin2;
+    multiStorageAdmin =
+        new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, defaultAdmin);
+
+    // Act
+    multiStorageAdmin.upgrade(options);
+
+    // Assert
+    verify(admin1).upgrade(options);
+    verify(admin2).upgrade(options);
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -683,4 +683,16 @@ public abstract class ConsensusCommitAdminTestBase {
     // Assert
     verify(distributedStorageAdmin).repairNamespace("ns", Collections.emptyMap());
   }
+
+  @Test
+  public void upgrade_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    admin.upgrade(options);
+
+    // Arrange
+    verify(distributedStorageAdmin).upgrade(options);
+  }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -9,6 +9,7 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.TransactionFactory;
+import com.scalar.db.util.AdminTestUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -113,6 +114,8 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   protected Map<String, String> getCreationOptions() {
     return Collections.emptyMap();
   }
+
+  protected abstract AdminTestUtils getAdminTestUtils(String testName);
 
   @AfterAll
   public void afterAll() throws Exception {
@@ -852,6 +855,25 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
 
     // Assert
     assertThat(namespaces).containsOnly(namespace1, namespace2);
+  }
+
+  @Test
+  public void
+      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces()
+          throws Exception {
+    AdminTestUtils adminTestUtils = getAdminTestUtils(TEST_NAME);
+    try {
+      // Arrange
+      adminTestUtils.dropNamespacesTable();
+
+      // Act
+      admin.upgrade(getCreationOptions());
+
+      // Assert
+      assertThat(admin.getNamespaceNames()).containsOnly(namespace1, namespace2);
+    } finally {
+      adminTestUtils.close();
+    }
   }
 
   protected boolean isIndexOnBooleanColumnSupported() {

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
@@ -5,6 +5,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.util.AdminTestUtils;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
@@ -85,6 +86,17 @@ public class ConsensusCommitAdminIntegrationTestWithServer
   @Test
   @Disabled("Retrieving the namespace names is not supported in ScalarDB server")
   public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
+
+  @Test
+  @Disabled("upgrade() is not supported in ScalarDB server")
+  @Override
+  public void
+      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    throw new UnsupportedOperationException();
+  }
 
   @SuppressWarnings("unused")
   private boolean isExternalServerUsed() {

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
@@ -1,6 +1,7 @@
 package com.scalar.db.server;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
@@ -30,6 +31,17 @@ public class DistributedStorageAdminIntegrationTestWithServer
   @Test
   @Disabled("Retrieving the namespace names is not supported in ScalarDB server")
   public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
+
+  @Test
+  @Disabled("upgrade() is not supported in ScalarDB server")
+  @Override
+  public void
+      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    throw new UnsupportedOperationException();
+  }
 
   @AfterAll
   @Override


### PR DESCRIPTION
## Description

Considering we have the two following requirement:
1. As a ScalarDB user, I want to be able to upgrade my ScalarDB environment (schema metadata and coordinator table) to support backward incompatible changes introduced by a new version. 
2. As a ScalarDB user, I want to be able to upgrade my ScalarDB environment to support backward incompatible changes introduced by the namespace management feature.

To address story `2` while also being able to address the more general story `1` for future work, we choose a generic API name, `upgrade()`. Currently, this method will only address the need to upgrade the environment because of the namespace management feature, but we can append new behaviors anytime to handle new features that break the backward compatibility of the environment.

## Related issues and/or PRs
- Related to https://github.com/scalar-labs/scalardb/pull/989

## Changes made

Add a new `void upgrade(Map<String, String> options)` method to the Admin API, which will create the namespace metadata table and create metadata for the existing namespace.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- A new `--upgrade` command will be added to the Schema Loader in another PR
- The documentation will be updated in another PR.
- `upgrade()` is not supported in the ScalarDB Server and JDBC Transaction Admin since these two components will be deleted before the 4.0.0 release.

## Release notes

Added a new method, `void upgrade(Map<String,String> options)`, to the Admin API. Running this method when updating an existing environment to ScalarDB 4.X is necessary to support backward incompatible changes introduced by the new  "namespaces management" feature. 