### PR TITLE
Add getUser() to AuthAdmin

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -2,6 +2,7 @@ package com.scalar.db.api;
 
 import com.scalar.db.exception.storage.ExecutionException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -18,6 +19,7 @@ public interface AuthAdmin {
    * @param username the username
    * @param password the password. If null, the user is created without a password
    * @param userOptions the user options
+   * @throws IllegalArgumentException if the user already exists
    * @throws ExecutionException if the operation fails
    */
   default void createUser(String username, @Nullable String password, UserOption... userOptions)
@@ -27,11 +29,13 @@ public interface AuthAdmin {
 
   /**
    * Alters a user with the given username, password and user options. If the password is null, the
-   * password is not changed.
+   * password is not changed. If empty, the password is deleted.
    *
    * @param username the username
-   * @param password the password. If null, the password is not changed
+   * @param password the password. If null, the password is not changed. If empty, the password is
+   *     deleted
    * @param userOptions the user options
+   * @throws IllegalArgumentException if the user does not exist
    * @throws ExecutionException if the operation fails
    */
   default void alterUser(String username, @Nullable String password, UserOption... userOptions)
@@ -43,6 +47,7 @@ public interface AuthAdmin {
    * Drops a user with the given username.
    *
    * @param username the username
+   * @throws IllegalArgumentException if the user does not exist
    * @throws ExecutionException if the operation fails
    */
   default void dropUser(String username) throws ExecutionException {
@@ -56,7 +61,8 @@ public interface AuthAdmin {
    * @param namespaceName the namespace name of the table
    * @param tableName the table name
    * @param privileges the privileges
-   * @throws ExecutionException if the user does not exist or the operation fails
+   * @throws IllegalArgumentException if the user does not exist or the table does not exist
+   * @throws ExecutionException if the operation fails
    */
   default void grant(
       String username, String namespaceName, String tableName, Privilege... privileges)
@@ -70,7 +76,8 @@ public interface AuthAdmin {
    * @param username the username
    * @param namespaceName the namespace name
    * @param privileges the privileges
-   * @throws ExecutionException if the user does not exist or the operation fails
+   * @throws IllegalArgumentException if the user does not exist or the namespace does not exist
+   * @throws ExecutionException if the operation fails
    */
   default void grant(String username, String namespaceName, Privilege... privileges)
       throws ExecutionException {
@@ -84,7 +91,8 @@ public interface AuthAdmin {
    * @param namespaceName the namespace name of the table
    * @param tableName the table name
    * @param privileges the privileges
-   * @throws ExecutionException if the user does not exist or the operation fails
+   * @throws IllegalArgumentException if the user does not exist or the table does not exist
+   * @throws ExecutionException if the operation fails
    */
   default void revoke(
       String username, String namespaceName, String tableName, Privilege... privileges)
@@ -98,10 +106,22 @@ public interface AuthAdmin {
    * @param username the username
    * @param namespaceName the namespace name
    * @param privileges the privileges
-   * @throws ExecutionException if the user does not exist or the operation fails
+   * @throws IllegalArgumentException if the user does not exist or the namespace does not exist
+   * @throws ExecutionException if the operation fails
    */
   default void revoke(String username, String namespaceName, Privilege... privileges)
       throws ExecutionException {
+    throw new UnsupportedOperationException("Not supported in the community edition");
+  }
+
+  /**
+   * Retrieve a {@link User} for the given username.
+   *
+   * @param username the username
+   * @return a {@link User} for the given username
+   * @throws ExecutionException if the operation fails
+   */
+  default Optional<User> getUser(String username) throws ExecutionException {
     throw new UnsupportedOperationException("Not supported in the community edition");
   }
 
@@ -122,7 +142,8 @@ public interface AuthAdmin {
    * @param namespaceName the namespace name of the table
    * @param tableName the table name
    * @return a set of privileges
-   * @throws ExecutionException if the user does not exist or the operation fails
+   * @throws IllegalArgumentException if the user does not exist or the table does not exist
+   * @throws ExecutionException if the operation fails
    */
   default Set<Privilege> getPrivileges(String username, String namespaceName, String tableName)
       throws ExecutionException {
@@ -135,7 +156,8 @@ public interface AuthAdmin {
    * @param username the username
    * @param namespaceName the namespace name
    * @return a set of privileges
-   * @throws ExecutionException if the user does not exist or the operation fails
+   * @throws IllegalArgumentException if the user does not exist or the namespace does not exist
+   * @throws ExecutionException if the operation fails
    */
   default Set<Privilege> getPrivileges(String username, String namespaceName)
       throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -115,7 +115,7 @@ public interface AuthAdmin {
   }
 
   /**
-   * Retrieve a {@link User} for the given username.
+   * Retrieves a {@link User} for the given username.
    *
    * @param username the username
    * @return a {@link User} for the given username
@@ -126,7 +126,7 @@ public interface AuthAdmin {
   }
 
   /**
-   * Retrieve a list of {@link User}s.
+   * Retrieves a list of {@link User}s.
    *
    * @return a list of {@link User}s
    * @throws ExecutionException if the operation fails
@@ -136,7 +136,7 @@ public interface AuthAdmin {
   }
 
   /**
-   * Retrieve privileges for the given table for the given user.
+   * Retrieves privileges for the given table for the given user.
    *
    * @param username the username
    * @param namespaceName the namespace name of the table
@@ -151,7 +151,7 @@ public interface AuthAdmin {
   }
 
   /**
-   * Retrieve privileges for all tables in the given namespace for the given user.
+   * Retrieves privileges for all tables in the given namespace for the given user.
    *
    * @param username the username
    * @param namespaceName the namespace name


### PR DESCRIPTION
## Description

This PR adds the `getUser()` method to the `AuthAdmin` interface.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1318

## Changes made

- Added the `getUser()` method to the `AuthAdmin` interface
- Revised Javadoc

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
