### PR TITLE
Add "permissions" in release workflow to use configure-aws-credentials

### DIFF
--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -27,6 +27,10 @@ on:
       OSSRH_PASSWORD:
         required: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   upload-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR fixes the issue in the release workflow. To authenticate with AWS ECR by using `configure-aws-credentials` action, we have to set `permissions` configuration according to the [document of `configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials).

## Related issues and/or PRs

N/A

## Changes made

* Update release workflows to push container images.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
