### PR TITLE
Backport to branch(3) : Bump org.xerial:sqlite-jdbc from 3.45.0.0 to 3.45.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
         postgresqlDriverVersion = '42.7.1'
         oracleDriverVersion = '21.11.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
-        sqliteDriverVersion = '3.45.0.0'
+        sqliteDriverVersion = '3.45.1.0'
         grpcVersion = '1.60.0'
         protobufVersion = '3.21.12'
         annotationVersion = '1.3.2'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1489