### PR TITLE
Disable implicit pre-read by default for Put operations

### DIFF
--- a/core/src/main/java/com/scalar/db/api/OperationBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/OperationBuilder.java
@@ -108,7 +108,7 @@ class OperationBuilder {
 
   interface ClearProjections<T> {
     /**
-     * Clear the list of projections
+     * Clears the list of projections
      *
      * @return the operation builder
      */
@@ -127,7 +127,7 @@ class OperationBuilder {
 
   interface ClearCondition<T> {
     /**
-     * Remove the condition
+     * Removes the condition
      *
      * @return the operation builder
      */
@@ -266,14 +266,14 @@ class OperationBuilder {
 
   interface ClearValues<T> {
     /**
-     * Clear the list of values
+     * Clears the list of values
      *
      * @return the operation builder
      */
     T clearValues();
 
     /**
-     * Clear the value for the given column
+     * Clears the value for the given column
      *
      * @param columnName a column name
      * @return the operation builder
@@ -283,11 +283,18 @@ class OperationBuilder {
 
   interface ImplicitPreReadEnabled<T> {
     /**
-     * Disable implicit pre-read for this put operation.
+     * Disables implicit pre-read for this put operation.
      *
      * @return the operation builder
      */
     T disableImplicitPreRead();
+
+    /**
+     * Enables implicit pre-read for this put operation.
+     *
+     * @return the operation builder
+     */
+    T enableImplicitPreRead();
 
     /**
      * Sets whether implicit pre-read is enabled or not for this put operation.
@@ -338,7 +345,7 @@ class OperationBuilder {
 
   interface ClearOrderings<T> {
     /**
-     * Clear the list of orderings
+     * Clears the list of orderings
      *
      * @return the scan operation builder
      */
@@ -387,14 +394,14 @@ class OperationBuilder {
 
   interface ClearBoundaries<T> {
     /**
-     * Remove the scan starting boundary
+     * Removes the scan starting boundary
      *
      * @return the scan operation builder
      */
     T clearStart();
 
     /**
-     * Remove the scan ending boundary
+     * Removes the scan ending boundary
      *
      * @return the scan operation builder
      */
@@ -403,7 +410,7 @@ class OperationBuilder {
 
   interface All<T> {
     /**
-     * Specify the Scan operation will retrieve all the entries of the database
+     * Specifies the Scan operation will retrieve all the entries of the database
      *
      * @return the scan operation builder
      */
@@ -504,7 +511,7 @@ class OperationBuilder {
 
   interface ClearConditions<T> {
     /**
-     * Clear all conditions
+     * Clears all conditions
      *
      * @return the scan operation builder
      */

--- a/core/src/main/java/com/scalar/db/api/OperationBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/OperationBuilder.java
@@ -108,7 +108,7 @@ class OperationBuilder {
 
   interface ClearProjections<T> {
     /**
-     * Clears the list of projections
+     * Clears the list of projections.
      *
      * @return the operation builder
      */
@@ -127,7 +127,7 @@ class OperationBuilder {
 
   interface ClearCondition<T> {
     /**
-     * Removes the condition
+     * Removes the condition.
      *
      * @return the operation builder
      */
@@ -266,14 +266,14 @@ class OperationBuilder {
 
   interface ClearValues<T> {
     /**
-     * Clears the list of values
+     * Clears the list of values.
      *
      * @return the operation builder
      */
     T clearValues();
 
     /**
-     * Clears the value for the given column
+     * Clears the value for the given column.
      *
      * @param columnName a column name
      * @return the operation builder
@@ -345,7 +345,7 @@ class OperationBuilder {
 
   interface ClearOrderings<T> {
     /**
-     * Clears the list of orderings
+     * Clears the list of orderings.
      *
      * @return the scan operation builder
      */
@@ -394,14 +394,14 @@ class OperationBuilder {
 
   interface ClearBoundaries<T> {
     /**
-     * Removes the scan starting boundary
+     * Removes the scan starting boundary.
      *
      * @return the scan operation builder
      */
     T clearStart();
 
     /**
-     * Removes the scan ending boundary
+     * Removes the scan ending boundary.
      *
      * @return the scan operation builder
      */
@@ -410,7 +410,7 @@ class OperationBuilder {
 
   interface All<T> {
     /**
-     * Specifies the Scan operation will retrieve all the entries of the database
+     * Specifies the Scan operation will retrieve all the entries of the database.
      *
      * @return the scan operation builder
      */
@@ -511,7 +511,7 @@ class OperationBuilder {
 
   interface ClearConditions<T> {
     /**
-     * Clears all conditions
+     * Clears all conditions.
      *
      * @return the scan operation builder
      */

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -39,7 +39,7 @@ public class Put extends Mutation {
 
   private final Map<String, Column<?>> columns;
 
-  private boolean implicitPreReadEnabled = true;
+  private boolean implicitPreReadEnabled;
 
   /**
    * Constructs a {@code Put} with the specified partition {@link Key}.

--- a/core/src/main/java/com/scalar/db/api/PutBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/PutBuilder.java
@@ -83,7 +83,7 @@ public class PutBuilder {
     @Nullable Key clusteringKey;
     @Nullable com.scalar.db.api.Consistency consistency;
     @Nullable MutationCondition condition;
-    boolean implicitPreReadEnabled = true;
+    boolean implicitPreReadEnabled;
 
     private Buildable(@Nullable String namespace, String table, Key partitionKey) {
       super(namespace, table, partitionKey);
@@ -205,6 +205,12 @@ public class PutBuilder {
     @Override
     public Buildable disableImplicitPreRead() {
       implicitPreReadEnabled = false;
+      return this;
+    }
+
+    @Override
+    public Buildable enableImplicitPreRead() {
+      implicitPreReadEnabled = true;
       return this;
     }
 
@@ -410,13 +416,19 @@ public class PutBuilder {
     }
 
     @Override
-    public Buildable disableImplicitPreRead() {
+    public BuildableFromExisting disableImplicitPreRead() {
       super.disableImplicitPreRead();
       return this;
     }
 
     @Override
-    public Buildable implicitPreReadEnabled(boolean implicitPreReadEnabled) {
+    public BuildableFromExisting enableImplicitPreRead() {
+      super.enableImplicitPreRead();
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting implicitPreReadEnabled(boolean implicitPreReadEnabled) {
       super.implicitPreReadEnabled(implicitPreReadEnabled);
       return this;
     }

--- a/core/src/test/java/com/scalar/db/api/PutBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/PutBuilderTest.java
@@ -186,7 +186,7 @@ public class PutBuilderTest {
             .withIntValue("int2", Integer.valueOf(Integer.MAX_VALUE))
             .withTextValue("text", "a_value")
             .withCondition(condition1)
-            .setImplicitPreReadEnabled(false);
+            .setImplicitPreReadEnabled(true);
 
     // Act
     Put newPut = Put.newBuilder(existingPut).build();
@@ -243,7 +243,7 @@ public class PutBuilderTest {
             .textValue("text", "another_value")
             .value(TextColumn.of("text2", "foo"))
             .condition(condition2)
-            .implicitPreReadEnabled(false)
+            .enableImplicitPreRead()
             .build();
 
     // Assert
@@ -268,7 +268,7 @@ public class PutBuilderTest {
                 .withTextValue("text", "another_value")
                 .withTextValue("text2", "foo")
                 .withCondition(condition2)
-                .setImplicitPreReadEnabled(false));
+                .setImplicitPreReadEnabled(true));
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/util/ProtoUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ProtoUtilsTest.java
@@ -911,7 +911,7 @@ public class ProtoUtilsTest {
                             .build())
                     .build())
             .setConsistency(com.scalar.db.rpc.Consistency.CONSISTENCY_EVENTUAL)
-            .setImplicitPreReadEnabled(false)
+            .setImplicitPreReadEnabled(true)
             .setNamespace("ns")
             .setTable("tbl")
             .build();
@@ -945,7 +945,7 @@ public class ProtoUtilsTest {
                         .and(ConditionBuilder.column("col7").isNotNullBlob())
                         .build())
                 .consistency(Consistency.EVENTUAL)
-                .disableImplicitPreRead()
+                .enableImplicitPreRead()
                 .build());
   }
 
@@ -1016,7 +1016,7 @@ public class ProtoUtilsTest {
                         .setType(com.scalar.db.rpc.MutateCondition.Type.PUT_IF_NOT_EXISTS))
                 .setNamespace("ns")
                 .setTable("tbl")
-                .setImplicitPreReadEnabled(true)
+                .setImplicitPreReadEnabled(false)
                 .build());
   }
 
@@ -1057,7 +1057,7 @@ public class ProtoUtilsTest {
                 MutateCondition.newBuilder()
                     .setType(com.scalar.db.rpc.MutateCondition.Type.PUT_IF_NOT_EXISTS))
             .setConsistency(com.scalar.db.rpc.Consistency.CONSISTENCY_EVENTUAL)
-            .setImplicitPreReadEnabled(true)
+            .setImplicitPreReadEnabled(false)
             .setNamespace("ns")
             .setTable("tbl")
             .build();
@@ -1082,7 +1082,7 @@ public class ProtoUtilsTest {
                 .blobValue("col7", (byte[]) null)
                 .condition(ConditionBuilder.putIfNotExists())
                 .consistency(Consistency.EVENTUAL)
-                .implicitPreReadEnabled(true)
+                .disableImplicitPreRead()
                 .build());
   }
 
@@ -1317,7 +1317,7 @@ public class ProtoUtilsTest {
                         .and(ConditionBuilder.column("col5").isLessThanOrEqualToDouble(4.56))
                         .build())
                 .consistency(Consistency.EVENTUAL)
-                .implicitPreReadEnabled(true)
+                .enableImplicitPreRead()
                 .build());
   }
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -657,7 +657,7 @@ You can't specify clustering-key boundaries and orderings in `Scan` without spec
 {% capture notice--info %}
 **Note**
 
-When you update an existing record, you need to read the record by using `Get` or `Scan` before using a `Put` operation. Otherwise, the operation will fail due to a conflict. This occurs because ScalarDB assumes that another transaction wrote the record. Instead of reading the record explicitly, you can enable implicit pre-read. See [Enable implicit pre-read for `Put` operations](#enable-implicit-pre-read-for-put-operations) for details.
+When you update an existing record, you need to read the record by using `Get` or `Scan` before using a `Put` operation. Otherwise, the operation will fail due to a conflict. This occurs because of the specification of ScalarDB to manage transactions properly. Instead of reading the record explicitly, you can enable implicit pre-read. See [Enable implicit pre-read for `Put` operations](#enable-implicit-pre-read-for-put-operations) for details.
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -657,7 +657,7 @@ You can't specify clustering-key boundaries and orderings in `Scan` without spec
 {% capture notice--info %}
 **Note**
 
-When you update an existing record, you need to read the record by using `Get` or `Scan` before using a `Put` operation. Otherwise, the operation will fail due to a conflict. This occurs because of the specification of ScalarDB to manage transactions properly. Instead of reading the record explicitly, you can enable implicit pre-read. See [Enable implicit pre-read for `Put` operations](#enable-implicit-pre-read-for-put-operations) for details.
+When you update an existing record, you need to read the record by using `Get` or `Scan` before using a `Put` operation. Otherwise, the operation will fail due to a conflict. This occurs because of the specification of ScalarDB to manage transactions properly. Instead of reading the record explicitly, you can enable implicit pre-read. For details, see [Enable implicit pre-read for `Put` operations](#enable-implicit-pre-read-for-put-operations).
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
@@ -716,7 +716,13 @@ Put put =
         .build();
 ```
 
-Note that if you are certain that a record you are trying to mutate does not exist, you should not enable implicit pre-read for the `Put` operation for better performance. For example, if you load initial data, you should not enable implicit pre-read. A `Put` operation without implicit pre-read is faster than `Put` operation with implicit pre-read because the operation skips an unnecessary read.
+{% capture notice--info %}
+**Note**
+
+If you are certain that a record you are trying to mutate does not exist, you should not enable implicit pre-read for the `Put` operation for better performance. For example, if you load initial data, you should not enable implicit pre-read. A `Put` operation without implicit pre-read is faster than `Put` operation with implicit pre-read because the operation skips an unnecessary read.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 #### `Delete` operation
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -755,6 +755,15 @@ You can write arbitrary conditions (for example, a bank account balance must be 
 
 When a `Put` or `Delete` operation includes a condition, the operation is executed only if the specified condition is met. If the condition is not met when the operation is executed, an exception called `UnsatisfiedConditionException` will be thrown.
 
+{% capture notice--info %}
+**Note**
+
+When you specify a condition in a `Put` operation, you need to read the record beforehand or enable implicit pre-read.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+
 ##### Conditions for `Put`
 
 You can specify a condition in a `Put` operation as follows:

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -654,6 +654,14 @@ You can't specify clustering-key boundaries and orderings in `Scan` without spec
 
 `Put` is an operation to put a record specified by a primary key. The operation behaves as an upsert operation for a record, in which the operation updates the record if the record exists or inserts the record if the record does not exist.
 
+{% capture notice--info %}
+**Note**
+
+When you update an existing record, you need to read the record by using `Get` or `Scan` before using a `Put` operation. Otherwise, the operation will fail due to a conflict. This occurs because ScalarDB assumes that another transaction wrote the record. Instead of reading the record explicitly, you can enable implicit pre-read. See [Enable implicit pre-read for `Put` operations](#enable-implicit-pre-read-for-put-operations) for details.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
 You need to create a `Put` object first, and then you can execute the object by using the `transaction.put()` method as follows:
 
 ```java
@@ -689,13 +697,11 @@ Put put =
         .build();
 ```
 
-##### Disable implicit pre-read for `Put` operations
+##### Enable implicit pre-read for `Put` operations
 
-In Consensus Commit, an application must read a record before mutating the record with `Put` and `Delete` operations to obtain the latest states of the record if the record exists. If an application does not read the record explicitly in a transaction, ScalarDB will read the record on behalf of the application before committing the transaction. We call this feature *implicit pre-read*.
+In Consensus Commit, an application must read a record before mutating the record with `Put` and `Delete` operations to obtain the latest states of the record if the record exists. Instead of reading the record explicitly, you can enable *implicit pre-read*. By enabling implicit pre-read, if an application does not read the record explicitly in a transaction, ScalarDB will read the record on behalf of the application before committing the transaction.
 
-If you are certain that a record you are trying to mutate does not exist, you can disable implicit pre-read for the `Put` operation for better performance. For example, if you load initial data, you can and should disable implicit pre-read. A `Put` operation without implicit pre-read is faster than a regular `Put` operation because the operation skips an unnecessary read. However, if the record exists, the operation will fail due to a conflict. This occurs because ScalarDB assumes that another transaction wrote the record.
-
-You can disable implicit pre-read for a `Put` operation by specifying `disableImplicitPreRead()` in the `Put` operation builder as follows:
+You can enable implicit pre-read for a `Put` operation by specifying `enableImplicitPreRead()` in the `Put` operation builder as follows:
 
 ```java
 Put put =
@@ -706,13 +712,23 @@ Put put =
         .clusteringKey(clusteringKey)
         .floatValue("c4", 1.23F)
         .doubleValue("c5", 4.56)
-        .disableImplicitPreRead()
+        .enableImplicitPreRead()
         .build();
 ```
+
+Note that if you are certain that a record you are trying to mutate does not exist, you should not enable implicit pre-read for the `Put` operation for better performance. For example, if you load initial data, you should not enable implicit pre-read. A `Put` operation without implicit pre-read is faster than `Put` operation with implicit pre-read because the operation skips an unnecessary read.
 
 #### `Delete` operation
 
 `Delete` is an operation to delete a record specified by a primary key.
+
+{% capture notice--info %}
+**Note**
+
+When you delete a record, you don't have to read the record beforehand because implicit pre-read is always enabled for `Delete` operations.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 You need to create a `Delete` object first, and then you can execute the object by using the `transaction.delete()` method as follows:
 

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -683,7 +683,7 @@ Put put =
 {% capture notice--info %}
 **Note**
 
-If you specify `disableImplicitPreRead()` or `implicitPreReadEnabled()` in the `Put` operation builder, they will be ignored.
+If you specify `enableImplicitPreRead()`, `disableImplicitPreRead()`, or `implicitPreReadEnabled()` in the `Put` operation builder, they will be ignored.
 
 {% endcapture %}
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -599,6 +599,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
             .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
             .intValue(BALANCE, expected)
+            .enableImplicitPreRead()
             .build();
     transaction.put(put);
     transaction.commit();
@@ -839,7 +840,11 @@ public abstract class DistributedTransactionIntegrationTestBase {
   public void mutateAndCommit_ShouldMutateRecordsProperly() throws TransactionException {
     // Arrange
     populateRecords();
-    Put put = preparePut(0, 0).withIntValue(BALANCE, INITIAL_BALANCE - 100);
+    Put put =
+        Put.newBuilder(preparePut(0, 0))
+            .intValue(BALANCE, INITIAL_BALANCE - 100)
+            .enableImplicitPreRead()
+            .build();
     Delete delete = prepareDelete(1, 0);
 
     DistributedTransaction transaction = manager.begin();
@@ -1126,6 +1131,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
                         ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
                     .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
                     .build())
+            .enableImplicitPreRead()
             .build();
 
     // Act
@@ -1150,6 +1156,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         Put.newBuilder(put)
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
             .build();
 
     // Act
@@ -1170,7 +1177,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
       throws TransactionException {
     // Arrange
     Put putIfNotExists =
-        Put.newBuilder(preparePut(0, 0)).condition(ConditionBuilder.putIfNotExists()).build();
+        Put.newBuilder(preparePut(0, 0))
+            .condition(ConditionBuilder.putIfNotExists())
+            .enableImplicitPreRead()
+            .build();
 
     // Act
     put(putIfNotExists);
@@ -1235,6 +1245,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         Put.newBuilder(preparePut(0, 0))
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(ConditionBuilder.putIf(ConditionBuilder.column(BALANCE).isNullInt()).build())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert
@@ -1252,6 +1263,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
         Put.newBuilder(preparePut(0, 0))
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert
@@ -1267,7 +1279,11 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     Put put = preparePut(0, 0);
     put(put);
-    Put putIfNotExists = Put.newBuilder(put).condition(ConditionBuilder.putIfNotExists()).build();
+    Put putIfNotExists =
+        Put.newBuilder(put)
+            .condition(ConditionBuilder.putIfNotExists())
+            .enableImplicitPreRead()
+            .build();
 
     // Act Assert
     assertThatThrownBy(() -> put(putIfNotExists)).isInstanceOf(UnsatisfiedConditionException.class);
@@ -1336,6 +1352,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
                         ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
                     .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
                     .build())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -516,6 +516,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
             .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
             .intValue(BALANCE, expected)
+            .enableImplicitPreRead()
             .build();
     transaction.put(put);
     transaction.prepare();
@@ -788,7 +789,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void mutateAndCommit_ShouldMutateRecordsProperly() throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, INITIAL_BALANCE - 100);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE - 100)
+            .enableImplicitPreRead()
+            .build();
     Delete delete = prepareDelete(1, 0, namespace1, TABLE_1);
 
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -819,7 +824,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateRecords(manager1, namespace1, TABLE_1);
     populateRecords(manager2, namespace2, TABLE_2);
 
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, INITIAL_BALANCE - 100);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE - 100)
+            .enableImplicitPreRead()
+            .build();
     Delete delete = prepareDelete(1, 0, namespace2, TABLE_2);
 
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
@@ -871,7 +880,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     populateRecords(manager1, namespace1, TABLE_1);
     populateRecords(manager2, namespace2, TABLE_2);
 
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, INITIAL_BALANCE - 100);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE - 100)
+            .enableImplicitPreRead()
+            .build();
     Delete delete = prepareDelete(1, 0, namespace2, TABLE_2);
 
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
@@ -1356,6 +1369,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
                         ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
                     .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
                     .build())
+            .enableImplicitPreRead()
             .build();
 
     // Act
@@ -1389,6 +1403,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
                         ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
                     .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
                     .build())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert
@@ -1412,6 +1427,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(
                 ConditionBuilder.putIf(ConditionBuilder.column(BALANCE).isNullText()).build())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert
@@ -1429,6 +1445,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert
@@ -1447,6 +1464,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         Put.newBuilder(put)
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
             .build();
 
     // Act
@@ -1469,6 +1487,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     Put putIfNotExists =
         Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
             .condition(ConditionBuilder.putIfNotExists())
+            .enableImplicitPreRead()
             .build();
 
     // Act
@@ -1494,6 +1513,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         Put.newBuilder(put)
             .intValue(BALANCE, INITIAL_BALANCE)
             .condition(ConditionBuilder.putIfNotExists())
+            .enableImplicitPreRead()
             .build();
 
     // Act Assert

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -1247,7 +1247,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   }
 
   @Test
-  public void putAndCommit_PutGivenForExistingAndNeverRead_ShouldUpdateRecord()
+  public void putAndCommit_PutWithImplicitPreReadEnabledGivenForExisting_ShouldUpdateRecord()
       throws TransactionException, ExecutionException {
     // Arrange
     populateRecordsWithNullMetadata(namespace1, TABLE_1);
@@ -1256,7 +1256,10 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
 
     // Act
     int expected = INITIAL_BALANCE + 100;
-    Put put = preparePut(0, 0, expected, namespace1, TABLE_1);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, expected, namespace1, TABLE_1))
+            .enableImplicitPreRead()
+            .build();
     transaction.put(put);
     transaction.commit();
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -1102,7 +1102,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void putAndCommit_PutGivenForExistingAndNeverRead_ShouldUpdateRecord()
+  public void putAndCommit_PutWithImplicitPreReadEnabledGivenForExisting_ShouldUpdateRecord()
       throws TransactionException, ExecutionException {
     // Arrange
     populateRecords(namespace1, TABLE_1);
@@ -1110,7 +1110,11 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Act
     int expected = INITIAL_BALANCE + 100;
-    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, expected);
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, expected)
+            .enableImplicitPreRead()
+            .build();
     transaction.put(put);
     transaction.commit();
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -1100,7 +1100,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void putAndCommit_PutGivenForExistingAndNeverRead_ShouldUpdateRecord()
+  public void putAndCommit_PutWithImplicitPreReadEnabledGivenForExisting_ShouldUpdateRecord()
       throws TransactionException {
     // Arrange
     populate(manager1, namespace1, TABLE_1);
@@ -1109,7 +1109,12 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     // Act
     int afterBalance = INITIAL_BALANCE + 100;
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, afterBalance));
+    Put put =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, afterBalance)
+            .enableImplicitPreRead()
+            .build();
+    transaction.put(put);
     transaction.prepare();
     transaction.commit();
 


### PR DESCRIPTION
## Description

This PR disables implicit pre-read by default for `Put` operations because the feature is backward incompatible.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1222

## Changes made

- Disabled implicit pre-read by default for `Put` operations
- Modified related unit tests and integration tests 
- Revised related documents

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
