### PR TITLE
Backport to branch(3) : Bump org.assertj:assertj-core from 3.25.1 to 3.25.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
         jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.10.1'
         commonsLangVersion = '3.14.0'
-        assertjVersion = '3.25.1'
+        assertjVersion = '3.25.2'
         mockitoVersion = '4.11.0'
         spotbugsVersion = '4.8.3'
         errorproneVersion = '2.10.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1475