### PR TITLE
Backport to branch(3.12) : Update CI to use no superuser for SQL Server test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -598,6 +598,7 @@ jobs:
           MSSQL_COLLATION: "Japanese_BIN2"
         ports:
           - 1433:1433
+        options: --name sqlserver17
 
     steps:
       - uses: actions/checkout@v4
@@ -608,10 +609,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Create no superuser
+        run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver17 SqlServer17
+
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer17
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -634,6 +638,7 @@ jobs:
           MSSQL_COLLATION: "Japanese_BIN2"
         ports:
           - 1433:1433
+        options: --name sqlserver19
 
     steps:
       - uses: actions/checkout@v4
@@ -644,10 +649,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Create no superuser
+        run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver19 SqlServer19
+
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer19
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -670,6 +678,7 @@ jobs:
           MSSQL_COLLATION: "Japanese_BIN2"
         ports:
           - 1433:1433
+        options: --name sqlserver22
 
     steps:
       - uses: actions/checkout@v4
@@ -680,10 +689,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
+      - name: Create no superuser
+        run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver22 SqlServer22
+
       - name: Setup and execute Gradle 'integrationTestJdbc' task
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=sa -Dscalardb.jdbc.password=SqlServer22
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()

--- a/ci/no-superuser/create-no-superuser-sqlserver.sh
+++ b/ci/no-superuser/create-no-superuser-sqlserver.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+# Get container name and password from arguments
+SQL_SERVER_CONTAINER_NAME=$1
+SQL_SERVER_PASSWORD=$2
+
+# Create login
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE LOGIN no_superuser WITH PASSWORD = 'no_superuser_password', DEFAULT_DATABASE = master , CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF"
+
+# Create database
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE DATABASE test_db"
+
+# Create no_superuser
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "CREATE USER no_superuser FOR LOGIN no_superuser"
+
+# Add roles
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_ddladmin', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datawriter', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datareader', @membername = 'no_superuser'"
+
+# Check if no_superuser can access SQL Server (for debugging purposes)
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U no_superuser -P no_superuser_password -d test_db -Q "SELECT @@version"


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1542