### PR TITLE
Add a requirement for privileges of underlying databases

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4,6 +4,8 @@ This document explains the requirements and recommendations in the underlying da
 
 ## Common requirements
 
+This section describes common requirements for the underlying databases when using ScalarDB.
+
 ### Privileges to access the underlying databases
 
 ScalarDB operates the underlying databases not only for CRUD operations but also for performing operations like creating or altering schemas, tables, or indexes. Thus, ScalarDB requires a fully privileged account to access the underlying databases.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -6,7 +6,7 @@ This document explains the requirements and recommendations in the underlying da
 
 ### Privileges to access the underlying databases
 
-ScalarDB operates the underlying databases not only for CRUD operations but also for creating/altering schema, tables, indexes, and so on. Thus, ScalarDB requires a fully privileged account to access the underlying databases.
+ScalarDB operates the underlying databases not only for CRUD operations but also for performing operations like creating or altering schemas, tables, or indexes. Thus, ScalarDB requires a fully privileged account to access the underlying databases.
 
 ## Cassandra or Cassandra-compatible database requirements
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -8,7 +8,7 @@ This section describes common requirements for the underlying databases when usi
 
 ### Privileges to access the underlying databases
 
-ScalarDB operates the underlying databases not only for CRUD operations but also for performing operations like creating or altering schemas, tables, or indexes. Thus, ScalarDB requires a fully privileged account to access the underlying databases.
+ScalarDB operates the underlying databases not only for CRUD operations but also for performing operations like creating or altering schemas, tables, or indexes. Thus, ScalarDB basically requires a fully privileged account to access the underlying databases.
 
 ## Cassandra or Cassandra-compatible database requirements
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,6 +2,12 @@
 
 This document explains the requirements and recommendations in the underlying databases of ScalarDB to make ScalarDB applications work correctly.
 
+## Common requirements
+
+### Privileges to access the underlying databases
+
+ScalarDB operates the underlying databases not only for CRUD operations but also for creating/altering schema, tables, indexes, and so on. Thus, ScalarDB requires a fully privileged account to access the underlying databases.
+
 ## Cassandra or Cassandra-compatible database requirements
 
 The following are requirements to make ScalarDB on Cassandra or Cassandra-compatible databases work properly and for storage operations with `LINEARIZABLE` to provide linearizability and for transaction operations with `SERIALIZABLE` to provide strict serializability.


### PR DESCRIPTION
## Description

This PR adds a requirement for privileges of underlying databases.

## Related issues and/or PRs

- scalar-labs/scalardb-sql#392

## Changes made

- Update the requirement document regarding privileges of underlying databases

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added requirement for privileges of underlying databases.