### PR TITLE
Fix to prevent importing existing storage table

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -209,7 +209,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   @Override
   public void importTable(String namespace, String table, Map<String, String> options)
       throws ExecutionException {
-    TableMetadata tableMetadata = getTableMetadata(namespace, table);
+    TableMetadata tableMetadata = admin.getTableMetadata(namespace, table);
     if (tableMetadata != null) {
       throw new IllegalArgumentException(
           "Table already exists: " + ScalarDbUtils.getFullTableName(namespace, table));

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -633,7 +633,29 @@ public abstract class ConsensusCommitAdminTestBase {
   }
 
   @Test
-  public void importTable_WithTableAlreadyExists_ShouldThrowIllegalArgumentException()
+  public void importTable_WithStorageTableAlreadyExists_ShouldThrowIllegalArgumentException()
+      throws ExecutionException {
+    // Arrange
+    String primaryKeyColumn = "pk";
+    String column = "col";
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addColumn(primaryKeyColumn, DataType.INT)
+            .addColumn(column, DataType.INT)
+            .addPartitionKey(primaryKeyColumn)
+            .build();
+    when(distributedStorageAdmin.getTableMetadata(NAMESPACE, TABLE)).thenReturn(metadata);
+
+    // Act
+    Throwable thrown =
+        catchThrowable(() -> admin.importTable(NAMESPACE, TABLE, Collections.emptyMap()));
+
+    // Assert
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void importTable_WithTransactionTableAlreadyExists_ShouldThrowIllegalArgumentException()
       throws ExecutionException {
     // Arrange
     String primaryKeyColumn = "pk";


### PR DESCRIPTION
## Description

This PR fixes a bug that unintentionally changes a storage table to a transaction table using the import function. This happens because we used the consensus commit `getTableMetadata()` API to check the existence of tables, but `getTableMetadata()` returns null not only if the table does not exist but if transaction metadata does not exist.

## Related issues and/or PRs

- #931

## Changes made

- Check the table metadata using storage admin API

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Currently, we don't have an upgrade feature from storage to transaction, but probably we can do it easily using similar logic like import and repair in the future. 

## Release notes

Fixed to prevent importing existing storage table