### PR TITLE
Backport to branch(3) : Bump junitVersion from 5.10.0 to 5.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
         prometheusVersion = '0.16.0'
         commonsTextVersion = '1.11.0'
         jettyVersion = '9.4.53.v20231009'
-        junitVersion = '5.10.0'
+        junitVersion = '5.10.1'
         commonsLangVersion = '3.13.0'
         assertjVersion = '3.24.2'
         mockitoVersion = '4.11.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1267