### PR TITLE
[vuln-check-workflow] Fix incomplete skip of unexpected versions

### DIFF
--- a/ci/vuln-check/find_latest_release
+++ b/ci/vuln-check/find_latest_release
@@ -62,14 +62,22 @@ releases.each do |release|
     # Get the rest of string after `release_pattern` (e.g., "9.1")
     rest_versions = release[release_pattern.size..]
     cur = candidate_releases
+
+    # Validate `rest_versions`
+    begin
+      rest_versions.split('.').each do |x|
+        # Empty string is expected
+        Integer(x) unless x.empty?
+      end
+    rescue ArgumentError
+      STDERR.puts "Found invalid version unit '#{rest_versions}'. Skipping it."
+      next
+    end
+
+    # Update `candidate_releases`
     rest_versions.split('.').each do |part_of_version_str|
       next if part_of_version_str.empty?
-      begin
-        part_of_version = Integer(part_of_version_str)
-      rescue ArgumentError
-        STDERR.puts "Failed to convert string(#{part_of_version_str}) to integer. Skipping it."
-        next
-      end
+      part_of_version = Integer(part_of_version_str)
       # Just an idiom for map initialization
       cur[part_of_version] ||= {}
       cur = cur[part_of_version]


### PR DESCRIPTION
## Description

We made [the vulnerability check related script skip unexpected versions](https://github.com/scalar-labs/scalardb/pull/1452). But it was incomplete since the unexpected version `v3.11.0-alpha.1` contains another dot and it added a garbage version. The error handling should be enhanced.

## Related issues and/or PRs

https://github.com/scalar-labs/scalardb/pull/1452

## Changes made

This PR updates `ci/vuln-check/find_latest_release` to skip an unexpected version if any invalid version unit is included.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A