### PR TITLE
Add API doc for `admin.repairTable` method for v3.X

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -243,7 +243,7 @@ TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 ```
 ### Repair a table
 
-You can repair table metadata of an existing table as follows:
+You can repair the table metadata of an existing table as follows:
 
 ```java
 // Repair the table "ns.tbl" with options.

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -241,6 +241,19 @@ You can get table metadata as follows:
 // Get the table metadata for "ns.tbl".
 TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 ```
+### Repair a table
+
+You can repair table metadata of an existing table as follows:
+
+```java
+// Repair the table "ns.tbl" with options.
+TableMetadata tableMetadata =
+    TableMetadata.newBuilder()
+        ...
+        .build();
+Map<String, String> options = ...;
+admin.repairTable("ns", "tbl", tableMetadata, options);
+```
 
 ### Specify operations for the Coordinator table
 

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -390,7 +390,7 @@ TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 
 ### Repair a table
 
-You can repair table metadata of an existing table as follows:
+You can repair the table metadata of an existing table as follows:
 
 ```java
 // Repair the table "ns.tbl" with options.

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -388,6 +388,20 @@ You can get table metadata as follows:
 TableMetadata tableMetadata = admin.getTableMetadata("ns", "tbl");
 ```
 
+### Repair a table
+
+You can repair table metadata of an existing table as follows:
+
+```java
+// Repair the table "ns.tbl" with options.
+TableMetadata tableMetadata =
+    TableMetadata.newBuilder()
+        ...
+        .build();
+Map<String, String> options = ...;
+admin.repairTable("ns", "tbl", tableMetadata, options);
+```
+
 ### Implement CRUD operations
 
 The following sections describe CRUD operations.


### PR DESCRIPTION
## Description

Add API documentation for the `admin.repairTable(...)` method to the v3.X doc version since it was missing.

## Related issues and/or PRs

N/A

## Changes made

Add a section for `admin.repairTable` method to the api-guide and api-abstraction documentation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This PR targets the `3` branch and will be backport to all 3.X release branches.

## Release notes

N/A
