### PR TITLE
Should not publish Schema Loader fat jar to Maven central

### DIFF
--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -74,6 +74,12 @@ spotbugsTest.reports {
 spotbugsTest.excludeFilter = file("${project.rootDir}/gradle/spotbugs-exclude.xml")
 
 // for archiving and uploading to maven central
+if (project.gradle.startParameter.taskNames.any { it.endsWith('publish') } ||
+        project.gradle.startParameter.taskNames.any { it.endsWith('publishToMavenLocal') }) {
+    // not to publish the fat jar to maven central
+    shadowJar.enabled = false
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {


### PR DESCRIPTION
## Description

After https://github.com/scalar-labs/scalardb/pull/1622, the Schema Loader fat jar was unintentionally published to Maven Central. This PR addresses the issue.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1622

## Changes made

- Made the Schema Loader fat jar not published when running `publish` or `publishToMavenLocal`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
