### PR TITLE
Add getStringFromFilePath() to ConfigUtils

### DIFF
--- a/core/src/main/java/com/scalar/db/config/ConfigUtils.java
+++ b/core/src/main/java/com/scalar/db/config/ConfigUtils.java
@@ -3,6 +3,11 @@ package com.scalar.db.config;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.text.StringSubstitutor;
@@ -34,7 +39,9 @@ public final class ConfigUtils {
 
   private ConfigUtils() {}
 
-  public static String getString(Properties properties, String name, String defaultValue) {
+  @Nullable
+  public static String getString(
+      Properties properties, String name, @Nullable String defaultValue) {
     String value = trimAndReplace(properties.getProperty(name));
     if (Strings.isNullOrEmpty(value)) {
       return defaultValue;
@@ -126,12 +133,28 @@ public final class ConfigUtils {
     }
   }
 
-  public static String[] getStringArray(Properties properties, String name, String[] defaultValue) {
+  @Nullable
+  public static String[] getStringArray(
+      Properties properties, String name, @Nullable String[] defaultValue) {
     String value = trimAndReplace(properties.getProperty(name));
     if (Strings.isNullOrEmpty(value)) {
       return defaultValue;
     }
     return value.split("\\s*,\\s*");
+  }
+
+  @Nullable
+  public static String getStringFromFilePath(
+      Properties properties, String pathName, @Nullable String defaultValue) {
+    String path = trimAndReplace(properties.getProperty(pathName));
+    if (Strings.isNullOrEmpty(path)) {
+      return defaultValue;
+    }
+    try {
+      return new String(Files.readAllBytes(new File(path).toPath()), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   @VisibleForTesting

--- a/core/src/test/java/com/scalar/db/config/ConfigUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/config/ConfigUtilsTest.java
@@ -4,10 +4,25 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironment
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ConfigUtilsTest {
+
+  @TempDir private Path folder;
+
+  private void writeToFile(File file, String content) throws IOException {
+    BufferedWriter writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8);
+    writer.write(content);
+    writer.close();
+  }
 
   @Test
   public void getString_ShouldBehaveCorrectly() {
@@ -102,6 +117,18 @@ public class ConfigUtilsTest {
     assertThat(ConfigUtils.getStringArray(properties, "name4", new String[] {"xxx", "yyy", "zzz"}))
         .isEqualTo(new String[] {"xxx", "yyy", "zzz"});
     assertThat(ConfigUtils.getBoolean(properties, "name5", null)).isNull();
+  }
+
+  @Test
+  public void getStringFromFilePath_ShouldBehaveCorrectly() throws IOException {
+    // Arrange
+    File filePath = folder.resolve("some_file").toFile();
+    writeToFile(filePath.getCanonicalFile(), "value");
+    Properties properties = new Properties();
+    properties.setProperty("name1", filePath.getCanonicalPath());
+
+    // Act Assert
+    assertThat(ConfigUtils.getStringFromFilePath(properties, "name1", null)).isEqualTo("value");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds a method `getStringFromFilePath()` to the `ConfigUtils` class. This method gets a configuration value from a file.

## Related issues and/or PRs

N/A

## Changes made

- Added `getStringFromFilePath()` to `ConfigUtils`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
