### PR TITLE
Wait until all groups get done when GroupCommitter is closed (was "Abort all in-flight groups on close in the group commit")

### DIFF
--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitMonitor.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitMonitor.java
@@ -1,0 +1,47 @@
+package com.scalar.db.util.groupcommit;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.io.Closeable;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class GroupCommitMonitor implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(GroupCommitMonitor.class);
+  private final ExecutorService executorService;
+
+  GroupCommitMonitor(String label, Supplier<Metrics> metricsSupplier) {
+    executorService =
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat(label + "-group-commit-monitor-%d")
+                .build());
+    startExecutorService(metricsSupplier);
+  }
+
+  private void startExecutorService(Supplier<Metrics> metricsSupplier) {
+    Runnable print =
+        () -> logger.debug("[MONITOR] Timestamp={}, Metrics={}", Instant.now(), metricsSupplier);
+
+    executorService.execute(
+        () -> {
+          while (!executorService.isShutdown()) {
+            print.run();
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+          }
+          print.run();
+        });
+  }
+
+  @Override
+  public void close() {
+    MoreExecutors.shutdownAndAwaitTermination(executorService, 10, TimeUnit.SECONDS);
+  }
+}

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitter.java
@@ -30,7 +30,7 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> implem
       delayedSlotMoveWorker;
   private final GroupCleanupWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> groupCleanupWorker;
 
