### PR TITLE
Add auto-pr.yaml for 3.6

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -1,0 +1,60 @@
+name: Auto-PR
+
+on:
+  pull_request:
+    branches:
+      - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
+    types:
+      - closed
+
+env:
+  TERM: dumb
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_PR_PAT }}
+      # Escape the PR title. See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable for details
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This is necessary to avoid unexpected auto-merge in git cherry-pick
+          fetch-depth: 0
+          # This is necessary for git-push
+          token: ${{ secrets.GH_PR_PAT }}
+
+      - name: Create pull requests
+        run: |
+          assignee=$(ci/auto-pr/fetch_gh_user_info "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.pull_request.user.login }}")
+          echo -------------
+          echo "assignee: $assignee"
+          echo -------------
+          if [[ -z $assignee ]]; then
+            # For instance, we can't assign `debendabot` to a new PR.
+            new_pr_assignee="${{ github.event.pull_request.merged_by.login }}"
+          else
+            new_pr_assignee="${{ github.event.pull_request.user.login }}"
+          fi
+
+          versions=$(ci/auto-pr/fetch_gh_proj_versions "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}" "${{ github.event.number }}")
+          echo -------------
+          echo "versions: $versions"
+          echo -------------
+
+          branches=$(ci/auto-pr/conv_proj_version_to_branch $versions)
+          echo -------------
+          echo "branches: $branches"
+          echo -------------
+
+          ci/auto-pr/create_pull_requests \
+            "${{ github.event.number }}" \
+            "${{ github.event.pull_request.html_url }}" \
+            "$PR_TITLE" \
+            "${{ github.sha }}" \
+            "$new_pr_assignee" \
+            $branches
+


### PR DESCRIPTION
## Description

(See https://github.com/scalar-labs/scalardb/pull/1217 for details) The Auto PR workflow file is still missing. We need to add it to `3.6`.

## Related issues and/or PRs

Fixes https://github.com/scalar-labs/scalardb/pull/1217

## Changes made

Add `ci/auto-pr.yaml`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A