### PR TITLE
Remove the CI trigger for branch pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-      - "[0-9]+"
-      - "[0-9]+.[0-9]+"
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
 
 env:
   TERM: dumb


### PR DESCRIPTION
## Description

To reduce the CI time, we will implement the following measures:

1. Remove the CI trigger for branch pushes.
2. Enable "Require branches to be up to date before merging" in GitHub branch protection rules.

After implementing these changes, we need to ensure that a branch for a PR is up to date and run CI for it before merging it (2). As a result, CI does not need to be run after merging into the main branch, support branches, or release branches (1).

This PR does the step 1.

## Related issues and/or PRs

N/A

## Changes made

- Removed the CI trigger for branch pushes.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
