### PR TITLE
Should not create PR for base branch in Auto-PR

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -46,6 +46,8 @@ jobs:
           echo -------------
 
           branches=$(ci/auto-pr/conv_proj_version_to_branch $versions)
+          # Remove the base branch from the list because the target change is already merged to the branch.
+          branches=$(echo "$branches" | sed "/^${{ github.base_ref }}$/d")
           echo -------------
           echo "branches: $branches"
           echo -------------

--- a/ci/auto-pr/conv_proj_version_to_branch
+++ b/ci/auto-pr/conv_proj_version_to_branch
@@ -12,8 +12,7 @@ versions.inject(Set.new) {|acc, v|
       # e.g. project: "ScalarDB 4.0.0" -> branch: "master"
       #
       # This GitHub project corresponds to `main`/`master` branch.
-      # The target change is already merged to the default branch.
-      # Nonthing to do.
+      acc << "master"
     else
       # e.g. project: "ScalarDB 3.8.0" -> branch: "3"
       #


### PR DESCRIPTION
## Description

Currently, if we create a PR based on a release branch, Auto-PR creates a PR for the base branch in addition to other target branches. Since the target change is already merged to the base branch, it's unnecessary. This PR addresses this issue.

## Related issues and/or PRs

N/A

## Changes made

- Change not to create a PR for a base branch

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I've tested it in my private repository.

## Release notes

N/A
