### PR TITLE
Add auto-commit transaction manager

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/AutoCommitTransactionAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/AutoCommitTransactionAdminIntegrationTestWithCassandra.java
@@ -1,0 +1,20 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionAdminIntegrationTestBase;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class AutoCommitTransactionAdminIntegrationTestWithCassandra
+    extends AutoCommitTransactionAdminIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return CassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/AutoCommitTransactionIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/AutoCommitTransactionIntegrationTestWithCassandra.java
@@ -1,15 +1,17 @@
 package com.scalar.db.storage.cassandra;
 
-import com.scalar.db.api.DistributedStorageIntegrationTestBase;
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionIntegrationTestBase;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class CassandraIntegrationTest extends DistributedStorageIntegrationTestBase {
+public class AutoCommitTransactionIntegrationTestWithCassandra
+    extends AutoCommitTransactionIntegrationTestBase {
+
   @Override
-  protected Properties getProperties(String testName) {
+  protected Properties getProps(String testName) {
     return CassandraEnv.getProperties(testName);
   }
 
@@ -23,5 +25,6 @@ public class CassandraIntegrationTest extends DistributedStorageIntegrationTestB
           + "the condition is considered satisfied. This behavior differs from that of other adapters")
   @Override
   @Test
-  public void put_withPutIfIsNullWhenRecordDoesNotExist_shouldThrowNoMutationException() {}
+  public void
+      put_withPutIfIsNullWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/AutoCommitTransactionIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/AutoCommitTransactionIntegrationTestWithCassandra.java
@@ -27,4 +27,9 @@ public class AutoCommitTransactionIntegrationTestWithCassandra
   @Test
   public void
       put_withPutIfIsNullWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException() {}
+
+  @Disabled("Disabled because this test case is flaky for Cassandra")
+  @Override
+  @Test
+  public void delete_withDeleteIfExistsWhenRecordsExists_shouldDeleteProperly() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/AutoCommitTransactionAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/AutoCommitTransactionAdminIntegrationTestWithCosmos.java
@@ -1,0 +1,40 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionAdminIntegrationTestBase;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+public class AutoCommitTransactionAdminIntegrationTestWithCosmos
+    extends AutoCommitTransactionAdminIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return CosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getNamespace1() {
+    return getNamespace(super.getNamespace1());
+  }
+
+  @Override
+  protected String getNamespace2() {
+    return getNamespace(super.getNamespace2());
+  }
+
+  @Override
+  protected String getNamespace3() {
+    return getNamespace(super.getNamespace3());
+  }
+
+  private String getNamespace(String namespace) {
+    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
+    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/AutoCommitTransactionIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/AutoCommitTransactionIntegrationTestWithCosmos.java
@@ -1,0 +1,27 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionIntegrationTestBase;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+public class AutoCommitTransactionIntegrationTestWithCosmos
+    extends AutoCommitTransactionIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return CosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getNamespaceBaseName() {
+    String namespaceBaseName = super.getNamespaceBaseName();
+    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
+    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/AutoCommitTransactionAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/AutoCommitTransactionAdminIntegrationTestWithDynamo.java
@@ -1,0 +1,24 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionAdminIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class AutoCommitTransactionAdminIntegrationTestWithDynamo
+    extends AutoCommitTransactionAdminIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return DynamoEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
+  }
+
+  @Override
+  protected boolean isIndexOnBooleanColumnSupported() {
+    return false;
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/AutoCommitTransactionIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/AutoCommitTransactionIntegrationTestWithDynamo.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+
+public class AutoCommitTransactionIntegrationTestWithDynamo
+    extends AutoCommitTransactionIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return DynamoEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/AutoCommitTransactionAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/AutoCommitTransactionAdminIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,19 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionAdminIntegrationTestBase;
+import com.scalar.db.util.AdminTestUtils;
+import java.util.Properties;
+
+public class AutoCommitTransactionAdminIntegrationTestWithJdbcDatabase
+    extends AutoCommitTransactionAdminIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    return new JdbcAdminTestUtils(getProperties(testName));
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/AutoCommitTransactionIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/AutoCommitTransactionIntegrationTestWithJdbcDatabase.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.transaction.autocommit.AutoCommitTransactionIntegrationTestBase;
+import java.util.Properties;
+
+public class AutoCommitTransactionIntegrationTestWithJdbcDatabase
+    extends AutoCommitTransactionIntegrationTestBase {
+
+  @Override
+  protected Properties getProps(String testName) {
+    return JdbcEnv.getProperties(testName);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -20,9 +20,7 @@ public class JdbcTransactionAdminIntegrationTest
     return properties;
   }
 
-  // Disable several tests for the coordinator tables since JDBC transaction doesn't have
-  // coordinator tables
-  @Disabled("JDBC transaction doesn't have coordinator tables")
+  @Disabled("JDBC transactions don't have Coordinator tables")
   @Test
   @Override
   public void createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly()
@@ -30,7 +28,7 @@ public class JdbcTransactionAdminIntegrationTest
     super.createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly();
   }
 
-  @Disabled("JDBC transaction doesn't have coordinator tables")
+  @Disabled("JDBC transactions don't have Coordinator tables")
   @Test
   @Override
   public void
@@ -39,7 +37,7 @@ public class JdbcTransactionAdminIntegrationTest
         .createCoordinatorTables_CoordinatorTablesAlreadyExist_ShouldThrowIllegalArgumentException();
   }
 
-  @Disabled("JDBC transaction doesn't have coordinator tables")
+  @Disabled("JDBC transactions don't have Coordinator tables")
   @Test
   @Override
   public void
@@ -48,7 +46,7 @@ public class JdbcTransactionAdminIntegrationTest
         .createCoordinatorTables_IfNotExist_CoordinatorTablesAlreadyExist_ShouldNotThrowAnyException();
   }
 
-  @Disabled("JDBC transaction doesn't have coordinator tables")
+  @Disabled("JDBC transactions don't have Coordinator tables")
   @Test
   @Override
   public void dropCoordinatorTables_ShouldDropCoordinatorTablesCorrectly()
@@ -56,7 +54,7 @@ public class JdbcTransactionAdminIntegrationTest
     super.dropCoordinatorTables_ShouldDropCoordinatorTablesCorrectly();
   }
 
-  @Disabled("JDBC transaction doesn't have coordinator tables")
+  @Disabled("JDBC transactions don't have Coordinator tables")
   @Test
   @Override
   public void
@@ -65,7 +63,7 @@ public class JdbcTransactionAdminIntegrationTest
     super.dropCoordinatorTables_CoordinatorTablesDoNotExist_ShouldThrowIllegalArgumentException();
   }
 
-  @Disabled("JDBC transaction doesn't have coordinator tables")
+  @Disabled("JDBC transactions don't have Coordinator tables")
   @Test
   @Override
   public void dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException()
