### PR TITLE
Backport to branch(3) : Bump dropwizardMetricsVersion from 4.2.23 to 4.2.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
         annotationVersion = '1.3.2'
         picocliVersion = '4.7.5'
         scalarAdminVersion = '2.1.2'
-        dropwizardMetricsVersion = '4.2.23'
+        dropwizardMetricsVersion = '4.2.24'
         prometheusVersion = '0.16.0'
         commonsTextVersion = '1.11.0'
         jettyVersion = '9.4.53.v20231009'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1455