### PR TITLE
Add options to Admin.importTable()

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -408,9 +408,11 @@ public interface Admin {
    *
    * @param namespace an existing namespace
    * @param table an existing table
+   * @param options options to import
    * @throws IllegalArgumentException if the table is already managed by ScalarDB, if the target
    *     table does not exist, or if the table does not meet the requirement of ScalarDB table
    * @throws ExecutionException if the operation fails
    */
-  void importTable(String namespace, String table) throws ExecutionException;
+  void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException;
 }

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -290,7 +290,8 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) throws ExecutionException {
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
     TableMetadata tableMetadata = getTableMetadata(namespace, table);
     if (tableMetadata != null) {
       throw new IllegalArgumentException(
@@ -298,7 +299,7 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
     }
 
     try {
-      admin.importTable(namespace, table);
+      admin.importTable(namespace, table, options);
     } catch (ExecutionException e) {
       throw new ExecutionException(
           "Importing the table failed: " + ScalarDbUtils.getFullTableName(namespace, table), e);

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -107,8 +107,9 @@ public class AdminService implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) throws ExecutionException {
-    admin.importTable(namespace, table);
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
+    admin.importTable(namespace, table, options);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -201,7 +201,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) {
+  public void importTable(String namespace, String table, Map<String, String> options) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in Cassandra");
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -566,7 +566,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) {
+  public void importTable(String namespace, String table, Map<String, String> options) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in Cosmos DB");
   }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1214,7 +1214,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) {
+  public void importTable(String namespace, String table, Map<String, String> options) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in DynamoDB");
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -5,7 +5,6 @@ import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -490,11 +489,12 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) throws ExecutionException {
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
     TableMetadata tableMetadata = getImportTableMetadata(namespace, table);
 
     // add ScalarDB metadata
-    repairTable(namespace, table, tableMetadata, ImmutableMap.of());
+    repairTable(namespace, table, tableMetadata, options);
   }
 
   private String getSelectColumnsStatement() {

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -196,8 +196,9 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) throws ExecutionException {
-    getAdmin(namespace, table).importTable(namespace, table);
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
+    getAdmin(namespace, table).importTable(namespace, table, options);
   }
 
   private DistributedStorageAdmin getAdmin(String namespace) {

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
@@ -340,7 +340,7 @@ public class GrpcAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) {
+  public void importTable(String namespace, String table, Map<String, String> options) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in ScalarDB Server");
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -6,7 +6,6 @@ import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.get
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.removeTransactionMetaColumns;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
@@ -193,7 +192,8 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) throws ExecutionException {
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
     TableMetadata tableMetadata = admin.getTableMetadata(namespace, table);
     if (tableMetadata != null) {
       throw new IllegalArgumentException(
@@ -216,8 +216,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
     }
 
     // add ScalarDB metadata
-    admin.repairTable(
-        namespace, table, buildTransactionTableMetadata(tableMetadata), ImmutableMap.of());
+    admin.repairTable(namespace, table, buildTransactionTableMetadata(tableMetadata), options);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -91,8 +91,9 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) throws ExecutionException {
-    jdbcAdmin.importTable(namespace, table);
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
+    jdbcAdmin.importTable(namespace, table, options);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
@@ -395,7 +395,7 @@ public class GrpcTransactionAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table) {
+  public void importTable(String namespace, String table, Map<String, String> options) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in ScalarDB Server");
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -606,7 +606,8 @@ public class CassandraAdminTest {
     Throwable thrown2 =
         catchThrowable(
             () -> cassandraAdmin.addRawColumnToTable(namespace, table, column, DataType.INT));
-    Throwable thrown3 = catchThrowable(() -> cassandraAdmin.importTable(namespace, table));
+    Throwable thrown3 =
+        catchThrowable(() -> cassandraAdmin.importTable(namespace, table, Collections.emptyMap()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -855,7 +855,8 @@ public abstract class CosmosAdminTestBase {
     Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(namespace, table));
     Throwable thrown2 =
         catchThrowable(() -> admin.addRawColumnToTable(namespace, table, column, DataType.INT));
-    Throwable thrown3 = catchThrowable(() -> admin.importTable(namespace, table));
+    Throwable thrown3 =
+        catchThrowable(() -> admin.importTable(namespace, table, Collections.emptyMap()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1183,7 +1183,8 @@ public abstract class DynamoAdminTestBase {
     Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(NAMESPACE, TABLE));
     Throwable thrown2 =
         catchThrowable(() -> admin.addRawColumnToTable(NAMESPACE, TABLE, "c1", DataType.INT));
-    Throwable thrown3 = catchThrowable(() -> admin.importTable(NAMESPACE, TABLE));
+    Throwable thrown3 =
+        catchThrowable(() -> admin.importTable(NAMESPACE, TABLE, Collections.emptyMap()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -2519,7 +2519,7 @@ public abstract class JdbcAdminTestBase {
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
 
     // Act
-    admin.importTable(NAMESPACE, TABLE);
+    admin.importTable(NAMESPACE, TABLE, Collections.emptyMap());
 
     // Assert
     for (int i = 0; i < expectedSqlStatements.size(); i++) {
@@ -2536,7 +2536,8 @@ public abstract class JdbcAdminTestBase {
     JdbcAdmin admin = createJdbcAdminFor(RdbEngine.SQLITE);
 
     // Act
-    Throwable thrown = catchThrowable(() -> admin.importTable(NAMESPACE, TABLE));
+    Throwable thrown =
+        catchThrowable(() -> admin.importTable(NAMESPACE, TABLE, Collections.emptyMap()));
 
     // Assert
     assertThat(thrown).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
@@ -1,7 +1,7 @@
 package com.scalar.db.storage.rpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -340,15 +340,12 @@ public class GrpcAdminTest {
     String table = "tbl";
     String column = "col";
 
-    // Act
-    Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(namespace, table));
-    Throwable thrown2 =
-        catchThrowable(() -> admin.addRawColumnToTable(namespace, table, column, DataType.INT));
-    Throwable thrown3 = catchThrowable(() -> admin.importTable(namespace, table));
-
-    // Assert
-    assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
-    assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
-    assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
+    // Act Assert
+    assertThatThrownBy(() -> admin.getImportTableMetadata(namespace, table))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> admin.addRawColumnToTable(namespace, table, column, DataType.INT))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> admin.importTable(namespace, table, Collections.emptyMap()))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -1,5 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.buildTransactionTableMetadata;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getBeforeImageColumnName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -594,6 +595,7 @@ public abstract class ConsensusCommitAdminTestBase {
   @Test
   public void importTable_ShouldCallStorageAdminProperly() throws ExecutionException {
     // Arrange
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
     String primaryKeyColumn = "pk";
     String column = "col";
     TableMetadata metadata =
@@ -609,7 +611,7 @@ public abstract class ConsensusCommitAdminTestBase {
         .addRawColumnToTable(anyString(), anyString(), anyString(), any(DataType.class));
 
     // Act
-    admin.importTable(NAMESPACE, TABLE);
+    admin.importTable(NAMESPACE, TABLE, options);
 
     // Assert
     verify(distributedStorageAdmin).getTableMetadata(NAMESPACE, TABLE);
@@ -624,6 +626,8 @@ public abstract class ConsensusCommitAdminTestBase {
             NAMESPACE, TABLE, getBeforeImageColumnName(column, metadata), DataType.INT);
     verify(distributedStorageAdmin, never())
         .addRawColumnToTable(NAMESPACE, TABLE, primaryKeyColumn, DataType.INT);
+    verify(distributedStorageAdmin)
+        .repairTable(NAMESPACE, TABLE, buildTransactionTableMetadata(metadata), options);
   }
 
   @Test
@@ -641,7 +645,8 @@ public abstract class ConsensusCommitAdminTestBase {
     when(distributedStorageAdmin.getTableMetadata(NAMESPACE, TABLE)).thenReturn(metadata);
 
     // Act
-    Throwable thrown = catchThrowable(() -> admin.importTable(NAMESPACE, TABLE));
+    Throwable thrown =
+        catchThrowable(() -> admin.importTable(NAMESPACE, TABLE, Collections.emptyMap()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
@@ -673,7 +678,8 @@ public abstract class ConsensusCommitAdminTestBase {
     when(distributedStorageAdmin.getTableMetadata(NAMESPACE, TABLE)).thenReturn(metadata);
 
     // Act
-    Throwable thrown = catchThrowable(() -> admin.importTable(NAMESPACE, TABLE));
+    Throwable thrown =
+        catchThrowable(() -> admin.importTable(NAMESPACE, TABLE, Collections.emptyMap()));
 
     // Assert
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -235,9 +235,9 @@ public class JdbcTransactionAdminTest {
     String table = "tbl";
 
     // Act
-    admin.importTable(namespace, table);
+    admin.importTable(namespace, table, Collections.emptyMap());
 
     // Assert
-    verify(jdbcAdmin).importTable(namespace, table);
+    verify(jdbcAdmin).importTable(namespace, table, Collections.emptyMap());
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionAdminTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.transaction.rpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -410,5 +411,16 @@ public class GrpcTransactionAdminTest {
                 .setColumnName(columnName)
                 .setColumnType(com.scalar.db.rpc.DataType.DATA_TYPE_TEXT)
                 .build());
+  }
+
+  @Test
+  public void unsupportedOperations_ShouldThrowUnsupportedException() {
+    // Arrange
+    String namespace = "sample_ns";
+    String table = "tbl";
+
+    // Act Assert
+    assertThatThrownBy(() -> admin.importTable(namespace, table, Collections.emptyMap()))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
@@ -102,14 +102,15 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
     admin.createNamespace(getNamespace(), getCreationOptions());
 
     // Act Assert
-    assertThatThrownBy(() -> admin.importTable(getNamespace(), "unsupported_db"))
+    assertThatThrownBy(
+            () -> admin.importTable(getNamespace(), "unsupported_db", Collections.emptyMap()))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
   private void importTable_ForImportableTable_ShouldImportProperly(
       String table, TableMetadata metadata) throws ExecutionException {
     // Act
-    admin.importTable(getNamespace(), table);
+    admin.importTable(getNamespace(), table, Collections.emptyMap());
 
     // Assert
     assertThat(admin.tableExists(getNamespace(), table)).isTrue();
@@ -119,14 +120,15 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
   private void importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(String table) {
     // Act Assert
     assertThatThrownBy(
-            () -> admin.importTable(getNamespace(), table),
+            () -> admin.importTable(getNamespace(), table, Collections.emptyMap()),
             "non-importable data type test failed: " + table)
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   private void importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
     // Act Assert
-    assertThatThrownBy(() -> admin.importTable(getNamespace(), "non-existing-table"))
+    assertThatThrownBy(
+            () -> admin.importTable(getNamespace(), "non-existing-table", Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
@@ -102,14 +102,15 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
     admin.createNamespace(getNamespace(), getCreationOptions());
 
     // Act Assert
-    assertThatThrownBy(() -> admin.importTable(getNamespace(), "unsupported_db"))
+    assertThatThrownBy(
+            () -> admin.importTable(getNamespace(), "unsupported_db", Collections.emptyMap()))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
   private void importTable_ForImportableTable_ShouldImportProperly(
       String table, TableMetadata metadata) throws ExecutionException {
     // Act
-    admin.importTable(getNamespace(), table);
+    admin.importTable(getNamespace(), table, Collections.emptyMap());
 
     // Assert
     assertThat(admin.tableExists(getNamespace(), table)).isTrue();
@@ -118,13 +119,14 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
 
   private void importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(String table) {
     // Act Assert
-    assertThatThrownBy(() -> admin.importTable(getNamespace(), table))
+    assertThatThrownBy(() -> admin.importTable(getNamespace(), table, Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   private void importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException() {
     // Act Assert
-    assertThatThrownBy(() -> admin.importTable(getNamespace(), "non-existing-table"))
+    assertThatThrownBy(
+            () -> admin.importTable(getNamespace(), "non-existing-table", Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
@@ -1,5 +1,6 @@
 package com.scalar.db.schemaloader;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -16,21 +17,26 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class ImportSchemaParser {
   private final JsonObject schemaJson;
+  private final Map<String, String> options;
 
-  public ImportSchemaParser(Path jsonFilePath) throws SchemaLoaderException {
+  public ImportSchemaParser(Path jsonFilePath, Map<String, String> options)
+      throws SchemaLoaderException {
     try (Reader reader = Files.newBufferedReader(jsonFilePath)) {
       schemaJson = JsonParser.parseReader(reader).getAsJsonObject();
     } catch (IOException | JsonParseException e) {
       throw new SchemaLoaderException("Parsing the schema JSON failed", e);
     }
+    this.options = ImmutableMap.copyOf(options);
   }
 
-  public ImportSchemaParser(String serializedSchemaJson) throws SchemaLoaderException {
+  public ImportSchemaParser(String serializedSchemaJson, Map<String, String> options)
+      throws SchemaLoaderException {
     try {
       schemaJson = JsonParser.parseString(serializedSchemaJson).getAsJsonObject();
     } catch (JsonParseException e) {
       throw new SchemaLoaderException("Parsing the schema JSON failed", e);
     }
+    this.options = ImmutableMap.copyOf(options);
   }
 
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW
@@ -41,7 +47,7 @@ public class ImportSchemaParser {
     List<ImportTableSchema> tableSchemaList = new ArrayList<>();
     for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {
       tableSchemaList.add(
-          new ImportTableSchema(entry.getKey(), entry.getValue().getAsJsonObject()));
+          new ImportTableSchema(entry.getKey(), entry.getValue().getAsJsonObject(), options));
     }
     return tableSchemaList;
   }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
@@ -1,16 +1,21 @@
 package com.scalar.db.schemaloader;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonObject;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 public class ImportTableSchema {
-  private static final String TRANSACTION = "transaction";
   private final String namespace;
   private final String tableName;
   private final boolean isTransactionTable;
+  private final ImmutableMap<String, String> options;
 
-  public ImportTableSchema(String tableFullName, JsonObject tableDefinition)
+  public ImportTableSchema(
+      String tableFullName, JsonObject tableDefinition, Map<String, String> options)
       throws SchemaLoaderException {
     String[] fullName = tableFullName.split("\\.", -1);
     if (fullName.length != 2) {
@@ -20,11 +25,30 @@ public class ImportTableSchema {
     }
     namespace = fullName[0];
     tableName = fullName[1];
-    if (tableDefinition.keySet().contains(TRANSACTION)) {
-      isTransactionTable = tableDefinition.get(TRANSACTION).getAsBoolean();
+    if (tableDefinition.keySet().contains(TableSchema.TRANSACTION)) {
+      isTransactionTable = tableDefinition.get(TableSchema.TRANSACTION).getAsBoolean();
     } else {
       isTransactionTable = true;
     }
+    this.options = buildOptions(tableDefinition, options);
+  }
+
+  private ImmutableMap<String, String> buildOptions(
+      JsonObject tableDefinition, Map<String, String> globalOptions) {
+    ImmutableMap.Builder<String, String> optionsBuilder = ImmutableMap.builder();
+    optionsBuilder.putAll(globalOptions);
+    Set<String> keysToIgnore =
+        ImmutableSet.of(
+            TableSchema.PARTITION_KEY,
+            TableSchema.CLUSTERING_KEY,
+            TableSchema.TRANSACTION,
+            TableSchema.COLUMNS,
+            TableSchema.SECONDARY_INDEX);
+    tableDefinition.entrySet().stream()
+        .filter(entry -> !keysToIgnore.contains(entry.getKey()))
+        .forEach(entry -> optionsBuilder.put(entry.getKey(), entry.getValue().getAsString()));
+    // If an option is defined globally and in the JSON file, the JSON file value is used
+    return optionsBuilder.buildKeepingLast();
   }
 
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW
@@ -41,5 +65,9 @@ public class ImportTableSchema {
 
   public boolean isTransactionTable() {
     return isTransactionTable;
+  }
+
+  public Map<String, String> getOptions() {
+    return options;
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaLoader.java
@@ -513,13 +513,15 @@ public class SchemaLoader {
    *
    * @param configProperties ScalarDB config properties
    * @param serializedSchemaJson serialized json string schema.
+   * @param options specific options for importing.
    * @throws SchemaLoaderException thrown when importing tables fails.
    */
-  public static void importTables(Properties configProperties, String serializedSchemaJson)
+  public static void importTables(
+      Properties configProperties, String serializedSchemaJson, Map<String, String> options)
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Right<>(configProperties);
     Either<Path, String> schema = new Right<>(serializedSchemaJson);
-    importTables(config, schema);
+    importTables(config, schema, options);
   }
 
   /**
@@ -527,13 +529,15 @@ public class SchemaLoader {
    *
    * @param configProperties ScalarDB properties.
    * @param schemaPath path to the schema file.
+   * @param options specific options for importing.
    * @throws SchemaLoaderException thrown when importing tables fails.
    */
-  public static void importTables(Properties configProperties, Path schemaPath)
+  public static void importTables(
+      Properties configProperties, Path schemaPath, Map<String, String> options)
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Right<>(configProperties);
     Either<Path, String> schema = new Left<>(schemaPath);
-    importTables(config, schema);
+    importTables(config, schema, options);
   }
 
   /**
@@ -541,13 +545,15 @@ public class SchemaLoader {
    *
    * @param configPath path to the ScalarDB config.
    * @param serializedSchemaJson serialized json string schema.
+   * @param options specific options for importing.
    * @throws SchemaLoaderException thrown when importing tables fails.
    */
-  public static void importTables(Path configPath, String serializedSchemaJson)
+  public static void importTables(
+      Path configPath, String serializedSchemaJson, Map<String, String> options)
       throws SchemaLoaderException {
     Either<Path, Properties> config = new Left<>(configPath);
     Either<Path, String> schema = new Right<>(serializedSchemaJson);
-    importTables(config, schema);
+    importTables(config, schema, options);
   }
 
   /**
@@ -555,22 +561,25 @@ public class SchemaLoader {
    *
    * @param configPath path to the ScalarDB config.
    * @param schemaPath path to the schema file.
+   * @param options specific options for importing.
    * @throws SchemaLoaderException thrown when importing tables fails.
    */
-  public static void importTables(Path configPath, Path schemaPath) throws SchemaLoaderException {
+  public static void importTables(Path configPath, Path schemaPath, Map<String, String> options)
+      throws SchemaLoaderException {
     Either<Path, Properties> config = new Left<>(configPath);
     Either<Path, String> schema = new Left<>(schemaPath);
-    importTables(config, schema);
+    importTables(config, schema, options);
   }
 
-  private static void importTables(Either<Path, Properties> config, Either<Path, String> schema)
+  private static void importTables(
+      Either<Path, Properties> config, Either<Path, String> schema, Map<String, String> options)
       throws SchemaLoaderException {
     // Parse the schema
-    List<ImportTableSchema> tableSchemaList = getImportTableSchemaList(schema);
+    List<ImportTableSchema> tableSchemaList = getImportTableSchemaList(schema, options);
 
     // Import tables
     try (SchemaOperator operator = getSchemaOperator(config)) {
-      operator.importTables(tableSchemaList);
+      operator.importTables(tableSchemaList, options);
     }
   }
 
@@ -612,25 +621,25 @@ public class SchemaLoader {
     }
   }
 
-  private static List<ImportTableSchema> getImportTableSchemaList(Either<Path, String> schema)
-      throws SchemaLoaderException {
+  private static List<ImportTableSchema> getImportTableSchemaList(
+      Either<Path, String> schema, Map<String, String> options) throws SchemaLoaderException {
     if ((schema.isLeft() && schema.getLeft() != null)
         || (schema.isRight() && schema.getRight() != null)) {
-      ImportSchemaParser schemaParser = getImportSchemaParser(schema);
+      ImportSchemaParser schemaParser = getImportSchemaParser(schema, options);
       return schemaParser.parse();
     }
     return Collections.emptyList();
   }
 
   @VisibleForTesting
-  static ImportSchemaParser getImportSchemaParser(Either<Path, String> schema)
-      throws SchemaLoaderException {
+  static ImportSchemaParser getImportSchemaParser(
+      Either<Path, String> schema, Map<String, String> options) throws SchemaLoaderException {
     assert (schema.isLeft() && schema.getLeft() != null)
         || (schema.isRight() && schema.getRight() != null);
     if (schema.isLeft()) {
-      return new ImportSchemaParser(schema.getLeft());
+      return new ImportSchemaParser(schema.getLeft(), options);
     } else {
-      return new ImportSchemaParser(schema.getRight());
+      return new ImportSchemaParser(schema.getRight(), options);
     }
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -367,15 +367,16 @@ public class SchemaOperator implements AutoCloseable {
     }
   }
 
-  public void importTables(List<ImportTableSchema> tableSchemaList) throws SchemaLoaderException {
+  public void importTables(List<ImportTableSchema> tableSchemaList, Map<String, String> options)
+      throws SchemaLoaderException {
     for (ImportTableSchema tableSchema : tableSchemaList) {
       String namespace = tableSchema.getNamespace();
       String table = tableSchema.getTable();
       try {
         if (tableSchema.isTransactionTable()) {
-          transactionAdmin.get().importTable(namespace, table);
+          transactionAdmin.get().importTable(namespace, table, options);
         } else {
-          storageAdmin.get().importTable(namespace, table);
+          storageAdmin.get().importTable(namespace, table, options);
         }
         logger.info("Importing the table {} in the namespace {} succeeded", table, namespace);
       } catch (ExecutionException e) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
@@ -20,11 +20,11 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class TableSchema {
 
-  private static final String COLUMNS = "columns";
-  private static final String TRANSACTION = "transaction";
-  private static final String PARTITION_KEY = "partition-key";
-  private static final String CLUSTERING_KEY = "clustering-key";
-  private static final String SECONDARY_INDEX = "secondary-index";
+  static final String COLUMNS = "columns";
+  static final String TRANSACTION = "transaction";
+  static final String PARTITION_KEY = "partition-key";
+  static final String CLUSTERING_KEY = "clustering-key";
+  static final String SECONDARY_INDEX = "secondary-index";
   private static final ImmutableMap<String, DataType> DATA_MAP_TYPE =
       ImmutableMap.<String, DataType>builder()
           .put("BOOLEAN", DataType.BOOLEAN)

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/SchemaLoaderCommand.java
@@ -1,5 +1,6 @@
 package com.scalar.db.schemaloader.command;
 
+import com.google.common.collect.ImmutableMap;
 import com.scalar.db.schemaloader.SchemaLoader;
 import com.scalar.db.schemaloader.SchemaLoaderException;
 import com.scalar.db.storage.cassandra.CassandraAdmin;
@@ -7,7 +8,6 @@ import com.scalar.db.storage.cassandra.CassandraAdmin.CompactionStrategy;
 import com.scalar.db.storage.cassandra.CassandraAdmin.ReplicationStrategy;
 import com.scalar.db.storage.dynamo.DynamoAdmin;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import org.slf4j.Logger;
@@ -36,7 +36,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
   @Option(
       names = "--replication-factor",
       description = "The replication factor (supported in Cassandra)")
-  private String replicaFactor;
+  private String replicationFactor;
 
   @Option(names = "--ru", description = "Base resource unit (supported in DynamoDB, Cosmos DB)")
   private String ru;
@@ -118,26 +118,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
   }
 
   private void createTables() throws SchemaLoaderException {
-    Map<String, String> options = new HashMap<>();
-    if (replicationStrategy != null) {
-      options.put(CassandraAdmin.REPLICATION_STRATEGY, replicationStrategy.toString());
-    }
-    if (compactionStrategy != null) {
-      options.put(CassandraAdmin.COMPACTION_STRATEGY, compactionStrategy.toString());
-    }
-    if (replicaFactor != null) {
-      options.put(CassandraAdmin.REPLICATION_FACTOR, replicaFactor);
-    }
-    if (ru != null) {
-      options.put(DynamoAdmin.REQUEST_UNIT, ru);
-    }
-    if (noScaling != null) {
-      options.put(DynamoAdmin.NO_SCALING, noScaling.toString());
-    }
-    if (noBackup != null) {
-      options.put(DynamoAdmin.NO_BACKUP, noBackup.toString());
-    }
-
+    Map<String, String> options = prepareAllOptions();
     SchemaLoader.load(configPath, schemaFile, options, coordinator);
   }
 
@@ -146,10 +127,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       throw new IllegalArgumentException(
           "Specifying the '--schema-file' option is required when using the '--repair-all' option");
     }
-    Map<String, String> options = new HashMap<>();
-    if (noBackup != null) {
-      options.put(DynamoAdmin.NO_BACKUP, noBackup.toString());
-    }
+    Map<String, String> options = prepareAllOptions();
     SchemaLoader.repairTables(configPath, schemaFile, options, coordinator);
   }
 
@@ -158,10 +136,7 @@ public class SchemaLoaderCommand implements Callable<Integer> {
       throw new IllegalArgumentException(
           "Specifying the '--schema-file' option is required when using the '--alter' option");
     }
-    Map<String, String> options = new HashMap<>();
-    if (noScaling != null) {
-      options.put(DynamoAdmin.NO_SCALING, noScaling.toString());
-    }
+    Map<String, String> options = prepareOptions(DynamoAdmin.NO_SCALING);
     SchemaLoader.alterTables(configPath, schemaFile, options);
   }
 
@@ -176,7 +151,58 @@ public class SchemaLoaderCommand implements Callable<Integer> {
           "Specifying the '--coordinator' option with the '--import' option is not allowed."
               + " Create coordinator tables separately");
     }
+    Map<String, String> options = prepareAllOptions();
+    SchemaLoader.importTables(configPath, schemaFile, options);
+  }
 
-    SchemaLoader.importTables(configPath, schemaFile);
+  private Map<String, String> prepareAllOptions() {
+    return prepareOptions(
+        CassandraAdmin.REPLICATION_STRATEGY,
+        CassandraAdmin.COMPACTION_STRATEGY,
+        CassandraAdmin.REPLICATION_FACTOR,
+        DynamoAdmin.REQUEST_UNIT,
+        DynamoAdmin.NO_SCALING,
+        DynamoAdmin.NO_BACKUP);
+  }
+
+  private Map<String, String> prepareOptions(String... options) {
+    ImmutableMap.Builder<String, String> optionToValue = ImmutableMap.builder();
+    for (String option : options) {
+      switch (option) {
+        case CassandraAdmin.REPLICATION_STRATEGY:
+          if (replicationStrategy != null) {
+            optionToValue.put(CassandraAdmin.REPLICATION_STRATEGY, replicationStrategy.toString());
+          }
+          break;
+        case CassandraAdmin.COMPACTION_STRATEGY:
+          if (compactionStrategy != null) {
+            optionToValue.put(CassandraAdmin.COMPACTION_STRATEGY, compactionStrategy.toString());
+          }
+          break;
+        case CassandraAdmin.REPLICATION_FACTOR:
+          if (replicationFactor != null) {
+            optionToValue.put(CassandraAdmin.REPLICATION_FACTOR, replicationFactor);
+          }
+          break;
+        case DynamoAdmin.REQUEST_UNIT:
+          if (ru != null) {
+            optionToValue.put(DynamoAdmin.REQUEST_UNIT, ru);
+          }
+          break;
+        case DynamoAdmin.NO_SCALING:
+          if (noScaling != null) {
+            optionToValue.put(DynamoAdmin.NO_SCALING, noScaling.toString());
+          }
+          break;
+        case DynamoAdmin.NO_BACKUP:
+          if (noBackup != null) {
+            optionToValue.put(DynamoAdmin.NO_BACKUP, noBackup.toString());
+          }
+          break;
+        default:
+          throw new AssertionError("Unknown option " + option);
+      }
+    }
+    return optionToValue.build();
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/ImportSchemaParserTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/ImportSchemaParserTest.java
@@ -1,8 +1,11 @@
 package com.scalar.db.schemaloader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class ImportSchemaParserTest {
@@ -11,6 +14,7 @@ public class ImportSchemaParserTest {
   public void parse_ProperSerializedSchemaJsonAndOptionsGiven_ShouldParseCorrectly()
       throws SchemaLoaderException {
     // Arrange
+    Map<String, String> globalOptions = ImmutableMap.of("ru", "4000", "replication-factor", "1");
     String serializedSchemaJson =
         "{"
             + "  \"sample_db.sample_table1\": {"
@@ -45,7 +49,7 @@ public class ImportSchemaParserTest {
             + "    \"compaction-strategy\": \"LCS\""
             + "  }"
             + "}";
-    ImportSchemaParser parser = new ImportSchemaParser(serializedSchemaJson);
+    ImportSchemaParser parser = new ImportSchemaParser(serializedSchemaJson, globalOptions);
 
     // Act
     List<ImportTableSchema> actual = parser.parse();
@@ -56,13 +60,22 @@ public class ImportSchemaParserTest {
     assertThat(actual.get(0).getNamespace()).isEqualTo("sample_db");
     assertThat(actual.get(0).getTable()).isEqualTo("sample_table1");
     assertThat(actual.get(0).isTransactionTable()).isTrue();
+    assertThat(actual.get(0).getOptions())
+        .containsOnly(entry("ru", "4000"), entry("replication-factor", "1"));
 
     assertThat(actual.get(1).getNamespace()).isEqualTo("sample_db");
     assertThat(actual.get(1).getTable()).isEqualTo("sample_table2");
     assertThat(actual.get(1).isTransactionTable()).isFalse();
+    assertThat(actual.get(1).getOptions())
+        .containsOnly(entry("ru", "4000"), entry("replication-factor", "1"));
 
     assertThat(actual.get(2).getNamespace()).isEqualTo("sample_db");
     assertThat(actual.get(2).getTable()).isEqualTo("sample_table3");
     assertThat(actual.get(2).isTransactionTable()).isTrue();
+    assertThat(actual.get(2).getOptions())
+        .containsOnly(
+            entry("ru", "5000"),
+            entry("compaction-strategy", "LCS"),
+            entry("replication-factor", "1"));
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaLoaderTest.java
@@ -2,6 +2,7 @@ package com.scalar.db.schemaloader;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mockStatic;
@@ -46,7 +47,7 @@ public class SchemaLoaderTest {
         .when(() -> SchemaLoader.getSchemaParser(any(), anyMap()))
         .thenReturn(parser);
     schemaLoaderMockedStatic
-        .when(() -> SchemaLoader.getImportSchemaParser(any()))
+        .when(() -> SchemaLoader.getImportSchemaParser(any(), anyMap()))
         .thenReturn(importSchemaParser);
     when(parser.parse()).thenReturn(Collections.emptyList());
     when(importSchemaParser.parse()).thenReturn(Collections.emptyList());
@@ -719,11 +720,11 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.importTables(configProperties, SERIALIZED_SCHEMA_JSON);
+    SchemaLoader.importTables(configProperties, SERIALIZED_SCHEMA_JSON, options);
 
     // Assert
     verify(importSchemaParser).parse();
-    verify(operator).importTables(anyList());
+    verify(operator).importTables(anyList(), eq(options));
   }
 
   @Test
@@ -733,11 +734,11 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.importTables(configFilePath, SERIALIZED_SCHEMA_JSON);
+    SchemaLoader.importTables(configFilePath, SERIALIZED_SCHEMA_JSON, options);
 
     // Assert
     verify(importSchemaParser).parse();
-    verify(operator).importTables(anyList());
+    verify(operator).importTables(anyList(), eq(options));
   }
 
   @Test
@@ -747,11 +748,11 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.importTables(configProperties, schemaFilePath);
+    SchemaLoader.importTables(configProperties, schemaFilePath, options);
 
     // Assert
     verify(importSchemaParser).parse();
-    verify(operator).importTables(anyList());
+    verify(operator).importTables(anyList(), eq(options));
   }
 
   @Test
@@ -760,10 +761,10 @@ public class SchemaLoaderTest {
     // Arrange
 
     // Act
-    SchemaLoader.importTables(configFilePath, schemaFilePath);
+    SchemaLoader.importTables(configFilePath, schemaFilePath, options);
 
     // Assert
     verify(importSchemaParser).parse();
-    verify(operator).importTables(anyList());
+    verify(operator).importTables(anyList(), eq(options));
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -513,10 +513,10 @@ public class SchemaOperatorTest {
     when(importTableSchema.getTable()).thenReturn("tb");
 
     // Act
-    operator.importTables(tableSchemaList);
+    operator.importTables(tableSchemaList, options);
 
     // Assert
-    verify(transactionAdmin, times(3)).importTable("ns", "tb");
+    verify(transactionAdmin, times(3)).importTable("ns", "tb", options);
     verifyNoInteractions(storageAdmin);
   }
 
@@ -530,10 +530,10 @@ public class SchemaOperatorTest {
     when(importTableSchema.getTable()).thenReturn("tb");
 
     // Act
-    operator.importTables(tableSchemaList);
+    operator.importTables(tableSchemaList, options);
 
     // Assert
-    verify(storageAdmin, times(3)).importTable("ns", "tb");
+    verify(storageAdmin, times(3)).importTable("ns", "tb", options);
     verifyNoInteractions(transactionAdmin);
   }
 }

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/command/SchemaLoaderCommandTest.java
@@ -355,13 +355,37 @@ public class SchemaLoaderCommandTest {
     // Arrange
     String schemaFile = "path_to_file";
     String configFile = "path_to_config_file";
+    Map<String, String> options =
+        ImmutableMap.<String, String>builder()
+            .put(CassandraAdmin.REPLICATION_STRATEGY, replicationStrategy)
+            .put(CassandraAdmin.COMPACTION_STRATEGY, compactionStrategy)
+            .put(CassandraAdmin.REPLICATION_FACTOR, replicationFactor)
+            .put(DynamoAdmin.REQUEST_UNIT, ru)
+            .put(DynamoAdmin.NO_SCALING, noScaling.toString())
+            .put(DynamoAdmin.NO_BACKUP, noBackup.toString())
+            .build();
 
     // Act
-    commandLine.execute("-f", schemaFile, "--import", "--config", configFile);
+    commandLine.execute(
+        "-f",
+        schemaFile,
+        "--import",
+        "--config",
+        configFile,
+        "--replication-strategy",
+        replicationStrategy,
+        "--compaction-strategy",
+        compactionStrategy,
+        "--replication-factor",
+        replicationFactor,
+        "--ru",
+        ru,
+        "--no-scaling",
+        "--no-backup");
 
     // Assert
     schemaLoaderMockedStatic.verify(
-        () -> SchemaLoader.importTables(Paths.get(configFile), Paths.get(schemaFile)));
+        () -> SchemaLoader.importTables(Paths.get(configFile), Paths.get(schemaFile), options));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR applied part of the change in https://github.com/scalar-labs/scalardb/pull/1260, especially adding the `options` argument to the `Admin.importTable()` method, to the branch `3`.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1260

## Changes made

- Added the `options` argument to the `Admin.importTable()` method

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
