### PR TITLE
Backport to branch(3) : Bump org.apache.commons:commons-dbcp2 from 2.10.0 to 2.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
         azureCosmosVersion = '4.51.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.21.0'
-        commonsDbcp2Version = '2.10.0'
+        commonsDbcp2Version = '2.11.0'
         mysqlDriverVersion = '8.0.33'
         postgresqlDriverVersion = '42.6.0'
         oracleDriverVersion = '21.11.0.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1242