### PR TITLE
Backport to branch(3.8) : Bump org.postgresql:postgresql from 42.5.1 to 42.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         awssdkVersion = '2.19.16'
         commonsDbcp2Version = '2.8.0'
         mysqlDriverVersion = '8.0.31'
-        postgresqlDriverVersion = '42.5.1'
+        postgresqlDriverVersion = '42.7.2'
         oracleDriverVersion = '19.8.0.0'
         sqlserverDriverVersion = '8.4.1.jre8'
         grpcVersion = '1.60.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1547