@@ -73,8 +71,9 @@ public class JdbcTransactionAdminIntegrationTest
     super.dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException();
   }
 
+  // TODO: implement later
   @Test
-  @Disabled("JDBC Transaction Admin does not support upgrade()")
+  @Disabled("JDBC transactions don't support upgrade()")
   @Override
   public void
       upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -37,7 +37,7 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
   @Override
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
 
-  @Disabled
+  @Disabled("JDBC transaction doesn't support implicit pre-read")
   @Override
   public void
       putAndCommit_PutWithImplicitPreReadDisabledGivenForExisting_ShouldThrowCommitConflictException() {}

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -21,23 +21,23 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
     return properties;
   }
 
-  @Disabled("JDBC transaction doesn't support getState()")
+  @Disabled("JDBC transactions don't support getState()")
   @Override
   public void getState_forSuccessfulTransaction_ShouldReturnCommittedState() {}
 
-  @Disabled("JDBC transaction doesn't support getState()")
+  @Disabled("JDBC transactions don't support getState()")
   @Override
   public void getState_forFailedTransaction_ShouldReturnAbortedState() {}
 
-  @Disabled("JDBC transaction doesn't support abort()")
+  @Disabled("JDBC transactions don't support abort()")
   @Override
   public void abort_forOngoingTransaction_ShouldAbortCorrectly() {}
 
-  @Disabled("JDBC transaction doesn't support rollback()")
+  @Disabled("JDBC transactions don't support rollback()")
   @Override
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
 
-  @Disabled("JDBC transaction doesn't support implicit pre-read")
+  @Disabled("JDBC transactions don't support implicit pre-read")
   @Override
   public void
       putAndCommit_PutWithImplicitPreReadDisabledGivenForExisting_ShouldThrowCommitConflictException() {}

--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionProvider.java
@@ -1,6 +1,7 @@
 package com.scalar.db.api;
 
 import com.scalar.db.config.DatabaseConfig;
+import javax.annotation.Nullable;
 
 /**
  * A class that creates {@link DistributedTransactionManager}, {@link DistributedTransactionAdmin},
@@ -39,7 +40,10 @@ public interface DistributedTransactionProvider {
    * Creates an instance of {@link TwoPhaseCommitTransactionManager} for the transaction manager.
    *
    * @param config a database config
-   * @return an instance of {@link TwoPhaseCommitTransactionManager} for the transaction manager
+   * @return an instance of {@link TwoPhaseCommitTransactionManager} for the transaction manager. If
+   *     the transaction manager does not support the two-phase commit interface, returns {@code
+   *     null}.
    */
+  @Nullable
   TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(DatabaseConfig config);
 }

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -572,27 +572,15 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0124", "Columns must be specified. Table: %s", "", ""),
   SCHEMA_LOADER_PARSE_ERROR_INVALID_COLUMN_TYPE(
       Category.USER_ERROR, "0125", "Invalid column type. Table: %s; Column: %s; Type: %s", "", ""),
-  JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED(
-      Category.USER_ERROR,
-      "0126",
-      "The two-phase commit interface is not supported in JDBC transactions",
-      "",
-      ""),
-  AUTO_COMMIT_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED(
-      Category.USER_ERROR,
-      "0127",
-      "The two-phase commit interface is not supported in auto-commit transactions",
-      "",
-      ""),
   AUTO_COMMIT_TRANSACTION_GETTING_TRANSACTION_STATE_NOT_SUPPORTED(
       Category.USER_ERROR,
-      "0128",
+      "0126",
       "Getting a transaction state is not supported in auto-commit transactions",
       "",
       ""),
   AUTO_COMMIT_TRANSACTION_ROLLING_BACK_TRANSACTION_NOT_SUPPORTED(
       Category.USER_ERROR,
-      "0129",
+      "0127",
       "Rolling back a transaction is not supported in auto-commit transactions",
       "",
       ""),

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -572,6 +572,30 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0124", "Columns must be specified. Table: %s", "", ""),
   SCHEMA_LOADER_PARSE_ERROR_INVALID_COLUMN_TYPE(
       Category.USER_ERROR, "0125", "Invalid column type. Table: %s; Column: %s; Type: %s", "", ""),
+  JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0126",
+      "The two-phase commit interface is not supported in JDBC transactions",
+      "",
+      ""),
+  AUTO_COMMIT_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0127",
+      "The two-phase commit interface is not supported in auto-commit transactions",
+      "",
+      ""),
+  AUTO_COMMIT_TRANSACTION_GETTING_TRANSACTION_STATE_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0128",
+      "Getting a transaction state is not supported in auto-commit transactions",
+      "",
+      ""),
+  AUTO_COMMIT_TRANSACTION_ROLLING_BACK_TRANSACTION_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0129",
+      "Rolling back a transaction is not supported in auto-commit transactions",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/service/ProviderManager.java
+++ b/core/src/main/java/com/scalar/db/service/ProviderManager.java
@@ -13,6 +13,7 @@ import com.scalar.db.config.DatabaseConfig;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
+import javax.annotation.Nullable;
 
 /**
  * This class loads {@link DistributedStorageProvider} and {@link DistributedTransactionProvider}
@@ -113,8 +114,10 @@ final class ProviderManager {
    * Returns an instance of {@link TwoPhaseCommitTransactionManager}.
    *
    * @param config a database config
-   * @return an instance of {@link TwoPhaseCommitTransactionManager}
+   * @return an instance of {@link TwoPhaseCommitTransactionManager}. If the transaction manager
+   *     does not support the two-phase commit interface, returns {@code null}.
    */
+  @Nullable
   public static TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     return getDistributedTransactionProvider(config.getTransactionManager())

--- a/core/src/main/java/com/scalar/db/service/TransactionFactory.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionFactory.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /**
  * A factory class to instantiate {@link DistributedTransactionManager} and {@link
@@ -50,8 +51,10 @@ public class TransactionFactory {
   /**
    * Returns a {@link TwoPhaseCommitTransactionManager} instance
    *
-   * @return a {@link TwoPhaseCommitTransactionManager} instance
+   * @return a {@link TwoPhaseCommitTransactionManager} instance. If the transaction manager does
+   *     not support the two-phase commit interface, returns {@code null}.
    */
+  @Nullable
   public TwoPhaseCommitTransactionManager getTwoPhaseCommitTransactionManager() {
     return ProviderManager.createTwoPhaseCommitTransactionManager(config);
   }

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransaction.java
@@ -22,7 +22,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
 
