### PR TITLE
Add TRANSACTION_MANAGER_NAME to XXXConfig

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -17,6 +17,7 @@ public class JdbcConfig {
   private static final Logger logger = LoggerFactory.getLogger(JdbcConfig.class);
 
   public static final String STORAGE_NAME = "jdbc";
+  public static final String TRANSACTION_MANAGER_NAME = STORAGE_NAME;
   public static final String PREFIX = DatabaseConfig.PREFIX + STORAGE_NAME + ".";
   public static final String CONNECTION_POOL_MIN_IDLE = PREFIX + "connection_pool.min_idle";
   public static final String CONNECTION_POOL_MAX_IDLE = PREFIX + "connection_pool.max_idle";
@@ -83,7 +84,7 @@ public class JdbcConfig {
   public JdbcConfig(DatabaseConfig databaseConfig) {
     String storage = databaseConfig.getStorage();
     String transactionManager = databaseConfig.getTransactionManager();
-    if (!storage.equals(STORAGE_NAME) && !transactionManager.equals(STORAGE_NAME)) {
+    if (!storage.equals(STORAGE_NAME) && !transactionManager.equals(TRANSACTION_MANAGER_NAME)) {
       throw new IllegalArgumentException(
           DatabaseConfig.STORAGE
               + " or "

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 public class ConsensusCommitConfig {
   private static final Logger logger = LoggerFactory.getLogger(ConsensusCommitConfig.class);
 
+  public static final String TRANSACTION_MANAGER_NAME = "consensus-commit";
   public static final String PREFIX = DatabaseConfig.PREFIX + "consensus_commit.";
   public static final String ISOLATION_LEVEL = PREFIX + "isolation_level";
   public static final String SERIALIZABLE_STRATEGY = PREFIX + "serializable_strategy";
@@ -58,9 +59,9 @@ public class ConsensusCommitConfig {
 
   public ConsensusCommitConfig(DatabaseConfig databaseConfig) {
     String transactionManager = databaseConfig.getTransactionManager();
-    if (!"consensus-commit".equals(transactionManager)) {
+    if (!transactionManager.equals(TRANSACTION_MANAGER_NAME)) {
       throw new IllegalArgumentException(
-          DatabaseConfig.TRANSACTION_MANAGER + " should be 'consensus-commit'");
+          DatabaseConfig.TRANSACTION_MANAGER + " should be '" + TRANSACTION_MANAGER_NAME + "'");
     }
 
     if (databaseConfig.getProperties().containsKey("scalar.db.isolation_level")) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitProvider.java
@@ -9,7 +9,7 @@ import com.scalar.db.config.DatabaseConfig;
 public class ConsensusCommitProvider implements DistributedTransactionProvider {
   @Override
   public String getName() {
-    return "consensus-commit";
+    return ConsensusCommitConfig.TRANSACTION_MANAGER_NAME;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -5,11 +5,12 @@ import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.DistributedTransactionProvider;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcConfig;
 
 public class JdbcTransactionProvider implements DistributedTransactionProvider {
   @Override
   public String getName() {
-    return "jdbc";
+    return JdbcConfig.TRANSACTION_MANAGER_NAME;
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR adds `TRANSACTION_MANAGER_NAME` variables to `XXXConfig`, specifically for transaction managers (`ConsensusCommitConfig` and `JdbcConfig`). These variables allow us to reference the transaction manager names elsewhere.

## Related issues and/or PRs

N/A

## Changes made

- Added static final variable `TRANSACTION_MANAGER_NAME` to `ConsensusCommitConfig` and `JdbcConfig`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
