### PR TITLE
Fix CVE-2023-39325 and GHSA-m425-mq94-257g

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.17
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.22
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/


### PR DESCRIPTION
## Description

This PR fixes CVE-2023-39325 and GHSA-m425-mq94-257g by upgrading grpc-health-probe to `0.4.22`. 

## Related issues and/or PRs

N/A

## Changes made

- Upgraded grpc-health-probe to `0.4.22`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Upgraded grpc-health-probe to fix security issues. CVE-2023-39325 GHSA-m425-mq94-257g