### PR TITLE
Use username "sa" instead of "SA" in CI of SQL Server

### DIFF
--- a/ci/no-superuser/create-no-superuser-sqlserver.sh
+++ b/ci/no-superuser/create-no-superuser-sqlserver.sh
@@ -6,18 +6,18 @@ SQL_SERVER_CONTAINER_NAME=$1
 SQL_SERVER_PASSWORD=$2
 
 # Create login
-docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE LOGIN no_superuser WITH PASSWORD = 'no_superuser_password', DEFAULT_DATABASE = master , CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE LOGIN no_superuser WITH PASSWORD = 'no_superuser_password', DEFAULT_DATABASE = master , CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF"
 
 # Create database
-docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE DATABASE test_db"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d master -Q "CREATE DATABASE test_db"
 
 # Create no_superuser
-docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "CREATE USER no_superuser FOR LOGIN no_superuser"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d test_db -Q "CREATE USER no_superuser FOR LOGIN no_superuser"
 
 # Add roles
-docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_ddladmin', @membername = 'no_superuser'"
-docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datawriter', @membername = 'no_superuser'"
-docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datareader', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_ddladmin', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datawriter', @membername = 'no_superuser'"
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d test_db -Q "EXEC sp_addrolemember @rolename = 'db_datareader', @membername = 'no_superuser'"
 
 # Check if no_superuser can access SQL Server (for debugging purposes)
 docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U no_superuser -P no_superuser_password -d test_db -Q "SELECT @@version"


### PR DESCRIPTION
## Description

This PR update the username of `SA` that is a `root` user of SQL Server.

Before we can use `SA` as a username because SQL Server treat username with case-insensitive.

However, recently we updated CI to set `Japanese_BIN2` as a collation of SQL Server.

As a result, SQL Server treat username with case-sensitive.

So, if we use `SA` as a username, the authentication of SQL Server failed.

To fix this issue, I updated username from `SA` to `sa`.

Please take a look!

## Related issues and/or PRs

* https://github.com/scalar-labs/scalardb/actions/runs/8073265726/job/22056629519

## Changes made

* Update `create-no-superuser-sqlserver.sh` to use username `sa`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I tested SQL Server with collation `Japanese_BIN2` as follows.

* Run SQL Server with collation `Japanese_BIN2`.
  ```console
  docker run -d --name sqlserver22 -e "MSSQL_PID=Express" -e "SA_PASSWORD=SqlServer22" -e "ACCEPT_EULA=Y" -e "MSSQL_COLLATION=Japanese_BIN2" mcr.microsoft.com/mssql/  server:2022-latest
  ```
* Run the `sqlcmd` with username `SA`.
  ```console
  $ docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${SQL_SERVER_PASSWORD} -d master -Q "SELECT 1"
  Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Login failed for user 'SA'..
  ```
* Run the `sqlcmd` with username `sa`.
  ```console
  $ docker exec -t ${SQL_SERVER_CONTAINER_NAME} /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SQL_SERVER_PASSWORD} -d master -Q "SELECT 1"
  
  -----------
            1
  
  (1 rows affected)
  ```

## Release notes

N/A