+@NotThreadSafe
 public class AutoCommitTransaction extends AbstractDistributedTransaction {
 
   private final String txId;

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransaction.java
@@ -1,0 +1,119 @@
+package com.scalar.db.transaction.autocommit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.common.AbstractDistributedTransaction;
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+public class AutoCommitTransaction extends AbstractDistributedTransaction {
+
+  private final String txId;
+  private final DistributedStorage storage;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public AutoCommitTransaction(String txId, DistributedStorage storage) {
+    this.txId = txId;
+    this.storage = storage;
+  }
+
+  @Override
+  public String getId() {
+    return txId;
+  }
+
+  @Override
+  public Optional<Result> get(Get get) throws CrudException {
+    try {
+      return storage.get(copyAndSetTargetToIfNot(get).withConsistency(Consistency.LINEARIZABLE));
+    } catch (ExecutionException e) {
+      throw new CrudException(e.getMessage(), e, txId);
+    }
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) throws CrudException {
+    try (Scanner scanner =
+        storage.scan(copyAndSetTargetToIfNot(scan).withConsistency(Consistency.LINEARIZABLE))) {
+      return scanner.all();
+    } catch (ExecutionException | IOException e) {
+      throw new CrudException(e.getMessage(), e, txId);
+    }
+  }
+
+  @Override
+  public void put(Put put) throws CrudException {
+    try {
+      storage.put(copyAndSetTargetToIfNot(put).withConsistency(Consistency.LINEARIZABLE));
+    } catch (NoMutationException e) {
+      throw new UnsatisfiedConditionException(e.getMessage(), e, txId);
+    } catch (ExecutionException e) {
+      throw new CrudException(e.getMessage(), e, txId);
+    }
+  }
+
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    mutate(puts);
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    try {
+      storage.delete(copyAndSetTargetToIfNot(delete).withConsistency(Consistency.LINEARIZABLE));
+    } catch (NoMutationException e) {
+      throw new UnsatisfiedConditionException(e.getMessage(), e, txId);
+    } catch (ExecutionException e) {
+      throw new CrudException(e.getMessage(), e, txId);
+    }
+  }
+
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    mutate(deletes);
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    checkArgument(!mutations.isEmpty(), CoreError.EMPTY_MUTATIONS_SPECIFIED.buildMessage());
+    for (Mutation mutation : mutations) {
+      if (mutation instanceof Put) {
+        put((Put) mutation);
+      } else if (mutation instanceof Delete) {
+        delete((Delete) mutation);
+      }
+    }
+  }
+
+  @Override
+  public void commit() {
+    // Do nothing
+  }
+
+  @Override
+  public void rollback() {
+    // Do nothing
+  }
+
+  @VisibleForTesting
+  DistributedStorage getStorage() {
+    return storage;
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdmin.java
@@ -1,0 +1,154 @@
+package com.scalar.db.transaction.autocommit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.CheckedDistributedStorageAdmin;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.service.StorageFactory;
+import java.util.Map;
+import java.util.Set;
+
+public class AutoCommitTransactionAdmin implements DistributedTransactionAdmin {
+
+  private final DistributedStorageAdmin distributedStorageAdmin;
+
+  @Inject
+  public AutoCommitTransactionAdmin(DatabaseConfig databaseConfig) {
+    StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());
+    distributedStorageAdmin =
+        new CheckedDistributedStorageAdmin(storageFactory.getStorageAdmin(), databaseConfig);
+  }
+
+  @VisibleForTesting
+  AutoCommitTransactionAdmin(DistributedStorageAdmin distributedStorageAdmin) {
+    this.distributedStorageAdmin = distributedStorageAdmin;
+  }
+
+  @Override
+  public void createNamespace(String namespace, Map<String, String> options)
+      throws ExecutionException {
+    distributedStorageAdmin.createNamespace(namespace, options);
+  }
+
+  @Override
+  public void createTable(
+      String namespace, String table, TableMetadata metadata, Map<String, String> options)
+      throws ExecutionException {
+    distributedStorageAdmin.createTable(namespace, table, metadata, options);
+  }
+
+  @Override
+  public void dropTable(String namespace, String table) throws ExecutionException {
+    distributedStorageAdmin.dropTable(namespace, table);
+  }
+
+  @Override
+  public void dropNamespace(String namespace) throws ExecutionException {
+    distributedStorageAdmin.dropNamespace(namespace);
+  }
+
+  @Override
+  public void truncateTable(String namespace, String table) throws ExecutionException {
+    distributedStorageAdmin.truncateTable(namespace, table);
+  }
+
+  @Override
+  public void createIndex(
+      String namespace, String table, String columnName, Map<String, String> options)
+      throws ExecutionException {
+    distributedStorageAdmin.createIndex(namespace, table, columnName, options);
+  }
+
+  @Override
+  public void dropIndex(String namespace, String table, String columnName)
+      throws ExecutionException {
+    distributedStorageAdmin.dropIndex(namespace, table, columnName);
+  }
+
+  @Override
+  public TableMetadata getTableMetadata(String namespace, String table) throws ExecutionException {
+    return distributedStorageAdmin.getTableMetadata(namespace, table);
+  }
+
+  @Override
+  public Set<String> getNamespaceTableNames(String namespace) throws ExecutionException {
+    return distributedStorageAdmin.getNamespaceTableNames(namespace);
+  }
+
+  @Override
+  public boolean namespaceExists(String namespace) throws ExecutionException {
+    return distributedStorageAdmin.namespaceExists(namespace);
+  }
+
+  @Override
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
+    distributedStorageAdmin.importTable(namespace, table, options);
+  }
+
+  @Override
+  public void repairTable(
+      String namespace, String table, TableMetadata metadata, Map<String, String> options)
+      throws ExecutionException {
+    distributedStorageAdmin.repairTable(namespace, table, metadata, options);
+  }
+
+  @Override
+  public void addNewColumnToTable(
+      String namespace, String table, String columnName, DataType columnType)
+      throws ExecutionException {
+    distributedStorageAdmin.addNewColumnToTable(namespace, table, columnName, columnType);
+  }
+
+  @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    return distributedStorageAdmin.getNamespaceNames();
+  }
+
+  @Override
+  public void repairNamespace(String namespace, Map<String, String> options)
+      throws ExecutionException {
+    distributedStorageAdmin.repairNamespace(namespace, options);
+  }
+
+  @Override
+  public void upgrade(Map<String, String> options) throws ExecutionException {
+    distributedStorageAdmin.upgrade(options);
+  }
+
+  @Override
+  public void createCoordinatorTables(Map<String, String> options) {
+    // Do nothing since the auto-commit transactions don't have coordinator tables
+  }
+
+  @Override
+  public void dropCoordinatorTables() {
+    // Do nothing since the auto-commit transactions don't have coordinator tables
+  }
+
+  @Override
+  public void truncateCoordinatorTables() {
+    // Do nothing since the auto-commit transactions don't have coordinator tables
+  }
+
+  @Override
+  public boolean coordinatorTablesExist() {
+    // Always return true since the auto-commit transactions don't have coordinator tables
+    return true;
+  }
+
+  @Override
+  public void repairCoordinatorTables(Map<String, String> options) {
+    // Do nothing since the auto-commit transactions don't have coordinator tables
+  }
+
+  @Override
+  public void close() {
+    distributedStorageAdmin.close();
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdmin.java
@@ -12,7 +12,9 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.service.StorageFactory;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class AutoCommitTransactionAdmin implements DistributedTransactionAdmin {
 
   private final DistributedStorageAdmin distributedStorageAdmin;

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionConfig.java
@@ -1,0 +1,8 @@
+package com.scalar.db.transaction.autocommit;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class AutoCommitTransactionConfig {
+  public static final String TRANSACTION_MANAGER_NAME = "auto-commit";
+}

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionManager.java
@@ -12,7 +12,9 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.service.StorageFactory;
 import java.util.UUID;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class AutoCommitTransactionManager
     extends ActiveTransactionManagedDistributedTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionManager.java
@@ -1,0 +1,115 @@
+package com.scalar.db.transaction.autocommit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Isolation;
+import com.scalar.db.api.SerializableStrategy;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.service.StorageFactory;
+import java.util.UUID;
+
+public class AutoCommitTransactionManager
+    extends ActiveTransactionManagedDistributedTransactionManager {
+
+  private final DistributedStorage storage;
+
+  public AutoCommitTransactionManager(DatabaseConfig databaseConfig) {
+    super(databaseConfig);
+    StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());
+    storage = storageFactory.getStorage();
+  }
+
+  @VisibleForTesting
+  AutoCommitTransactionManager(DatabaseConfig databaseConfig, DistributedStorage storage) {
+    super(databaseConfig);
+    this.storage = storage;
+  }
+
+  @Override
+  public DistributedTransaction begin() throws TransactionException {
+    String txId = UUID.randomUUID().toString();
+    return begin(txId);
+  }
+
+  @Override
+  public DistributedTransaction begin(String txId) throws TransactionException {
+    AutoCommitTransaction transaction = new AutoCommitTransaction(txId, storage);
+    getNamespace().ifPresent(transaction::withNamespace);
+    getTable().ifPresent(transaction::withTable);
+    return decorate(transaction);
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(Isolation isolation) throws TransactionException {
+    return begin();
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(String txId, Isolation isolation)
+      throws TransactionException {
+    return begin(txId);
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
+      throws TransactionException {
+    return begin();
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
+    return begin();
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(String txId, SerializableStrategy strategy)
+      throws TransactionException {
+    return begin(txId);
+  }
+
+  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
+  @Override
+  public DistributedTransaction start(
+      String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
+    return begin(txId);
+  }
+
+  @Override
+  public TransactionState getState(String txId) {
+    throw new UnsupportedOperationException(
+        CoreError.AUTO_COMMIT_TRANSACTION_GETTING_TRANSACTION_STATE_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public TransactionState rollback(String txId) {
+    throw new UnsupportedOperationException(
+        CoreError.AUTO_COMMIT_TRANSACTION_ROLLING_BACK_TRANSACTION_NOT_SUPPORTED.buildMessage());
+  }
+
+  @Override
+  public void close() {
+    storage.close();
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionProvider.java
@@ -1,4 +1,4 @@
-package com.scalar.db.transaction.jdbc;
+package com.scalar.db.transaction.autocommit;
 
 import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
@@ -6,28 +6,28 @@ import com.scalar.db.api.DistributedTransactionProvider;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.jdbc.JdbcConfig;
 
-public class JdbcTransactionProvider implements DistributedTransactionProvider {
+public class AutoCommitTransactionProvider implements DistributedTransactionProvider {
+
   @Override
   public String getName() {
-    return JdbcConfig.TRANSACTION_MANAGER_NAME;
+    return AutoCommitTransactionConfig.TRANSACTION_MANAGER_NAME;
   }
 
   @Override
   public DistributedTransactionManager createDistributedTransactionManager(DatabaseConfig config) {
-    return new JdbcTransactionManager(config);
+    return new AutoCommitTransactionManager(config);
   }
 
   @Override
   public DistributedTransactionAdmin createDistributedTransactionAdmin(DatabaseConfig config) {
-    return new JdbcTransactionAdmin(config);
+    return new AutoCommitTransactionAdmin(config);
   }
 
   @Override
   public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
     throw new UnsupportedOperationException(
-        CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
+        CoreError.AUTO_COMMIT_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionProvider.java
@@ -4,8 +4,8 @@ import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.DistributedTransactionProvider;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
-import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
+import javax.annotation.Nullable;
 
 public class AutoCommitTransactionProvider implements DistributedTransactionProvider {
 
@@ -24,10 +24,10 @@ public class AutoCommitTransactionProvider implements DistributedTransactionProv
     return new AutoCommitTransactionAdmin(config);
   }
 
+  @Nullable
   @Override
   public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
-    throw new UnsupportedOperationException(
-        CoreError.AUTO_COMMIT_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
+    return null;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionProvider.java
@@ -4,9 +4,9 @@ import com.scalar.db.api.DistributedTransactionAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.DistributedTransactionProvider;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
-import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.jdbc.JdbcConfig;
+import javax.annotation.Nullable;
 
 public class JdbcTransactionProvider implements DistributedTransactionProvider {
   @Override
@@ -24,10 +24,10 @@ public class JdbcTransactionProvider implements DistributedTransactionProvider {
     return new JdbcTransactionAdmin(config);
   }
 
+  @Nullable
   @Override
   public TwoPhaseCommitTransactionManager createTwoPhaseCommitTransactionManager(
       DatabaseConfig config) {
-    throw new UnsupportedOperationException(
-        CoreError.JDBC_TRANSACTION_TWO_PHASE_COMMIT_NOT_SUPPORTED.buildMessage());
+    return null;
   }
 }

--- a/core/src/main/resources/META-INF/services/com.scalar.db.api.DistributedTransactionProvider
+++ b/core/src/main/resources/META-INF/services/com.scalar.db.api.DistributedTransactionProvider
@@ -1,3 +1,4 @@
 com.scalar.db.transaction.consensuscommit.ConsensusCommitProvider
 com.scalar.db.transaction.jdbc.JdbcTransactionProvider
 com.scalar.db.transaction.rpc.GrpcTransactionProvider
+com.scalar.db.transaction.autocommit.AutoCommitTransactionProvider

--- a/core/src/test/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdminTest.java
@@ -1,0 +1,289 @@
+package com.scalar.db.transaction.autocommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AutoCommitTransactionAdminTest {
+
+  @Mock private DistributedStorageAdmin distributedStorageAdmin;
+  private AutoCommitTransactionAdmin admin;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    admin = new AutoCommitTransactionAdmin(distributedStorageAdmin);
+  }
+
+  @Test
+  public void createNamespace_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.createNamespace("ns", Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).createNamespace("ns", Collections.emptyMap());
+  }
+
+  @Test
+  public void createTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
+
+    // Act
+    admin.createTable("ns", "tbl", metadata, Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).createTable("ns", "tbl", metadata, Collections.emptyMap());
+  }
+
+  @Test
+  public void dropTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropTable("ns", "tbl");
+
+    // Assert
+    verify(distributedStorageAdmin).dropTable("ns", "tbl");
+  }
+
+  @Test
+  public void dropNamespace_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropNamespace("ns");
+
+    // Assert
+    verify(distributedStorageAdmin).dropNamespace("ns");
+  }
+
+  @Test
+  public void truncateTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.truncateTable("ns", "tbl");
+
+    // Assert
+    verify(distributedStorageAdmin).truncateTable("ns", "tbl");
+  }
+
+  @Test
+  public void createIndex_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.createIndex("ns", "tbl", "col", Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).createIndex("ns", "tbl", "col", Collections.emptyMap());
+  }
+
+  @Test
+  public void dropIndex_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+
+    // Act
+    admin.dropIndex("ns", "tbl", "col");
+
+    // Assert
+    verify(distributedStorageAdmin).dropIndex("ns", "tbl", "col");
+  }
+
+  @Test
+  public void getTableMetadata_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
+    when(distributedStorageAdmin.getTableMetadata(any(), any())).thenReturn(metadata);
+
+    // Act
+    TableMetadata actual = admin.getTableMetadata("ns", "tbl");
+
+    // Assert
+    verify(distributedStorageAdmin).getTableMetadata("ns", "tbl");
+    assertThat(actual).isEqualTo(metadata);
+  }
+
+  @Test
+  public void getNamespaceTableNames_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    Set<String> tableNames = ImmutableSet.of("tbl1", "tbl2", "tbl3");
+    when(distributedStorageAdmin.getNamespaceTableNames(any())).thenReturn(tableNames);
+
+    // Act
+    Set<String> actual = admin.getNamespaceTableNames("ns");
+
+    // Assert
+    verify(distributedStorageAdmin).getNamespaceTableNames("ns");
+    assertThat(actual).isEqualTo(tableNames);
+  }
+
+  @Test
+  public void namespaceExists_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.namespaceExists(any())).thenReturn(true);
+
+    // Act
+    boolean actual = admin.namespaceExists("ns");
+
+    // Assert
+    verify(distributedStorageAdmin).namespaceExists("ns");
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void createCoordinatorTables_ShouldDoNothing() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.createCoordinatorTables(Collections.emptyMap()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void dropCoordinatorTables_ShouldDoNothing() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.dropCoordinatorTables()).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void truncateCoordinatorTables_ShouldDoNothing() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> admin.truncateCoordinatorTables()).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void coordinatorTablesExist_ShouldReturnTrue() {
+    // Arrange
+
+    // Act
+    boolean actual = admin.coordinatorTablesExist();
+
+    // Assert
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void repairTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    TableMetadata metadata =
+        TableMetadata.newBuilder().addColumn("c1", DataType.INT).addPartitionKey("c1").build();
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    admin.repairTable(namespace, table, metadata, options);
+
+    // Assert
+    verify(distributedStorageAdmin).repairTable(namespace, table, metadata, options);
+  }
+
+  @Test
+  public void repairCoordinatorTables_ShouldDoNothing() {
+    // Arrange
+
+    // Act
+    assertThatCode(() -> admin.repairCoordinatorTables(Collections.emptyMap()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void addNewColumnToTable_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+    String column = "c1";
+    DataType dataType = DataType.TEXT;
+
+    // Act
+    admin.addNewColumnToTable(namespace, table, column, dataType);
+
+    // Assert
+    verify(distributedStorageAdmin).addNewColumnToTable(namespace, table, column, dataType);
+  }
+
+  @Test
+  public void importTable_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    String table = "tbl";
+
+    // Act
+    admin.importTable(namespace, table, Collections.emptyMap());
+
+    // Assert
+    verify(distributedStorageAdmin).importTable(namespace, table, Collections.emptyMap());
+  }
+
+  @Test
+  public void getNamespaceNames_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    Set<String> namespaceNames = ImmutableSet.of("n1", "n2");
+    when(distributedStorageAdmin.getNamespaceNames()).thenReturn(namespaceNames);
+
+    // Act
+    Set<String> actualNamespaces = admin.getNamespaceNames();
+
+    // Assert
+    verify(distributedStorageAdmin).getNamespaceNames();
+    assertThat(actualNamespaces).containsOnly("n1", "n2");
+  }
+
+  @Test
+  public void repairNamespace_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    admin.repairNamespace(namespace, options);
+
+    // Assert
+    verify(distributedStorageAdmin).repairNamespace(namespace, options);
+  }
+
+  @Test
+  public void upgrade_ShouldCallDistributedStorageAdminProperly() throws ExecutionException {
+    // Arrange
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    admin.upgrade(options);
+
+    // Assert
+    verify(distributedStorageAdmin).upgrade(options);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionManagerTest.java
@@ -1,0 +1,67 @@
+package com.scalar.db.transaction.autocommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.common.DecoratedDistributedTransaction;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.transaction.TransactionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AutoCommitTransactionManagerTest {
+
+  @Mock private DistributedStorage storage;
+  @Mock private DatabaseConfig databaseConfig;
+
+  private AutoCommitTransactionManager transactionManager;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    transactionManager = new AutoCommitTransactionManager(databaseConfig, storage);
+  }
+
+  @Test
+  public void begin_ShouldReturnAutoCommitTransaction() throws TransactionException {
+    // Arrange
+
+    // Act
+    DistributedTransaction transaction = transactionManager.begin();
+
+    // Assert
+    assertThat(transaction.getId()).isNotNull();
+
+    assertThat(transaction).isInstanceOf(DecoratedDistributedTransaction.class);
+    DecoratedDistributedTransaction decoratedTransaction =
+        (DecoratedDistributedTransaction) transaction;
+    assertThat(decoratedTransaction.getOriginalTransaction())
+        .isInstanceOf(AutoCommitTransaction.class);
+    assertThat(((AutoCommitTransaction) decoratedTransaction.getOriginalTransaction()).getStorage())
+        .isEqualTo(storage);
+  }
+
+  @Test
+  public void begin_WithTransactionId_ShouldReturnAutoCommitTransaction()
+      throws TransactionException {
+    // Arrange
+    String transactionId = "id";
+
+    // Act
+    DistributedTransaction transaction = transactionManager.begin(transactionId);
+
+    // Assert
+    assertThat(transaction.getId()).isEqualTo(transactionId);
+
+    assertThat(transaction).isInstanceOf(DecoratedDistributedTransaction.class);
+    DecoratedDistributedTransaction decoratedTransaction =
+        (DecoratedDistributedTransaction) transaction;
+    assertThat(decoratedTransaction.getOriginalTransaction())
+        .isInstanceOf(AutoCommitTransaction.class);
+    assertThat(((AutoCommitTransaction) decoratedTransaction.getOriginalTransaction()).getStorage())
+        .isEqualTo(storage);
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionTest.java
@@ -1,0 +1,331 @@
+package com.scalar.db.transaction.autocommit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scanner;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AutoCommitTransactionTest {
+
+  private static final String TRANSACTION_ID = "id";
+
+  @Mock private DistributedStorage storage;
+
+  private AutoCommitTransaction transaction;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    transaction = new AutoCommitTransaction(TRANSACTION_ID, storage);
+  }
+
+  @Test
+  public void getId_ShouldReturnTransactionId() {
+    // Arrange
+
+    // Act
+    String id = transaction.getId();
+
+    // Assert
+    assertThat(id).isEqualTo(TRANSACTION_ID);
+  }
+
+  @Test
+  public void get_ShouldReturnResult() throws ExecutionException, CrudException {
+    // Arrange
+    Get get =
+        Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Get getWithLinearizableConsistency =
+        Get.newBuilder(get).consistency(com.scalar.db.api.Consistency.LINEARIZABLE).build();
+
+    Result result = mock(Result.class);
+    when(storage.get(getWithLinearizableConsistency)).thenReturn(Optional.of(result));
+
+    // Act
+    Optional<Result> actual = transaction.get(get);
+
+    // Assert
+    verify(storage).get(getWithLinearizableConsistency);
+    assertThat(actual).isEqualTo(Optional.of(result));
+  }
+
+  @Test
+  public void get_ExecutionExceptionThrownByStorage_ShouldThrowCrudException()
+      throws ExecutionException {
+    // Arrange
+    Get get =
+        Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Get getWithLinearizableConsistency =
+        Get.newBuilder(get).consistency(Consistency.LINEARIZABLE).build();
+
+    ExecutionException exception = new ExecutionException("error");
+    when(storage.get(getWithLinearizableConsistency)).thenThrow(exception);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.get(get))
+        .isInstanceOf(CrudException.class)
+        .hasMessageContaining("error")
+        .hasCause(exception);
+  }
+
+  @Test
+  public void scan_ShouldReturnResults() throws ExecutionException, CrudException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Scan scanWithLinearizableConsistency =
+        Scan.newBuilder(scan).consistency(Consistency.LINEARIZABLE).build();
+
+    List<Result> results = Arrays.asList(mock(Result.class), mock(Result.class));
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.all()).thenReturn(results);
+    when(storage.scan(scanWithLinearizableConsistency)).thenReturn(scanner);
+
+    // Act
+    List<Result> actual = transaction.scan(scan);
+
+    // Assert
+    verify(storage).scan(scanWithLinearizableConsistency);
+    assertThat(actual).isEqualTo(results);
+  }
+
+  @Test
+  public void scan_ExecutionExceptionThrownByStorage_ShouldThrowCrudException()
+      throws ExecutionException {
+    // Arrange
+    Scan scan =
+        Scan.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Scan scanWithLinearizableConsistency =
+        Scan.newBuilder(scan).consistency(Consistency.LINEARIZABLE).build();
+
+    ExecutionException exception = new ExecutionException("error");
+    when(storage.scan(scanWithLinearizableConsistency)).thenThrow(exception);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.scan(scan))
+        .isInstanceOf(CrudException.class)
+        .hasMessageContaining("error")
+        .hasCause(exception);
+  }
+
+  @Test
+  public void put_ShouldCallStorageProperly() throws ExecutionException, CrudException {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("id", 0))
+            .intValue("col", 0)
+            .build();
+    Put putWithLinearizableConsistency =
+        Put.newBuilder(put).consistency(Consistency.LINEARIZABLE).build();
+
+    // Act
+    transaction.put(put);
+
+    // Assert
+    verify(storage).put(putWithLinearizableConsistency);
+  }
+
+  @Test
+  public void put_ExecutionExceptionThrownByStorage_ShouldThrowCrudException()
+      throws ExecutionException {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("id", 0))
+            .intValue("col", 0)
+            .build();
+    Put putWithLinearizableConsistency =
+        Put.newBuilder(put).consistency(Consistency.LINEARIZABLE).build();
+
+    ExecutionException exception = new ExecutionException("error");
+    doThrow(exception).when(storage).put(putWithLinearizableConsistency);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.put(put))
+        .isInstanceOf(CrudException.class)
+        .hasMessageContaining("error")
+        .hasCause(exception);
+  }
+
+  @Test
+  public void put_NoMutationExceptionThrownByStorage_ShouldThrowUnsatisfiedConditionException()
+      throws ExecutionException {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("id", 0))
+            .intValue("col", 0)
+            .build();
+    Put putWithLinearizableConsistency =
+        Put.newBuilder(put).consistency(Consistency.LINEARIZABLE).build();
+
+    NoMutationException exception = new NoMutationException("error");
+    doThrow(exception).when(storage).put(putWithLinearizableConsistency);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.put(put))
+        .isInstanceOf(UnsatisfiedConditionException.class)
+        .hasMessageContaining("error")
+        .hasCause(exception);
+  }
+
+  @Test
+  public void put_MultiplePutGiven_ShouldCallStorageProperly()
+      throws ExecutionException, CrudException {
+    // Arrange
+    Put put1 =
+        Put.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("id", 0))
+            .intValue("col", 0)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("id", 1))
+            .intValue("col", 1)
+            .build();
+    Put put1WithLinearizableConsistency =
+        Put.newBuilder(put1).consistency(Consistency.LINEARIZABLE).build();
+    Put put2WithLinearizableConsistency =
+        Put.newBuilder(put2).consistency(Consistency.LINEARIZABLE).build();
+
+    // Act
+    transaction.put(Arrays.asList(put1, put2));
+
+    // Assert
+    verify(storage).put(put1WithLinearizableConsistency);
+    verify(storage).put(put2WithLinearizableConsistency);
+  }
+
+  @Test
+  public void delete_ShouldCallStorageProperly() throws ExecutionException, CrudException {
+    // Arrange
+    Delete delete =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Delete deleteWithLinearizableConsistency =
+        Delete.newBuilder(delete).consistency(Consistency.LINEARIZABLE).build();
+
+    // Act
+    transaction.delete(delete);
+
+    // Assert
+    verify(storage).delete(deleteWithLinearizableConsistency);
+  }
+
+  @Test
+  public void delete_ExecutionExceptionThrownByStorage_ShouldThrowCrudException()
+      throws ExecutionException {
+    // Arrange
+    Delete delete =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Delete deleteWithLinearizableConsistency =
+        Delete.newBuilder(delete).consistency(Consistency.LINEARIZABLE).build();
+
+    ExecutionException exception = new ExecutionException("error");
+    doThrow(exception).when(storage).delete(deleteWithLinearizableConsistency);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.delete(delete))
+        .isInstanceOf(CrudException.class)
+        .hasMessageContaining("error")
+        .hasCause(exception);
+  }
+
+  @Test
+  public void delete_NoMutationExceptionThrownByStorage_ShouldThrowUnsatisfiedConditionException()
+      throws ExecutionException {
+    // Arrange
+    Delete delete =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Delete deleteWithLinearizableConsistency =
+        Delete.newBuilder(delete).consistency(Consistency.LINEARIZABLE).build();
+
+    NoMutationException exception = new NoMutationException("error");
+    doThrow(exception).when(storage).delete(deleteWithLinearizableConsistency);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.delete(delete))
+        .isInstanceOf(UnsatisfiedConditionException.class)
+        .hasMessageContaining("error")
+        .hasCause(exception);
+  }
+
+  @Test
+  public void delete_MultipleDeleteGiven_ShouldCallStorageProperly()
+      throws ExecutionException, CrudException {
+    // Arrange
+    Delete delete1 =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Delete delete2 =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 1)).build();
+    Delete delete1WithLinearizableConsistency =
+        Delete.newBuilder(delete1).consistency(Consistency.LINEARIZABLE).build();
+    Delete delete2WithLinearizableConsistency =
+        Delete.newBuilder(delete2).consistency(Consistency.LINEARIZABLE).build();
+
+    // Act
+    transaction.delete(Arrays.asList(delete1, delete2));
+
+    // Assert
+    verify(storage).delete(delete1WithLinearizableConsistency);
+    verify(storage).delete(delete2WithLinearizableConsistency);
+  }
+
+  @Test
+  public void mutate_ShouldCallStorageProperly() throws ExecutionException, CrudException {
+    // Arrange
+    Put put =
+        Put.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofInt("id", 0))
+            .intValue("col", 0)
+            .build();
+    Put putWithLinearizableConsistency =
+        Put.newBuilder(put).consistency(Consistency.LINEARIZABLE).build();
+    Delete delete =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("id", 0)).build();
+    Delete deleteWithLinearizableConsistency =
+        Delete.newBuilder(delete).consistency(Consistency.LINEARIZABLE).build();
+
+    // Act
+    transaction.mutate(Arrays.asList(put, delete));
+
+    // Assert
+    verify(storage).put(putWithLinearizableConsistency);
+    verify(storage).delete(deleteWithLinearizableConsistency);
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1045,6 +1045,25 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @Test
+  public void put_withPutIfIsNullWhenRecordDoesNotExist_shouldThrowNoMutationException()
+      throws ExecutionException {
+    // Arrange
+    Put putIf =
+        Put.newBuilder(preparePuts().get(0))
+            .intValue(COL_NAME3, 100)
+            .condition(
+                ConditionBuilder.putIf(ConditionBuilder.column(COL_NAME3).isNullInt()).build())
+            .enableImplicitPreRead()
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> storage.put(putIf)).isInstanceOf(NoMutationException.class);
+
+    Optional<Result> result = storage.get(prepareGet(0, 0));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
   public void delete_DeleteWithPartitionKeyAndClusteringKeyGiven_ShouldDeleteSingleRecordProperly()
       throws IOException, ExecutionException {
     // Arrange

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -1238,7 +1238,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
-  public void put_withPutIfWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException()
+  public void put_withPutIfIsNullWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException()
       throws TransactionException {
     // Arrange
     Put putIf =

--- a/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdminIntegrationTestBase.java
@@ -24,7 +24,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
 
   // Disable several tests for the coordinator tables since auto-commit transaction doesn't have
   // coordinator tables
-  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Disabled("Auto-commit transactions don't have Coordinator tables")
   @Test
   @Override
   public void createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly()
@@ -32,7 +32,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
     super.createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly();
   }
 
-  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Disabled("Auto-commit transactions don't have Coordinator tables")
   @Test
   @Override
   public void
@@ -41,7 +41,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
         .createCoordinatorTables_CoordinatorTablesAlreadyExist_ShouldThrowIllegalArgumentException();
   }
 
