### PR TITLE
Add usages and comments about the inclusive param of `ScanBuilder`'s `start()` and `end()`

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -632,8 +632,8 @@ Scan scan =
         .namespace("ns")
         .table("tbl")
         .partitionKey(partitionKey)
-        .start(startClusteringKey)
-        .end(endClusteringKey)
+        .start(startClusteringKey, true)    // Include startClusteringKey
+        .end(endClusteringKey, false)       // Exclude endClusteringKey
         .projections("c1", "c2", "c3", "c4")
         .orderings(Scan.Ordering.desc("c2"), Scan.Ordering.asc("c3"))
         .limit(10)

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -562,8 +562,8 @@ Scan scan =
         .namespace("ns")
         .table("tbl")
         .partitionKey(partitionKey)
-        .start(startClusteringKey)
-        .end(endClusteringKey)
+        .start(startClusteringKey, true)    // Include startClusteringKey
+        .end(endClusteringKey, false)       // Exclude endClusteringKey
         .projections("c1", "c2", "c3", "c4")
         .orderings(Scan.Ordering.desc("c2"), Scan.Ordering.asc("c3"))
         .limit(10)


### PR DESCRIPTION
## Description

When I read the document to know how to specify inclusive/exclusive with ScanBuilder's `start()` and `end()`, I noticed the document didn't mention it. It would be helpful for users if the document shows how to specify `inclusive` param.

## Related issues and/or PRs

N/A

## Changes made

This PR added the usage and comment about `inclusive` param of `ScanBuilder`'s `start()` and `end()`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Maybe I should've added some sentences about how to specify the parameter not just adding the comments (sorry, I'm lazy). Feel free to suggest changes if needed.

## Release notes

None
