### PR TITLE
Backport to branch(3) : Bump junitVersion from 5.10.1 to 5.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
         prometheusVersion = '0.16.0'
         commonsTextVersion = '1.11.0'
         jettyVersion = '9.4.53.v20231009'
-        junitVersion = '5.10.1'
+        junitVersion = '5.10.2'
         commonsLangVersion = '3.14.0'
         assertjVersion = '3.25.2'
         mockitoVersion = '4.11.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1487