### PR TITLE
Backport to branch(3.8) : Fix NullPointerException in EXTRA_READ validation

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -355,7 +355,7 @@ public class Snapshot {
               }
               // Check if read records are not changed
               TransactionResult latestResult = currentReadMap.get(key);
-              if (isChanged(Optional.of(latestResult), readSet.get(key))) {
+              if (isChanged(Optional.ofNullable(latestResult), readSet.get(key))) {
                 throwExceptionDueToAntiDependency();
               }
               validatedReadSet.add(key);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -938,6 +938,34 @@ public class SnapshotTest {
   }
 
   @Test
+  public void
+      toSerializableWithExtraRead_ScannedResultDeleted_ShouldThrowValidationConflictException()
+          throws ExecutionException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    Scan scan = prepareScan();
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(key, Optional.of(result));
+    snapshot.put(scan, Collections.singletonList(key));
+    DistributedStorage storage = mock(DistributedStorage.class);
+    Scan scanWithProjections =
+        Scan.newBuilder(scan)
+            .projections(Attribute.ID, Attribute.VERSION, ANY_NAME_1, ANY_NAME_2)
+            .build();
+    Scanner scanner = mock(Scanner.class);
+    when(scanner.iterator()).thenReturn(Collections.emptyIterator());
+    when(storage.scan(scanWithProjections)).thenReturn(scanner);
+
+    // Act Assert
+    assertThatThrownBy(() -> snapshot.toSerializableWithExtraRead(storage))
+        .isInstanceOf(ValidationConflictException.class);
+
+    // Assert
+    verify(storage).scan(scanWithProjections);
+  }
+
+  @Test
   public void put_DeleteGivenAfterPut_PutSupercedesDelete() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1624