### PR TITLE
Remove hard-coded collation in JDBC adapter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,15 +227,11 @@ jobs:
     name: MySQL 5.7 integration test
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-        ports:
-          - 3306:3306
-
     steps:
+      - name: Run MySQL 5.7
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8
@@ -260,15 +256,11 @@ jobs:
     name: MySQL 8.0 integration test
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-        ports:
-          - 3306:3306
-
     steps:
+      - name: Run MySQL 8.0
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.0 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8
@@ -293,15 +285,11 @@ jobs:
     name: MySQL 8.1 integration test
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8.1
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-        ports:
-          - 3306:3306
-
     steps:
+      - name: Run MySQL 8.1
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.1 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8
@@ -607,6 +595,7 @@ jobs:
           MSSQL_PID: "Express"
           SA_PASSWORD: "SqlServer17"
           ACCEPT_EULA: "Y"
+          MSSQL_COLLATION: "Japanese_BIN2"
         ports:
           - 1433:1433
 
@@ -642,6 +631,7 @@ jobs:
           MSSQL_PID: "Express"
           SA_PASSWORD: "SqlServer19"
           ACCEPT_EULA: "Y"
+          MSSQL_COLLATION: "Japanese_BIN2"
         ports:
           - 1433:1433
 
@@ -677,6 +667,7 @@ jobs:
           MSSQL_PID: "Express"
           SA_PASSWORD: "SqlServer22"
           ACCEPT_EULA: "Y"
+          MSSQL_COLLATION: "Japanese_BIN2"
         ports:
           - 1433:1433
 
@@ -733,15 +724,11 @@ jobs:
     name: MariaDB 10 integration test
     runs-on: ubuntu-latest
 
-    services:
-      mariadb:
-        image: mariadb:10.11
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-        ports:
-          - 3306:3306
-
     steps:
+      - name: Run MariaDB 10.11
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:10.11 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8
@@ -774,14 +761,12 @@ jobs:
           HEAP_NEWSIZE: 512m
         ports:
           - 9042:9042
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-        ports:
-          - 3306:3306
 
     steps:
+      - name: Run MySQL 8
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8
@@ -806,15 +791,11 @@ jobs:
     name: ScalarDB Server integration test
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-        ports:
-          - 3306:3306
-
     steps:
+      - name: Run MySQL 8
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 8

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraJapaneseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraJapaneseIntegrationTest.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.api.DistributedStorageJapaneseIntegrationTestBase;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class CassandraJapaneseIntegrationTest
+    extends DistributedStorageJapaneseIntegrationTestBase {
+  @Override
+  protected Properties getProperties(String testName) {
+    return CassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosJapaneseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosJapaneseIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.api.DistributedStorageJapaneseIntegrationTestBase;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+public class CosmosJapaneseIntegrationTest extends DistributedStorageJapaneseIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return CosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getNamespace() {
+    String namespace = super.getNamespace();
+    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
+    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoJapaneseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoJapaneseIntegrationTest.java
@@ -1,0 +1,18 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.DistributedStorageJapaneseIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class DynamoJapaneseIntegrationTest extends DistributedStorageJapaneseIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return DynamoEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseJapaneseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseJapaneseIntegrationTest.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.DistributedStorageJapaneseIntegrationTestBase;
+import java.util.Properties;
+
+public class JdbcDatabaseJapaneseIntegrationTest
+    extends DistributedStorageJapaneseIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return JdbcEnv.getProperties(testName);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -23,16 +23,12 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Override
   public String[] createSchemaSqls(String fullSchema) {
-    return new String[] {
-      "CREATE SCHEMA " + enclose(fullSchema) + " character set utf8 COLLATE utf8_bin"
-    };
+    return new String[] {"CREATE SCHEMA " + enclose(fullSchema)};
   }
 
   @Override
   public String[] createSchemaIfNotExistsSqls(String schema) {
-    return new String[] {
-      "CREATE SCHEMA IF NOT EXISTS " + enclose(schema) + " character set utf8 COLLATE utf8_bin"
-    };
+    return new String[] {"CREATE SCHEMA IF NOT EXISTS " + enclose(schema)};
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -176,7 +176,7 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
       case INT:
         return "INT";
       case TEXT:
-        return "VARCHAR(8000) COLLATE Latin1_General_BIN";
+        return "VARCHAR(8000)";
       default:
         throw new AssertionError();
     }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -288,12 +288,9 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createNamespace_forX_shouldExecuteCreateNamespaceStatement(
         RdbEngine.MYSQL,
-        Collections.singletonList("CREATE SCHEMA `my_ns` character set utf8 COLLATE utf8_bin"),
+        Collections.singletonList("CREATE SCHEMA `my_ns`"),
         "SELECT 1 FROM `" + METADATA_SCHEMA + "`.`namespaces` LIMIT 1",
-        Collections.singletonList(
-            "CREATE SCHEMA IF NOT EXISTS `"
-                + METADATA_SCHEMA
-                + "` character set utf8 COLLATE utf8_bin"),
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`"),
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
             + "`.`namespaces`(`namespace_name` VARCHAR(128), PRIMARY KEY (`namespace_name`))",
@@ -472,7 +469,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_ForX_CreateTableAndIndexes(
         RdbEngine.SQL_SERVER,
-        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000) COLLATE Latin1_General_BIN,"
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
             + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3] ASC,[c1] DESC,[c4] ASC))",
         "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
         "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])");
