### PR TITLE
Revert "Make auto-pr robust to avoid timing issue or etc"

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -6,6 +6,8 @@ on:
       - master
       - "[0-9]+"
       - "[0-9]+.[0-9]+"
+    types:
+      - closed
 
 env:
   TERM: dumb


### PR DESCRIPTION
Reverts scalar-labs/scalardb#1347

as Auto-PR workflow hasn't worked since it was merged.