### PR TITLE
[vuln-check-workflow] Skip unexpected versions to continue

### DIFF
--- a/ci/vuln-check/find_latest_release
+++ b/ci/vuln-check/find_latest_release
@@ -64,7 +64,12 @@ releases.each do |release|
     cur = candidate_releases
     rest_versions.split('.').each do |part_of_version_str|
       next if part_of_version_str.empty?
-      part_of_version = Integer(part_of_version_str)
+      begin
+        part_of_version = Integer(part_of_version_str)
+      rescue ArgumentError
+        STDERR.puts "Failed to convert string(#{part_of_version_str}) to integer. Skipping it."
+        next
+      end
       # Just an idiom for map initialization
       cur[part_of_version] ||= {}
       cur = cur[part_of_version]


### PR DESCRIPTION
## Description

The `vuln-check` workflow recently [fails](https://github.com/scalar-labs/scalardb/actions/runs/7575331488/job/20631706075) because we recently created `v3.11.0-alpha.1` that's not expected format for `vuln-check`. We need to modify the workflow and/or related scripts to handle the issue.

## Related issues and/or PRs

N/A

## Changes made

This PR made `find_latest_release` script called by `vuln-check` workflow skip unexpected format versions to continue.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

We'll port this change to other projects which have `vuln-check` workflow once we confirm this change works.

## Release notes

None