-  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Disabled("Auto-commit transactions don't have Coordinator tables")
   @Test
   @Override
   public void
@@ -50,7 +50,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
         .createCoordinatorTables_IfNotExist_CoordinatorTablesAlreadyExist_ShouldNotThrowAnyException();
   }
 
-  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Disabled("Auto-commit transactions don't have Coordinator tables")
   @Test
   @Override
   public void dropCoordinatorTables_ShouldDropCoordinatorTablesCorrectly()
@@ -58,7 +58,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
     super.dropCoordinatorTables_ShouldDropCoordinatorTablesCorrectly();
   }
 
-  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Disabled("Auto-commit transactions don't have Coordinator tables")
   @Test
   @Override
   public void
@@ -67,7 +67,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
     super.dropCoordinatorTables_CoordinatorTablesDoNotExist_ShouldThrowIllegalArgumentException();
   }
 
-  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Disabled("Auto-commit transactions don't have Coordinator tables")
   @Test
   @Override
   public void dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException()
@@ -76,7 +76,7 @@ public abstract class AutoCommitTransactionAdminIntegrationTestBase
   }
 
   @Test
-  @Disabled("We don't test this case for auto-commit transaction")
+  @Disabled("This case is not tested for auto-commit transactions")
   @Override
   public void
       upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}

