### PR TITLE
Backport to branch(3) : Bump org.apache.commons:commons-lang3 from 3.13.0 to 3.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
         commonsTextVersion = '1.11.0'
         jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.10.1'
-        commonsLangVersion = '3.13.0'
+        commonsLangVersion = '3.14.0'
         assertjVersion = '3.24.2'
         mockitoVersion = '4.11.0'
         spotbugsVersion = '4.8.1'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1326