### PR TITLE
Backport to branch(3) : Bump org.xerial:sqlite-jdbc from 3.43.2.1 to 3.43.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
         postgresqlDriverVersion = '42.6.0'
         oracleDriverVersion = '21.11.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
-        sqliteDriverVersion = '3.43.2.1'
+        sqliteDriverVersion = '3.43.2.2'
         grpcVersion = '1.53.0'
         protobufVersion = '3.21.12'
         annotationVersion = '1.3.2'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1239