--- a/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionAdminIntegrationTestBase.java
@@ -1,0 +1,88 @@
+package com.scalar.db.transaction.autocommit;
+
+import com.scalar.db.api.DistributedTransactionAdminIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.util.AdminTestUtils;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public abstract class AutoCommitTransactionAdminIntegrationTestBase
+    extends DistributedTransactionAdminIntegrationTestBase {
+
+  @Override
+  protected final Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(getProps(testName));
+    properties.setProperty(
+        DatabaseConfig.TRANSACTION_MANAGER, AutoCommitTransactionConfig.TRANSACTION_MANAGER_NAME);
+    return properties;
+  }
+
+  protected abstract Properties getProps(String testName);
+
+  // Disable several tests for the coordinator tables since auto-commit transaction doesn't have
+  // coordinator tables
+  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Test
+  @Override
+  public void createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly()
+      throws ExecutionException {
+    super.createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly();
+  }
+
+  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Test
+  @Override
+  public void
+      createCoordinatorTables_CoordinatorTablesAlreadyExist_ShouldThrowIllegalArgumentException() {
+    super
+        .createCoordinatorTables_CoordinatorTablesAlreadyExist_ShouldThrowIllegalArgumentException();
+  }
+
+  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Test
+  @Override
+  public void
+      createCoordinatorTables_IfNotExist_CoordinatorTablesAlreadyExist_ShouldNotThrowAnyException() {
+    super
+        .createCoordinatorTables_IfNotExist_CoordinatorTablesAlreadyExist_ShouldNotThrowAnyException();
+  }
+
+  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Test
+  @Override
+  public void dropCoordinatorTables_ShouldDropCoordinatorTablesCorrectly()
+      throws ExecutionException {
+    super.dropCoordinatorTables_ShouldDropCoordinatorTablesCorrectly();
+  }
+
+  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Test
+  @Override
+  public void
+      dropCoordinatorTables_CoordinatorTablesDoNotExist_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    super.dropCoordinatorTables_CoordinatorTablesDoNotExist_ShouldThrowIllegalArgumentException();
+  }
+
+  @Disabled("auto-commit transaction doesn't have coordinator tables")
+  @Test
+  @Override
+  public void dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException()
+      throws ExecutionException {
+    super.dropCoordinatorTables_IfExist_CoordinatorTablesDoNotExist_ShouldNotThrowAnyException();
+  }
+
+  @Test
+  @Disabled("We don't test this case for auto-commit transaction")
+  @Override
+  public void
+      upgrade_WhenMetadataTableExistsButNotNamespacesTable_ShouldCreateNamespacesTableAndImportExistingNamespaces() {}
+
+  @Override
+  protected AdminTestUtils getAdminTestUtils(String testName) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionIntegrationTestBase.java
@@ -24,40 +24,40 @@ public abstract class AutoCommitTransactionIntegrationTestBase
 
   protected abstract Properties getProps(String testName);
 
