### PR TITLE
Backport to branch(3) : Wait until all groups get done when GroupCommitter is closed (was "Abort all in-flight groups on close in the group commit")

### DIFF
--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitMonitor.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitMonitor.java
@@ -1,0 +1,47 @@
+package com.scalar.db.util.groupcommit;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.io.Closeable;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class GroupCommitMonitor implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(GroupCommitMonitor.class);
+  private final ExecutorService executorService;
+
+  GroupCommitMonitor(String label, Supplier<Metrics> metricsSupplier) {
+    executorService =
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat(label + "-group-commit-monitor-%d")
+                .build());
+    startExecutorService(metricsSupplier);
+  }
+
+  private void startExecutorService(Supplier<Metrics> metricsSupplier) {
+    Runnable print =
+        () -> logger.debug("[MONITOR] Timestamp={}, Metrics={}", Instant.now(), metricsSupplier);
+
+    executorService.execute(
+        () -> {
+          while (!executorService.isShutdown()) {
+            print.run();
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+          }
+          print.run();
+        });
+  }
+
+  @Override
+  public void close() {
+    MoreExecutors.shutdownAndAwaitTermination(executorService, 10, TimeUnit.SECONDS);
+  }
+}

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
@@ -2,6 +2,7 @@ package com.scalar.db.util.groupcommit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
@@ -20,10 +21,14 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> {
   // Groups
   @Nullable private NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V> currentGroup;
   // Note: Using ConcurrentHashMap results in less performance.
-  private final Map<PARENT_KEY, NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>>
+  @VisibleForTesting
+  protected final Map<PARENT_KEY, NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>>
       normalGroupMap = new HashMap<>();
-  private final Map<FULL_KEY, DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>>
+
+  @VisibleForTesting
+  protected final Map<FULL_KEY, DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_KEY, V>>
       delayedGroupMap = new HashMap<>();
+
   // Only this class uses this type of lock since the class can be heavy hotspot and StampedLock has
   // basically better performance than `synchronized` keyword.
   private final StampedLock lock = new StampedLock();

--- a/core/src/main/java/com/scalar/db/util/groupcommit/Metrics.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/Metrics.java
@@ -6,11 +6,11 @@ import javax.annotation.concurrent.Immutable;
 // TODO: Remove after introducing a proper metrics.
 @Immutable
 class Metrics {
-  public final int queueLengthOfGroupCloseWorker;
-  public final int queueLengthOfDelayedSlotMoveWorker;
-  public final int queueLengthOfGroupCleanupWorker;
-  public final int sizeOfNormalGroupMap;
-  public final int sizeOfDelayedGroupMap;
+  private final int queueLengthOfGroupCloseWorker;
+  private final int queueLengthOfDelayedSlotMoveWorker;
+  private final int queueLengthOfGroupCleanupWorker;
+  private final int sizeOfNormalGroupMap;
+  private final int sizeOfDelayedGroupMap;
 
   Metrics(
       int queueLengthOfGroupCloseWorker,
@@ -35,4 +35,14 @@ class Metrics {
         .add("sizeOfDelayedGroupMap", sizeOfDelayedGroupMap)
         .toString();
   }
+
+  public boolean hasRemaining() {
+    return queueLengthOfGroupCloseWorker > 0
+        || queueLengthOfDelayedSlotMoveWorker > 0
+        || queueLengthOfGroupCleanupWorker > 0
+        || sizeOfNormalGroupMap > 0
+        || sizeOfDelayedGroupMap > 0;
+  }
+
+  // Add getters if necessary
 }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
@@ -299,11 +299,7 @@ class GroupCommitterConcurrentTest {
       Metrics metrics = null;
       for (int i = 0; i < 60; i++) {
         metrics = groupCommitter.getMetrics();
-        if (metrics.sizeOfNormalGroupMap == 0
-            && metrics.sizeOfDelayedGroupMap == 0
-            && metrics.queueLengthOfGroupCloseWorker == 0
-            && metrics.queueLengthOfDelayedSlotMoveWorker == 0
-            && metrics.queueLengthOfGroupCleanupWorker == 0) {
+        if (!metrics.hasRemaining()) {
           noGarbage = true;
           break;
         }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,15 @@ class GroupCommitterTest {
   private static final int TIMEOUT_CHECK_INTERVAL_MILLIS = 10;
 
   @Mock private Emittable<String, Integer> emitter;
+  @Mock private GroupManager<String, String, String, String, Integer> groupManager;
+  @Mock private GroupSizeFixWorker<String, String, String, String, Integer> groupSizeFixWorker;
+
+  @Mock
+  private DelayedSlotMoveWorker<String, String, String, String, Integer> delayedSlotMoveWorker;
+
+  @Mock private GroupCleanupWorker<String, String, String, String, Integer> groupCleanupWorker;
+  @Mock private GroupCommitMonitor groupCommitMonitor;
+  @Mock private Metrics metrics;
 
   private GroupCommitter<String, String, String, String, Integer> createGroupCommitter(
       int slotCapacity, int groupSizeFixTimeoutMillis, int delayedSlotMoveTimeoutMillis) {
@@ -61,6 +71,19 @@ class GroupCommitterTest {
 
       verify(emitter, never()).execute(any(), any());
     }
+  }
+
+  @Test
+  void reserve_WhenAlreadyClosed_ShouldThrowException() {
+    // Arrange
+    GroupCommitter<String, String, String, String, Integer> groupCommitter =
+        createGroupCommitter(2, 100, 400);
+    groupCommitter.setEmitter(emitter);
+    groupCommitter.close();
+
+    // Act
+    // Assert
+    assertThrows(GroupCommitException.class, () -> groupCommitter.reserve("child-key"));
   }
 
   @Test
@@ -398,5 +421,87 @@ class GroupCommitterTest {
       // - NormalGroup("0000", DONE, slots:[Slot("child-key-1"), Slot("child-key-2")])
       verify(testableEmitter).execute("0000", Arrays.asList(11, 22));
     }
+  }
+
+  private class TestableGroupCommitter
+      extends GroupCommitter<String, String, String, String, Integer> {
+
+    TestableGroupCommitter(
+        GroupCommitConfig config, KeyManipulator<String, String, String, String> keyManipulator) {
+      super("test", config, keyManipulator);
+    }
+
+    @Override
+    GroupManager<String, String, String, String, Integer> createGroupManager(
+        GroupCommitConfig config, KeyManipulator<String, String, String, String> keyManipulator) {
+      return groupManager;
+    }
+
+    @Override
+    GroupCleanupWorker<String, String, String, String, Integer> createGroupCleanupWorker(
+        String label,
+        GroupCommitConfig config,
+        GroupManager<String, String, String, String, Integer> groupManager) {
+      return groupCleanupWorker;
+    }
+
+    @Override
+    DelayedSlotMoveWorker<String, String, String, String, Integer> createDelayedSlotMoveWorker(
+        String label,
+        GroupCommitConfig config,
+        GroupManager<String, String, String, String, Integer> groupManager,
+        GroupCleanupWorker<String, String, String, String, Integer> groupCleanupWorker) {
+      return delayedSlotMoveWorker;
+    }
+
+    @Override
+    GroupSizeFixWorker<String, String, String, String, Integer> createGroupSizeFixWorker(
+        String label,
+        GroupCommitConfig config,
+        GroupManager<String, String, String, String, Integer> groupManager,
+        DelayedSlotMoveWorker<String, String, String, String, Integer> delayedSlotMoveWorker,
+        GroupCleanupWorker<String, String, String, String, Integer> groupCleanupWorker) {
+      return groupSizeFixWorker;
+    }
+
+    @Override
+    GroupCommitMonitor createMonitor(String label) {
+      return groupCommitMonitor;
+    }
+
+    @Override
+    Metrics getMetrics() {
+      return metrics;
+    }
+  }
+
+  @Test
+  void close_WhenNoOngoingGroup_ShouldCloseAllResources()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // Arrange
+    doReturn(true).when(metrics).hasRemaining();
+    TestableGroupCommitter groupCommitter =
+        new TestableGroupCommitter(
+            new GroupCommitConfig(20, 100, 400, 60, 10), new TestableKeyManipulator());
+    ExecutorService executorService = Executors.newCachedThreadPool();
+
+    // Act
+    // Assert
+    Future<?> future = executorService.submit(groupCommitter::close);
+    executorService.shutdown();
+    TimeUnit.SECONDS.sleep(2);
+
+    verify(groupSizeFixWorker, never()).close();
+    verify(delayedSlotMoveWorker, never()).close();
+    verify(groupCleanupWorker, never()).close();
+    verify(groupCommitMonitor, never()).close();
+    doReturn(false).when(metrics).hasRemaining();
+
+    future.get(2, TimeUnit.SECONDS);
+
+    verify(groupSizeFixWorker).close();
+    verify(delayedSlotMoveWorker).close();
+    verify(groupCleanupWorker).close();
+    verify(groupCommitMonitor).close();
   }
 }

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
@@ -24,6 +24,10 @@ class GroupManagerTest {
   @Mock private Emittable<String, Integer> emittable;
   @Mock private GroupSizeFixWorker<String, String, String, String, Integer> groupSizeFixWorker;
   @Mock private GroupCleanupWorker<String, String, String, String, Integer> groupCleanupWorker;
+  @Mock private NormalGroup<String, String, String, String, Integer> normalGroup1;
+  @Mock private NormalGroup<String, String, String, String, Integer> normalGroup2;
+  @Mock private DelayedGroup<String, String, String, String, Integer> delayedGroup1;
+  @Mock private DelayedGroup<String, String, String, String, Integer> delayedGroup2;
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1650