### PR TITLE
Backport to branch(3) : Bump org.apache.commons:commons-dbcp2 from 2.11.0 to 2.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
         azureCosmosVersion = '4.56.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.25.1'
-        commonsDbcp2Version = '2.11.0'
+        commonsDbcp2Version = '2.12.0'
         mysqlDriverVersion = '8.0.33'
         postgresqlDriverVersion = '42.7.2'
         oracleDriverVersion = '21.13.0.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1582