### PR TITLE
Avoid NPE when checking SQLState in JDBC storage

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -138,6 +138,9 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // Error number: 1022; Symbol: ER_DUP_KEY; SQLSTATE: 23000
     // Message: Can't write; duplicate key in table '%s'
     // etc... See: <https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html>

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -151,6 +151,9 @@ class RdbEngineOracle implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // Integrity constraint violation
     return e.getSQLState().equals("23000");
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -121,24 +121,36 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 42P07: duplicate_table
     return e.getSQLState().equals("42P07");
   }
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 23505: unique_violation
     return e.getSQLState().equals("23505");
   }
 
   @Override
   public boolean isUndefinedTableError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 42P01: undefined_table
     return e.getSQLState().equals("42P01");
   }
 
   @Override
   public boolean isConflictError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 40001: serialization_failure
     // 40P01: deadlock_detected
     return e.getSQLState().equals("40001") || e.getSQLState().equals("40P01");

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -115,6 +115,9 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 23000: Integrity constraint violation
     return e.getSQLState().equals("23000");
   }


### PR DESCRIPTION
## Description

I faced NPE when testing ScalarDB using PostgreSQL as a storage and a connection issue happened. I checked what occurred by adding a debug log.

- RdbEnginePostgresql.java

```java
@Override
public boolean isUndefinedTableError(SQLException e) {
  logger.info("[========= DEBUG ===========]", e);
  logger.info("[========= DEBUG ===========] SQLState:{}", e.getSQLState());
  // 42P01: undefined_table
  return e.getSQLState().equals("42P01");
}
```

```
[main] INFO com.scalar.db.storage.jdbc.RdbEnginePostgresql - [========= DEBUG ===========]
java.sql.SQLException: Cannot create PoolableConnectionFactory (Connection to postgresql:5442 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.)                                              
     at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:633)
     at org.apache.commons.dbcp2.BasicDataSource.createDataSource(BasicDataSource.java:535)
     at org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:711)
     at com.scalar.db.storage.jdbc.JdbcAdmin.getTableMetadata(JdbcAdmin.java:435)
     at com.scalar.db.common.CheckedDistributedStorageAdmin.getTableMetadata(CheckedDistributedStorageAdmin.java:172)
     at com.scalar.db.transaction.consensuscommit.TransactionTableMetadataManager$1.load(TransactionTableMetadataManager.java:35)
     at com.scalar.db.transaction.consensuscommit.TransactionTableMetadataManager$1.load(TransactionTableMetadataManager.java:30)
     at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3576)
     at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2318)
     at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2191)
     at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081)
     at com.google.common.cache.LocalCache.get(LocalCache.java:4019)
     at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4042)
     at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5024)
     at com.scalar.db.transaction.consensuscommit.TransactionTableMetadataManager.getTransactionTableMetadata(TransactionTableMetadataManager.java:71)
     at com.scalar.db.transaction.consensuscommit.TransactionTableMetadataManager.getTransactionTableMetadata(TransactionTableMetadataManager.java:56)
     at com.scalar.db.transaction.consensuscommit.CrudHandler.getFromStorage(CrudHandler.java:181)
     at com.scalar.db.transaction.consensuscommit.CrudHandler.get(CrudHandler.java:76)
     at com.scalar.db.transaction.consensuscommit.ConsensusCommit.get(ConsensusCommit.java:85)
     at com.scalar.db.common.AbstractDistributedTransactionManager$StateManagedTransaction.get(AbstractDistributedTransactionManager.java:124)
     at com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager$ActiveTransaction.get(ActiveTransactionManagedDistributedTransactionManager.java:98)
     at sample.order.model.Item.get(Item.java:43)
     at sample.order.OrderService.loadItemIfNotExists(OrderService.java:91)
     at sample.order.OrderService.loadInitialData(OrderService.java:76)
     at sample.order.OrderService.<init>(OrderService.java:69)
     at sample.order.OrderServiceServer.start(OrderServiceServer.java:36)
     at sample.order.OrderServiceServer.call(OrderServiceServer.java:30)
     at sample.order.OrderServiceServer.call(OrderServiceServer.java:11)
     at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
     at picocli.CommandLine.access$1500(CommandLine.java:148)
     at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
     at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
     at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
     at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
     at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
     at picocli.CommandLine.execute(CommandLine.java:2
     at sample.order.OrderServiceServer.main(OrderServiceServer.java:71)
Caused by: org.postgresql.util.PSQLException: Connection to postgresql:5442 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
     at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:342)
     at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)
     at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:263)
     at org.postgresql.Driver.makeConnection(Driver.java:443)
     at org.postgresql.Driver.connect(Driver.java:297)
     at org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52)
     at org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:414)
     at org.apache.commons.dbcp2.BasicDataSource.validateConnectionFactory(BasicDataSource.java:113)
     at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:629)
     ... 36 more
Caused by: java.net.ConnectException: Connection refused (Connection refused)
     at java.net.PlainSocketImpl.socketConnect(Native Method)
     at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
     at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
     at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
     at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
     at java.net.Socket.connect(Socket.java:607)
     at org.postgresql.core.PGStream.createSocket(PGStream.java:243)
     at org.postgresql.core.PGStream.<init>(PGStream.java:98)
     at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:132)
     at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:258)
     ... 44 more
[main] INFO com.scalar.db.storage.jdbc.RdbEnginePostgresql - [========= DEBUG ===========] SQLState:null
```
That came from a silly configuration issue and ScalarDB failed to connect to the PostgreSQL. But the problem is `RdbEnginePostgresql#isDuplicateTableError()` tried to use nullable `SQLException.SQLState`. The possibility of nullable SQLState should be taken care of.

## Related issues and/or PRs

N/A

## Changes made

This PR simply added null check for `SQLException.SQLState` in `RdbEngineXxxxx.isXxxxxError()`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This PR doesn't add any tests since it's just-in-case fix.

## Release notes

Improved some error handling to avoid potential NPE in JDBC storages.
