### PR TITLE
Make auto-pr robust to avoid timing issue or etc

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -6,8 +6,6 @@ on:
       - master
       - "[0-9]+"
       - "[0-9]+.[0-9]+"
-    types:
-      - closed
 
 env:
   TERM: dumb


### PR DESCRIPTION
## Description

We recently observed a few times that Auto-PR workflow wasn't triggered. I asked GitHub support and they recommended the following options:

1. Use [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event instead of [pull_request](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) event

2. Remove the current guard condition `types: closed` to mitigate the risk of failing to trigger the workflow

For 1, `pull_request_target` is more powerful. But it also introduces some security concerns. So, trying 2 would be reasonable.

## Related issues and/or PRs

N/A

## Changes made

This PR removes the guard condition `types: closed` to mitigate the risk of failing to invoke the workflow. It should be okay since the workflow also has `if_merged: if: github.event.pull_request.merged == true` condition.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A