### PR TITLE
Should perform lazy recovery in implicit pre-read

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -89,7 +89,7 @@ public class CrudHandler {
       return;
     }
     throw new UncommittedRecordException(
-        result.get(), "This record needs recovery", snapshot.getId());
+        get, result.get(), "This record needs recovery", snapshot.getId());
   }
 
   private Optional<Result> createGetResult(Snapshot.Key key, List<String> projections)
@@ -136,7 +136,7 @@ public class CrudHandler {
         TransactionResult result = new TransactionResult(r);
         if (!result.isCommitted()) {
           throw new UncommittedRecordException(
-              result, "The record needs recovery", snapshot.getId());
+              scan, result, "The record needs recovery", snapshot.getId());
         }
 
         Snapshot.Key key = new Snapshot.Key(scan, r);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/UncommittedRecordException.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/UncommittedRecordException.java
@@ -19,14 +19,6 @@ public class UncommittedRecordException extends CrudConflictException {
     results = ImmutableList.of(result);
   }
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
-  public UncommittedRecordException(
-      Selection selection, List<TransactionResult> results, String message, String transactionId) {
-    super(message, transactionId);
-    this.selection = selection;
-    this.results = ImmutableList.copyOf(results);
-  }
-
   @SuppressFBWarnings("EI_EXPOSE_REP")
   public Selection getSelection() {
     return selection;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/UncommittedRecordException.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/UncommittedRecordException.java
@@ -1,38 +1,38 @@
 package com.scalar.db.transaction.consensuscommit;
 
 import com.google.common.collect.ImmutableList;
+import com.scalar.db.api.Selection;
 import com.scalar.db.exception.transaction.CrudConflictException;
-import java.util.ArrayList;
-import java.util.Collections;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 
 public class UncommittedRecordException extends CrudConflictException {
+
+  private final Selection selection;
   private final List<TransactionResult> results;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public UncommittedRecordException(
-      TransactionResult result, String message, String transactionId) {
-    this(result, message, null, transactionId);
+      Selection selection, TransactionResult result, String message, String transactionId) {
+    super(message, transactionId);
+    this.selection = selection;
+    results = ImmutableList.of(result);
   }
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public UncommittedRecordException(
-      TransactionResult result, String message, Throwable cause, String transactionId) {
-    super(message, cause, transactionId);
-    results = Collections.singletonList(result);
+      Selection selection, List<TransactionResult> results, String message, String transactionId) {
+    super(message, transactionId);
+    this.selection = selection;
+    this.results = ImmutableList.copyOf(results);
   }
 
-  public UncommittedRecordException(
-      List<TransactionResult> results, String message, String transactionId) {
-    this(results, message, null, transactionId);
-  }
-
-  public UncommittedRecordException(
-      List<TransactionResult> results, String message, Throwable cause, String transactionId) {
-    super(message, cause, transactionId);
-    this.results = new ArrayList<>();
-    this.results.addAll(results);
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public Selection getSelection() {
+    return selection;
   }
 
   public List<TransactionResult> getResults() {
-    return ImmutableList.copyOf(results);
+    return results;
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -188,12 +188,24 @@ public class CrudHandlerTest {
           throws CrudException, ExecutionException {
     // Arrange
     Get get = prepareGet();
-    Optional<Result> expected = Optional.of(prepareResult(TransactionState.PREPARED));
+    result = prepareResult(TransactionState.PREPARED);
+    Optional<Result> expected = Optional.of(result);
     when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
     when(storage.get(get)).thenReturn(expected);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.get(get)).isInstanceOf(UncommittedRecordException.class);
+    assertThatThrownBy(() -> handler.get(get))
+        .isInstanceOf(UncommittedRecordException.class)
+        .satisfies(
+            e -> {
+              UncommittedRecordException exception = (UncommittedRecordException) e;
+              assertThat(exception.getSelection()).isEqualTo(get);
+              assertThat(exception.getResults().size()).isEqualTo(1);
+              assertThat(exception.getResults().get(0)).isEqualTo(result);
+            });
+
+    verify(snapshot, never())
+        .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
   }
 
   @Test
@@ -260,10 +272,17 @@ public class CrudHandlerTest {
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(scan)).thenReturn(scanner);
 
-    // Act
-    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(UncommittedRecordException.class);
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scan))
+        .isInstanceOf(UncommittedRecordException.class)
+        .satisfies(
+            e -> {
+              UncommittedRecordException exception = (UncommittedRecordException) e;
+              assertThat(exception.getSelection()).isEqualTo(scan);
+              assertThat(exception.getResults().size()).isEqualTo(1);
+              assertThat(exception.getResults().get(0)).isEqualTo(result);
+            });
 
-    // Assert
     verify(snapshot, never())
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
   }
@@ -475,10 +494,17 @@ public class CrudHandlerTest {
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(any(ScanAll.class))).thenReturn(scanner);
 
-    // Act
-    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(UncommittedRecordException.class);
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scan))
+        .isInstanceOf(UncommittedRecordException.class)
+        .satisfies(
+            e -> {
+              UncommittedRecordException exception = (UncommittedRecordException) e;
+              assertThat(exception.getSelection()).isEqualTo(scan);
+              assertThat(exception.getResults().size()).isEqualTo(1);
+              assertThat(exception.getResults().get(0)).isEqualTo(result);
+            });
 
-    // Assert
     verify(snapshot, never())
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     verify(snapshot, never()).verify(any());
@@ -839,7 +865,14 @@ public class CrudHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> handler.readUnread(key, getForKey))
-        .isInstanceOf(UncommittedRecordException.class);
+        .isInstanceOf(UncommittedRecordException.class)
+        .satisfies(
+            e -> {
+              UncommittedRecordException exception = (UncommittedRecordException) e;
+              assertThat(exception.getSelection()).isEqualTo(getForKey);
+              assertThat(exception.getResults().size()).isEqualTo(1);
+              assertThat(exception.getResults().get(0)).isEqualTo(result);
+            });
   }
 
   @Test


### PR DESCRIPTION
## Description

Currently, when uncommitted records are read while executing implicit pre-read, lazy recovery is not performed, which is unexpected behavior. This PR addresses issue.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1222

## Changes made

- Make changes to perform lazy recovery when uncommitted records are read while executing implicit pre-read.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed a bug where lazy recovery is not performed when uncommitted records are read while executing implicit pre-read.