### PR TITLE
Backport to branch(3.9) : Remove the CI trigger for branch pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-      - "[0-9]+"
-      - "[0-9]+.[0-9]+"
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
 
 env:
   TERM: dumb


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1620