### PR TITLE
Make Cosmos DB consistency level configurable

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -2,9 +2,7 @@ package com.scalar.db.storage.cosmos;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
-import com.azure.cosmos.CosmosClientBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.scalar.db.api.Delete;
@@ -55,13 +53,7 @@ public class Cosmos extends AbstractDistributedStorage {
 
     CosmosConfig config = new CosmosConfig(databaseConfig);
 
-    client =
-        new CosmosClientBuilder()
-            .endpoint(config.getEndpoint())
-            .key(config.getKey())
-            .directMode()
-            .consistencyLevel(ConsistencyLevel.STRONG)
-            .buildClient();
+    client = CosmosUtils.buildCosmosClient(config);
 
     TableMetadataManager metadataManager =
         new TableMetadataManager(

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -2,9 +2,7 @@ package com.scalar.db.storage.cosmos;
 
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
-import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
-import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
@@ -72,13 +70,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   @Inject
   public CosmosAdmin(DatabaseConfig databaseConfig) {
     CosmosConfig config = new CosmosConfig(databaseConfig);
-    client =
-        new CosmosClientBuilder()
-            .endpoint(config.getEndpoint())
-            .key(config.getKey())
-            .directMode()
-            .consistencyLevel(ConsistencyLevel.STRONG)
-            .buildClient();
+    client = CosmosUtils.buildCosmosClient(config);
     metadataDatabase = config.getMetadataDatabase();
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
@@ -3,6 +3,8 @@ package com.scalar.db.storage.cosmos;
 import static com.scalar.db.config.ConfigUtils.getString;
 
 import com.scalar.db.config.DatabaseConfig;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,9 +20,12 @@ public class CosmosConfig {
   @Deprecated
   public static final String TABLE_METADATA_DATABASE = PREFIX + "table_metadata.database";
 
+  public static final String CONSISTENCY_LEVEL = PREFIX + "consistency_level";
+
   private final String endpoint;
   private final String key;
   private final String metadataDatabase;
+  @Nullable private final String consistencyLevel;
 
   public CosmosConfig(DatabaseConfig databaseConfig) {
     String storage = databaseConfig.getStorage();
@@ -48,6 +53,8 @@ public class CosmosConfig {
     } else {
       metadataDatabase = databaseConfig.getSystemNamespaceName();
     }
+
+    consistencyLevel = getString(databaseConfig.getProperties(), CONSISTENCY_LEVEL, null);
   }
 
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW
@@ -64,5 +71,9 @@ public class CosmosConfig {
 
   public String getMetadataDatabase() {
     return metadataDatabase;
+  }
+
+  public Optional<String> getConsistencyLevel() {
+    return Optional.ofNullable(consistencyLevel);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosUtils.java
@@ -1,10 +1,43 @@
 package com.scalar.db.storage.cosmos;
 
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Locale;
+
 public final class CosmosUtils {
 
   private CosmosUtils() {}
 
   public static String quoteKeyword(String keyword) {
     return "[\"" + keyword + "\"]";
+  }
+
+  public static CosmosClient buildCosmosClient(CosmosConfig config) {
+    return new CosmosClientBuilder()
+        .endpoint(config.getEndpoint())
+        .key(config.getKey())
+        .directMode()
+        .consistencyLevel(getConsistencyLevel(config))
+        .buildClient();
+  }
+
+  @VisibleForTesting
+  static ConsistencyLevel getConsistencyLevel(CosmosConfig config) {
+    ConsistencyLevel consistencyLevel =
+        config
+            .getConsistencyLevel()
+            .map(c -> ConsistencyLevel.valueOf(c.toUpperCase(Locale.ROOT)))
+            .orElse(ConsistencyLevel.STRONG);
+
+    // Only STRONG and BOUNDED_STALENESS are supported
+    if (consistencyLevel != ConsistencyLevel.STRONG
+        && consistencyLevel != ConsistencyLevel.BOUNDED_STALENESS) {
+      throw new IllegalArgumentException(
+          "The specified consistency level is not supported:" + consistencyLevel);
+    }
+
+    return consistencyLevel;
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosConfigTest.java
@@ -13,6 +13,7 @@ public class CosmosConfigTest {
   private static final String ANY_KEY = "any_key";
   private static final String COSMOS_STORAGE = "cosmos";
   private static final String ANY_TABLE_METADATA_DATABASE = "any_database";
+  private static final String ANY_CONSISTENCY_LEVEL = "any_consistency_level";
 
   @Test
   public void constructor_AllPropertiesGiven_ShouldLoadProperly() {
@@ -22,6 +23,7 @@ public class CosmosConfigTest {
     props.setProperty(DatabaseConfig.PASSWORD, ANY_KEY);
     props.setProperty(DatabaseConfig.STORAGE, COSMOS_STORAGE);
     props.setProperty(DatabaseConfig.SYSTEM_NAMESPACE_NAME, ANY_TABLE_METADATA_DATABASE);
+    props.setProperty(CosmosConfig.CONSISTENCY_LEVEL, ANY_CONSISTENCY_LEVEL);
 
     // Act
     CosmosConfig config = new CosmosConfig(new DatabaseConfig(props));
@@ -30,6 +32,7 @@ public class CosmosConfigTest {
     assertThat(config.getEndpoint()).isEqualTo(ANY_ENDPOINT);
     assertThat(config.getKey()).isEqualTo(ANY_KEY);
     assertThat(config.getMetadataDatabase()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
+    assertThat(config.getConsistencyLevel()).hasValue(ANY_CONSISTENCY_LEVEL);
   }
 
   @Test
@@ -45,7 +48,7 @@ public class CosmosConfigTest {
   }
 
   @Test
-  public void constructor_WithoutTableMetadataDatabase_ShouldLoadProperly() {
+  public void constructor_WithoutSystemNamespaceNameAndConsistencyLevel_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_ENDPOINT);
@@ -60,6 +63,7 @@ public class CosmosConfigTest {
     assertThat(config.getKey()).isEqualTo(ANY_KEY);
     assertThat(config.getMetadataDatabase())
         .isEqualTo(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+    assertThat(config.getConsistencyLevel()).isEmpty();
   }
 
   @Test
@@ -78,6 +82,7 @@ public class CosmosConfigTest {
     assertThat(config.getEndpoint()).isEqualTo(ANY_ENDPOINT);
     assertThat(config.getKey()).isEqualTo(ANY_KEY);
     assertThat(config.getMetadataDatabase()).isEqualTo(ANY_TABLE_METADATA_DATABASE);
+    assertThat(config.getConsistencyLevel()).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosUtilsTest.java
@@ -1,0 +1,67 @@
+package com.scalar.db.storage.cosmos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.azure.cosmos.ConsistencyLevel;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CosmosUtilsTest {
+
+  @Mock private CosmosConfig cosmosConfig;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void getConsistencyLevel_ShouldReturnStrongConsistency() {
+    // Arrange
+
+    // Act
+    ConsistencyLevel actual = CosmosUtils.getConsistencyLevel(cosmosConfig);
+
+    // Assert
+    assertThat(actual).isEqualTo(ConsistencyLevel.STRONG);
+  }
+
+  @Test
+  public void getConsistencyLevel_StrongGiven_ShouldReturnStrongConsistency() {
+    // Arrange
+    when(cosmosConfig.getConsistencyLevel()).thenReturn(Optional.of("STRONG"));
+
+    // Act
+    ConsistencyLevel actual = CosmosUtils.getConsistencyLevel(cosmosConfig);
+
+    // Assert
+    assertThat(actual).isEqualTo(ConsistencyLevel.STRONG);
+  }
+
+  @Test
+  public void getConsistencyLevel_BoundedStalenessGiven_ShouldReturnBoundedStalenessConsistency() {
+    // Arrange
+    when(cosmosConfig.getConsistencyLevel()).thenReturn(Optional.of("bounded_staleness"));
+
+    // Act
+    ConsistencyLevel actual = CosmosUtils.getConsistencyLevel(cosmosConfig);
+
+    // Assert
+    assertThat(actual).isEqualTo(ConsistencyLevel.BOUNDED_STALENESS);
+  }
+
+  @Test
+  public void getConsistencyLevel_InvalidConsistencyGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    when(cosmosConfig.getConsistencyLevel()).thenReturn(Optional.of("any"));
+
+    // Act Assert
+    Assertions.assertThatThrownBy(() -> CosmosUtils.getConsistencyLevel(cosmosConfig))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -80,11 +80,12 @@ The following configurations are available for Cassandra:
 
 The following configurations are available for CosmosDB for NoSQL:
 
-| Name                                 | Description                                                                                              | Default    |
-|--------------------------------------|----------------------------------------------------------------------------------------------------------|------------|
-| `scalar.db.storage`                  | `cosmos` must be specified.                                                                              | -          |
-| `scalar.db.contact_points`           | Azure Cosmos DB for NoSQL endpoint with which ScalarDB should communicate.                               |            |
-| `scalar.db.password`                 | Either a master or read-only key used to perform authentication for accessing Azure Cosmos DB for NoSQL. |            |
+| Name                                 | Description                                                                                              | Default  |
+|--------------------------------------|----------------------------------------------------------------------------------------------------------|----------|
+| `scalar.db.storage`                  | `cosmos` must be specified.                                                                              | -        |
+| `scalar.db.contact_points`           | Azure Cosmos DB for NoSQL endpoint with which ScalarDB should communicate.                               |          |
+| `scalar.db.password`                 | Either a master or read-only key used to perform authentication for accessing Azure Cosmos DB for NoSQL. |          |
+| `scalar.db.cosmos.consistency_level` | Consistency level used for Cosmos DB operations. `STRONG` or `BOUNDED_STALENESS` can be specified.       | `STRONG` |
 
 </div>
 <div id="DynamoDB" class="tabcontent" markdown="1">


### PR DESCRIPTION
## Description

This PR makes Cosmos DB consistency level configurable by the property `scalar.db.cosmos.consistency_level` in the Cosmos DB adapter. `STRONG` or `BOUNDED_STALENESS` can be specified.

## Related issues and/or PRs

N/A

## Changes made

- Made Cosmos DB consistency level configurable

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Made Cosmos DB consistency level configurable in the Cosmos DB adapter. Users can change the consistency level used for Cosmos DB operations by specifying the property `scalar.db.cosmos.consistency_level`. `STRONG` or `BOUNDED_STALENESS` can be specified.
