### PR TITLE
Backport to branch(3) : Bump log4jVersion from 2.21.1 to 2.22.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ subprojects {
         errorproneVersion = '2.10.0'
         errorproneJavacVersion = '9+181-r4173-1'
         gsonVersion = '2.10.1'
-        log4jVersion = '2.21.1'
+        log4jVersion = '2.22.0'
         stefanbirknerSystemLambdaVersion = '1.2.1'
         spotbugsPluginVersion = '5.2.3'
         errorpronePluginVersion = '2.0.2'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1298