-  @Disabled("auto-commit transaction doesn't support getState()")
+  @Disabled("Auto-commit transactions don't support getState()")
   @Override
   public void getState_forSuccessfulTransaction_ShouldReturnCommittedState() {}
 
-  @Disabled("auto-commit transaction doesn't support getState()")
+  @Disabled("Auto-commit transactions don't support getState()")
   @Override
   public void getState_forFailedTransaction_ShouldReturnAbortedState() {}
 
-  @Disabled("auto-commit transaction doesn't support abort()")
+  @Disabled("Auto-commit transactions don't support abort()")
   @Override
   public void abort_forOngoingTransaction_ShouldAbortCorrectly() {}
 
-  @Disabled("auto-commit transaction doesn't support rollback()")
+  @Disabled("Auto-commit transactions don't support rollback()")
   @Override
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
 
-  @Disabled("auto-commit transaction doesn't support implicit pre-read")
+  @Disabled("Auto-commit transactions don't support implicit pre-read")
   @Override
   public void
       putAndCommit_PutWithImplicitPreReadDisabledGivenForExisting_ShouldThrowCommitConflictException() {}
 
-  @Disabled("auto-commit transaction doesn't support transaction abort")
+  @Disabled("Auto-commit transactions don't support aborting transactions")
   @Override
   public void putAndAbort_ShouldNotCreateRecord() {}
 
