### PR TITLE
Should execute lazy recovery for Put and Delete in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -91,7 +91,12 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
   public void put(Put put) throws CrudException {
     put = copyAndSetTargetToIfNot(put);
     checkMutation(put);
-    crud.put(put);
+    try {
+      crud.put(put);
+    } catch (UncommittedRecordException e) {
+      lazyRecovery(e);
+      throw e;
+    }
   }
 
   @Override
@@ -106,7 +111,12 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
   public void delete(Delete delete) throws CrudException {
     delete = copyAndSetTargetToIfNot(delete);
     checkMutation(delete);
-    crud.delete(delete);
+    try {
+      crud.delete(delete);
+    } catch (UncommittedRecordException e) {
+      lazyRecovery(e);
+      throw e;
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -97,7 +97,12 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
   private void putInternal(Put put) throws CrudException {
     put = copyAndSetTargetToIfNot(put);
     checkMutation(put);
-    crud.put(put);
+    try {
+      crud.put(put);
+    } catch (UncommittedRecordException e) {
+      lazyRecovery(e);
+      throw e;
+    }
   }
 
   @Override
@@ -116,7 +121,12 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
   private void deleteInternal(Delete delete) throws CrudException {
     delete = copyAndSetTargetToIfNot(delete);
     checkMutation(delete);
-    crud.delete(delete);
+    try {
+      crud.delete(delete);
+    } catch (UncommittedRecordException e) {
+      lazyRecovery(e);
+      throw e;
+    }
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -186,6 +186,25 @@ public class ConsensusCommitTest {
   }
 
   @Test
+  public void put_PutGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
+      throws CrudException {
+    // Arrange
+    Put put = preparePut();
+    Get get = prepareGet();
+
+    TransactionResult result = mock(TransactionResult.class);
+    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
+    doThrow(toThrow).when(crud).put(put);
+    when(toThrow.getSelection()).thenReturn(get);
+    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.put(put)).isInstanceOf(UncommittedRecordException.class);
+
+    verify(recovery).recover(get, result);
+  }
+
+  @Test
   public void delete_DeleteGiven_ShouldCallCrudHandlerDelete()
       throws CrudException, ExecutionException {
     // Arrange
@@ -213,6 +232,26 @@ public class ConsensusCommitTest {
     // Assert
     verify(crud, times(2)).delete(delete);
     verify(mutationOperationChecker, times(2)).check(delete);
+  }
+
+  @Test
+  public void delete_DeleteGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
+      throws CrudException {
+    // Arrange
+    Delete delete = prepareDelete();
+    Get get = prepareGet();
+
+    TransactionResult result = mock(TransactionResult.class);
+    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
+    doThrow(toThrow).when(crud).delete(delete);
+    when(toThrow.getSelection()).thenReturn(get);
+    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.delete(delete))
+        .isInstanceOf(UncommittedRecordException.class);
+
+    verify(recovery).recover(get, result);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -188,6 +188,25 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
+  public void put_PutGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
+      throws CrudException {
+    // Arrange
+    Put put = preparePut();
+    Get get = prepareGet();
+
+    TransactionResult result = mock(TransactionResult.class);
+    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
+    doThrow(toThrow).when(crud).put(put);
+    when(toThrow.getSelection()).thenReturn(get);
+    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.put(put)).isInstanceOf(UncommittedRecordException.class);
+
+    verify(recovery).recover(get, result);
+  }
+
+  @Test
   public void delete_DeleteGiven_ShouldCallCrudHandlerDelete()
       throws CrudException, ExecutionException {
     // Arrange
@@ -215,6 +234,26 @@ public class TwoPhaseConsensusCommitTest {
     // Assert
     verify(crud, times(2)).delete(delete);
     verify(mutationOperationChecker, times(2)).check(delete);
+  }
+
+  @Test
+  public void delete_DeleteGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
+      throws CrudException {
+    // Arrange
+    Delete delete = prepareDelete();
+    Get get = prepareGet();
+
+    TransactionResult result = mock(TransactionResult.class);
+    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
+    doThrow(toThrow).when(crud).delete(delete);
+    when(toThrow.getSelection()).thenReturn(get);
+    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.delete(delete))
+        .isInstanceOf(UncommittedRecordException.class);
+
+    verify(recovery).recover(get, result);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR modifies the code to execute lazy recovery for put and delete operations. In put and delete operations, the implicit pre-read can be executed when the mutation condition is specified for the operations. In such cases, when an uncommitted record is read in the implicit pre-read, we should execute lazy recovery. This PR addresses this issue.

## Related issues and/or PRs

N/A

## Changes made

- Modified the code to execute lazy recovery for put and delete operations when an uncommitted record is read in the implicit pre-read.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed a bug where lazy recovery was not executed for the implicit pre-read of put and delete operations.
