### PR TITLE
Port auto-pr workflow to branch `3`

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
     types:
       - closed
 
@@ -15,11 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_PR_PAT }}
+      # Escape the PR title. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable for details
+      PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # This is necessary to avoid unexpected auto-merge in git cherry-pick
           fetch-depth: 0
+          # This is necessary for git-push
+          token: ${{ secrets.GH_PR_PAT }}
 
       - name: Create pull requests
         run: |
@@ -47,7 +53,7 @@ jobs:
           ci/auto-pr/create_pull_requests \
             "${{ github.event.number }}" \
             "${{ github.event.pull_request.html_url }}" \
-            "${{ github.event.pull_request.title }}" \
+            "$PR_TITLE" \
             "${{ github.sha }}" \
             "$new_pr_assignee" \
             $branches


### PR DESCRIPTION
## Description

We allowed Auto PR workflow to work with release/support branches. But it didn't work since the destination branches don't have the workflow.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1118

## Changes made

This PR copies the latest Auto PR workflow file to the release/support branch.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This change is to update the existing old workflow. The diff is same as the diff between `3.10` and `master`. As for other release/support branches that don't have the workflow file, I'll create another PR to create it.

## Release notes

N/A