### PR TITLE
Extract ScalarDbUtils.isMutationSetOverlappedWith()

### DIFF
--- a/core/src/main/java/com/scalar/db/common/PrimaryKey.java
+++ b/core/src/main/java/com/scalar/db/common/PrimaryKey.java
@@ -1,0 +1,107 @@
+package com.scalar.db.common;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ComparisonChain;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.Key;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+
+public class PrimaryKey implements Comparable<PrimaryKey> {
+
+  private final String namespaceName;
+  private final String tableName;
+  private final Key partitionKey;
+  private final Optional<Key> clusteringKey;
+
+  public PrimaryKey(Get get) {
+    this((Operation) get);
+  }
+
+  public PrimaryKey(Put put) {
+    this((Operation) put);
+  }
+
+  public PrimaryKey(Delete delete) {
+    this((Operation) delete);
+  }
+
+  public PrimaryKey(Scan scan, Result result) {
+    this.namespaceName = scan.forNamespace().get();
+    this.tableName = scan.forTable().get();
+    this.partitionKey = result.getPartitionKey().get();
+    this.clusteringKey = result.getClusteringKey();
+  }
+
+  private PrimaryKey(Operation operation) {
+    namespaceName = operation.forNamespace().get();
+    tableName = operation.forTable().get();
+    partitionKey = operation.getPartitionKey();
+    clusteringKey = operation.getClusteringKey();
+  }
+
+  public String getNamespaceName() {
+    return namespaceName;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public Key getPartitionKey() {
+    return partitionKey;
+  }
+
+  public Optional<Key> getClusteringKey() {
+    return clusteringKey;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespaceName, tableName, partitionKey, clusteringKey);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof PrimaryKey)) {
+      return false;
+    }
+    PrimaryKey another = (PrimaryKey) o;
+    return this.namespaceName.equals(another.namespaceName)
+        && this.tableName.equals(another.tableName)
+        && this.partitionKey.equals(another.partitionKey)
+        && this.clusteringKey.equals(another.clusteringKey);
+  }
+
+  @Override
+  public int compareTo(PrimaryKey o) {
+    return ComparisonChain.start()
+        .compare(this.namespaceName, o.namespaceName)
+        .compare(this.tableName, o.tableName)
+        .compare(this.partitionKey, o.partitionKey)
+        .compare(
+            this.clusteringKey.orElse(null),
+            o.clusteringKey.orElse(null),
+            Comparator.nullsFirst(Comparator.naturalOrder()))
+        .result();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespaceName", namespaceName)
+        .add("tableName", tableName)
+        .add("partitionKey", partitionKey)
+        .add("clusteringKey", clusteringKey)
+        .toString();
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/MergedResult.java
@@ -11,6 +11,7 @@ import com.scalar.db.io.Column;
 import com.scalar.db.io.DoubleColumn;
 import com.scalar.db.io.FloatColumn;
 import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -44,14 +45,14 @@ public class MergedResult extends AbstractResult {
   /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
   @Deprecated
   @Override
-  public Optional<com.scalar.db.io.Key> getPartitionKey() {
+  public Optional<Key> getPartitionKey() {
     return Optional.of(put.getPartitionKey());
   }
 
   /** @deprecated As of release 3.8.0. Will be removed in release 5.0.0 */
   @Deprecated
   @Override
-  public Optional<com.scalar.db.io.Key> getClusteringKey() {
+  public Optional<Key> getClusteringKey() {
     return put.getClusteringKey();
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -1,34 +1,25 @@
 package com.scalar.db.transaction.consensuscommit;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ComparisonChain;
-import com.scalar.db.api.ConditionalExpression;
-import com.scalar.db.api.ConditionalExpression.Operator;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.LikeExpression;
-import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scan.Conjunction;
-import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.PrimaryKey;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
-import com.scalar.db.io.Column;
 import com.scalar.db.transaction.consensuscommit.ParallelExecutor.ParallelExecutorTask;
 import com.scalar.db.util.ScalarDbUtils;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -39,10 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,10 +43,10 @@ public class Snapshot {
   private final SerializableStrategy strategy;
   private final TransactionTableMetadataManager tableMetadataManager;
   private final ParallelExecutor parallelExecutor;
-  private final ConcurrentMap<Key, Optional<TransactionResult>> readSet;
-  private final Map<Scan, List<Key>> scanSet;
-  private final Map<Key, Put> writeSet;
-  private final Map<Key, Delete> deleteSet;
+  private final ConcurrentMap<PrimaryKey, Optional<TransactionResult>> readSet;
+  private final Map<Scan, List<PrimaryKey>> scanSet;
+  private final Map<PrimaryKey, Put> writeSet;
+  private final Map<PrimaryKey, Delete> deleteSet;
 
   public Snapshot(
       String id,
@@ -84,10 +72,10 @@ public class Snapshot {
       SerializableStrategy strategy,
       TransactionTableMetadataManager tableMetadataManager,
       ParallelExecutor parallelExecutor,
-      ConcurrentMap<Key, Optional<TransactionResult>> readSet,
-      Map<Scan, List<Key>> scanSet,
-      Map<Key, Put> writeSet,
-      Map<Key, Delete> deleteSet) {
+      ConcurrentMap<PrimaryKey, Optional<TransactionResult>> readSet,
+      Map<Scan, List<PrimaryKey>> scanSet,
+      Map<PrimaryKey, Put> writeSet,
+      Map<PrimaryKey, Delete> deleteSet) {
     this.id = id;
     this.isolation = isolation;
     this.strategy = strategy;
@@ -112,15 +100,15 @@ public class Snapshot {
 
   // Although this class is not thread-safe, this method is actually thread-safe because the readSet
   // is a concurrent map
-  public void put(Key key, Optional<TransactionResult> result) {
+  public void put(PrimaryKey key, Optional<TransactionResult> result) {
     readSet.put(key, result);
   }
 
-  public void put(Scan scan, List<Key> keys) {
+  public void put(Scan scan, List<PrimaryKey> keys) {
     scanSet.put(scan, keys);
   }
 
-  public void put(Key key, Put put) {
+  public void put(PrimaryKey key, Put put) {
     if (deleteSet.containsKey(key)) {
       throw new IllegalArgumentException(
           CoreError.CONSENSUS_COMMIT_WRITING_ALREADY_DELETED_DATA_NOT_ALLOWED.buildMessage());
@@ -134,16 +122,16 @@ public class Snapshot {
     }
   }
 
-  public void put(Key key, Delete delete) {
+  public void put(PrimaryKey key, Delete delete) {
     writeSet.remove(key);
     deleteSet.put(key, delete);
   }
 
-  public boolean containsKeyInReadSet(Key key) {
+  public boolean containsKeyInReadSet(PrimaryKey key) {
     return readSet.containsKey(key);
   }
 
-  public Optional<TransactionResult> getFromReadSet(Key key) {
+  public Optional<TransactionResult> getFromReadSet(PrimaryKey key) {
     return readSet.getOrDefault(key, Optional.empty());
   }
 
@@ -155,7 +143,7 @@ public class Snapshot {
     return new ArrayList<>(deleteSet.values());
   }
 
-  public Optional<TransactionResult> get(Key key) throws CrudException {
+  public Optional<TransactionResult> get(PrimaryKey key) throws CrudException {
     if (deleteSet.containsKey(key)) {
       return Optional.empty();
     } else if (readSet.containsKey(key)) {
@@ -173,14 +161,15 @@ public class Snapshot {
             .buildMessage());
   }
 
-  private TableMetadata getTableMetadata(Key key) throws CrudException {
+  private TableMetadata getTableMetadata(PrimaryKey key) throws CrudException {
     try {
       TransactionTableMetadata metadata =
-          tableMetadataManager.getTransactionTableMetadata(key.getNamespace(), key.getTable());
+          tableMetadataManager.getTransactionTableMetadata(
+              key.getNamespaceName(), key.getTableName());
       if (metadata == null) {
         throw new IllegalArgumentException(
             CoreError.TABLE_NOT_FOUND.buildMessage(
-                ScalarDbUtils.getFullTableName(key.getNamespace(), key.getTable())));
+                ScalarDbUtils.getFullTableName(key.getNamespaceName(), key.getTableName())));
       }
       return metadata.getTableMetadata();
     } catch (ExecutionException e) {
@@ -197,7 +186,7 @@ public class Snapshot {
     return metadata.getTableMetadata();
   }
 
-  public Optional<List<Key>> get(Scan scan) {
+  public Optional<List<PrimaryKey>> get(Scan scan) {
     if (scanSet.containsKey(scan)) {
       return Optional.ofNullable(scanSet.get(scan));
     }
@@ -205,7 +194,7 @@ public class Snapshot {
   }
 
   public void verify(Scan scan) {
-    if (isWriteSetOverlappedWith(scan)) {
+    if (ScalarDbUtils.isMutationSetOverlappedWith(scan, scanSet.get(scan), writeSet)) {
       throw new IllegalArgumentException(
           CoreError.CONSENSUS_COMMIT_READING_ALREADY_WRITTEN_DATA_NOT_ALLOWED.buildMessage());
     }
@@ -215,154 +204,15 @@ public class Snapshot {
       throws ExecutionException, PreparationConflictException {
     toSerializableWithExtraWrite(composer);
 
-    for (Entry<Key, Put> entry : writeSet.entrySet()) {
+    for (Entry<PrimaryKey, Put> entry : writeSet.entrySet()) {
       TransactionResult result =
           readSet.containsKey(entry.getKey()) ? readSet.get(entry.getKey()).orElse(null) : null;
       composer.add(entry.getValue(), result);
     }
-    for (Entry<Key, Delete> entry : deleteSet.entrySet()) {
+    for (Entry<PrimaryKey, Delete> entry : deleteSet.entrySet()) {
       TransactionResult result =
           readSet.containsKey(entry.getKey()) ? readSet.get(entry.getKey()).orElse(null) : null;
       composer.add(entry.getValue(), result);
-    }
-  }
-
-  private boolean isWriteSetOverlappedWith(Scan scan) {
-    if (scan instanceof ScanAll) {
-      return isWriteSetOverlappedWith((ScanAll) scan);
-    }
-
-    for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
-      Put put = entry.getValue();
-
-      if (!put.forNamespace().equals(scan.forNamespace())
-          || !put.forTable().equals(scan.forTable())
-          || !put.getPartitionKey().equals(scan.getPartitionKey())) {
-        continue;
-      }
-
-      // If partition keys match and a primary key does not have a clustering key
-      if (!put.getClusteringKey().isPresent()) {
-        return true;
-      }
-
-      com.scalar.db.io.Key writtenKey = put.getClusteringKey().get();
-      boolean isStartGiven = scan.getStartClusteringKey().isPresent();
-      boolean isEndGiven = scan.getEndClusteringKey().isPresent();
-
-      // If no range is specified, which means it scans the whole partition space
-      if (!isStartGiven && !isEndGiven) {
-        return true;
-      }
-
-      if (isStartGiven && isEndGiven) {
-        com.scalar.db.io.Key startKey = scan.getStartClusteringKey().get();
-        com.scalar.db.io.Key endKey = scan.getEndClusteringKey().get();
-        // If startKey <= writtenKey <= endKey
-        if ((scan.getStartInclusive() && writtenKey.equals(startKey))
-            || (writtenKey.compareTo(startKey) > 0 && writtenKey.compareTo(endKey) < 0)
-            || (scan.getEndInclusive() && writtenKey.equals(endKey))) {
-          return true;
-        }
-      }
-
-      if (isStartGiven && !isEndGiven) {
-        com.scalar.db.io.Key startKey = scan.getStartClusteringKey().get();
-        // If startKey <= writtenKey
-        if ((scan.getStartInclusive() && startKey.equals(writtenKey))
-            || writtenKey.compareTo(startKey) > 0) {
-          return true;
-        }
-      }
-
-      if (!isStartGiven) {
-        com.scalar.db.io.Key endKey = scan.getEndClusteringKey().get();
-        // If writtenKey <= endKey
-        if ((scan.getEndInclusive() && writtenKey.equals(endKey))
-            || writtenKey.compareTo(endKey) < 0) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private boolean isWriteSetOverlappedWith(ScanAll scan) {
-    for (Map.Entry<Key, Put> entry : writeSet.entrySet()) {
-      // We need to consider three cases here to prevent scan-after-write.
-      //   1) A put operation overlaps the scan range regardless of the update (put) results.
-      //   2) A put operation does not overlap the scan range as a result of the update.
-      //   3) A put operation overlaps the scan range as a result of the update.
-      // See the following examples. Assume that we have a table with two columns whose names are
-      // "key" and "value" and two records in the table: (key=1, value=2) and (key=2, key=3).
-      // Case 2 covers a transaction that puts (1, 4) and then scans "where value < 3". In this
-      // case, there is no overlap, but we intentionally prohibit it due to the consistency and
-      // simplicity of snapshot management. We can find case 2 using the scan results.
-      // Case 3 covers a transaction that puts (2, 2) and then scans "where value < 3". In this
-      // case, we cannot find the overlap using the scan results since the database is not updated
-      // yet. Thus, we need to evaluate if the scan condition potentially matches put operations.
-
-      // Check for cases 1 and 2
-      if (scanSet.get(scan).contains(entry.getKey())) {
-        return true;
-      }
-
-      // Check for case 3
-      Put put = entry.getValue();
-      if (!put.forNamespace().equals(scan.forNamespace())
-          || !put.forTable().equals(scan.forTable())) {
-        continue;
-      }
-
-      if (scan.getConjunctions().isEmpty()) {
-        return true;
-      }
-
-      Map<String, Column<?>> columns = new HashMap<>(put.getColumns());
-      put.getPartitionKey().getColumns().forEach(column -> columns.put(column.getName(), column));
-      put.getClusteringKey()
-          .ifPresent(
-              key -> key.getColumns().forEach(column -> columns.put(column.getName(), column)));
-      for (Conjunction conjunction : scan.getConjunctions()) {
-        boolean allMatched = true;
-        for (ConditionalExpression condition : conjunction.getConditions()) {
-          if (!columns.containsKey(condition.getColumn().getName())
-              || !match(columns.get(condition.getColumn().getName()), condition)) {
-            allMatched = false;
-            break;
-          }
-        }
-        if (allMatched) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  @SuppressWarnings("unchecked")
-  private <T> boolean match(Column<T> column, ConditionalExpression condition) {
-    assert column.getClass() == condition.getColumn().getClass();
-    switch (condition.getOperator()) {
-      case EQ:
-      case IS_NULL:
-        return column.equals(condition.getColumn());
-      case NE:
-      case IS_NOT_NULL:
-        return !column.equals(condition.getColumn());
-      case GT:
-        return column.compareTo((Column<T>) condition.getColumn()) > 0;
-      case GTE:
-        return column.compareTo((Column<T>) condition.getColumn()) >= 0;
-      case LT:
-        return column.compareTo((Column<T>) condition.getColumn()) < 0;
-      case LTE:
-        return column.compareTo((Column<T>) condition.getColumn()) <= 0;
-      case LIKE:
-      case NOT_LIKE:
-        return isMatched((LikeExpression) condition, column.getTextValue());
-      default:
-        throw new AssertionError("Unknown operator: " + condition.getOperator());
     }
   }
 
@@ -373,8 +223,8 @@ public class Snapshot {
       return;
     }
 
-    for (Map.Entry<Key, Optional<TransactionResult>> entry : readSet.entrySet()) {
-      Key key = entry.getKey();
+    for (Map.Entry<PrimaryKey, Optional<TransactionResult>> entry : readSet.entrySet()) {
+      PrimaryKey key = entry.getKey();
       if (writeSet.containsKey(key) || deleteSet.containsKey(key)) {
         continue;
       }
@@ -385,8 +235,8 @@ public class Snapshot {
         Put put =
             new Put(key.getPartitionKey(), key.getClusteringKey().orElse(null))
                 .withConsistency(Consistency.LINEARIZABLE)
-                .forNamespace(key.getNamespace())
-                .forTable(key.getTable());
+                .forNamespace(key.getNamespaceName())
+                .forTable(key.getTableName());
         writeSet.put(entry.getKey(), put);
       } else {
         // For non-existing records, special care is needed to guarantee Serializable. The records
@@ -397,8 +247,8 @@ public class Snapshot {
         Get get =
             new Get(key.getPartitionKey(), key.getClusteringKey().orElse(null))
                 .withConsistency(Consistency.LINEARIZABLE)
-                .forNamespace(key.getNamespace())
-                .forTable(key.getTable());
+                .forNamespace(key.getNamespaceName())
+                .forTable(key.getTableName());
         composer.add(get, null);
       }
     }
@@ -419,11 +269,11 @@ public class Snapshot {
     List<ParallelExecutorTask> tasks = new ArrayList<>();
 
     // Read set by scan is re-validated to check if there is no anti-dependency
-    for (Map.Entry<Scan, List<Key>> entry : scanSet.entrySet()) {
+    for (Map.Entry<Scan, List<PrimaryKey>> entry : scanSet.entrySet()) {
       tasks.add(
           () -> {
-            Map<Key, TransactionResult> currentReadMap = new HashMap<>();
-            Set<Key> validatedReadSet = new HashSet<>();
+            Map<PrimaryKey, TransactionResult> currentReadMap = new HashMap<>();
+            Set<PrimaryKey> validatedReadSet = new HashSet<>();
             Scanner scanner = null;
             try {
               Scan scan = entry.getKey();
@@ -438,7 +288,7 @@ public class Snapshot {
                 if (transactionResult.getId() != null && transactionResult.getId().equals(id)) {
                   continue;
                 }
-                currentReadMap.put(new Key(scan, result), transactionResult);
+                currentReadMap.put(new PrimaryKey(scan, result), transactionResult);
               }
             } finally {
               if (scanner != null) {
@@ -450,7 +300,7 @@ public class Snapshot {
               }
             }
 
-            for (Key key : entry.getValue()) {
+            for (PrimaryKey key : entry.getValue()) {
               if (writeSet.containsKey(key) || deleteSet.containsKey(key)) {
                 continue;
               }
@@ -470,14 +320,14 @@ public class Snapshot {
     }
 
     // Calculate read set validated by scan
-    Set<Key> validatedReadSetByScan = new HashSet<>();
-    for (List<Key> values : scanSet.values()) {
+    Set<PrimaryKey> validatedReadSetByScan = new HashSet<>();
+    for (List<PrimaryKey> values : scanSet.values()) {
       validatedReadSetByScan.addAll(values);
     }
 
     // Read set by get is re-validated to check if there is no anti-dependency
-    for (Map.Entry<Key, Optional<TransactionResult>> entry : readSet.entrySet()) {
-      Key key = entry.getKey();
+    for (Map.Entry<PrimaryKey, Optional<TransactionResult>> entry : readSet.entrySet()) {
+      PrimaryKey key = entry.getKey();
       if (writeSet.containsKey(key)
           || deleteSet.containsKey(key)
           || validatedReadSetByScan.contains(key)) {
@@ -492,8 +342,8 @@ public class Snapshot {
                     .withProjection(Attribute.ID)
                     .withProjection(Attribute.VERSION)
                     .withConsistency(Consistency.LINEARIZABLE)
-                    .forNamespace(key.getNamespace())
-                    .forTable(key.getTable());
+                    .forNamespace(key.getNamespaceName())
+                    .forTable(key.getTableName());
 
             Optional<TransactionResult> latestResult = storage.get(get).map(TransactionResult::new);
             // Check if a read record is not changed
@@ -534,153 +384,5 @@ public class Snapshot {
 
   public boolean isValidationRequired() {
     return isExtraReadEnabled();
-  }
-
-  @VisibleForTesting
-  boolean isMatched(LikeExpression likeExpression, String value) {
-    String escape = likeExpression.getEscape();
-    String regexPattern =
-        convertRegexPatternFrom(
-            likeExpression.getTextValue(), escape.isEmpty() ? null : escape.charAt(0));
-    if (likeExpression.getOperator().equals(Operator.LIKE)) {
-      return value != null && Pattern.compile(regexPattern).matcher(value).matches();
-    } else {
-      return value != null && !Pattern.compile(regexPattern).matcher(value).matches();
-    }
-  }
-
-  /**
-   * Convert SQL 'like' pattern to a Java regular expression. Underscores (_) are converted to '.'
-   * and percent signs (%) are converted to '.*', other characters are quoted literally. If an
-   * escape character specified, escaping is done for '_', '%', and the escape character itself.
-   * Although we validate the pattern when constructing {@code LikeExpression}, we will assert it
-   * just in case. This method is implemented referencing the following Spark SQL implementation.
-   * https://github.com/apache/spark/blob/a8eadebd686caa110c4077f4199d11e797146dc5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
-   *
-   * @param likePattern a SQL LIKE pattern to convert
-   * @param escape an escape character.
-   * @return the equivalent Java regular expression of the given pattern
-   */
-  private String convertRegexPatternFrom(String likePattern, @Nullable Character escape) {
-    assert likePattern != null : "LIKE pattern must not be null";
-
-    StringBuilder out = new StringBuilder();
-    char[] chars = likePattern.toCharArray();
-    for (int i = 0; i < chars.length; i++) {
-      char c = chars[i];
-      if (escape != null && c == escape && i + 1 < chars.length) {
-        char nextChar = chars[++i];
-        if (nextChar == '_' || nextChar == '%') {
-          out.append(Pattern.quote(Character.toString(nextChar)));
-        } else if (nextChar == escape) {
-          out.append(Pattern.quote(Character.toString(nextChar)));
-        } else {
-          throw new AssertionError("LIKE pattern must not include only escape character");
-        }
-      } else if (escape != null && c == escape) {
-        throw new AssertionError("LIKE pattern must not end with escape character");
-      } else if (c == '_') {
-        out.append(".");
-      } else if (c == '%') {
-        out.append(".*");
-      } else {
-        out.append(Pattern.quote(Character.toString(c)));
-      }
-    }
-
-    return "(?s)" + out; // (?s) enables dotall mode, causing "." to match new lines
-  }
-
-  @Immutable
-  public static final class Key implements Comparable<Key> {
-    private final String namespace;
-    private final String table;
-    private final com.scalar.db.io.Key partitionKey;
-    private final Optional<com.scalar.db.io.Key> clusteringKey;
-
-    public Key(Get get) {
-      this((Operation) get);
-    }
-
-    public Key(Put put) {
-      this((Operation) put);
-    }
-
-    public Key(Delete delete) {
-      this((Operation) delete);
-    }
-
-    public Key(Scan scan, Result result) {
-      this.namespace = scan.forNamespace().get();
-      this.table = scan.forTable().get();
-      this.partitionKey = result.getPartitionKey().get();
-      this.clusteringKey = result.getClusteringKey();
-    }
-
-    private Key(Operation operation) {
-      namespace = operation.forNamespace().get();
-      table = operation.forTable().get();
-      partitionKey = operation.getPartitionKey();
-      clusteringKey = operation.getClusteringKey();
-    }
-
-    public String getNamespace() {
-      return namespace;
-    }
-
-    public String getTable() {
-      return table;
-    }
-
-    public com.scalar.db.io.Key getPartitionKey() {
-      return partitionKey;
-    }
-
-    public Optional<com.scalar.db.io.Key> getClusteringKey() {
-      return clusteringKey;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(namespace, table, partitionKey, clusteringKey);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (o == this) {
-        return true;
-      }
-      if (!(o instanceof Key)) {
-        return false;
-      }
-      Key another = (Key) o;
-      return this.namespace.equals(another.namespace)
-          && this.table.equals(another.table)
-          && this.partitionKey.equals(another.partitionKey)
-          && this.clusteringKey.equals(another.clusteringKey);
-    }
-
-    @Override
-    public int compareTo(Key o) {
-      return ComparisonChain.start()
-          .compare(this.namespace, o.namespace)
-          .compare(this.table, o.table)
-          .compare(this.partitionKey, o.partitionKey)
-          .compare(
-              this.clusteringKey.orElse(null),
-              o.clusteringKey.orElse(null),
-              Comparator.nullsFirst(Comparator.naturalOrder()))
-          .result();
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("namespace", namespace)
-          .add("table", table)
-          .add("partitionKey", partitionKey)
-          .add("clusteringKey", clusteringKey)
-          .toString();
-    }
   }
 }

--- a/core/src/test/java/com/scalar/db/common/PrimaryKeyTest.java
+++ b/core/src/test/java/com/scalar/db/common/PrimaryKeyTest.java
@@ -1,4 +1,4 @@
-package com.scalar.db.transaction.consensuscommit;
+package com.scalar.db.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -6,7 +6,7 @@ import com.scalar.db.api.Get;
 import com.scalar.db.io.Key;
 import org.junit.jupiter.api.Test;
 
-public class SnapshotKeyTest {
+public class PrimaryKeyTest {
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -41,10 +41,10 @@ public class SnapshotKeyTest {
   public void equals_SameOperationGivenInConstructor_ShouldReturnTrue() {
     // Arrange
     Get get = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(get);
+    PrimaryKey key = new PrimaryKey(get);
 
     // Act
-    boolean res = key.equals(new Snapshot.Key(get));
+    boolean res = key.equals(new PrimaryKey(get));
 
     // Assert
     assertThat(res).isTrue();
@@ -54,11 +54,11 @@ public class SnapshotKeyTest {
   public void equals_EquivalentOperationGivenInConstructor_ShouldReturnTrue() {
     // Arrange
     Get one = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareGet();
 
     // Act
-    boolean res = key.equals(new Snapshot.Key(another));
+    boolean res = key.equals(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isTrue();
@@ -68,11 +68,11 @@ public class SnapshotKeyTest {
   public void equals_NonEquivalentOperationGivenInConstructor_ShouldReturnFalse() {
     // Arrange
     Get one = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareAnotherGet();
 
     // Act
-    boolean res = key.equals(new Snapshot.Key(another));
+    boolean res = key.equals(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isFalse();
@@ -82,11 +82,11 @@ public class SnapshotKeyTest {
   public void equals_EquivalentOperationWithoutClusteringKeyGivenInConstructor_ShouldReturnTrue() {
     // Arrange
     Get one = prepareGetWithoutClusteringKey();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareGetWithoutClusteringKey();
 
     // Act
-    boolean res = key.equals(new Snapshot.Key(another));
+    boolean res = key.equals(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isTrue();
@@ -97,11 +97,11 @@ public class SnapshotKeyTest {
       equals_NonEquivalentOperationWithoutClusteringKeyGivenInConstructor_ShouldReturnFalse() {
     // Arrange
     Get one = prepareGetWithoutClusteringKey();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareAnotherGet();
 
     // Act
-    boolean res = key.equals(new Snapshot.Key(another));
+    boolean res = key.equals(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isFalse();
@@ -111,10 +111,10 @@ public class SnapshotKeyTest {
   public void compareTo_SameOperationGivenInConstructor_ShouldReturnZero() {
     // Arrange
     Get get = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(get);
+    PrimaryKey key = new PrimaryKey(get);
 
     // Act
-    int res = key.compareTo(new Snapshot.Key(get));
+    int res = key.compareTo(new PrimaryKey(get));
 
     // Assert
     assertThat(res).isEqualTo(0);
@@ -124,11 +124,11 @@ public class SnapshotKeyTest {
   public void compareTo_EquivalentOperationGivenInConstructor_ShouldReturnZero() {
     // Arrange
     Get one = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareGet();
 
     // Act
-    int res = key.compareTo(new Snapshot.Key(another));
+    int res = key.compareTo(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isEqualTo(0);
@@ -138,11 +138,11 @@ public class SnapshotKeyTest {
   public void compareTo_BiggerOperationGivenInConstructor_ShouldReturnNegative() {
     // Arrange
     Get one = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareAnotherGet();
 
     // Act
-    int res = key.compareTo(new Snapshot.Key(another));
+    int res = key.compareTo(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isLessThan(0);
@@ -152,11 +152,11 @@ public class SnapshotKeyTest {
   public void compareTo_LesserOperationGivenInConstructor_ShouldReturnPositive() {
     // Arrange
     Get one = prepareAnotherGet();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareGet();
 
     // Act
-    int res = key.compareTo(new Snapshot.Key(another));
+    int res = key.compareTo(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isGreaterThan(0);
@@ -167,11 +167,11 @@ public class SnapshotKeyTest {
       compareTo_SameOperationExceptWithClusteringKeyGivenInConstructor_ShouldReturnNegative() {
     // Arrange
     Get one = prepareGetWithoutClusteringKey();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareGet();
 
     // Act
-    int res = key.compareTo(new Snapshot.Key(another));
+    int res = key.compareTo(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isLessThan(0);
@@ -182,11 +182,11 @@ public class SnapshotKeyTest {
       compareTo_SameOperationExceptWithoutClusteringKeyGivenInConstructor_ShouldReturnPositive() {
     // Arrange
     Get one = prepareGet();
-    Snapshot.Key key = new Snapshot.Key(one);
+    PrimaryKey key = new PrimaryKey(one);
     Get another = prepareGetWithoutClusteringKey();
 
     // Act
-    int res = key.compareTo(new Snapshot.Key(another));
+    int res = key.compareTo(new PrimaryKey(another));
 
     // Assert
     assertThat(res).isGreaterThan(0);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TransactionState;
+import com.scalar.db.common.PrimaryKey;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
@@ -99,8 +100,8 @@ public class CommitHandlerTest {
     // different partition
     Put put1 = preparePut1();
     Put put2 = preparePut2();
-    snapshot.put(new Snapshot.Key(put1), put1);
-    snapshot.put(new Snapshot.Key(put2), put2);
+    snapshot.put(new PrimaryKey(put1), put1);
+    snapshot.put(new PrimaryKey(put2), put2);
 
     return snapshot;
   }
@@ -117,8 +118,8 @@ public class CommitHandlerTest {
     // same partition
     Put put1 = preparePut1();
     Put put3 = preparePut3();
-    snapshot.put(new Snapshot.Key(put1), put1);
-    snapshot.put(new Snapshot.Key(put3), put3);
+    snapshot.put(new PrimaryKey(put1), put1);
+    snapshot.put(new PrimaryKey(put3), put3);
 
     return snapshot;
   }

--- a/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/util/ScalarDbUtilsTest.java
@@ -2,8 +2,11 @@ package com.scalar.db.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
@@ -143,5 +146,181 @@ public class ScalarDbUtilsTest {
     assertThat(actual.get(0).forTable()).isEqualTo(TABLE);
     assertThat(actual.get(1).forNamespace()).isEqualTo(NAMESPACE);
     assertThat(actual.get(1).forTable()).isEqualTo(TABLE);
+  }
+
+  @Test
+  public void isMatched_SomePatternsWithoutEscapeGiven_ShouldReturnBooleanProperly() {
+    // Arrange
+
+    // Act Assert
+    // The following tests are added referring to the similar tests in Spark.
+    // https://github.com/apache/spark/blob/master/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+    // simple patterns
+    assertThat(ScalarDbUtils.isMatched(prepareLike("abdef"), "abdef")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a\\__b"), "a_%b")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a_%b"), "addb")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a\\__b"), "addb")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%\\%b"), "addb")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%\\%b"), "a_%b")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%"), "addb")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("**"), "addb")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%"), "abc")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("b%"), "abc")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("bc%"), "abc")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a_b"), "a\nb")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%b"), "ab")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%b"), "a\nb")).isTrue();
+
+    // empty input
+    assertThat(ScalarDbUtils.isMatched(prepareLike(""), "")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike(""), "a")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a"), "")).isFalse();
+
+    // SI-17647 double-escaping backslash
+    assertThat(ScalarDbUtils.isMatched(prepareLike("%\\\\%"), "\\\\\\\\")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("%%"), "%%")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("\\\\\\__"), "\\__")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("%\\\\%\\%"), "\\\\\\__")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("%\\\\"), "_\\\\\\%")).isFalse();
+
+    // unicode
+    assertThat(ScalarDbUtils.isMatched(prepareLike("_\u20AC_"), "a\u20ACa")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("_€_"), "a€a")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("_\u20AC_"), "a€a")).isTrue();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("_€_"), "a\u20ACa")).isTrue();
+
+    // case
+    assertThat(ScalarDbUtils.isMatched(prepareLike("a%"), "A")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("A%"), "a")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareLike("_a_"), "AaA")).isTrue();
+
+    // example
+    assertThat(
+            ScalarDbUtils.isMatched(
+                prepareLike("\\%SystemDrive\\%\\\\Users%"), "%SystemDrive%\\Users\\John"))
+        .isTrue();
+  }
+
+  @Test
+  public void isMatched_SomePatternsWithEscapeGiven_ShouldReturnBooleanProperly() {
+    // Arrange
+
+    // Act Assert
+    // The following tests are added referring to the similar tests in Spark.
+    // https://github.com/apache/spark/blob/master/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+    ImmutableList.of("/", "#", "\"")
+        .forEach(
+            escape -> {
+              // simple patterns
+              assertThat(ScalarDbUtils.isMatched(prepareLike("abdef", escape), "abdef")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a" + escape + "__b", escape), "a_%b"))
+                  .isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a_%b", escape), "addb")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a" + escape + "__b", escape), "addb"))
+                  .isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%" + escape + "%b", escape), "addb"))
+                  .isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%" + escape + "%b", escape), "a_%b"))
+                  .isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%", escape), "addb")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("**", escape), "addb")).isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%", escape), "abc")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("b%", escape), "abc")).isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("bc%", escape), "abc")).isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a_b", escape), "a\nb")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%b", escape), "ab")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%b", escape), "a\nb")).isTrue();
+
+              // empty input
+              assertThat(ScalarDbUtils.isMatched(prepareLike("", escape), "")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("", escape), "a")).isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a", escape), "")).isFalse();
+
+              // SI-17647 double-escaping backslash
+              assertThat(
+                      ScalarDbUtils.isMatched(
+                          prepareLike(String.format("%%%s%s%%", escape, escape), escape),
+                          String.format("%s%s%s%s", escape, escape, escape, escape)))
+                  .isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("%%", escape), "%%")).isTrue();
+              assertThat(
+                      ScalarDbUtils.isMatched(
+                          prepareLike(String.format("%s%s%s__", escape, escape, escape), escape),
+                          String.format("%s__", escape)))
+                  .isTrue();
+              assertThat(
+                      ScalarDbUtils.isMatched(
+                          prepareLike(
+                              String.format("%%%s%s%%%s%%", escape, escape, escape), escape),
+                          String.format("%s%s%s__", escape, escape, escape)))
+                  .isFalse();
+              assertThat(
+                      ScalarDbUtils.isMatched(
+                          prepareLike(String.format("%%%s%s", escape, escape), escape),
+                          String.format("_%s%s%s%%", escape, escape, escape)))
+                  .isFalse();
+
+              // unicode
+              assertThat(ScalarDbUtils.isMatched(prepareLike("_\u20AC_", escape), "a\u20ACa"))
+                  .isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("_€_", escape), "a€a")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("_\u20AC_", escape), "a€a")).isTrue();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("_€_", escape), "a\u20ACa")).isTrue();
+
+              // case
+              assertThat(ScalarDbUtils.isMatched(prepareLike("a%", escape), "A")).isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("A%", escape), "a")).isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareLike("_a_", escape), "AaA")).isTrue();
+
+              // example
+              assertThat(
+                      ScalarDbUtils.isMatched(
+                          prepareLike(
+                              String.format(
+                                  "%s%%SystemDrive%s%%%s%sUsers%%", escape, escape, escape, escape),
+                              escape),
+                          String.format("%%SystemDrive%%%sUsers%sJohn", escape, escape)))
+                  .isTrue();
+            });
+  }
+
+  @Test
+  public void isMatched_IsNotLikeOperatorWithSomePatternsGiven_ShouldReturnBooleanProperly() {
+    // Arrange
+
+    // Act Assert
+    assertThat(ScalarDbUtils.isMatched(prepareNotLike("abdef"), "abdef")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareNotLike("a\\__b"), "a_%b")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareNotLike("a_%b"), "addb")).isFalse();
+    assertThat(ScalarDbUtils.isMatched(prepareNotLike("a\\__b"), "addb")).isTrue();
+    ImmutableList.of("/", "#", "\"")
+        .forEach(
+            escape -> {
+              assertThat(ScalarDbUtils.isMatched(prepareNotLike("abdef", escape), "abdef"))
+                  .isFalse();
+              assertThat(
+                      ScalarDbUtils.isMatched(prepareNotLike("a" + escape + "__b", escape), "a_%b"))
+                  .isFalse();
+              assertThat(ScalarDbUtils.isMatched(prepareNotLike("a_%b", escape), "addb")).isFalse();
+              assertThat(
+                      ScalarDbUtils.isMatched(prepareNotLike("a" + escape + "__b", escape), "addb"))
+                  .isTrue();
+            });
+  }
+
+  private LikeExpression prepareLike(String pattern) {
+    return ConditionBuilder.column("col1").isLikeText(pattern);
+  }
+
+  private LikeExpression prepareLike(String pattern, String escape) {
+    return ConditionBuilder.column("col1").isLikeText(pattern, escape);
+  }
+
+  private LikeExpression prepareNotLike(String pattern) {
+    return ConditionBuilder.column("col1").isNotLikeText(pattern);
+  }
+
+  private LikeExpression prepareNotLike(String pattern, String escape) {
+    return ConditionBuilder.column("col1").isNotLikeText(pattern, escape);
   }
 }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
@@ -18,13 +18,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 class NormalGroupTest {
   private Emittable<String, Integer> emitter;
   private TestableKeyManipulator keyManipulator;
-  @Mock private Slot<String, String, String, String, Integer> slot1;
-  @Mock private Slot<String, String, String, String, Integer> slot2;
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
## Description

This PR extracts the logic of `Snapshot.isWriteSetOverlappedWith()` and moves it into `ScalarDbUtils.isMutationSetOverlappedWith()` to reuse the logic in other places.

## Related issues and/or PRs

N/A

## Changes made

- Introduced `PrimaryKey` and replaced it with `Snapshot.Key`
- Moved the logic of `Snapshot.isWriteSetOverlappedWith()` into `ScalarDbUtils.isMutationSetOverlappedWith()`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