-  // Executors
+  // Monitor
   private final GroupCommitMonitor groupCommitMonitor;
 
   // This contains logics of how to treat keys.

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
@@ -216,15 +216,4 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> {
   int sizeOfDelayedGroupMap() {
     return delayedGroupMap.size();
   }
-
-  void abortAllGroups() {
-    for (NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> group :
-        normalGroupMap.values()) {
-      group.abort();
-    }
-    for (DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> group :
-        delayedGroupMap.values()) {
-      group.abort();
-    }
-  }
 }

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
@@ -28,6 +28,7 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> {
   @VisibleForTesting
   protected final Map<FULL_KEY, DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>>
       delayedGroupMap = new HashMap<>();
+
   // Only this class uses this type of lock since the class can be heavy hotspot and StampedLock has
   // basically better performance than `synchronized` keyword.
   private final StampedLock lock = new StampedLock();

--- a/core/src/main/java/com/scalar/db/util/groupcommit/Metrics.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/Metrics.java
@@ -6,11 +6,11 @@ import javax.annotation.concurrent.Immutable;
 // TODO: Remove after introducing a proper metrics.
 @Immutable
 class Metrics {
-  public final int queueLengthOfGroupCloseWorker;
-  public final int queueLengthOfDelayedSlotMoveWorker;
-  public final int queueLengthOfGroupCleanupWorker;
-  public final int sizeOfNormalGroupMap;
-  public final int sizeOfDelayedGroupMap;
+  private final int queueLengthOfGroupCloseWorker;
+  private final int queueLengthOfDelayedSlotMoveWorker;
+  private final int queueLengthOfGroupCleanupWorker;
+  private final int sizeOfNormalGroupMap;
+  private final int sizeOfDelayedGroupMap;
 
   Metrics(
       int queueLengthOfGroupCloseWorker,
@@ -35,4 +35,14 @@ class Metrics {
         .add("sizeOfDelayedGroupMap", sizeOfDelayedGroupMap)
         .toString();
   }
+
+  public boolean hasRemaining() {
+    return queueLengthOfGroupCloseWorker > 0
+        || queueLengthOfDelayedSlotMoveWorker > 0
+        || queueLengthOfGroupCleanupWorker > 0
+        || sizeOfNormalGroupMap > 0
+        || sizeOfDelayedGroupMap > 0;
+  }
+
+  // Add getters if necessary
 }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
@@ -299,11 +299,7 @@ class GroupCommitterConcurrentTest {
       Metrics metrics = null;
       for (int i = 0; i < 60; i++) {
         metrics = groupCommitter.getMetrics();
-        if (metrics.sizeOfNormalGroupMap == 0
-            && metrics.sizeOfDelayedGroupMap == 0
-            && metrics.queueLengthOfGroupCloseWorker == 0
-            && metrics.queueLengthOfDelayedSlotMoveWorker == 0
-            && metrics.queueLengthOfGroupCleanupWorker == 0) {
+        if (!metrics.hasRemaining()) {
           noGarbage = true;
           break;
         }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
@@ -410,14 +410,6 @@ class GroupCommitterTest {
 
   private class TestableGroupCommitter
       extends GroupCommitter<String, String, String, String, Integer> {
-    /*
-    private final GroupManager<String, String, String, String, Integer> groupManager;
-    private final GroupSizeFixWorker<String, String, String, String, Integer> groupSizeFixWorker;
-    private final DelayedSlotMoveWorker<String, String, String, String, Integer> delayedSlotMoveWorker;
-    private final GroupCleanupWorker<String, String, String, String, Integer> groupCleanupWorker;
-    private final GroupCommitMonitor groupCommitMonitor;
-
-     */
 
     TestableGroupCommitter(
         GroupCommitConfig config, KeyManipulator<String, String, String, String> keyManipulator) {

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.util.groupcommit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
@@ -586,43 +585,5 @@ class GroupManagerTest {
         (DelayedGroup<String, String, String, String, Integer>) groupManager.getGroup(keys2);
     assertThat(delayedGroupForKey2.isSizeFixed()).isTrue();
     assertThat(delayedGroupForKey2.isReady()).isFalse();
-  }
-
-  private static class TestableGroupManager
-      extends GroupManager<String, String, String, String, Integer> {
-    TestableGroupManager(GroupCommitConfig config, KeyManipulator keyManipulator) {
-      super(config, keyManipulator);
-    }
-
-    void directlyAddNormalGroup(
-        String parentKey, NormalGroup<String, String, String, String, Integer> group) {
-      normalGroupMap.put(parentKey, group);
-    }
-
-    void directlyAddDelayedGroup(
-        String fullKey, DelayedGroup<String, String, String, String, Integer> group) {
-      delayedGroupMap.put(fullKey, group);
-    }
-  }
-
-  @Test
-  void abortAllGroups_ShouldAbortAllGroups() {
-    // Arrange
-    TestableGroupManager groupManager =
-        new TestableGroupManager(
-            new GroupCommitConfig(2, 100, 400, 60, TIMEOUT_CHECK_INTERVAL_MILLIS), keyManipulator);
-    groupManager.directlyAddNormalGroup("dummy-ng-1", normalGroup1);
-    groupManager.directlyAddNormalGroup("dummy-ng-2", normalGroup2);
-    groupManager.directlyAddDelayedGroup("dummy-dg-1", delayedGroup1);
-    groupManager.directlyAddDelayedGroup("dummy-dg-2", delayedGroup2);
-
-    // Act
-    groupManager.abortAllGroups();
-
-    // Assert
-    verify(normalGroup1).abort();
-    verify(normalGroup2).abort();
-    verify(delayedGroup1).abort();
-    verify(delayedGroup2).abort();
   }
 }


### PR DESCRIPTION
## Description

If an application using the group commit feature doesn't abort in-flight transactions (in-flight `slots` in terms of the group commit package) that failed before commit phase (before calling `ready()` method in terms of the group commit package), the client threads that have those failed in-flight transactions will wait until `old-group-timeout` is triggered even if `close()` is called. What if the application recreates the transaction manager including the GroupCommitter while there are failed in-flight transactions? The new GroupCommitter doesn't have any information about the in-flight transactions, resulting in that no one aborts them and the clients will wait forever. This case might sounds very weird, but https://github.com/scalar-labs/scalar-jepsen tests this type of situation, great. To prevent the client threads from waiting forever even in this case, ~~all the groups should be aborted~~ GroupCommitter should wait until all groups get done when `GroupCommitter.close()` is called.

This issue happens if the following steps are executed
1. `client#1` begins `txn#1`
  i. The NormalGroup contains `[txn#1(empty)]` now
2. `client#2` begins `txn#2`
  i. The NormalGroup contains `[txn#1(empty), txn#2(empty)]` now
3. `txn#1` failes in the CRUD (execution) phase, and `client#1` doesn't abort it for some reason
  i. The NormalGroup contains `[txn#1(empty), txn#2(empty)]` now
4. `txn#2` executes some CRUD operations and try committing
  i. The NormalGroup contains `[txn#1(empty), txn#2(snapshot-for-txn#2)]` now
5. The application closes the TransactionManager by calling `close()` which results in calling `GroupCommitter.close()`, then all the background workers stop
  i. The NormalGroup contains `[txn#1(empty), txn#2(snapshot-for-txn#2)]` now
6. `client#2` is still waiting on the CompletableFuture inside the slot for `txn#2`
  i. The NormalGroup contains `[txn#1(empty), txn#2(snapshot-for-txn#2)]` now
7. No background workers taking care of the NormalGroup is running. `client#2` gets stuck since the NormalGroup won't be READY due to the open slot for `txn#1`

[This comment](https://github.com/scalar-labs/scalardb/pull/1650#discussion_r1566716082) contains an example code to reproduce this issue. It might be helpful to understand.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1607

## Changes made

This PR makes GroupCommitter ~~abort all the in-flight slots by calling a newly added `GroupManager#abortAllGroups()`~~ wait until all groups get done when `GroupCommitter.close()` is called. To test the behaviors, some initialization codes are refactored.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A (The group commit package isn't used yet).