### PR TITLE
Update CI to use no superuser for SQL Server test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -609,6 +609,7 @@ jobs:
           ACCEPT_EULA: "Y"
         ports:
           - 1433:1433
+        options: --name sqlserver17
 
     steps:
       - uses: actions/checkout@v4
@@ -619,10 +620,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Create no superuser
+        run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver17 SqlServer17
+
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer17
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -644,6 +648,7 @@ jobs:
           ACCEPT_EULA: "Y"
         ports:
           - 1433:1433
+        options: --name sqlserver19
 
     steps:
       - uses: actions/checkout@v4
@@ -654,10 +659,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Create no superuser
+        run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver19 SqlServer19
+
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer19
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -679,6 +687,7 @@ jobs:
           ACCEPT_EULA: "Y"
         ports:
           - 1433:1433
+        options: --name sqlserver22
 
     steps:
       - uses: actions/checkout@v4
@@ -689,10 +698,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Create no superuser
+        run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver22 SqlServer22
+
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer22
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()

--- a/ci/no-superuser/create-no-superuser-sqlserver.sh
+++ b/ci/no-superuser/create-no-superuser-sqlserver.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+# Get container name and password from arguments
+SQL_SERVER_CONTAINER_NAME=$1
+SQL_SERVER_PASSWORD=$2
+
+# Create login
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE LOGIN no_superuser WITH PASSWORD = 'no_superuser_password', DEFAULT_DATABASE = master , CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF"
+
+# Create database
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE DATABASE test_db"
+
+# Create no_superuser
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "CREATE USER no_superuser FOR LOGIN no_superuser"
+
+# Add roles
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_ddladmin', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datawriter', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datareader', @membername = 'no_superuser'"
+
+# Check if no_superuser can access SQL Server (for debugging purposes)
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U no_superuser -P no_superuser_password -d test_db -Q "SELECT @@version"


### PR DESCRIPTION
## Description

This PR updates the CI (integration test) for SQL Server.

At this time, we are using a superuser (full privilege user) to test each backend DB. And, we state `ScalarDB basically requires a fully privileged account to access the underlying databases` in our document.

However, in some enterprise projects, the fully privileged user is not acceptable for some security reasons. For example, we got an inquiry `Q. What privileges do we need when we use MS SQL Server as a backend DB of ScalarDB?` from actual users.

So, we discussed and decided to test the backend DB by using no superuser one by one.

As a first step, I updated the SQL Server test in this PR.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

* Add new script to create no superuser account in the backend SQL Server (`ci/no-superuser/create-no-superuser-sqlserver.sh`).
* Update CI to use no superuser to access SQL Server from ScalarDB (`.github/workflows/ci.yaml`).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

We will update the document `Requirements and Recommendations for the Underlying Databases of ScalarDB` after updating several DBs to use no superuser. In other words, I will update the document in another PR later after we test each DB with no superuser, which means we officially support no superuser.

## Release notes

N/A