-  @Disabled("auto-commit transaction doesn't support transaction rollback")
+  @Disabled("Auto-commit transactions don't support rolling back transactions")
   @Override
   public void putAndRollback_ShouldNotCreateRecord() {}
 
-  @Disabled("auto-commit transaction doesn't support transaction abort")
+  @Disabled("Auto-commit transactions don't support aborting transactions")
   @Override
   public void deleteAndAbort_ShouldNotDeleteRecord() {}
 
-  @Disabled("auto-commit transaction doesn't support transaction rollback")
+  @Disabled("Auto-commit transactions don't support rolling back transactions")
   @Override
   public void deleteAndRollback_ShouldNotDeleteRecord() {}
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/autocommit/AutoCommitTransactionIntegrationTestBase.java
@@ -1,0 +1,63 @@
+package com.scalar.db.transaction.autocommit;
+
+import com.scalar.db.api.DistributedTransactionIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+
+public abstract class AutoCommitTransactionIntegrationTestBase
+    extends DistributedTransactionIntegrationTestBase {
+
+  @Override
+  protected String getTestName() {
+    return "tx_at";
+  }
+
+  @Override
+  protected final Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.putAll(getProps(testName));
+    properties.setProperty(
+        DatabaseConfig.TRANSACTION_MANAGER, AutoCommitTransactionConfig.TRANSACTION_MANAGER_NAME);
+    return properties;
+  }
+
+  protected abstract Properties getProps(String testName);
+
+  @Disabled("auto-commit transaction doesn't support getState()")
+  @Override
+  public void getState_forSuccessfulTransaction_ShouldReturnCommittedState() {}
+
+  @Disabled("auto-commit transaction doesn't support getState()")
+  @Override
+  public void getState_forFailedTransaction_ShouldReturnAbortedState() {}
+
+  @Disabled("auto-commit transaction doesn't support abort()")
+  @Override
+  public void abort_forOngoingTransaction_ShouldAbortCorrectly() {}
+
+  @Disabled("auto-commit transaction doesn't support rollback()")
+  @Override
+  public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
+
+  @Disabled("auto-commit transaction doesn't support implicit pre-read")
+  @Override
+  public void
+      putAndCommit_PutWithImplicitPreReadDisabledGivenForExisting_ShouldThrowCommitConflictException() {}
+
+  @Disabled("auto-commit transaction doesn't support transaction abort")
+  @Override
+  public void putAndAbort_ShouldNotCreateRecord() {}
+
+  @Disabled("auto-commit transaction doesn't support transaction rollback")
+  @Override
+  public void putAndRollback_ShouldNotCreateRecord() {}
+
+  @Disabled("auto-commit transaction doesn't support transaction abort")
+  @Override
+  public void deleteAndAbort_ShouldNotDeleteRecord() {}
+
+  @Disabled("auto-commit transaction doesn't support transaction rollback")
+  @Override
+  public void deleteAndRollback_ShouldNotDeleteRecord() {}
+}


### PR DESCRIPTION
## Description

This PR introduces the auto-commit transaction manager, which delegates operations (Get, Scan, Put, and Delete) to the storage API. Users can utilize the auto-commit transaction manager by specifying `scalar.db.transaction_manager` as `auto-commit`.

The auto-commit transaction manager basically passes operations to the storage API. As a result, the operations are not executed transactionally. In fact, it does nothing when `commit()` and `rollback()` are invoked.

## Related issues and/or PRs

N/A

## Changes made

- Added the auto-commit transaction manager implementation and unit tests for it.
- Added integration tests for it.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Introduced the auto-commit transaction manager, which delegates operations (Get, Scan, Put, and Delete) to the storage API. Users can utilize the auto-commit transaction manager by specifying `scalar.db.transaction_manager` as `auto-commit`.
