### PR TITLE
Update documentation for the repair feature

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -361,19 +361,23 @@ public interface Admin {
   }
 
   /**
-   * Repair a namespace which may be in an unknown state.
+   * Repair a namespace which may be in an unknown state, such as the namespace exists in the
+   * underlying storage but not its ScalarDB metadata or vice versa. This will recreate the
+   * namespace and its metadata if necessary.
    *
-   * @param namespace an existing namespace
+   * @param namespace a namespace
    * @param options options to repair
    * @throws ExecutionException if the operation fails
    */
   void repairNamespace(String namespace, Map<String, String> options) throws ExecutionException;
 
   /**
-   * Repair a table which may be in an unknown state.
+   * Repair a table which may be in an unknown state, such as the table exists in the underlying
+   * storage but not its ScalarDB metadata or vice versa. This will recreate the table, its
+   * secondary indexes and their metadata if necessary.
    *
-   * @param namespace an existing namespace
-   * @param table an existing table
+   * @param namespace a namespace
+   * @param table a table
    * @param metadata the metadata associated to the table to repair
    * @param options options to repair
    * @throws ExecutionException if the operation fails

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -361,8 +361,8 @@ public interface Admin {
   }
 
   /**
-   * Repair a namespace which may be in an unknown state, such as the namespace exists in the
-   * underlying storage but not its ScalarDB metadata or vice versa. This will recreate the
+   * Repair a namespace that may be in an unknown state, such as the namespace exists in the
+   * underlying storage but not its ScalarDB metadata or vice versa. This will re-create the
    * namespace and its metadata if necessary.
    *
    * @param namespace a namespace
@@ -372,9 +372,9 @@ public interface Admin {
   void repairNamespace(String namespace, Map<String, String> options) throws ExecutionException;
 
   /**
-   * Repair a table which may be in an unknown state, such as the table exists in the underlying
-   * storage but not its ScalarDB metadata or vice versa. This will recreate the table, its
-   * secondary indexes and their metadata if necessary.
+   * Repair a table that may be in an unknown state, such as the table exists in the underlying
+   * storage but not its ScalarDB metadata or vice versa. This will re-create the table, its
+   * secondary indexes, and their metadata if necessary.
    *
    * @param namespace a namespace
    * @param table a table

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -250,6 +250,36 @@ You can get table metadata as follows:
 TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 ```
 
+### Repair a namespace
+
+If a namespace is in an unknown state such as the namespace exists in the underlying storage but not its ScalarDB metadata or vice versa.
+This method will recreate the namespace and its metadata if necessary.
+
+You can repair the namespace as follows:
+
+```java
+// Repair the namespace "ns" with options.
+Map<String, String> options = ...;
+admin.repairNamespace("ns", options);
+```
+
+### Repair a table
+
+If a table is in an unknown state such as the table exists in the underlying storage but not its ScalarDB metadata or vice versa.
+This method will recreate the table, its secondary indexes and their metadata if necessary.
+
+You can repair the table as follows:
+
+```java
+// Repair the table "ns.tbl" with options.
+TableMetadata tableMetadata =
+    TableMetadata.newBuilder()
+        ...
+        .build();
+Map<String, String> options = ...;
+admin.repairTable("ns", "tbl", tableMetadata, options);
+```
+
 ### Specify operations for the Coordinator table
 
 The Coordinator table is used by the [Transactional API](#transactional-api) to track the statuses of transactions.

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -252,8 +252,7 @@ TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 
 ### Repair a namespace
 
-If a namespace is in an unknown state such as the namespace exists in the underlying storage but not its ScalarDB metadata or vice versa.
-This method will recreate the namespace and its metadata if necessary.
+If a namespace is in an unknown state, such as the namespace exists in the underlying storage but not its ScalarDB metadata or vice versa, this method will re-create the namespace and its metadata if necessary.
 
 You can repair the namespace as follows:
 
@@ -265,8 +264,7 @@ admin.repairNamespace("ns", options);
 
 ### Repair a table
 
-If a table is in an unknown state such as the table exists in the underlying storage but not its ScalarDB metadata or vice versa.
-This method will recreate the table, its secondary indexes and their metadata if necessary.
+If a table is in an unknown state, such as the table exists in the underlying storage but not its ScalarDB metadata or vice versa, this method will re-create the table, its secondary indexes, and their metadata if necessary.
 
 You can repair the table as follows:
 

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -83,8 +83,8 @@ Create/Delete schemas in the storage defined in the config file
       --no-backup     Disable continuous backup (supported in DynamoDB)
       --no-scaling    Disable auto-scaling (supported in DynamoDB, Cosmos DB)
       --repair-all    Repair namespaces and tables that are in an unknown
-                        state: it recreates namespaces, tables, secondary
-                        indexes and their metadata if necessary.          
+                        state: it re-creates namespaces, tables, secondary
+                        indexes, and their metadata if necessary.          
       --replication-factor=<replicaFactor>
                       The replication factor (supported in Cassandra)
       --replication-strategy=<replicationStrategy>
@@ -388,8 +388,8 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --jdbc -j <JDBC_URL> -u <USER> 
 
 ### Repair namespaces and tables
 
-You can repair namespaces and tables by using the properties file. Namespaces and tables can be in an unknown state such as namespace or table exists in the underlying storage but not their ScalarDB metadata or vice versa. This command will recreate the namespaces, the tables, the secondary indexes and their metadata if necessary.
-To repair them, run the following command, replacing the contents in the angle brackets as described:
+You can repair namespaces and tables by using the properties file. The reason for repairing namespaces and tables is because they can be in an unknown state, such as a namespace or table exists in the underlying storage but not its ScalarDB metadata or vice versa. 
+Repairing the namespaces, the tables, the secondary indexes, and their metadata requires re-creating them if necessary. To repair them, run the following command, replacing the contents in the angle brackets as described:
 
 ```console
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f <PATH_TO_SCHEMA_FILE> [--coordinator] --repair-all 

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -82,10 +82,9 @@ Create/Delete schemas in the storage defined in the config file
                       Path to the schema json file
       --no-backup     Disable continuous backup (supported in DynamoDB)
       --no-scaling    Disable auto-scaling (supported in DynamoDB, Cosmos DB)
-      --repair-all    Repair tables : it repairs the table metadata of
-                               existing tables. When using Cosmos DB, it
-                               additionally repairs stored procedure attached
-                               to each table
+      --repair-all    Repair namespaces and tables that are in an unknown
+                        state: it recreates namespaces, tables, secondary
+                        indexes and their metadata if necessary.          
       --replication-factor=<replicaFactor>
                       The replication factor (supported in Cassandra)
       --replication-strategy=<replicationStrategy>
@@ -387,9 +386,10 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --jdbc -j <JDBC_URL> -u <USER> 
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
 
-### Repair tables
+### Repair namespaces and tables
 
-You can repair the table metadata of existing tables by using the properties file. To repair table metadata of existing tables, run the following command, replacing the contents in the angle brackets as described:
+You can repair namespaces and tables by using the properties file. Namespaces and tables can be in an unknown state such as namespace or table exists in the underlying storage but not their ScalarDB metadata or vice versa. This command will recreate the namespaces, the tables, the secondary indexes and their metadata if necessary.
+To repair them, run the following command, replacing the contents in the angle brackets as described:
 
 ```console
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f <PATH_TO_SCHEMA_FILE> [--coordinator] --repair-all 
@@ -663,8 +663,8 @@ public class SchemaLoaderSample {
     Map<String, String> indexCreationOptions = new HashMap<>();
     indexCreationOptions.put(DynamoAdmin.NO_SCALING, "true");
 
-    Map<String, String> tableReparationOptions = new HashMap<>();
-    indexCreationOptions.put(DynamoAdmin.NO_BACKUP, "true");
+    Map<String, String> reparationOptions = new HashMap<>();
+    reparationOptions.put(DynamoAdmin.NO_BACKUP, "true");
 
     // Create tables.
     SchemaLoader.load(configFilePath, schemaFilePath, tableCreationOptions, createCoordinatorTables);
@@ -672,8 +672,8 @@ public class SchemaLoaderSample {
     // Alter tables.
     SchemaLoader.alterTables(configFilePath, alteredSchemaFilePath, indexCreationOptions);
 
-    // Repair tables.
-    SchemaLoader.repairTables(configFilePath, schemaFilePath, tableReparationOptions, repairCoordinatorTables);
+    // Repair namespaces and tables.
+    SchemaLoader.repairAll(configFilePath, schemaFilePath, reparationOptions, repairCoordinatorTables);
 
     // Delete tables.
     SchemaLoader.unload(configFilePath, schemaFilePath, deleteCoordinatorTables);
@@ -692,8 +692,8 @@ SchemaLoader.load(configFilePath, serializedSchemaJson, tableCreationOptions, cr
 // Alter tables.
 SchemaLoader.alterTables(configFilePath, serializedAlteredSchemaFilePath, indexCreationOptions);
 
-// Repair tables.
-SchemaLoader.repairTables(configFilePath, serializedSchemaJson, tableReparationOptions, repairCoordinatorTables);
+// Repair namespaces and tables.
+SchemaLoader.repairAll(configFilePath, serializedSchemaJson, reparationOptions, repairCoordinatorTables);
 
 // Delete tables.
 SchemaLoader.unload(configFilePath, serializedSchemaJson, deleteCoordinatorTables);
@@ -708,8 +708,8 @@ SchemaLoader.load(properties, serializedSchemaJson, tableCreationOptions, create
 // Alter tables.
 SchemaLoader.alterTables(properties, serializedAlteredSchemaFilePath, indexCreationOptions);
 
-// Repair tables.
-SchemaLoader.repairTables(properties, serializedSchemaJson, tableReparationOptions, repairCoordinatorTables);
+// Repair namespaces and tables.
+SchemaLoader.repairAll(properties, serializedSchemaJson, reparationOptions, repairCoordinatorTables);
 
 // Delete tables.
 SchemaLoader.unload(properties, serializedSchemaJson, deleteCoordinatorTables);

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -388,8 +388,7 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --jdbc -j <JDBC_URL> -u <USER> 
 
 ### Repair namespaces and tables
 
-You can repair namespaces and tables by using the properties file. The reason for repairing namespaces and tables is because they can be in an unknown state, such as a namespace or table exists in the underlying storage but not its ScalarDB metadata or vice versa. 
-Repairing the namespaces, the tables, the secondary indexes, and their metadata requires re-creating them if necessary. To repair them, run the following command, replacing the contents in the angle brackets as described:
+You can repair namespaces and tables by using the properties file. The reason for repairing namespaces and tables is because they can be in an unknown state, such as a namespace or table exists in the underlying storage but not its ScalarDB metadata or vice versa. Repairing the namespaces, the tables, the secondary indexes, and their metadata requires re-creating them if necessary. To repair them, run the following command, replacing the contents in the angle brackets as described:
 
 ```console
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f <PATH_TO_SCHEMA_FILE> [--coordinator] --repair-all 

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -407,8 +407,7 @@ TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 
 ### Repair a namespace
 
-If a namespace is in an unknown state such as the namespace exists in the underlying storage but not its ScalarDB metadata or vice versa.
-This method will recreate the namespace and its metadata if necessary.
+If a namespace is in an unknown state, such as the namespace exists in the underlying storage but not its ScalarDB metadata or vice versa, this method will re-create the namespace and its metadata if necessary.
 
 You can repair the namespace as follows:
 
@@ -420,8 +419,7 @@ Map<String, String> options = ...;
 
 ### Repair a table
 
-If a table is in an unknown state such as the table exists in the underlying storage but not its ScalarDB metadata or vice versa.
-This method will recreate the table, its secondary indexes and their metadata if necessary.
+If a table is in an unknown state, such as the table exists in the underlying storage but not its ScalarDB metadata or vice versa, this method will re-create the table, its secondary indexes, and their metadata if necessary.
 
 You can repair the table as follows:
 

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -405,6 +405,36 @@ You can get table metadata as follows:
 TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 ```
 
+### Repair a namespace
+
+If a namespace is in an unknown state such as the namespace exists in the underlying storage but not its ScalarDB metadata or vice versa.
+This method will recreate the namespace and its metadata if necessary.
+
+You can repair the namespace as follows:
+
+```java
+// Repair the namespace "ns" with options.
+Map<String, String> options = ...;
+    admin.repairNamespace("ns", options);
+```
+
+### Repair a table
+
+If a table is in an unknown state such as the table exists in the underlying storage but not its ScalarDB metadata or vice versa.
+This method will recreate the table, its secondary indexes and their metadata if necessary.
+
+You can repair the table as follows:
+
+```java
+// Repair the table "ns.tbl" with options.
+TableMetadata tableMetadata =
+    TableMetadata.newBuilder()
+        ...
+        .build();
+Map<String, String> options = ...; 
+admin.repairTable("ns", "tbl", tableMetadata, options);
+```
+
 ### Implement CRUD operations
 
 The following sections describe CRUD operations.

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -285,7 +285,10 @@ public class SchemaLoader {
   }
 
   /**
-   * Repair namespaces and tables defined in the schema that are in an unknown state.
+   * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
+   * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
+   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
+   * if necessary.
    *
    * @param configProperties ScalarDB config properties
    * @param serializedSchemaJson serialized json string schema.
@@ -305,7 +308,10 @@ public class SchemaLoader {
   }
 
   /**
-   * Repair namespaces and tables defined in the schema file that are in an unknown state.
+   * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
+   * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
+   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
+   * if necessary.
    *
    * @param configProperties ScalarDB properties.
    * @param schemaPath path to the schema file.
@@ -325,7 +331,10 @@ public class SchemaLoader {
   }
 
   /**
-   * Repair namespaces and tables defined in the schema that are in an unknown state.
+   * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
+   * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
+   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
+   * if necessary.
    *
    * @param configPath path to the ScalarDB config.
    * @param serializedSchemaJson serialized json string schema.
@@ -345,7 +354,10 @@ public class SchemaLoader {
   }
 
   /**
-   * Repair namespaces and tables defined in the schema file that are in an unknown state.
+   * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
+   * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
+   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
+   * if necessary.
    *
    * @param configPath path to the ScalarDB config.
    * @param schemaPath path to the schema file.

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -287,8 +287,8 @@ public class SchemaLoader {
   /**
    * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
    * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
-   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
-   * if necessary.
+   * versa. This will re-create the namespaces, the tables, the secondary indexes, and their
+   * metadata if necessary.
    *
    * @param configProperties ScalarDB config properties
    * @param serializedSchemaJson serialized json string schema.
@@ -310,8 +310,8 @@ public class SchemaLoader {
   /**
    * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
    * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
-   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
-   * if necessary.
+   * versa. This will re-create the namespaces, the tables, the secondary indexes, and their
+   * metadata if necessary.
    *
    * @param configProperties ScalarDB properties.
    * @param schemaPath path to the schema file.
@@ -333,8 +333,8 @@ public class SchemaLoader {
   /**
    * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
    * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
-   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
-   * if necessary.
+   * versa. This will re-create the namespaces, the tables, the secondary indexes, and their
+   * metadata if necessary.
    *
    * @param configPath path to the ScalarDB config.
    * @param serializedSchemaJson serialized json string schema.
@@ -356,8 +356,8 @@ public class SchemaLoader {
   /**
    * Repair namespaces and tables defined in the schema that are in an unknown state, such as the
    * namespace or table exists in the underlying storage but not its ScalarDB metadata or vice
-   * versa. This will recreate the namespaces, the tables, the secondary indexes and their metadata
-   * if necessary.
+   * versa. This will re-create the namespaces, the tables, the secondary indexes, and their
+   * metadata if necessary.
    *
    * @param configPath path to the ScalarDB config.
    * @param schemaPath path to the schema file.

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -79,7 +79,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
     @Option(
         names = {"--repair-all"},
         description =
-            "Repair namespaces and tables that are in an unknown state: it recreates namespaces, tables, secondary indexes and their metadata if necessary.",
+            "Repair namespaces and tables that are in an unknown state: it re-creates namespaces, tables, secondary indexes, and their metadata if necessary.",
         defaultValue = "false")
     boolean repairAll;
 


### PR DESCRIPTION
## Description
The Admin API `repairTable()` method has existed since v3.6, but its behavior has changed (cf. #1125). Also, a new `repairNamespace` method was added to the Admin API (#1107). Finally, the `--repair-all` command of the Schema Loader will not only repair table but also repair namespace.  (#1203)

This PR will update the documentation for these changes.


## Related issues and/or PRs
- #1125 
- #1107 
- #1203

## Changes made

- Update javadoc for the Admin API `repairTable` and `repairNamespace`
- Add sections in the api-guide and storage abstraction guide for the Admin API `repairTable` and `repairNamespace`
- Update the Schema Loader doc 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
