### PR TITLE
Add missing Auto-PR workflow file

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -1,0 +1,60 @@
+name: Auto-PR
+
+on:
+  pull_request:
+    branches:
+      - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
+    types:
+      - closed
+
+env:
+  TERM: dumb
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_PR_PAT }}
+      # Escape the PR title. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable for details
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This is necessary to avoid unexpected auto-merge in git cherry-pick
+          fetch-depth: 0
+          # This is necessary for git-push
+          token: ${{ secrets.GH_PR_PAT }}
+
+      - name: Create pull requests
+        run: |
+          assignee=$(ci/auto-pr/fetch_gh_user_info "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.pull_request.user.login }}")
+          echo -------------
+          echo "assignee: $assignee"
+          echo -------------
+          if [[ -z $assignee ]]; then
+            # For instance, we can't assign `debendabot` to a new PR.
+            new_pr_assignee="${{ github.event.pull_request.merged_by.login }}"
+          else
+            new_pr_assignee="${{ github.event.pull_request.user.login }}"
+          fi
+
+          versions=$(ci/auto-pr/fetch_gh_proj_versions "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.number }}")
+          echo -------------
+          echo "versions: $versions"
+          echo -------------
+
+          branches=$(ci/auto-pr/conv_proj_version_to_branch $versions)
+          echo -------------
+          echo "branches: $branches"
+          echo -------------
+
+          ci/auto-pr/create_pull_requests \
+            "${{ github.event.number }}" \
+            "${{ github.event.pull_request.html_url }}" \
+            "$PR_TITLE" \
+            "${{ github.sha }}" \
+            "$new_pr_assignee" \
+            $branches
+


### PR DESCRIPTION
## Description

We tried to port `auto-pr.yaml` to the old branches `3.9` or older in https://github.com/scalar-labs/scalardb/pull/1210. But the PR didn't contain related scripts. The change was applied only to `3.9` because Auto-PR didn't work due to the missing scripts.

We also ported the missing related scripts to the old branches `3.9` or older in https://github.com/scalar-labs/scalardb/pull/1212. They were ported to `3.9` or older branches as expected. But the first change for `auto-pr.yaml` isn't ported to `3.8` or older ones since the second PR created only the related scripts.

So we need to port `auto-pr.yaml` to `3.8` or older branches... Sorry for trying and errors PRs.

## Related issues and/or PRs

Fixes https://github.com/scalar-labs/scalardb/pull/1210 and https://github.com/scalar-labs/scalardb/pull/1212

## Changes made

Port `ci/auto-pr.yaml` to branch `3.8` or older.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A