### PR TITLE
Backport to branch(3.11) : Add usages and comments about the inclusive param of `ScanBuilder`'s `start()` and `end()`

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -599,8 +599,8 @@ Scan scan =
         .namespace("ns")
         .table("tbl")
         .partitionKey(partitionKey)
-        .start(startClusteringKey)
-        .end(endClusteringKey)
+        .start(startClusteringKey, true)    // Include startClusteringKey
+        .end(endClusteringKey, false)       // Exclude endClusteringKey
         .projections("c1", "c2", "c3", "c4")
         .orderings(Scan.Ordering.desc("c2"), Scan.Ordering.asc("c3"))
         .limit(10)

--- a/docs/storage-abstraction.md
+++ b/docs/storage-abstraction.md
@@ -521,8 +521,8 @@ Scan scan =
         .namespace("ns")
         .table("tbl")
         .partitionKey(partitionKey)
-        .start(startClusteringKey)
-        .end(endClusteringKey)
+        .start(startClusteringKey, true)    // Include startClusteringKey
+        .end(endClusteringKey, false)       // Exclude endClusteringKey
         .projections("c1", "c2", "c3", "c4")
         .orderings(Scan.Ordering.desc("c2"), Scan.Ordering.asc("c3"))
         .limit(10)


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1464