### PR TITLE
Revert "Update the trigger of the GitHub Action to work only on master branch push (#1187)"

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
 
 jobs:
   release:


### PR DESCRIPTION
## Description

This PR reverts the commit of #1187 because we use snapshot versions of non-master/main branches in other repositories.

## Related issues and/or PRs

#1187

## Changes made

- Revert the change of #1187

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
