### PR TITLE
Fix flaky test and warnings in group commit

### DIFF
--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
@@ -497,7 +497,7 @@ class GroupCommitterTest {
     verify(groupCommitMonitor, never()).close();
     doReturn(false).when(metrics).hasRemaining();
 
-    future.get(2, TimeUnit.SECONDS);
+    future.get(10, TimeUnit.SECONDS);
 
     verify(groupSizeFixWorker).close();
     verify(delayedSlotMoveWorker).close();

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
@@ -24,10 +24,6 @@ class GroupManagerTest {
   @Mock private Emittable<String, Integer> emittable;
   @Mock private GroupSizeFixWorker<String, String, String, String, Integer> groupSizeFixWorker;
   @Mock private GroupCleanupWorker<String, String, String, String, Integer> groupCleanupWorker;
-  @Mock private NormalGroup<String, String, String, String, Integer> normalGroup1;
-  @Mock private NormalGroup<String, String, String, String, Integer> normalGroup2;
-  @Mock private DelayedGroup<String, String, String, String, Integer> delayedGroup1;
-  @Mock private DelayedGroup<String, String, String, String, Integer> delayedGroup2;
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
@@ -18,13 +18,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 class NormalGroupTest {
   private Emittable<String, Integer> emitter;
   private TestableKeyManipulator keyManipulator;
-  @Mock private Slot<String, String, String, String, Integer> slot1;
-  @Mock private Slot<String, String, String, String, Integer> slot2;
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
## Description

Some warnings showed and a test failure happened in https://github.com/scalar-labs/scalardb/actions/runs/8733852248/job/23963337908. The warnings should be removed and the flaky test should be fixed. 

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1650
- 
## Changes made

- Fix the warnings by removing the unused variables
- Fix the flaky test by increasing the timeout

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A