@@ -569,7 +566,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_IfNotExistsForX_createTableAndIndexesIfNotExists(
         RdbEngine.SQL_SERVER,
-        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000) COLLATE Latin1_General_BIN,"
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
             + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3] ASC,[c1] DESC,[c4] ASC))",
         "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
         "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])");
@@ -754,7 +751,7 @@ public class JdbcAdminTest {
       throws Exception {
     addTableMetadata_createMetadataTableIfNotExistsForXAndOverwriteMetadata_ShouldWorkProperly(
         RdbEngine.MYSQL,
-        "CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "` character set utf8 COLLATE utf8_bin",
+        "CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`",
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
             + "`.`metadata`("
@@ -920,7 +917,7 @@ public class JdbcAdminTest {
       throws Exception {
     addTableMetadata_createMetadataTableIfNotExistsForX_ShouldWorkProperly(
         RdbEngine.MYSQL,
-        "CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "` character set utf8 COLLATE utf8_bin",
+        "CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`",
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
             + "`.`metadata`("
@@ -2883,13 +2880,9 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     repairNamespace_forX_shouldWorkProperly(
         RdbEngine.MYSQL,
-        Collections.singletonList(
-            "CREATE SCHEMA IF NOT EXISTS `my_ns` character set utf8 COLLATE utf8_bin"),
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS `my_ns`"),
         "SELECT 1 FROM `scalardb`.`namespaces` LIMIT 1",
-        Collections.singletonList(
-            "CREATE SCHEMA IF NOT EXISTS `"
-                + METADATA_SCHEMA
-                + "` character set utf8 COLLATE utf8_bin"),
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`"),
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
             + "`.`namespaces`(`namespace_name` VARCHAR(128), PRIMARY KEY (`namespace_name`))",
@@ -3031,10 +3024,7 @@ public class JdbcAdminTest {
         RdbEngine.MYSQL,
         "SELECT 1 FROM `" + METADATA_SCHEMA + "`.`metadata` LIMIT 1",
         "SELECT 1 FROM `" + METADATA_SCHEMA + "`.`namespaces` LIMIT 1",
-        ImmutableList.of(
-            "CREATE SCHEMA IF NOT EXISTS `"
-                + METADATA_SCHEMA
-                + "` character set utf8 COLLATE utf8_bin"),
+        ImmutableList.of("CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`"),
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
             + "`.`namespaces`(`namespace_name` VARCHAR(128), PRIMARY KEY (`namespace_name`))",
@@ -3244,10 +3234,7 @@ public class JdbcAdminTest {
     createNamespaceTableIfNotExists_forX_shouldCreateMetadataSchemaAndNamespacesTableIfNotExists(
         RdbEngine.MYSQL,
         "SELECT 1 FROM `" + METADATA_SCHEMA + "`.`namespaces` LIMIT 1",
-        Collections.singletonList(
-            "CREATE SCHEMA IF NOT EXISTS `"
-                + METADATA_SCHEMA
-                + "` character set utf8 COLLATE utf8_bin"),
+        Collections.singletonList("CREATE SCHEMA IF NOT EXISTS `" + METADATA_SCHEMA + "`"),
         "CREATE TABLE IF NOT EXISTS `"
             + METADATA_SCHEMA
             + "`.`namespaces`(`namespace_name` VARCHAR(128), PRIMARY KEY (`namespace_name`))",

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
@@ -1,0 +1,180 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.StorageFactory;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DistributedStorageJapaneseIntegrationTestBase {
+
+  private static final String TEST_NAME = "storage_jp";
+  private static final String NAMESPACE = "int_test_" + TEST_NAME;
+  private static final String TABLE = "test_table";
+  private static final String COL_NAME1 = "c1";
+  private static final String COL_NAME2 = "c2";
+  private static final String COL_NAME3 = "c3";
+
+  private DistributedStorage storage;
+  private DistributedStorageAdmin admin;
+  private String namespace;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
+    admin = factory.getStorageAdmin();
+    namespace = getNamespace();
+    createTable();
+    storage = factory.getStorage();
+  }
+
+  protected abstract Properties getProperties(String testName);
+
+  protected String getNamespace() {
+    return NAMESPACE;
+  }
+
+  private void createTable() throws ExecutionException {
+    Map<String, String> options = getCreationOptions();
+    admin.createNamespace(namespace, true, options);
+    admin.createTable(
+        namespace,
+        TABLE,
+        TableMetadata.newBuilder()
+            .addColumn(COL_NAME1, DataType.TEXT)
+            .addColumn(COL_NAME2, DataType.TEXT)
+            .addColumn(COL_NAME3, DataType.TEXT)
+            .addPartitionKey(COL_NAME1)
+            .addClusteringKey(COL_NAME2)
+            .build(),
+        true,
+        options);
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    truncateTable();
+  }
+
+  private void truncateTable() throws ExecutionException {
+    admin.truncateTable(namespace, TABLE);
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    dropTable();
+    admin.close();
+    storage.close();
+  }
+
+  private void dropTable() throws ExecutionException {
+    admin.dropTable(namespace, TABLE);
+    admin.dropNamespace(namespace);
+  }
+
+  @Test
+  public void operation_ShouldWorkProperly() throws ExecutionException, IOException {
+    // Arrange
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+            .clusteringKey(Key.ofText(COL_NAME2, "あああ"))
+            .textValue(COL_NAME3, "アアア")
+            .build());
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+            .clusteringKey(Key.ofText(COL_NAME2, "いいい"))
+            .textValue(COL_NAME3, "イイイ")
+            .build());
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+            .clusteringKey(Key.ofText(COL_NAME2, "ううう"))
+            .textValue(COL_NAME3, "ウウウ")
+            .build());
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(COL_NAME1, "いいい"))
+            .clusteringKey(Key.ofText(COL_NAME2, "あああ"))
+            .textValue(COL_NAME3, "アアア")
+            .build());
+
+    // Act Assert
+    Optional<Result> result =
+        storage.get(
+            Get.newBuilder()
+                .namespace(namespace)
+                .table(TABLE)
+                .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+                .clusteringKey(Key.ofText(COL_NAME2, "あああ"))
+                .build());
+    assertThat(result).isPresent();
+    assertThat(result.get().getText(COL_NAME1)).isEqualTo("あああ");
+    assertThat(result.get().getText(COL_NAME2)).isEqualTo("あああ");
+    assertThat(result.get().getText(COL_NAME3)).isEqualTo("アアア");
+
+    Scanner scanner =
+        storage.scan(
+            Scan.newBuilder()
+                .namespace(namespace)
+                .table(TABLE)
+                .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+                .build());
+    List<Result> results = scanner.all();
+    assertThat(results).hasSize(3);
+    assertThat(results.get(0).getText(COL_NAME1)).isEqualTo("あああ");
+    assertThat(results.get(0).getText(COL_NAME2)).isEqualTo("あああ");
+    assertThat(results.get(0).getText(COL_NAME3)).isEqualTo("アアア");
+    assertThat(results.get(1).getText(COL_NAME1)).isEqualTo("あああ");
+    assertThat(results.get(1).getText(COL_NAME2)).isEqualTo("いいい");
+    assertThat(results.get(1).getText(COL_NAME3)).isEqualTo("イイイ");
+    assertThat(results.get(2).getText(COL_NAME1)).isEqualTo("あああ");
+    assertThat(results.get(2).getText(COL_NAME2)).isEqualTo("ううう");
+    assertThat(results.get(2).getText(COL_NAME3)).isEqualTo("ウウウ");
+    scanner.close();
+
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+            .clusteringKey(Key.ofText(COL_NAME2, "あああ"))
+            .build();
+    storage.delete(delete);
+    result =
+        storage.get(
+            Get.newBuilder()
+                .namespace(namespace)
+                .table(TABLE)
+                .partitionKey(Key.ofText(COL_NAME1, "あああ"))
+                .clusteringKey(Key.ofText(COL_NAME2, "あああ"))
+                .build());
+    assertThat(result).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

Currently, in the JDBC adapter, we use a hard-coded collation for SQL Server when creating tables. However, we've encountered an issue where Japanese cannot be used with the hard-coded collation in SQL Server. To resolve this, this PR removes the hard-coded collation for SQL Server. For consistency, it also eliminates the hard-coded collation for MySQL. As a result, the collation configured in the database will be used when creating tables.

## Related issues and/or PRs

N/A

## Changes made

- Removed the default collation for SQL Server and MySQL in JDBC adapter.
- Add an integration test for Japanese.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Removed the hard-coded collation for MySQL and SQL Server in the JDBC adapter. As a result, the collation configured in the underlying database will be used when creating tables.
