### PR TITLE
Revert PR #1411

### DIFF
--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -27,10 +27,6 @@ on:
       OSSRH_PASSWORD:
         required: true
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   upload-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR reverts to PR #1411. Sorry, I had a misunderstanding about the current workflow's structures... 🙇‍♀️

The workflow `upload-artifacts.yaml` is called from the parent workflow `release.yaml`. And the parent workflow `release.yaml` has the configuration of `permissions`.

So, the `upload-artifacts.yaml` can run with the same `permissions` settings that are inherited from `release.yaml`. Therefore, we don't need to set `permissions` on the `upload-artifacts.yaml` side explicitly.

FYI: The action ran properly when we released `v3.10.2` yesterday, without the fixes of #1411. Also from this log, we can see that we don't need the fix of #1411.
https://github.com/scalar-labs/scalardb/actions/runs/7322292094

## Related issues and/or PRs

#1411

## Changes made

* Update (revert) `upload-artifacts.yaml` file.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
