### PR TITLE
Refactor DecoratedDistributedTransaction and DecoratedTwoPhaseCommitTransaction

### DIFF
--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -77,67 +77,59 @@ public abstract class ActiveTransactionManagedDistributedTransactionManager
     return new ActiveTransaction(super.decorate(transaction));
   }
 
-  private class ActiveTransaction extends AbstractDistributedTransaction
-      implements DecoratedDistributedTransaction {
-
-    private final DistributedTransaction transaction;
+  private class ActiveTransaction extends DecoratedDistributedTransaction {
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private ActiveTransaction(DistributedTransaction transaction) throws TransactionException {
-      this.transaction = transaction;
+      super(transaction);
       add(this);
     }
 
     @Override
-    public String getId() {
-      return transaction.getId();
-    }
-
-    @Override
     public synchronized Optional<Result> get(Get get) throws CrudException {
-      return transaction.get(get);
+      return super.get(get);
     }
 
     @Override
     public synchronized List<Result> scan(Scan scan) throws CrudException {
-      return transaction.scan(scan);
+      return super.scan(scan);
     }
 
     @Override
     public synchronized void put(Put put) throws CrudException {
-      transaction.put(put);
+      super.put(put);
     }
 
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
-      transaction.put(puts);
+      super.put(puts);
     }
 
     @Override
     public synchronized void delete(Delete delete) throws CrudException {
-      transaction.delete(delete);
+      super.delete(delete);
     }
 
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
-      transaction.delete(deletes);
+      super.delete(deletes);
     }
 
     @Override
     public synchronized void mutate(List<? extends Mutation> mutations) throws CrudException {
-      transaction.mutate(mutations);
+      super.mutate(mutations);
     }
 
     @Override
     public synchronized void commit() throws CommitException, UnknownTransactionStatusException {
-      transaction.commit();
+      super.commit();
       remove(getId());
     }
 
     @Override
     public synchronized void rollback() throws RollbackException {
       try {
-        transaction.rollback();
+        super.rollback();
       } finally {
         remove(getId());
       }
@@ -146,18 +138,10 @@ public abstract class ActiveTransactionManagedDistributedTransactionManager
     @Override
     public void abort() throws AbortException {
       try {
-        transaction.abort();
+        super.abort();
       } finally {
         remove(getId());
       }
-    }
-
-    @Override
-    public DistributedTransaction getOriginalTransaction() {
-      if (transaction instanceof DecoratedDistributedTransaction) {
-        return ((DecoratedDistributedTransaction) transaction).getOriginalTransaction();
-      }
-      return transaction;
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -79,77 +79,69 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     return new ActiveTransaction(super.decorate(transaction));
   }
 
-  private class ActiveTransaction extends AbstractTwoPhaseCommitTransaction
-      implements DecoratedTwoPhaseCommitTransaction {
-
-    private final TwoPhaseCommitTransaction transaction;
+  private class ActiveTransaction extends DecoratedTwoPhaseCommitTransaction {
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private ActiveTransaction(TwoPhaseCommitTransaction transaction) throws TransactionException {
-      this.transaction = transaction;
+      super(transaction);
       add(this);
     }
 
     @Override
-    public String getId() {
-      return transaction.getId();
-    }
-
-    @Override
     public synchronized Optional<Result> get(Get get) throws CrudException {
-      return transaction.get(get);
+      return super.get(get);
     }
 
     @Override
     public synchronized List<Result> scan(Scan scan) throws CrudException {
-      return transaction.scan(scan);
+      return super.scan(scan);
     }
 
     @Override
     public synchronized void put(Put put) throws CrudException {
-      transaction.put(put);
+      super.put(put);
     }
 
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
-      transaction.put(puts);
+      super.put(puts);
     }
 
     @Override
     public synchronized void delete(Delete delete) throws CrudException {
-      transaction.delete(delete);
+      super.delete(delete);
     }
 
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
-      transaction.delete(deletes);
+      super.delete(deletes);
     }
 
     @Override
     public synchronized void mutate(List<? extends Mutation> mutations) throws CrudException {
-      transaction.mutate(mutations);
+      super.mutate(mutations);
     }
 
     @Override
     public synchronized void prepare() throws PreparationException {
-      transaction.prepare();
+      super.prepare();
     }
 
     @Override
     public synchronized void validate() throws ValidationException {
-      transaction.validate();
+      super.validate();
     }
 
     @Override
     public synchronized void commit() throws CommitException, UnknownTransactionStatusException {
-      transaction.commit();
+      super.commit();
       remove(getId());
     }
 
     @Override
     public synchronized void rollback() throws RollbackException {
       try {
-        transaction.rollback();
+        super.rollback();
       } finally {
         remove(getId());
       }
@@ -158,18 +150,10 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     @Override
     public void abort() throws AbortException {
       try {
-        transaction.abort();
+        super.abort();
       } finally {
         remove(getId());
       }
-    }
-
-    @Override
-    public TwoPhaseCommitTransaction getOriginalTransaction() {
-      if (transaction instanceof DecoratedTwoPhaseCommitTransaction) {
-        return ((DecoratedTwoPhaseCommitTransaction) transaction).getOriginalTransaction();
-      }
-      return transaction;
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
@@ -1,7 +1,122 @@
 package com.scalar.db.common;
 
+import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.transaction.AbortException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import java.util.List;
+import java.util.Optional;
 
-public interface DecoratedDistributedTransaction extends DistributedTransaction {
-  DistributedTransaction getOriginalTransaction();
+public abstract class DecoratedDistributedTransaction implements DistributedTransaction {
+
+  private final DistributedTransaction decoratedTransaction;
+
+  public DecoratedDistributedTransaction(DistributedTransaction decoratedTransaction) {
+    this.decoratedTransaction = decoratedTransaction;
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public void with(String namespace, String tableName) {
+    decoratedTransaction.with(namespace, tableName);
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public void withNamespace(String namespace) {
+    decoratedTransaction.withNamespace(namespace);
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public Optional<String> getNamespace() {
+    return decoratedTransaction.getNamespace();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public void withTable(String tableName) {
+    decoratedTransaction.withTable(tableName);
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public Optional<String> getTable() {
+    return decoratedTransaction.getTable();
+  }
+
+  @Override
+  public String getId() {
+    return decoratedTransaction.getId();
+  }
+
+  @Override
+  public Optional<Result> get(Get get) throws CrudException {
+    return decoratedTransaction.get(get);
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) throws CrudException {
+    return decoratedTransaction.scan(scan);
+  }
+
+  @Override
+  public void put(Put put) throws CrudException {
+    decoratedTransaction.put(put);
+  }
+
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    decoratedTransaction.put(puts);
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    decoratedTransaction.delete(delete);
+  }
+
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    decoratedTransaction.delete(deletes);
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    decoratedTransaction.mutate(mutations);
+  }
+
+  @Override
+  public void commit() throws CommitException, UnknownTransactionStatusException {
+    decoratedTransaction.commit();
+  }
+
+  @Override
+  public void rollback() throws RollbackException {
+    decoratedTransaction.rollback();
+  }
+
+  @Override
+  public void abort() throws AbortException {
+    decoratedTransaction.abort();
+  }
+
+  public DistributedTransaction getOriginalTransaction() {
+    if (decoratedTransaction instanceof DecoratedDistributedTransaction) {
+      return ((DecoratedDistributedTransaction) decoratedTransaction).getOriginalTransaction();
+    }
+    return decoratedTransaction;
+  }
 }

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -1,7 +1,134 @@
 package com.scalar.db.common;
 
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.exception.transaction.AbortException;
+import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.ValidationException;
+import java.util.List;
+import java.util.Optional;
 
-public interface DecoratedTwoPhaseCommitTransaction extends TwoPhaseCommitTransaction {
-  TwoPhaseCommitTransaction getOriginalTransaction();
+public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseCommitTransaction {
+
+  private final TwoPhaseCommitTransaction decoratedTransaction;
+
+  public DecoratedTwoPhaseCommitTransaction(TwoPhaseCommitTransaction decoratedTransaction) {
+    this.decoratedTransaction = decoratedTransaction;
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public void with(String namespace, String tableName) {
+    decoratedTransaction.with(namespace, tableName);
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public void withNamespace(String namespace) {
+    decoratedTransaction.withNamespace(namespace);
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public Optional<String> getNamespace() {
+    return decoratedTransaction.getNamespace();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public void withTable(String tableName) {
+    decoratedTransaction.withTable(tableName);
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  @Override
+  public Optional<String> getTable() {
+    return decoratedTransaction.getTable();
+  }
+
+  @Override
+  public String getId() {
+    return decoratedTransaction.getId();
+  }
+
+  @Override
+  public Optional<Result> get(Get get) throws CrudException {
+    return decoratedTransaction.get(get);
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) throws CrudException {
+    return decoratedTransaction.scan(scan);
+  }
+
+  @Override
+  public void put(Put put) throws CrudException {
+    decoratedTransaction.put(put);
+  }
+
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    decoratedTransaction.put(puts);
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    decoratedTransaction.delete(delete);
+  }
+
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    decoratedTransaction.delete(deletes);
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    decoratedTransaction.mutate(mutations);
+  }
+
+  @Override
+  public void prepare() throws PreparationException {
+    decoratedTransaction.prepare();
+  }
+
+  @Override
+  public void validate() throws ValidationException {
+    decoratedTransaction.validate();
+  }
+
+  @Override
+  public void commit() throws CommitException, UnknownTransactionStatusException {
+    decoratedTransaction.commit();
+  }
+
+  @Override
+  public void rollback() throws RollbackException {
+    decoratedTransaction.rollback();
+  }
+
+  @Override
+  public void abort() throws AbortException {
+    decoratedTransaction.abort();
+  }
+
+  public TwoPhaseCommitTransaction getOriginalTransaction() {
+    if (decoratedTransaction instanceof DecoratedTwoPhaseCommitTransaction) {
+      return ((DecoratedTwoPhaseCommitTransaction) decoratedTransaction).getOriginalTransaction();
+    }
+    return decoratedTransaction;
+  }
 }


### PR DESCRIPTION
## Description

This PR refactors the `DecoratedDistributedTransaction` and `DecoratedTwoPhaseCommitTransaction` interfaces. This PR changes the interfaces to abstract classes and adds default methods to the classes to make easy to use.

## Related issues and/or PRs

N/A

## Changes made

- Changed the `DecoratedDistributedTransaction` and `DecoratedTwoPhaseCommitTransaction` interfaces to abstract classes
- Added default methods to the classes

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
