### PR TITLE
Backport to branch(3.7) : Fix CVE-2023-39325 and GHSA-m425-mq94-257g

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.17
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.22
 ENV DOCKERIZE_VERSION v0.6.1
 
 # Install grpc_health_probe for kubernetes.


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1297