### PR TITLE
Backport to branch(3.9) : Add "permissions" in release workflow to use configure-aws-credentials

### DIFF
--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -27,6 +27,10 @@ on:
       OSSRH_PASSWORD:
         required: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   upload-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1411