### PR TITLE
Backport to branch(3) : Bump awssdkVersion from 2.21.0 to 2.22.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
         cassandraDriverVersion = '3.11.5'
         azureCosmosVersion = '4.53.1'
         jooqVersion = '3.14.16'
-        awssdkVersion = '2.21.0'
+        awssdkVersion = '2.22.3'
         commonsDbcp2Version = '2.11.0'
         mysqlDriverVersion = '8.0.33'
         postgresqlDriverVersion = '42.7.1'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1402