### PR TITLE
Backport to branch(3) : Use the priority queue for DelayedSlotMoveWorker to easily reduce the latency to be handled in `util/groupcommit`

### DIFF
--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupSizeFixWorker.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupSizeFixWorker.java
@@ -1,5 +1,7 @@
 package com.scalar.db.util.groupcommit;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.concurrent.ThreadSafe;
 
 // A worker manages NormalGroup instances to size-fix timed-out groups and pass them to
@@ -32,6 +34,15 @@ class GroupSizeFixWorker<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>
     } else {
       delayedSlotMoveWorker.add(normalGroup);
     }
+  }
+
+  @Override
+  BlockingQueue<NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>> createQueue() {
+    // Use a normal queue because:
+    // - Queued groups are removed once processed, without being re-enqueued
+    // - No need for a priority queue since the order of queued groups is basically consistent with
+    //   the timeout order
+    return new LinkedBlockingQueue<>();
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/util/groupcommit/BackgroundWorkerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/BackgroundWorkerTest.java
@@ -6,6 +6,8 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.db.util.groupcommit.BackgroundWorker.RetryMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,11 @@ class BackgroundWorkerTest {
         int timeoutCheckIntervalMillis, RetryMode retryMode, Function<String, Boolean> func) {
       super("test", timeoutCheckIntervalMillis, retryMode);
       this.func = func;
+    }
+
+    @Override
+    BlockingQueue<String> createQueue() {
+      return new LinkedBlockingQueue<>();
     }
 
     @Override
@@ -95,7 +102,7 @@ class BackgroundWorkerTest {
     try (TestableBackgroundWorker worker =
         new TestableBackgroundWorker(
             200,
-            RetryMode.MOVE_TO_TAIL,
+            RetryMode.RE_ENQUEUE,
             item -> {
               processedItems.add(item);
               return false;


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1641