### PR TITLE
Backport to branch(3) : Bump com.azure:azure-cosmos from 4.55.1 to 4.56.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         guavaVersion = '32.1.3-jre'
         slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.11.5'
-        azureCosmosVersion = '4.55.1'
+        azureCosmosVersion = '4.56.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.24.0'
         commonsDbcp2Version = '2.11.0'

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -506,14 +506,12 @@ public abstract class CosmosAdminTestBase {
     verify(container)
         .queryItems(
             eq("SELECT t.id, t.concatenatedPartitionKey FROM " + "t"),
-            refEq(new CosmosQueryRequestOptions()),
+            any(CosmosQueryRequestOptions.class),
             eq(Record.class));
     verify(container)
-        .deleteItem(
-            eq("id1"), refEq(new PartitionKey("p1")), refEq(new CosmosItemRequestOptions()));
+        .deleteItem(eq("id1"), refEq(new PartitionKey("p1")), any(CosmosItemRequestOptions.class));
     verify(container)
-        .deleteItem(
-            eq("id2"), refEq(new PartitionKey("p2")), refEq(new CosmosItemRequestOptions()));
+        .deleteItem(eq("id2"), refEq(new PartitionKey("p2")), any(CosmosItemRequestOptions.class));
   }
 
   @Test
@@ -544,7 +542,7 @@ public abstract class CosmosAdminTestBase {
     verify(container)
         .queryItems(
             eq("SELECT * FROM metadata WHERE metadata.id LIKE 'ns.%'"),
-            refEq(new CosmosQueryRequestOptions()),
+            any(CosmosQueryRequestOptions.class),
             eq(CosmosTableMetadata.class));
   }
 


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1549