### PR TITLE
Backport to branch(3.10) : Bump scalar-labs/jre8 from 1.1.15 to 1.1.16 in /schema-loader

### DIFF
--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.15
+FROM ghcr.io/scalar-labs/jre8:1.1.16
 
 COPY scalardb-schema-loader-*.jar /app.jar
 


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1521