### PR TITLE
Backport to branch(3) : Avoid NPE when checking SQLState in JDBC storage

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -139,6 +139,9 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // Error number: 1022; Symbol: ER_DUP_KEY; SQLSTATE: 23000
     // Message: Can't write; duplicate key in table '%s'
     // etc... See: <https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html>

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -155,6 +155,9 @@ public class RdbEngineOracle implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // Integrity constraint violation
     return e.getSQLState().equals("23000");
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -125,24 +125,36 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateTableError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 42P07: duplicate_table
     return e.getSQLState().equals("42P07");
   }
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 23505: unique_violation
     return e.getSQLState().equals("23505");
   }
 
   @Override
   public boolean isUndefinedTableError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 42P01: undefined_table
     return e.getSQLState().equals("42P01");
   }
 
   @Override
   public boolean isConflictError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 40001: serialization_failure
     // 40P01: deadlock_detected
     return e.getSQLState().equals("40001") || e.getSQLState().equals("40P01");

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -120,6 +120,9 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
 
   @Override
   public boolean isDuplicateKeyError(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     // 23000: Integrity constraint violation
     return e.getSQLState().equals("23000");
   }


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1442