### PR TITLE
Added merging the release notes workflow

### DIFF
--- a/.github/workflows/merge-release-notes.yaml
+++ b/.github/workflows/merge-release-notes.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: "11"
+          java-version: '11'
 
       - name: Checkout release note scripts
         uses: actions/checkout@v4

--- a/.github/workflows/merge-release-notes.yaml
+++ b/.github/workflows/merge-release-notes.yaml
@@ -1,0 +1,61 @@
+name: Merge release notes
+
+on:
+  workflow_dispatch:
+
+jobs:
+  merge-release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
+          echo $VERSION
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: "11"
+
+      - name: Checkout release note scripts
+        uses: actions/checkout@v4
+        with:
+          repository: scalar-labs/actions
+          token: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+          path: ${{ github.workspace }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            release-note-script/src/main/java
+
+      - name: Move scripts to the working directory
+        run: cp ${{ github.workspace }}/release-note-script/src/main/java/* ${{ github.workspace }}
+
+      - name: Checkout the ScalarDB's release notes
+        run: |
+          gh release view v${{ steps.version.outputs.version }} --repo scalar-labs/scalardb --json body -q .body > scalardb.md
+          gh release view v${{ steps.version.outputs.version }} --repo scalar-labs/scalardb-cluster --json body -q .body > cluster.md
+          gh release view v${{ steps.version.outputs.version }} --repo scalar-labs/scalardb-graphql --json body -q .body > graphql.md
+          gh release view v${{ steps.version.outputs.version }} --repo scalar-labs/scalardb-sql --json body -q .body > sql.md
+        env:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+
+      - name: Create merged release note body
+        id: rn_body
+        run: |
+          java MergeReleaseNotes.java > rnbody.md
+
+      - name: Update release body
+        id: update_release_body
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          bodyFile: ./rnbody.md
+          name: v${{ steps.version.outputs.version }}
+          tag: v${{ steps.version.outputs.version }}
+          token: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+          draft: true
+          prerelease: true


### PR DESCRIPTION
## Description

This PR adds `merge-release-notes` workflow on GitHub Actions.

The workflow merges the release notes of the community edition (`ScalarDB`) and enterprise edition (`ScalarDB Cluster`, `ScalarDB GraphQL`, `ScalarDB SQL`) into one release note.
The merged release note replaces the ScalarDB's release note body for a specified version.

This workflow is invoked manually after ScalarDB's release notes (ScalarDB, ScalarDB Cluster, ScalarDB GraphQL, ScalarDB SQL) are created due to the new version release.


## Related issues and/or PRs

This PR related to #1231

## Changes made

Added `merge-release-notes.yaml` to merge the release notes of ScalarDB community edition and enterprise edition.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

`secrets.GH_PROJECT_ACCESS_TOKEN` used by this workflow is needed to create before running this workflow. It should include `admin:org`, `project`, `repo`, `workflow` permissions to access to the organization's project.

## Release notes

N/A
