### PR TITLE
Backport to branch(3) : Bump awssdkVersion from 2.23.3 to 2.24.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
         cassandraDriverVersion = '3.11.5'
         azureCosmosVersion = '4.54.0'
         jooqVersion = '3.14.16'
-        awssdkVersion = '2.23.3'
+        awssdkVersion = '2.24.0'
         commonsDbcp2Version = '2.11.0'
         mysqlDriverVersion = '8.0.33'
         postgresqlDriverVersion = '42.7.1'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1497