### PR TITLE
Backport to branch(3.9) : Bump org.postgresql:postgresql from 42.6.0 to 42.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         awssdkVersion = '2.20.54'
         commonsDbcp2Version = '2.9.0'
         mysqlDriverVersion = '8.0.33'
-        postgresqlDriverVersion = '42.6.0'
+        postgresqlDriverVersion = '42.7.2'
         oracleDriverVersion = '21.9.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
         sqliteDriverVersion = '3.42.0.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1547