### PR TITLE
Add Insert, Upsert, and Update to TransactionCrudOperable

### DIFF
--- a/core/src/main/java/com/scalar/db/api/ConditionBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ConditionBuilder.java
@@ -84,6 +84,26 @@ public class ConditionBuilder {
   }
 
   /**
+   * Returns a builder object for a UpdateIf condition.
+   *
+   * @param conditionalExpression a condition expression for a UpdateIf condition
+   * @return a builder object
+   */
+  public static UpdateIfBuilder updateIf(ConditionalExpression conditionalExpression) {
+    return new UpdateIfBuilder(conditionalExpression);
+  }
+
+  /**
+   * Creates a UpdateIf condition with the specified conditional expressions.
+   *
+   * @param conditionalExpressions condition expressions for a UpdateIf condition
+   * @return a UpdateIf condition
+   */
+  public static UpdateIf updateIf(List<ConditionalExpression> conditionalExpressions) {
+    return new UpdateIf(conditionalExpressions);
+  }
+
+  /**
    * Builds a conditional expression with the specified column and operator.
    *
    * <p>This method is primarily for internal use. Breaking changes can and will be introduced to
@@ -845,6 +865,47 @@ public class ConditionBuilder {
           || conditionalExpression.getOperator().equals(Operator.NOT_LIKE)) {
         throw new IllegalArgumentException(
             CoreError.CONDITION_BUILD_ERROR_CONDITION_NOT_ALLOWED_FOR_DELETE_IF.buildMessage(
+                conditionalExpression));
+      }
+    }
+  }
+
+  public static class UpdateIfBuilder {
+
+    private final List<ConditionalExpression> conditionalExpressions;
+
+    private UpdateIfBuilder(ConditionalExpression conditionalExpression) {
+      check(conditionalExpression);
+      conditionalExpressions = new ArrayList<>();
+      conditionalExpressions.add(conditionalExpression);
+    }
+
+    /**
+     * Adds a condition for a UpdateIf condition.
+     *
+     * @param conditionalExpression a condition for a UpdateIf condition
+     * @return a builder object
+     */
+    public UpdateIfBuilder and(ConditionalExpression conditionalExpression) {
+      check(conditionalExpression);
+      conditionalExpressions.add(conditionalExpression);
+      return this;
+    }
+
+    /**
+     * Builds a UpdateIf condition with the specified conditional expressions.
+     *
+     * @return a UpdateIf condition
+     */
+    public UpdateIf build() {
+      return new UpdateIf(conditionalExpressions);
+    }
+
+    private void check(ConditionalExpression conditionalExpression) {
+      if (conditionalExpression.getOperator().equals(Operator.LIKE)
+          || conditionalExpression.getOperator().equals(Operator.NOT_LIKE)) {
+        throw new IllegalArgumentException(
+            CoreError.CONDITION_BUILD_ERROR_CONDITION_NOT_ALLOWED_FOR_UPDATE_IF.buildMessage(
                 conditionalExpression));
       }
     }

--- a/core/src/main/java/com/scalar/db/api/Delete.java
+++ b/core/src/main/java/com/scalar/db/api/Delete.java
@@ -6,10 +6,12 @@ import com.google.common.base.MoreObjects;
 import com.scalar.db.api.DeleteBuilder.BuildableFromExisting;
 import com.scalar.db.api.DeleteBuilder.Namespace;
 import com.scalar.db.io.Key;
+import java.util.Optional;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A command to delete an entry from {@link DistributedStorage}.
+ * A command to delete an entry from a storage.
  *
  * @author Hiroyuki Yamada
  */
@@ -120,6 +122,12 @@ public class Delete extends Mutation {
   @Deprecated
   public Delete withCondition(MutationCondition condition) {
     return (Delete) super.withCondition(condition);
+  }
+
+  @Nonnull
+  @Override
+  public Optional<MutationCondition> getCondition() {
+    return super.getCondition();
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -125,14 +125,16 @@ public interface DistributedStorage {
   Optional<Result> get(Get get) throws ExecutionException;
 
   /**
-   * Retrieves results from the storage with the specified {@link Scan} or {@link ScanAll} command
-   * and returns {@link Scanner} to iterate the results.
+   * Retrieves results from the storage with the specified {@link Scan} or {@link ScanAll} or {@link
+   * ScanWithIndex} command and returns {@link Scanner} to iterate the results.
    *
    * <ul>
    *   <li>{@link Scan} : by specifying a partition key, it will return results within the
    *       partition. Results can be filtered by specifying a range of clustering keys.
    *   <li>{@link ScanAll} : for a given table, it will return all its records even if they span
    *       several partitions.
+   *   <li>{@link ScanWithIndex} : by specifying a index key, it will return results within the
+   *       index.
    * </ul>
    *
    * @param scan a {@code Scan} or {@code ScanAll} command

--- a/core/src/main/java/com/scalar/db/api/Get.java
+++ b/core/src/main/java/com/scalar/db/api/Get.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A command to retrieve an entry from {@link DistributedStorage}.
+ * A command to retrieve an entry from a storage.
  *
  * @author Hiroyuki Yamada
  */

--- a/core/src/main/java/com/scalar/db/api/GetWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/GetWithIndex.java
@@ -3,7 +3,10 @@ package com.scalar.db.api;
 import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
+import javax.annotation.concurrent.NotThreadSafe;
 
+/** A command to retrieve a entry of a storage by using a index. */
+@NotThreadSafe
 public class GetWithIndex extends Get {
 
   /**

--- a/core/src/main/java/com/scalar/db/api/Insert.java
+++ b/core/src/main/java/com/scalar/db/api/Insert.java
@@ -1,0 +1,131 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/** A command to insert an entry to a storage. */
+@NotThreadSafe
+public class Insert extends Mutation {
+
+  private final Map<String, Column<?>> columns;
+
+  Insert(
+      @Nullable String namespace,
+      String tableName,
+      Key partitionKey,
+      @Nullable Key clusteringKey,
+      Map<String, Column<?>> columns) {
+    super(namespace, tableName, partitionKey, clusteringKey, null);
+    this.columns = ImmutableMap.copyOf(columns);
+  }
+
+  public Map<String, Column<?>> getColumns() {
+    return columns;
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Nonnull
+  @Override
+  public Optional<MutationCondition> getCondition() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public Mutation withCondition(MutationCondition condition) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Consistency getConsistency() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  public Operation withConsistency(Consistency consistency) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void accept(OperationVisitor v) {
+    v.visit(this);
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this object. The other object is considered
+   * equal if:
+   *
+   * <ul>
+   *   <li>both super class instances are equal and
+   *   <li>it is also an {@code Insert} and
+   *   <li>both instances have the same values
+   * </ul>
+   *
+   * @param o an object to be tested for equality
+   * @return {@code true} if the other object is "equal to" this object otherwise {@code false}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof Insert)) {
+      return false;
+    }
+    Insert other = (Insert) o;
+    return columns.equals(other.columns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), columns);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", forNamespace())
+        .add("table", forTable())
+        .add("partitionKey", getPartitionKey())
+        .add("clusteringKey", getClusteringKey())
+        .add("columns", getColumns())
+        .toString();
+  }
+
+  /**
+   * Build a {@code Insert} operation using a builder.
+   *
+   * @return a {@code Insert} operation builder
+   */
+  public static InsertBuilder.Namespace newBuilder() {
+    return new InsertBuilder.Namespace();
+  }
+
+  /**
+   * Build a {@code Insert} operation from an existing {@code Insert} object using a builder. The
+   * builder will be parametrized by default with all the existing {@code Insert} object attributes.
+   *
+   * @param insert an existing {@code Insert} operation
+   * @return a {@code Insert} operation builder
+   */
+  public static InsertBuilder.BuildableFromExisting newBuilder(Insert insert) {
+    checkNotNull(insert);
+    return new InsertBuilder.BuildableFromExisting(insert);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/InsertBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/InsertBuilder.java
@@ -1,0 +1,345 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
+import com.scalar.db.api.OperationBuilder.ClearNamespace;
+import com.scalar.db.api.OperationBuilder.ClearValues;
+import com.scalar.db.api.OperationBuilder.ClusteringKey;
+import com.scalar.db.api.OperationBuilder.PartitionKeyBuilder;
+import com.scalar.db.api.OperationBuilder.TableBuilder;
+import com.scalar.db.api.OperationBuilder.Values;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class InsertBuilder {
+
+  public static class Namespace
+      implements OperationBuilder.Namespace<Table>, OperationBuilder.Table<PartitionKey> {
+
+    Namespace() {}
+
+    @Override
+    public Table namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      return new Table(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(null, tableName);
+    }
+  }
+
+  public static class Table extends TableBuilder<PartitionKey> {
+
+    private Table(String namespaceName) {
+      super(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(namespace, tableName);
+    }
+  }
+
+  public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
+
+    private PartitionKey(@Nullable String namespaceName, String tableName) {
+      super(namespaceName, tableName);
+    }
+
+    @Override
+    public Buildable partitionKey(Key partitionKey) {
+      checkNotNull(partitionKey);
+      return new Buildable(namespaceName, tableName, partitionKey);
+    }
+  }
+
+  public static class Buildable extends OperationBuilder.Buildable<Insert>
+      implements ClusteringKey<Buildable>, Values<Buildable> {
+    final Map<String, Column<?>> columns = new LinkedHashMap<>();
+    @Nullable Key clusteringKey;
+
+    private Buildable(@Nullable String namespace, String table, Key partitionKey) {
+      super(namespace, table, partitionKey);
+    }
+
+    @Override
+    public Buildable clusteringKey(Key clusteringKey) {
+      checkNotNull(clusteringKey);
+      this.clusteringKey = clusteringKey;
+      return this;
+    }
+
+    @Override
+    public Buildable booleanValue(String columnName, boolean value) {
+      columns.put(columnName, BooleanColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable booleanValue(String columnName, @Nullable Boolean value) {
+      if (value != null) {
+        return booleanValue(columnName, value.booleanValue());
+      }
+      columns.put(columnName, BooleanColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable intValue(String columnName, int value) {
+      columns.put(columnName, IntColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable intValue(String columnName, @Nullable Integer value) {
+      if (value != null) {
+        return intValue(columnName, value.intValue());
+      }
+      columns.put(columnName, IntColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable bigIntValue(String columnName, long value) {
+      columns.put(columnName, BigIntColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable bigIntValue(String columnName, @Nullable Long value) {
+      if (value != null) {
+        return bigIntValue(columnName, value.longValue());
+      }
+      columns.put(columnName, BigIntColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable floatValue(String columnName, float value) {
+      columns.put(columnName, FloatColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable floatValue(String columnName, @Nullable Float value) {
+      if (value != null) {
+        return floatValue(columnName, value.floatValue());
+      }
+      columns.put(columnName, FloatColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable doubleValue(String columnName, double value) {
+      columns.put(columnName, DoubleColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable doubleValue(String columnName, @Nullable Double value) {
+      if (value != null) {
+        return doubleValue(columnName, value.doubleValue());
+      }
+      columns.put(columnName, DoubleColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable textValue(String columnName, @Nullable String value) {
+      columns.put(columnName, TextColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable blobValue(String columnName, @Nullable byte[] value) {
+      columns.put(columnName, BlobColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable blobValue(String columnName, @Nullable ByteBuffer value) {
+      columns.put(columnName, BlobColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable value(Column<?> column) {
+      columns.put(column.getName(), column);
+      return this;
+    }
+
+    @Override
+    public Insert build() {
+      return new Insert(namespaceName, tableName, partitionKey, clusteringKey, columns);
+    }
+  }
+
+  public static class BuildableFromExisting extends Buildable
+      implements OperationBuilder.Namespace<BuildableFromExisting>,
+          OperationBuilder.Table<BuildableFromExisting>,
+          OperationBuilder.PartitionKey<BuildableFromExisting>,
+          ClearClusteringKey<BuildableFromExisting>,
+          ClearValues<BuildableFromExisting>,
+          ClearNamespace<BuildableFromExisting> {
+
+    BuildableFromExisting(Insert insert) {
+      super(
+          insert.forNamespace().orElse(null),
+          insert.forTable().orElse(null),
+          insert.getPartitionKey());
+      this.clusteringKey = insert.getClusteringKey().orElse(null);
+      this.columns.putAll(insert.getColumns());
+    }
+
+    @Override
+    public BuildableFromExisting namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      this.namespaceName = namespaceName;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting table(String tableName) {
+      checkNotNull(tableName);
+      this.tableName = tableName;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting partitionKey(Key partitionKey) {
+      checkNotNull(partitionKey);
+      this.partitionKey = partitionKey;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clusteringKey(Key clusteringKey) {
+      super.clusteringKey(clusteringKey);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting booleanValue(String columnName, boolean value) {
+      super.booleanValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting booleanValue(String columnName, @Nullable Boolean value) {
+      super.booleanValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting intValue(String columnName, int value) {
+      super.intValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting intValue(String columnName, @Nullable Integer value) {
+      super.intValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting bigIntValue(String columnName, long value) {
+      super.bigIntValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting bigIntValue(String columnName, @Nullable Long value) {
+      super.bigIntValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting floatValue(String columnName, float value) {
+      super.floatValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting floatValue(String columnName, @Nullable Float value) {
+      super.floatValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting doubleValue(String columnName, double value) {
+      super.doubleValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting doubleValue(String columnName, @Nullable Double value) {
+      super.doubleValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting textValue(String columnName, @Nullable String value) {
+      super.textValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting blobValue(String columnName, @Nullable byte[] value) {
+      super.blobValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting blobValue(String columnName, @Nullable ByteBuffer value) {
+      super.blobValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting value(Column<?> column) {
+      super.value(column);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearValues() {
+      columns.clear();
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearValue(String columnName) {
+      columns.remove(columnName);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearClusteringKey() {
+      this.clusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearNamespace() {
+      this.namespaceName = null;
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/Mutation.java
+++ b/core/src/main/java/com/scalar/db/api/Mutation.java
@@ -5,16 +5,20 @@ import com.scalar.db.io.Key;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * An abstraction for mutation operations such as {@link Put} and {@link Delete}.
+ * An abstraction for mutation operations such as {@link Put}, {@link Delete}, {@link Insert},
+ * {@link Upsert}, and {@link Update}.
  *
  * @author Hiroyuki Yamada
  */
 @NotThreadSafe
 public abstract class Mutation extends Operation {
-  private Optional<MutationCondition> condition;
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated private Optional<MutationCondition> condition;
 
   /**
    * @param partitionKey a partition key
@@ -37,11 +41,23 @@ public abstract class Mutation extends Operation {
     condition = mutation.condition;
   }
 
+  Mutation(
+      @Nullable String namespace,
+      String tableName,
+      Key partitionKey,
+      @Nullable Key clusteringKey,
+      @Nullable MutationCondition condition) {
+    super(namespace, tableName, partitionKey, clusteringKey);
+    this.condition = Optional.ofNullable(condition);
+  }
+
   /**
    * Returns the {@link MutationCondition}
    *
    * @return {@code MutationCondition}
+   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
    */
+  @Deprecated
   @Nonnull
   public Optional<MutationCondition> getCondition() {
     return condition;

--- a/core/src/main/java/com/scalar/db/api/MutationConditionVisitor.java
+++ b/core/src/main/java/com/scalar/db/api/MutationConditionVisitor.java
@@ -16,4 +16,6 @@ public interface MutationConditionVisitor {
   void visit(DeleteIf condition);
 
   void visit(DeleteIfExists condition);
+
+  void visit(UpdateIf condition);
 }

--- a/core/src/main/java/com/scalar/db/api/Operation.java
+++ b/core/src/main/java/com/scalar/db/api/Operation.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,15 @@ public abstract class Operation {
     this.clusteringKey = Optional.ofNullable(clusteringKey);
     namespace = Optional.empty();
     tableName = Optional.empty();
+    consistency = Consistency.SEQUENTIAL;
+  }
+
+  public Operation(
+      @Nullable String namespace, String tableName, Key partitionKey, @Nullable Key clusteringKey) {
+    this.partitionKey = checkNotNull(partitionKey);
+    this.clusteringKey = Optional.ofNullable(clusteringKey);
+    this.namespace = Optional.ofNullable(namespace);
+    this.tableName = Optional.of(tableName);
     consistency = Consistency.SEQUENTIAL;
   }
 

--- a/core/src/main/java/com/scalar/db/api/OperationVisitor.java
+++ b/core/src/main/java/com/scalar/db/api/OperationVisitor.java
@@ -14,4 +14,10 @@ public interface OperationVisitor {
   void visit(Put put);
 
   void visit(Delete delete);
+
+  void visit(Insert insert);
+
+  void visit(Upsert upsert);
+
+  void visit(Update update);
 }

--- a/core/src/main/java/com/scalar/db/api/Put.java
+++ b/core/src/main/java/com/scalar/db/api/Put.java
@@ -26,12 +26,14 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A command to put an entry to {@link DistributedStorage}.
+ * A command to put an entry to a storage.
  *
  * @author Hiroyuki Yamada
  */
@@ -100,7 +102,7 @@ public class Put extends Mutation {
 
   /**
    * Build a {@code Put} operation from an existing {@code Put} object using a builder. The builder
-   * will be parametrized by default with all the existing {@code Put} object attributes
+   * will be parametrized by default with all the existing {@code Put} object attributes.
    *
    * @param put an existing {@code Put} operation
    * @return a {@code Put} operation builder
@@ -751,6 +753,12 @@ public class Put extends Mutation {
   @Deprecated
   public Put withCondition(MutationCondition condition) {
     return (Put) super.withCondition(condition);
+  }
+
+  @Nonnull
+  @Override
+  public Optional<MutationCondition> getCondition() {
+    return super.getCondition();
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/api/Result.java
+++ b/core/src/main/java/com/scalar/db/api/Result.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
- * A result retrieved from {@link DistributedStorage}.
+ * A result retrieved from a storage.
  *
  * @author Hiroyuki Yamada
  */

--- a/core/src/main/java/com/scalar/db/api/Scan.java
+++ b/core/src/main/java/com/scalar/db/api/Scan.java
@@ -20,11 +20,11 @@ import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A command to retrieve entries within a partition from {@link DistributedStorage}. The scan range
- * is defined with a starting clustering key and an ending clustering key. {@link Ordering} can also
- * be specified to return {@link Result}s in ascending order or descending order of clustering keys.
- * The number of {@link Result} can also be limited. If none of these are set, it will return all
- * the {@link Result}s with a specified partition key in default clustering orders.
+ * A command to retrieve entries from a storage. The scan range is defined with a starting
+ * clustering key and an ending clustering key. {@link Ordering} can also be specified to return
+ * {@link Result}s in ascending order or descending order of clustering keys. The number of {@link
+ * Result} can also be limited. If none of these are set, it will return all the {@link Result}s
+ * with a specified partition key in default clustering orders.
  *
  * @author Hiroyuki Yamada
  */

--- a/core/src/main/java/com/scalar/db/api/ScanAll.java
+++ b/core/src/main/java/com/scalar/db/api/ScanAll.java
@@ -6,9 +6,8 @@ import java.util.Objects;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A command to retrieve all the entries of the database. The scan range of clustering key and
- * {@link Ordering} cannot be specified for this command. The number of {@link Result} can be
- * limited.
+ * A command to retrieve all the entries of a storage. The scan range of clustering key and {@link
+ * Ordering} cannot be specified for this command. The number of {@link Result} can be limited.
  */
 @NotThreadSafe
 public class ScanAll extends Scan {

--- a/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
+++ b/core/src/main/java/com/scalar/db/api/ScanWithIndex.java
@@ -3,7 +3,13 @@ package com.scalar.db.api;
 import com.scalar.db.io.Key;
 import java.util.Collection;
 import java.util.Objects;
+import javax.annotation.concurrent.NotThreadSafe;
 
+/**
+ * A command to retrieve entries of a storage by using a index. The number of {@link Result} can be
+ * limited.
+ */
+@NotThreadSafe
 public class ScanWithIndex extends Scan {
 
   /**

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -1,7 +1,10 @@
 package com.scalar.db.api;
 
+import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.RecordNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import java.util.List;
 import java.util.Optional;
@@ -44,7 +47,8 @@ public interface TransactionCrudOperable {
 
   /**
    * Inserts/Updates an entry to the storage through a transaction with the specified {@link Put}
-   * command.
+   * command. If a condition is specified in the {@link Put} command, and if the condition is not
+   * satisfied or the entry does not exist, it throws {@link UnsatisfiedConditionException}.
    *
    * @param put a {@code Put} command
    * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
@@ -52,13 +56,18 @@ public interface TransactionCrudOperable {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
-   * @throws UnsatisfiedConditionException if the mutation condition is not satisfied
+   * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
+   *     satisfied or the entry does not exist
+   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
    */
+  @Deprecated
   void put(Put put) throws CrudConflictException, CrudException, UnsatisfiedConditionException;
 
   /**
    * Inserts/Updates multiple entries to the storage through a transaction with the specified list
-   * of {@link Put} commands.
+   * of {@link Put} commands. If a condition is specified in the {@link Put} command, and if the
+   * condition is not satisfied or the entry does not exist, it throws {@link
+   * UnsatisfiedConditionException}.
    *
    * @param puts a list of {@code Put} commands
    * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
@@ -66,14 +75,18 @@ public interface TransactionCrudOperable {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
-   * @throws UnsatisfiedConditionException if the mutation condition is not satisfied
+   * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
+   *     satisfied or the entry does not exist
+   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
    */
+  @Deprecated
   void put(List<Put> puts)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException;
 
   /**
    * Deletes an entry from the storage through a transaction with the specified {@link Delete}
-   * command.
+   * command. If a condition is specified in the {@link Delete} command, and if the condition is not
+   * satisfied or the entry does not exist, it throws {@link UnsatisfiedConditionException}.
    *
    * @param delete a {@code Delete} command
    * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
@@ -81,14 +94,17 @@ public interface TransactionCrudOperable {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
-   * @throws UnsatisfiedConditionException if the mutation condition is not satisfied
+   * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
+   *     satisfied or the entry does not exist
    */
   void delete(Delete delete)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException;
 
   /**
    * Deletes entries from the storage through a transaction with the specified list of {@link
-   * Delete} commands.
+   * Delete} commands. If a condition is specified in the {@link Delete} command, and if the
+   * condition is not satisfied or the entry does not exist, it throws {@link
+   * UnsatisfiedConditionException}.
    *
    * @param deletes a list of {@code Delete} commands
    * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
@@ -96,10 +112,66 @@ public interface TransactionCrudOperable {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
-   * @throws UnsatisfiedConditionException if the mutation condition is not satisfied
+   * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
+   *     satisfied or the entry does not exist
+   * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
    */
+  @Deprecated
   void delete(List<Delete> deletes)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException;
+
+  /**
+   * Inserts an entry into the storage through a transaction with the specified {@link Insert}
+   * command.
+   *
+   * <p>If the entry already exists, a conflict error occurs. Note that the location where the
+   * conflict error is thrown depends on the implementation of the transaction manager. This method
+   * may throw {@link CrudConflictException}. Alternatively, {@link DistributedTransaction#commit()}
+   * or {@link TwoPhaseCommitTransaction#prepare()} may throw {@link CommitConflictException} or
+   * {@link PreparationConflictException} respectively in case of a conflict error.
+   *
+   * @param insert a {@code Insert} command
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
+   */
+  void insert(Insert insert) throws CrudConflictException, CrudException;
+
+  /**
+   * Inserts or updates an entry in the storage through a transaction with the specified {@link
+   * Upsert} command. If the entry already exists, it is updated; otherwise, it is inserted.
+   *
+   * @param upsert a {@code Upsert} command
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
+   */
+  void upsert(Upsert upsert) throws CrudConflictException, CrudException;
+
+  /**
+   * Updates an entry in the storage through a transaction with the specified {@link Update}
+   * command. If a condition is specified in the {@link Update} command, and if the condition is not
+   * satisfied or the entry does not exist, it throws {@link UnsatisfiedConditionException}. If no
+   * condition is specified in the {@link Update} command and the entry does not exist, it throws
+   * {@link RecordNotFoundException}.
+   *
+   * @param update an {@code Update} command
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
+   * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
+   *     satisfied or the entry does not exist
+   * @throws RecordNotFoundException if no condition is specified and the entry does not exist
+   */
+  void update(Update update)
+      throws CrudConflictException, CrudException, UnsatisfiedConditionException,
+          RecordNotFoundException;
 
   /**
    * Mutates entries of the storage through a transaction with the specified list of {@link
@@ -111,7 +183,11 @@ public interface TransactionCrudOperable {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
-   * @throws UnsatisfiedConditionException if the mutation condition is not satisfied
+   * @throws UnsatisfiedConditionException if a condition is specified in a {@link Put}, {@link
+   *     Delete}, or {@link Update} command, and if the condition is not satisfied or the entry does
+   *     not exist
+   * @throws RecordNotFoundException if no condition is specified in an {@link Update} command and
+   *     the entry does not exist
    */
   void mutate(List<? extends Mutation> mutations)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException;

--- a/core/src/main/java/com/scalar/db/api/Update.java
+++ b/core/src/main/java/com/scalar/db/api/Update.java
@@ -1,0 +1,124 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/** A command to update an entry to a storage. */
+@NotThreadSafe
+public class Update extends Mutation {
+
+  private final Map<String, Column<?>> columns;
+
+  Update(
+      @Nullable String namespace,
+      String tableName,
+      Key partitionKey,
+      @Nullable Key clusteringKey,
+      Map<String, Column<?>> columns,
+      @Nullable MutationCondition condition) {
+    super(namespace, tableName, partitionKey, clusteringKey, condition);
+    this.columns = ImmutableMap.copyOf(columns);
+  }
+
+  public Map<String, Column<?>> getColumns() {
+    return columns;
+  }
+
+  @Nonnull
+  @Override
+  public Optional<MutationCondition> getCondition() {
+    return super.getCondition();
+  }
+
+  @Override
+  public Consistency getConsistency() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  public Operation withConsistency(Consistency consistency) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void accept(OperationVisitor v) {
+    v.visit(this);
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this object. The other object is considered
+   * equal if:
+   *
+   * <ul>
+   *   <li>both super class instances are equal and
+   *   <li>it is also an {@code Update} and
+   *   <li>both instances have the same values
+   * </ul>
+   *
+   * @param o an object to be tested for equality
+   * @return {@code true} if the other object is "equal to" this object otherwise {@code false}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof Update)) {
+      return false;
+    }
+    Update other = (Update) o;
+    return columns.equals(other.columns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), columns);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", forNamespace())
+        .add("table", forTable())
+        .add("partitionKey", getPartitionKey())
+        .add("clusteringKey", getClusteringKey())
+        .add("columns", getColumns())
+        .add("condition", getCondition())
+        .toString();
+  }
+
+  /**
+   * Build a {@code Update} operation using a builder.
+   *
+   * @return a {@code Update} operation builder
+   */
+  public static UpdateBuilder.Namespace newBuilder() {
+    return new UpdateBuilder.Namespace();
+  }
+
+  /**
+   * Build a {@code Update} operation from an existing {@code Update} object using a builder. The
+   * builder will be parametrized by default with all the existing {@code Update} object attributes.
+   *
+   * @param update an existing {@code Update} operation
+   * @return a {@code Update} operation builder
+   */
+  public static UpdateBuilder.BuildableFromExisting newBuilder(Update update) {
+    checkNotNull(update);
+    return new UpdateBuilder.BuildableFromExisting(update);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/UpdateBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/UpdateBuilder.java
@@ -1,0 +1,369 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
+import com.scalar.db.api.OperationBuilder.ClearCondition;
+import com.scalar.db.api.OperationBuilder.ClearNamespace;
+import com.scalar.db.api.OperationBuilder.ClearValues;
+import com.scalar.db.api.OperationBuilder.ClusteringKey;
+import com.scalar.db.api.OperationBuilder.Condition;
+import com.scalar.db.api.OperationBuilder.PartitionKeyBuilder;
+import com.scalar.db.api.OperationBuilder.TableBuilder;
+import com.scalar.db.api.OperationBuilder.Values;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class UpdateBuilder {
+
+  public static class Namespace
+      implements OperationBuilder.Namespace<Table>, OperationBuilder.Table<PartitionKey> {
+
+    Namespace() {}
+
+    @Override
+    public Table namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      return new Table(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(null, tableName);
+    }
+  }
+
+  public static class Table extends TableBuilder<PartitionKey> {
+
+    private Table(String namespaceName) {
+      super(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(namespace, tableName);
+    }
+  }
+
+  public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
+
+    private PartitionKey(@Nullable String namespaceName, String tableName) {
+      super(namespaceName, tableName);
+    }
+
+    @Override
+    public Buildable partitionKey(Key partitionKey) {
+      checkNotNull(partitionKey);
+      return new Buildable(namespaceName, tableName, partitionKey);
+    }
+  }
+
+  public static class Buildable extends OperationBuilder.Buildable<Update>
+      implements ClusteringKey<Buildable>, Condition<Buildable>, Values<Buildable> {
+    final Map<String, Column<?>> columns = new LinkedHashMap<>();
+    @Nullable Key clusteringKey;
+    @Nullable MutationCondition condition;
+
+    private Buildable(@Nullable String namespace, String table, Key partitionKey) {
+      super(namespace, table, partitionKey);
+    }
+
+    @Override
+    public Buildable clusteringKey(Key clusteringKey) {
+      checkNotNull(clusteringKey);
+      this.clusteringKey = clusteringKey;
+      return this;
+    }
+
+    @Override
+    public Buildable condition(MutationCondition condition) {
+      checkNotNull(condition);
+      this.condition = condition;
+      return this;
+    }
+
+    @Override
+    public Buildable booleanValue(String columnName, boolean value) {
+      columns.put(columnName, BooleanColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable booleanValue(String columnName, @Nullable Boolean value) {
+      if (value != null) {
+        return booleanValue(columnName, value.booleanValue());
+      }
+      columns.put(columnName, BooleanColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable intValue(String columnName, int value) {
+      columns.put(columnName, IntColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable intValue(String columnName, @Nullable Integer value) {
+      if (value != null) {
+        return intValue(columnName, value.intValue());
+      }
+      columns.put(columnName, IntColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable bigIntValue(String columnName, long value) {
+      columns.put(columnName, BigIntColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable bigIntValue(String columnName, @Nullable Long value) {
+      if (value != null) {
+        return bigIntValue(columnName, value.longValue());
+      }
+      columns.put(columnName, BigIntColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable floatValue(String columnName, float value) {
+      columns.put(columnName, FloatColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable floatValue(String columnName, @Nullable Float value) {
+      if (value != null) {
+        return floatValue(columnName, value.floatValue());
+      }
+      columns.put(columnName, FloatColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable doubleValue(String columnName, double value) {
+      columns.put(columnName, DoubleColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable doubleValue(String columnName, @Nullable Double value) {
+      if (value != null) {
+        return doubleValue(columnName, value.doubleValue());
+      }
+      columns.put(columnName, DoubleColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable textValue(String columnName, @Nullable String value) {
+      columns.put(columnName, TextColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable blobValue(String columnName, @Nullable byte[] value) {
+      columns.put(columnName, BlobColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable blobValue(String columnName, @Nullable ByteBuffer value) {
+      columns.put(columnName, BlobColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable value(Column<?> column) {
+      columns.put(column.getName(), column);
+      return this;
+    }
+
+    @Override
+    public Update build() {
+      return new Update(namespaceName, tableName, partitionKey, clusteringKey, columns, condition);
+    }
+  }
+
+  public static class BuildableFromExisting extends Buildable
+      implements OperationBuilder.Namespace<BuildableFromExisting>,
+          OperationBuilder.Table<BuildableFromExisting>,
+          OperationBuilder.PartitionKey<BuildableFromExisting>,
+          ClearClusteringKey<BuildableFromExisting>,
+          ClearValues<BuildableFromExisting>,
+          ClearCondition<BuildableFromExisting>,
+          ClearNamespace<BuildableFromExisting> {
+
+    BuildableFromExisting(Update update) {
+      super(
+          update.forNamespace().orElse(null),
+          update.forTable().orElse(null),
+          update.getPartitionKey());
+      this.clusteringKey = update.getClusteringKey().orElse(null);
+      this.columns.putAll(update.getColumns());
+      this.condition = update.getCondition().orElse(null);
+    }
+
+    @Override
+    public BuildableFromExisting namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      this.namespaceName = namespaceName;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting table(String tableName) {
+      checkNotNull(tableName);
+      this.tableName = tableName;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting partitionKey(Key partitionKey) {
+      checkNotNull(partitionKey);
+      this.partitionKey = partitionKey;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clusteringKey(Key clusteringKey) {
+      super.clusteringKey(clusteringKey);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting condition(MutationCondition condition) {
+      super.condition(condition);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting booleanValue(String columnName, boolean value) {
+      super.booleanValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting booleanValue(String columnName, @Nullable Boolean value) {
+      super.booleanValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting intValue(String columnName, int value) {
+      super.intValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting intValue(String columnName, @Nullable Integer value) {
+      super.intValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting bigIntValue(String columnName, long value) {
+      super.bigIntValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting bigIntValue(String columnName, @Nullable Long value) {
+      super.bigIntValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting floatValue(String columnName, float value) {
+      super.floatValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting floatValue(String columnName, @Nullable Float value) {
+      super.floatValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting doubleValue(String columnName, double value) {
+      super.doubleValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting doubleValue(String columnName, @Nullable Double value) {
+      super.doubleValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting textValue(String columnName, @Nullable String value) {
+      super.textValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting blobValue(String columnName, @Nullable byte[] value) {
+      super.blobValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting blobValue(String columnName, @Nullable ByteBuffer value) {
+      super.blobValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting value(Column<?> column) {
+      super.value(column);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearValues() {
+      columns.clear();
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearValue(String columnName) {
+      columns.remove(columnName);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearClusteringKey() {
+      this.clusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearCondition() {
+      this.condition = null;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearNamespace() {
+      this.namespaceName = null;
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/UpdateIf.java
+++ b/core/src/main/java/com/scalar/db/api/UpdateIf.java
@@ -1,0 +1,79 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * An optional parameter of {@link Update} for conditional update. {@link Update} with this
+ * condition makes the operation take effect only if a specified condition is met.
+ */
+@Immutable
+public class UpdateIf implements MutationCondition {
+  private final List<ConditionalExpression> expressions;
+
+  /**
+   * Constructs a {@code UpdateIf} with the specified list of conditional expressions.
+   *
+   * @param expressions a list of expressions specified with {@code ConditionalExpression}s
+   */
+  UpdateIf(List<ConditionalExpression> expressions) {
+    checkNotNull(expressions);
+    this.expressions = ImmutableList.copyOf(expressions);
+  }
+
+  /**
+   * Returns the immutable list of conditional expressions.
+   *
+   * @return an immutable list of conditional expressions
+   */
+  @Override
+  @Nonnull
+  public List<ConditionalExpression> getExpressions() {
+    return expressions;
+  }
+
+  @Override
+  public void accept(MutationConditionVisitor visitor) {
+    visitor.visit(this);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(expressions);
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this object. The other object is considered
+   * equal if:
+   *
+   * <ul>
+   *   <li>it is also an {@code UpdateIf} and
+   *   <li>both instances have the same expressions
+   * </ul>
+   *
+   * @param o an object to be tested for equality
+   * @return {@code true} if the other object is "equal to" this object otherwise {@code false}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof UpdateIf)) {
+      return false;
+    }
+    UpdateIf other = (UpdateIf) o;
+    return expressions.equals(other.expressions);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("expressions", expressions).toString();
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/Upsert.java
+++ b/core/src/main/java/com/scalar/db/api/Upsert.java
@@ -1,0 +1,131 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/** A command to insert or update an entry to a storage. */
+@NotThreadSafe
+public class Upsert extends Mutation {
+
+  private final Map<String, Column<?>> columns;
+
+  Upsert(
+      @Nullable String namespace,
+      String tableName,
+      Key partitionKey,
+      @Nullable Key clusteringKey,
+      Map<String, Column<?>> columns) {
+    super(namespace, tableName, partitionKey, clusteringKey, null);
+    this.columns = ImmutableMap.copyOf(columns);
+  }
+
+  public Map<String, Column<?>> getColumns() {
+    return columns;
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Nonnull
+  @Override
+  public Optional<MutationCondition> getCondition() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public Mutation withCondition(MutationCondition condition) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Consistency getConsistency() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @deprecated As of release 3.6.0. Will be removed in release 5.0.0 */
+  @Deprecated
+  public Operation withConsistency(Consistency consistency) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void accept(OperationVisitor v) {
+    v.visit(this);
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this object. The other object is considered
+   * equal if:
+   *
+   * <ul>
+   *   <li>both super class instances are equal and
+   *   <li>it is also an {@code Upsert} and
+   *   <li>both instances have the same values
+   * </ul>
+   *
+   * @param o an object to be tested for equality
+   * @return {@code true} if the other object is "equal to" this object otherwise {@code false}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof Upsert)) {
+      return false;
+    }
+    Upsert other = (Upsert) o;
+    return columns.equals(other.columns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), columns);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", forNamespace())
+        .add("table", forTable())
+        .add("partitionKey", getPartitionKey())
+        .add("clusteringKey", getClusteringKey())
+        .add("columns", getColumns())
+        .toString();
+  }
+
+  /**
+   * Build a {@code Upsert} operation using a builder.
+   *
+   * @return a {@code Upsert} operation builder
+   */
+  public static UpsertBuilder.Namespace newBuilder() {
+    return new UpsertBuilder.Namespace();
+  }
+
+  /**
+   * Build a {@code Upsert} operation from an existing {@code Upsert} object using a builder. The
+   * builder will be parametrized by default with all the existing {@code Upsert} object attributes.
+   *
+   * @param upsert an existing {@code Upsert} operation
+   * @return a {@code Upsert} operation builder
+   */
+  public static UpsertBuilder.BuildableFromExisting newBuilder(Upsert upsert) {
+    checkNotNull(upsert);
+    return new UpsertBuilder.BuildableFromExisting(upsert);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/UpsertBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/UpsertBuilder.java
@@ -1,0 +1,345 @@
+package com.scalar.db.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.scalar.db.api.OperationBuilder.ClearClusteringKey;
+import com.scalar.db.api.OperationBuilder.ClearNamespace;
+import com.scalar.db.api.OperationBuilder.ClearValues;
+import com.scalar.db.api.OperationBuilder.ClusteringKey;
+import com.scalar.db.api.OperationBuilder.PartitionKeyBuilder;
+import com.scalar.db.api.OperationBuilder.TableBuilder;
+import com.scalar.db.api.OperationBuilder.Values;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class UpsertBuilder {
+
+  public static class Namespace
+      implements OperationBuilder.Namespace<Table>, OperationBuilder.Table<PartitionKey> {
+
+    Namespace() {}
+
+    @Override
+    public Table namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      return new Table(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(null, tableName);
+    }
+  }
+
+  public static class Table extends TableBuilder<PartitionKey> {
+
+    private Table(String namespaceName) {
+      super(namespaceName);
+    }
+
+    @Override
+    public PartitionKey table(String tableName) {
+      checkNotNull(tableName);
+      return new PartitionKey(namespace, tableName);
+    }
+  }
+
+  public static class PartitionKey extends PartitionKeyBuilder<Buildable> {
+
+    private PartitionKey(@Nullable String namespaceName, String tableName) {
+      super(namespaceName, tableName);
+    }
+
+    @Override
+    public Buildable partitionKey(Key partitionKey) {
+      checkNotNull(partitionKey);
+      return new Buildable(namespaceName, tableName, partitionKey);
+    }
+  }
+
+  public static class Buildable extends OperationBuilder.Buildable<Upsert>
+      implements ClusteringKey<Buildable>, Values<Buildable> {
+    final Map<String, Column<?>> columns = new LinkedHashMap<>();
+    @Nullable Key clusteringKey;
+
+    private Buildable(@Nullable String namespace, String table, Key partitionKey) {
+      super(namespace, table, partitionKey);
+    }
+
+    @Override
+    public Buildable clusteringKey(Key clusteringKey) {
+      checkNotNull(clusteringKey);
+      this.clusteringKey = clusteringKey;
+      return this;
+    }
+
+    @Override
+    public Buildable booleanValue(String columnName, boolean value) {
+      columns.put(columnName, BooleanColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable booleanValue(String columnName, @Nullable Boolean value) {
+      if (value != null) {
+        return booleanValue(columnName, value.booleanValue());
+      }
+      columns.put(columnName, BooleanColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable intValue(String columnName, int value) {
+      columns.put(columnName, IntColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable intValue(String columnName, @Nullable Integer value) {
+      if (value != null) {
+        return intValue(columnName, value.intValue());
+      }
+      columns.put(columnName, IntColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable bigIntValue(String columnName, long value) {
+      columns.put(columnName, BigIntColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable bigIntValue(String columnName, @Nullable Long value) {
+      if (value != null) {
+        return bigIntValue(columnName, value.longValue());
+      }
+      columns.put(columnName, BigIntColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable floatValue(String columnName, float value) {
+      columns.put(columnName, FloatColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable floatValue(String columnName, @Nullable Float value) {
+      if (value != null) {
+        return floatValue(columnName, value.floatValue());
+      }
+      columns.put(columnName, FloatColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable doubleValue(String columnName, double value) {
+      columns.put(columnName, DoubleColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable doubleValue(String columnName, @Nullable Double value) {
+      if (value != null) {
+        return doubleValue(columnName, value.doubleValue());
+      }
+      columns.put(columnName, DoubleColumn.ofNull(columnName));
+      return this;
+    }
+
+    @Override
+    public Buildable textValue(String columnName, @Nullable String value) {
+      columns.put(columnName, TextColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable blobValue(String columnName, @Nullable byte[] value) {
+      columns.put(columnName, BlobColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable blobValue(String columnName, @Nullable ByteBuffer value) {
+      columns.put(columnName, BlobColumn.of(columnName, value));
+      return this;
+    }
+
+    @Override
+    public Buildable value(Column<?> column) {
+      columns.put(column.getName(), column);
+      return this;
+    }
+
+    @Override
+    public Upsert build() {
+      return new Upsert(namespaceName, tableName, partitionKey, clusteringKey, columns);
+    }
+  }
+
+  public static class BuildableFromExisting extends Buildable
+      implements OperationBuilder.Namespace<BuildableFromExisting>,
+          OperationBuilder.Table<BuildableFromExisting>,
+          OperationBuilder.PartitionKey<BuildableFromExisting>,
+          ClearClusteringKey<BuildableFromExisting>,
+          ClearValues<BuildableFromExisting>,
+          ClearNamespace<BuildableFromExisting> {
+
+    BuildableFromExisting(Upsert upsert) {
+      super(
+          upsert.forNamespace().orElse(null),
+          upsert.forTable().orElse(null),
+          upsert.getPartitionKey());
+      this.clusteringKey = upsert.getClusteringKey().orElse(null);
+      this.columns.putAll(upsert.getColumns());
+    }
+
+    @Override
+    public BuildableFromExisting namespace(String namespaceName) {
+      checkNotNull(namespaceName);
+      this.namespaceName = namespaceName;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting table(String tableName) {
+      checkNotNull(tableName);
+      this.tableName = tableName;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting partitionKey(Key partitionKey) {
+      checkNotNull(partitionKey);
+      this.partitionKey = partitionKey;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clusteringKey(Key clusteringKey) {
+      super.clusteringKey(clusteringKey);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting booleanValue(String columnName, boolean value) {
+      super.booleanValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting booleanValue(String columnName, @Nullable Boolean value) {
+      super.booleanValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting intValue(String columnName, int value) {
+      super.intValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting intValue(String columnName, @Nullable Integer value) {
+      super.intValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting bigIntValue(String columnName, long value) {
+      super.bigIntValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting bigIntValue(String columnName, @Nullable Long value) {
+      super.bigIntValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting floatValue(String columnName, float value) {
+      super.floatValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting floatValue(String columnName, @Nullable Float value) {
+      super.floatValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting doubleValue(String columnName, double value) {
+      super.doubleValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting doubleValue(String columnName, @Nullable Double value) {
+      super.doubleValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting textValue(String columnName, @Nullable String value) {
+      super.textValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting blobValue(String columnName, @Nullable byte[] value) {
+      super.blobValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting blobValue(String columnName, @Nullable ByteBuffer value) {
+      super.blobValue(columnName, value);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting value(Column<?> column) {
+      super.value(column);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearValues() {
+      columns.clear();
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearValue(String columnName) {
+      columns.remove(columnName);
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearClusteringKey() {
+      this.clusteringKey = null;
+      return this;
+    }
+
+    @Override
+    public BuildableFromExisting clearNamespace() {
+      this.namespaceName = null;
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransaction.java
@@ -3,9 +3,12 @@ package com.scalar.db.common;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.List;
 import java.util.Optional;
@@ -74,5 +77,17 @@ public abstract class AbstractDistributedTransaction implements DistributedTrans
 
   protected Delete copyAndSetTargetToIfNot(Delete delete) {
     return ScalarDbUtils.copyAndSetTargetToIfNot(delete, namespace, tableName);
+  }
+
+  protected Insert copyAndSetTargetToIfNot(Insert insert) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(insert, namespace, tableName);
+  }
+
+  protected Upsert copyAndSetTargetToIfNot(Upsert upsert) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(upsert, namespace, tableName);
+  }
+
+  protected Update copyAndSetTargetToIfNot(Update update) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(update, namespace, tableName);
   }
 }

--- a/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractDistributedTransactionManager.java
@@ -5,10 +5,13 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.AbortException;
@@ -122,12 +125,16 @@ public abstract class AbstractDistributedTransactionManager
       return super.scan(scan);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public void put(Put put) throws CrudException {
       checkIfActive();
       super.put(put);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public void put(List<Put> puts) throws CrudException {
       checkIfActive();
@@ -140,10 +147,30 @@ public abstract class AbstractDistributedTransactionManager
       super.delete(delete);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public void delete(List<Delete> deletes) throws CrudException {
       checkIfActive();
       super.delete(deletes);
+    }
+
+    @Override
+    public void insert(Insert insert) throws CrudException {
+      checkIfActive();
+      super.insert(insert);
+    }
+
+    @Override
+    public void upsert(Upsert upsert) throws CrudException {
+      checkIfActive();
+      super.upsert(upsert);
+    }
+
+    @Override
+    public void update(Update update) throws CrudException {
+      checkIfActive();
+      super.update(update);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransaction.java
@@ -2,10 +2,13 @@ package com.scalar.db.common;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.util.ScalarDbUtils;
 import java.util.List;
 import java.util.Optional;
@@ -74,5 +77,17 @@ public abstract class AbstractTwoPhaseCommitTransaction implements TwoPhaseCommi
 
   protected Delete copyAndSetTargetToIfNot(Delete delete) {
     return ScalarDbUtils.copyAndSetTargetToIfNot(delete, namespace, tableName);
+  }
+
+  protected Insert copyAndSetTargetToIfNot(Insert insert) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(insert, namespace, tableName);
+  }
+
+  protected Upsert copyAndSetTargetToIfNot(Upsert upsert) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(upsert, namespace, tableName);
+  }
+
+  protected Update copyAndSetTargetToIfNot(Update update) {
+    return ScalarDbUtils.copyAndSetTargetToIfNot(update, namespace, tableName);
   }
 }

--- a/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManager.java
@@ -3,12 +3,15 @@ package com.scalar.db.common;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.AbortException;
@@ -128,12 +131,16 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
       return super.scan(scan);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public void put(Put put) throws CrudException {
       checkIfActive();
       super.put(put);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public void put(List<Put> puts) throws CrudException {
       checkIfActive();
@@ -146,10 +153,30 @@ public abstract class AbstractTwoPhaseCommitTransactionManager
       super.delete(delete);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public void delete(List<Delete> deletes) throws CrudException {
       checkIfActive();
       super.delete(deletes);
+    }
+
+    @Override
+    public void insert(Insert insert) throws CrudException {
+      checkIfActive();
+      super.insert(insert);
+    }
+
+    @Override
+    public void upsert(Upsert upsert) throws CrudException {
+      checkIfActive();
+      super.upsert(upsert);
+    }
+
+    @Override
+    public void update(Update update) throws CrudException {
+      checkIfActive();
+      super.update(update);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -3,10 +3,13 @@ package com.scalar.db.common;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.AbortException;
@@ -112,11 +115,15 @@ public abstract class ActiveTransactionManagedDistributedTransactionManager
       return super.scan(scan);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
       super.put(put);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
       super.put(puts);
@@ -127,9 +134,26 @@ public abstract class ActiveTransactionManagedDistributedTransactionManager
       super.delete(delete);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
       super.delete(deletes);
+    }
+
+    @Override
+    public void insert(Insert insert) throws CrudException {
+      super.insert(insert);
+    }
+
+    @Override
+    public void upsert(Upsert upsert) throws CrudException {
+      super.upsert(upsert);
+    }
+
+    @Override
+    public void update(Update update) throws CrudException {
+      super.update(update);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -2,11 +2,14 @@ package com.scalar.db.common;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.AbortException;
@@ -119,11 +122,15 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       return super.scan(scan);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public synchronized void put(Put put) throws CrudException {
       super.put(put);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public synchronized void put(List<Put> puts) throws CrudException {
       super.put(puts);
@@ -134,9 +141,26 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       super.delete(delete);
     }
 
+    /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+    @Deprecated
     @Override
     public synchronized void delete(List<Delete> deletes) throws CrudException {
       super.delete(deletes);
+    }
+
+    @Override
+    public void insert(Insert insert) throws CrudException {
+      super.insert(insert);
+    }
+
+    @Override
+    public void upsert(Upsert upsert) throws CrudException {
+      super.upsert(upsert);
+    }
+
+    @Override
+    public void update(Update update) throws CrudException {
+      super.update(update);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
@@ -3,10 +3,13 @@ package com.scalar.db.common;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
@@ -73,11 +76,15 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     return decoratedTransaction.scan(scan);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     decoratedTransaction.put(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     decoratedTransaction.put(puts);
@@ -88,9 +95,26 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     decoratedTransaction.delete(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     decoratedTransaction.delete(deletes);
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    decoratedTransaction.insert(insert);
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    decoratedTransaction.update(update);
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    decoratedTransaction.upsert(upsert);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -2,11 +2,14 @@ package com.scalar.db.common;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
@@ -75,11 +78,15 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     return decoratedTransaction.scan(scan);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     decoratedTransaction.put(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     decoratedTransaction.put(puts);
@@ -90,9 +97,26 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     decoratedTransaction.delete(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     decoratedTransaction.delete(deletes);
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    decoratedTransaction.insert(insert);
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    decoratedTransaction.upsert(upsert);
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    decoratedTransaction.update(update);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/checker/ColumnChecker.java
+++ b/core/src/main/java/com/scalar/db/common/checker/ColumnChecker.java
@@ -13,6 +13,7 @@ import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.TextColumn;
 import javax.annotation.concurrent.NotThreadSafe;
 
+/** A checker for the columns of a table for the storage abstraction. */
 @NotThreadSafe
 public class ColumnChecker implements ColumnVisitor {
   private final TableMetadata tableMetadata;

--- a/core/src/main/java/com/scalar/db/common/checker/ConditionChecker.java
+++ b/core/src/main/java/com/scalar/db/common/checker/ConditionChecker.java
@@ -10,9 +10,11 @@ import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.UpdateIf;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
+/** A checker for the conditions of mutations for the storage abstraction. */
 @NotThreadSafe
 public class ConditionChecker implements MutationConditionVisitor {
   private final TableMetadata tableMetadata;
@@ -82,5 +84,10 @@ public class ConditionChecker implements MutationConditionVisitor {
         break;
       }
     }
+  }
+
+  @Override
+  public void visit(UpdateIf condition) {
+    isValid = false;
   }
 }

--- a/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
+++ b/core/src/main/java/com/scalar/db/common/checker/OperationChecker.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
 
+/** A checker for the operations for the storage abstraction. */
 @ThreadSafe
 public class OperationChecker {
 
@@ -331,6 +332,10 @@ public class OperationChecker {
 
     Mutation first = mutations.get(0);
     for (Mutation mutation : mutations) {
+      // Check if each mutation is Put or Delete
+      checkMutationType(mutation);
+
+      // Check if all mutations are for the same partition
       if (!mutation.forNamespace().equals(first.forNamespace())
           || !mutation.forTable().equals(first.forTable())
           || !mutation.getPartitionKey().equals(first.getPartitionKey())) {
@@ -346,6 +351,13 @@ public class OperationChecker {
         assert mutation instanceof Delete;
         check((Delete) mutation);
       }
+    }
+  }
+
+  private void checkMutationType(Mutation mutation) {
+    if (!(mutation instanceof Put) && !(mutation instanceof Delete)) {
+      throw new IllegalArgumentException(
+          CoreError.OPERATION_CHECK_ERROR_UNSUPPORTED_MUTATION_TYPE.buildMessage(mutation));
     }
   }
 

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -572,6 +572,14 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0124", "Columns must be specified. Table: %s", "", ""),
   SCHEMA_LOADER_PARSE_ERROR_INVALID_COLUMN_TYPE(
       Category.USER_ERROR, "0125", "Invalid column type. Table: %s; Column: %s; Type: %s", "", ""),
+  OPERATION_CHECK_ERROR_UNSUPPORTED_MUTATION_TYPE(
+      Category.USER_ERROR, "0126", "The mutation type is not supported. Mutation: %s", "", ""),
+  CONDITION_BUILD_ERROR_CONDITION_NOT_ALLOWED_FOR_UPDATE_IF(
+      Category.USER_ERROR,
+      "0127",
+      "This condition is not allowed for the UpdateIf operation. Condition: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -665,6 +673,16 @@ public enum CoreError implements ScalarDbError {
       "An anti-dependency was found. The transaction has been aborted",
       "",
       ""),
+  CONSENSUS_COMMIT_RECORD_NOT_FOUND(
+      Category.CONCURRENCY_ERROR, "0023", "The record does not exist", "", ""),
+  JDBC_TRANSACTION_CONFLICT_OCCURRED_IN_INSERT(
+      Category.CONCURRENCY_ERROR,
+      "0024",
+      "A transaction conflict occurred in the Insert operation",
+      "",
+      ""),
+  JDBC_TRANSACTION_RECORD_NOT_FOUND(
+      Category.CONCURRENCY_ERROR, "0025", "The record does not exist", "", ""),
 
   //
   // Errors for the internal error category
@@ -774,10 +792,10 @@ public enum CoreError implements ScalarDbError {
   CONSENSUS_COMMIT_VALIDATION_FAILED(Category.INTERNAL_ERROR, "0037", "Validation failed", "", ""),
   CONSENSUS_COMMIT_EXECUTING_IMPLICIT_PRE_READ_FAILED(
       Category.INTERNAL_ERROR, "0038", "Executing implicit pre-read failed", "", ""),
-  CONSENSUS_COMMIT_GET_OPERATION_FAILED(
-      Category.INTERNAL_ERROR, "0039", "The Get operation failed", "", ""),
-  CONSENSUS_COMMIT_SCAN_OPERATION_FAILED(
-      Category.INTERNAL_ERROR, "0040", "The Scan operation failed", "", ""),
+  CONSENSUS_COMMIT_READING_RECORD_FROM_STORAGE_FAILED(
+      Category.INTERNAL_ERROR, "0039", "Reading a record from the storage failed", "", ""),
+  CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED(
+      Category.INTERNAL_ERROR, "0040", "Scanning records from the storage failed", "", ""),
   CONSENSUS_COMMIT_ROLLBACK_FAILED_BECAUSE_TRANSACTION_ALREADY_COMMITTED(
       Category.INTERNAL_ERROR,
       "0041",
@@ -785,6 +803,12 @@ public enum CoreError implements ScalarDbError {
       "",
       ""),
   CONSENSUS_COMMIT_ROLLBACK_FAILED(Category.INTERNAL_ERROR, "0042", "Rollback failed", "", ""),
+  JDBC_TRANSACTION_INSERT_OPERATION_FAILED(
+      Category.INTERNAL_ERROR, "0043", "The Insert operation failed", "", ""),
+  JDBC_TRANSACTION_UPSERT_OPERATION_FAILED(
+      Category.INTERNAL_ERROR, "0044", "The Upsert operation failed", "", ""),
+  JDBC_TRANSACTION_UPDATE_OPERATION_FAILED(
+      Category.INTERNAL_ERROR, "0045", "The Update operation failed", "", ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/exception/transaction/RecordNotFoundException.java
+++ b/core/src/main/java/com/scalar/db/exception/transaction/RecordNotFoundException.java
@@ -1,0 +1,18 @@
+package com.scalar.db.exception.transaction;
+
+import com.scalar.db.api.Update;
+
+/**
+ * An exception thrown when no condition is specified in the {@link Update} command and the entry
+ * does not exist.
+ */
+public class RecordNotFoundException extends CrudException {
+
+  public RecordNotFoundException(String message, String transactionId) {
+    super(message, transactionId);
+  }
+
+  public RecordNotFoundException(String message, Throwable cause, String transactionId) {
+    super(message, cause, transactionId);
+  }
+}

--- a/core/src/main/java/com/scalar/db/storage/cassandra/BatchComposer.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/BatchComposer.java
@@ -8,10 +8,13 @@ import com.datastax.driver.core.PreparedStatement;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.OperationVisitor;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -77,6 +80,24 @@ public class BatchComposer implements OperationVisitor {
   @Override
   public void visit(Delete delete) {
     composeWith(handlers.delete(), delete);
+  }
+
+  @Override
+  public void visit(Insert insert) {
+    throw new AssertionError(
+        "Insert operation is not supported since it is a transaction operation");
+  }
+
+  @Override
+  public void visit(Upsert upsert) {
+    throw new AssertionError(
+        "Upsert operation is not supported since it is a transaction operation");
+  }
+
+  @Override
+  public void visit(Update update) {
+    throw new AssertionError(
+        "Update operation is not supported since it is a transaction operation");
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -159,10 +159,11 @@ public class Cassandra extends AbstractDistributedStorage {
       Mutation mutation = mutations.get(0);
       if (mutation instanceof Put) {
         put((Put) mutation);
+        return;
       } else if (mutation instanceof Delete) {
         delete((Delete) mutation);
+        return;
       }
-      return;
     }
 
     mutations = copyAndSetTargetToIfNot(mutations);

--- a/core/src/main/java/com/scalar/db/storage/cassandra/ConditionSetter.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/ConditionSetter.java
@@ -21,6 +21,7 @@ import com.scalar.db.api.MutationConditionVisitor;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.api.UpdateIf;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -128,5 +129,10 @@ public class ConditionSetter implements MutationConditionVisitor {
       default:
         throw new AssertionError();
     }
+  }
+
+  @Override
+  public void visit(UpdateIf condition) {
+    throw new AssertionError("UpdateIf is not supported");
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/StatementHandlerManager.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/StatementHandlerManager.java
@@ -70,7 +70,7 @@ public class StatementHandlerManager {
       return delete();
     }
     // never comes here usually
-    throw new AssertionError("Unexpected operation was given");
+    throw new AssertionError("Unexpected operation was given: " + operation);
   }
 
   @Nonnull

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilder.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConditionalQueryBuilder.java
@@ -9,6 +9,7 @@ import com.scalar.db.api.MutationConditionVisitor;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.api.UpdateIf;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.jooq.Field;
@@ -119,5 +120,10 @@ public class ConditionalQueryBuilder implements MutationConditionVisitor {
       default:
         throw new AssertionError();
     }
+  }
+
+  @Override
+  public void visit(UpdateIf condition) {
+    throw new AssertionError("UpdateIf is not supported");
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -149,10 +149,11 @@ public class Cosmos extends AbstractDistributedStorage {
       Mutation mutation = mutations.get(0);
       if (mutation instanceof Put) {
         put((Put) mutation);
+        return;
       } else if (mutation instanceof Delete) {
         delete((Delete) mutation);
+        return;
       }
-      return;
     }
 
     mutations = copyAndSetTargetToIfNot(mutations);

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosMutation.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosMutation.java
@@ -3,8 +3,9 @@ package com.scalar.db.storage.cosmos;
 import static com.scalar.db.storage.cosmos.CosmosUtils.quoteKeyword;
 
 import com.azure.cosmos.models.CosmosStoredProcedureRequestOptions;
-import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIf;
+import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
@@ -37,6 +38,7 @@ public class CosmosMutation extends CosmosOperation {
       if (mutation instanceof Put) {
         return MutationType.PUT;
       } else {
+        assert mutation instanceof Delete;
         return MutationType.DELETE_IF;
       }
     }
@@ -47,6 +49,7 @@ public class CosmosMutation extends CosmosOperation {
     } else if (condition instanceof PutIfExists || condition instanceof PutIf) {
       return MutationType.PUT_IF;
     } else {
+      assert condition instanceof DeleteIf || condition instanceof DeleteIfExists;
       return MutationType.DELETE_IF;
     }
   }
@@ -122,8 +125,7 @@ public class CosmosMutation extends CosmosOperation {
     return visitor.get();
   }
 
-  @VisibleForTesting
-  enum MutationType {
+  public enum MutationType {
     PUT,
     PUT_IF_NOT_EXISTS,
     PUT_IF,

--- a/core/src/main/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilder.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/ConditionExpressionBuilder.java
@@ -7,6 +7,7 @@ import com.scalar.db.api.MutationConditionVisitor;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.api.UpdateIf;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -132,5 +133,10 @@ public class ConditionExpressionBuilder implements MutationConditionVisitor {
     index++;
 
     return String.join(" ", elements);
+  }
+
+  @Override
+  public void visit(UpdateIf condition) {
+    throw new AssertionError("UpdateIf is not supported");
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DeleteStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DeleteStatementHandler.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.dynamo;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
@@ -75,6 +76,7 @@ public class DeleteStatementHandler {
       if (delete.getCondition().get() instanceof DeleteIfExists) {
         condition = dynamoMutation.getIfExistsCondition();
       } else {
+        assert delete.getCondition().get() instanceof DeleteIf;
         condition = dynamoMutation.getIfExistsCondition() + " AND " + dynamoMutation.getCondition();
         builder.expressionAttributeNames(dynamoMutation.getConditionColumnMap());
         Map<String, AttributeValue> bindMap = dynamoMutation.getConditionBindMap();

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -177,10 +177,11 @@ public class Dynamo extends AbstractDistributedStorage {
       Mutation mutation = mutations.get(0);
       if (mutation instanceof Put) {
         put((Put) mutation);
+        return;
       } else if (mutation instanceof Delete) {
         delete((Delete) mutation);
+        return;
       }
-      return;
     }
 
     mutations = copyAndSetTargetToIfNot(mutations);

--- a/core/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/PutStatementHandler.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.dynamo;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
@@ -84,6 +85,7 @@ public class PutStatementHandler {
       expressionAttributeNameMap = dynamoMutation.getColumnMap();
       bindMap = dynamoMutation.getValueBindMap();
     } else {
+      assert put.getCondition().get() instanceof PutIf;
       expression = dynamoMutation.getUpdateExpression();
       condition = dynamoMutation.getIfExistsCondition() + " AND " + dynamoMutation.getCondition();
       expressionAttributeNameMap = dynamoMutation.getColumnMap();

--- a/core/src/main/java/com/scalar/db/storage/jdbc/ConditionalMutator.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/ConditionalMutator.java
@@ -10,6 +10,7 @@ import com.scalar.db.api.PutIf;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.UpdateIf;
 import com.scalar.db.storage.jdbc.query.DeleteQuery;
 import com.scalar.db.storage.jdbc.query.InsertQuery;
 import com.scalar.db.storage.jdbc.query.Query;
@@ -146,5 +147,10 @@ public class ConditionalMutator implements MutationConditionVisitor {
     } catch (SQLException e) {
       sqlException = e;
     }
+  }
+
+  @Override
+  public void visit(UpdateIf condition) {
+    throw new AssertionError("UpdateIf is not supported");
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -157,10 +157,11 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       Mutation mutation = mutations.get(0);
       if (mutation instanceof Put) {
         put((Put) mutation);
+        return;
       } else if (mutation instanceof Delete) {
         delete((Delete) mutation);
+        return;
       }
-      return;
     }
 
     mutations = copyAndSetTargetToIfNot(mutations);

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -128,10 +128,11 @@ public class MultiStorage extends AbstractDistributedStorage {
       Mutation mutation = mutations.get(0);
       if (mutation instanceof Put) {
         put((Put) mutation);
+        return;
       } else if (mutation instanceof Delete) {
         delete((Delete) mutation);
+        return;
       }
-      return;
     }
 
     mutations = copyAndSetTargetToIfNot(mutations);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -47,6 +47,7 @@ public class CommitMutationComposer extends AbstractMutationComposer {
       // for usual commit
       add((Delete) base, result);
     } else { // Selection
+      assert base instanceof Selection;
       add((Selection) base, result);
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitMutationOperationChecker.java
@@ -48,7 +48,8 @@ public class ConsensusCommitMutationOperationChecker {
   public void check(Mutation mutation) throws ExecutionException {
     if (mutation instanceof Put) {
       check((Put) mutation);
-    } else if (mutation instanceof Delete) {
+    } else {
+      assert mutation instanceof Delete;
       check((Delete) mutation);
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -135,7 +135,7 @@ public class CrudHandler {
     List<Snapshot.Key> keys = new ArrayList<>();
     Scanner scanner = null;
     try {
-      scanner = getFromStorage(scan);
+      scanner = scanFromStorage(scan);
       for (Result r : scanner) {
         TransactionResult result = new TransactionResult(r);
         if (!result.isCommitted()) {
@@ -265,11 +265,13 @@ public class CrudHandler {
       return storage.get(get).map(TransactionResult::new);
     } catch (ExecutionException e) {
       throw new CrudException(
-          CoreError.CONSENSUS_COMMIT_GET_OPERATION_FAILED.buildMessage(), e, snapshot.getId());
+          CoreError.CONSENSUS_COMMIT_READING_RECORD_FROM_STORAGE_FAILED.buildMessage(),
+          e,
+          snapshot.getId());
     }
   }
 
-  private Scanner getFromStorage(Scan scan) throws CrudException {
+  private Scanner scanFromStorage(Scan scan) throws CrudException {
     try {
       scan.clearProjections();
       // Retrieve only the after images columns when including the metadata is disabled, otherwise
@@ -283,7 +285,9 @@ public class CrudHandler {
       return storage.scan(scan);
     } catch (ExecutionException e) {
       throw new CrudException(
-          CoreError.CONSENSUS_COMMIT_SCAN_OPERATION_FAILED.buildMessage(), e, snapshot.getId());
+          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
+          e,
+          snapshot.getId());
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
@@ -49,7 +49,7 @@ public class PrepareMutationComposer extends AbstractMutationComposer {
     } else if (base instanceof Get) {
       add((Get) base);
     } else {
-      throw new IllegalArgumentException("PrepareMutationComposer.add only accepts Put or Delete");
+      throw new AssertionError("PrepareMutationComposer.add only accepts Put or Delete or Get");
     }
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -5,11 +5,14 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TransactionState;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractTwoPhaseCommitTransaction;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -18,9 +21,12 @@ import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.PreparationException;
+import com.scalar.db.exception.transaction.RecordNotFoundException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.exception.transaction.ValidationException;
+import com.scalar.db.util.ScalarDbUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Optional;
@@ -81,11 +87,15 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     }
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     putInternal(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     checkArgument(!puts.isEmpty());
@@ -110,6 +120,8 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     deleteInternal(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     checkArgument(!deletes.isEmpty());
@@ -130,13 +142,62 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
   }
 
   @Override
+  public void insert(Insert insert) throws CrudException {
+    insert = copyAndSetTargetToIfNot(insert);
+    Put put = ConsensusCommitUtils.createPutForInsert(insert);
+    checkMutation(put);
+    crud.put(put);
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    upsert = copyAndSetTargetToIfNot(upsert);
+    Put put = ConsensusCommitUtils.createPutForUpsert(upsert);
+    checkMutation(put);
+    try {
+      crud.put(put);
+    } catch (UncommittedRecordException e) {
+      lazyRecovery(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    update = copyAndSetTargetToIfNot(update);
+    ScalarDbUtils.checkUpdate(update);
+    Put put = ConsensusCommitUtils.createPutForUpdate(update);
+    checkMutation(put);
+    try {
+      crud.put(put);
+    } catch (UnsatisfiedConditionException e) {
+      if (update.getCondition().isPresent()) {
+        throw e;
+      } else {
+        throw new RecordNotFoundException(
+            CoreError.CONSENSUS_COMMIT_RECORD_NOT_FOUND.buildMessage(), e, getId());
+      }
+    } catch (UncommittedRecordException e) {
+      lazyRecovery(e);
+      throw e;
+    }
+  }
+
+  @Override
   public void mutate(List<? extends Mutation> mutations) throws CrudException {
     checkArgument(!mutations.isEmpty());
     for (Mutation m : mutations) {
       if (m instanceof Put) {
-        putInternal((Put) m);
+        put((Put) m);
       } else if (m instanceof Delete) {
-        deleteInternal((Delete) m);
+        delete((Delete) m);
+      } else if (m instanceof Insert) {
+        insert((Insert) m);
+      } else if (m instanceof Upsert) {
+        upsert((Upsert) m);
+      } else {
+        assert m instanceof Update;
+        update((Update) m);
       }
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransaction.java
@@ -2,10 +2,13 @@ package com.scalar.db.transaction.rpc;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransaction;
 import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
@@ -44,12 +47,17 @@ public class GrpcTransaction extends AbstractDistributedTransaction {
     return stream.scan(scan);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(Put put) throws CrudException {
     put = copyAndSetTargetToIfNot(put);
     stream.mutate(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     mutate(puts);
@@ -61,9 +69,27 @@ public class GrpcTransaction extends AbstractDistributedTransaction {
     stream.mutate(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     mutate(deletes);
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTwoPhaseCommitTransaction.java
@@ -2,10 +2,13 @@ package com.scalar.db.transaction.rpc;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractTwoPhaseCommitTransaction;
 import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
@@ -53,6 +56,9 @@ public class GrpcTwoPhaseCommitTransaction extends AbstractTwoPhaseCommitTransac
     stream.mutate(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException {
     mutate(puts);
@@ -64,9 +70,27 @@ public class GrpcTwoPhaseCommitTransaction extends AbstractTwoPhaseCommitTransac
     stream.mutate(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @SuppressWarnings("InlineMeSuggester")
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException {
     mutate(deletes);
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
+++ b/core/src/main/java/com/scalar/db/util/ScalarDbUtils.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Streams;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.GetWithIndex;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
@@ -12,6 +13,9 @@ import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.ScanWithIndex;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.UpdateIf;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BigIntValue;
@@ -45,14 +49,7 @@ public final class ScalarDbUtils {
   public static <T extends Mutation> List<T> copyAndSetTargetToIfNot(
       List<T> mutations, Optional<String> namespace, Optional<String> tableName) {
     return mutations.stream()
-        .map(
-            m -> {
-              if (m instanceof Put) {
-                return (T) copyAndSetTargetToIfNot((Put) m, namespace, tableName);
-              } else { // Delete
-                return (T) copyAndSetTargetToIfNot((Delete) m, namespace, tableName);
-              }
-            })
+        .map(m -> (T) copyAndSetTargetToIfNot(m, namespace, tableName))
         .collect(Collectors.toList());
   }
 
@@ -81,9 +78,15 @@ public final class ScalarDbUtils {
       Mutation mutation, Optional<String> namespace, Optional<String> tableName) {
     if (mutation instanceof Put) {
       return copyAndSetTargetToIfNot((Put) mutation, namespace, tableName);
-    } else {
-      assert mutation instanceof Delete;
+    } else if (mutation instanceof Delete) {
       return copyAndSetTargetToIfNot((Delete) mutation, namespace, tableName);
+    } else if (mutation instanceof Insert) {
+      return copyAndSetTargetToIfNot((Insert) mutation, namespace, tableName);
+    } else if (mutation instanceof Upsert) {
+      return copyAndSetTargetToIfNot((Upsert) mutation, namespace, tableName);
+    } else {
+      assert mutation instanceof Update;
+      return copyAndSetTargetToIfNot((Update) mutation, namespace, tableName);
     }
   }
 
@@ -97,6 +100,27 @@ public final class ScalarDbUtils {
   public static Delete copyAndSetTargetToIfNot(
       Delete delete, Optional<String> namespace, Optional<String> tableName) {
     Delete ret = new Delete(delete); // copy
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  public static Insert copyAndSetTargetToIfNot(
+      Insert insert, Optional<String> namespace, Optional<String> tableName) {
+    Insert ret = Insert.newBuilder(insert).build(); // copy
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  public static Upsert copyAndSetTargetToIfNot(
+      Upsert upsert, Optional<String> namespace, Optional<String> tableName) {
+    Upsert ret = Upsert.newBuilder(upsert).build(); // copy
+    setTargetToIfNot(ret, namespace, tableName);
+    return ret;
+  }
+
+  public static Update copyAndSetTargetToIfNot(
+      Update update, Optional<String> namespace, Optional<String> tableName) {
+    Update ret = Update.newBuilder(update).build(); // copy
     setTargetToIfNot(ret, namespace, tableName);
     return ret;
   }
@@ -245,5 +269,18 @@ public final class ScalarDbUtils {
       default:
         throw new AssertionError();
     }
+  }
+
+  public static void checkUpdate(Update update) {
+    // check if the condition is UpdateIf
+    update
+        .getCondition()
+        .ifPresent(
+            c -> {
+              if (!(c instanceof UpdateIf)) {
+                throw new IllegalArgumentException(
+                    CoreError.OPERATION_CHECK_ERROR_CONDITION.buildMessage(update));
+              }
+            });
   }
 }

--- a/core/src/test/java/com/scalar/db/api/ConditionBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/ConditionBuilderTest.java
@@ -781,4 +781,337 @@ public class ConditionBuilderTest {
     assertThat(thrown1).isInstanceOf(IllegalArgumentException.class);
     assertThat(thrown2).isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void updateIf_WithIsEqualToConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isEqualToBoolean(true))
+            .and(ConditionBuilder.column("col2").isEqualToInt(123))
+            .and(ConditionBuilder.column("col3").isEqualToBigInt(456L))
+            .and(ConditionBuilder.column("col4").isEqualToFloat(1.23F))
+            .and(ConditionBuilder.column("col5").isEqualToDouble(4.56))
+            .and(ConditionBuilder.column("col6").isEqualToText("text"))
+            .and(
+                ConditionBuilder.column("col7")
+                    .isEqualToBlob("blob1".getBytes(StandardCharsets.UTF_8)))
+            .and(
+                ConditionBuilder.column("col8")
+                    .isEqualToBlob(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(8);
+    assertThat(actual.getExpressions().get(0))
+        .isEqualTo(new ConditionalExpression("col1", true, Operator.EQ));
+    assertThat(actual.getExpressions().get(1))
+        .isEqualTo(new ConditionalExpression("col2", 123, Operator.EQ));
+    assertThat(actual.getExpressions().get(2))
+        .isEqualTo(new ConditionalExpression("col3", 456L, Operator.EQ));
+    assertThat(actual.getExpressions().get(3))
+        .isEqualTo(new ConditionalExpression("col4", 1.23F, Operator.EQ));
+    assertThat(actual.getExpressions().get(4))
+        .isEqualTo(new ConditionalExpression("col5", 4.56D, Operator.EQ));
+    assertThat(actual.getExpressions().get(5))
+        .isEqualTo(new ConditionalExpression("col6", "text", Operator.EQ));
+    assertThat(actual.getExpressions().get(6))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col7", "blob1".getBytes(StandardCharsets.UTF_8), Operator.EQ));
+    assertThat(actual.getExpressions().get(7))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col8", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.EQ));
+  }
+
+  @Test
+  public void updateIf_WithIsNotEqualToConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isNotEqualToBoolean(true))
+            .and(ConditionBuilder.column("col2").isNotEqualToInt(123))
+            .and(ConditionBuilder.column("col3").isNotEqualToBigInt(456L))
+            .and(ConditionBuilder.column("col4").isNotEqualToFloat(1.23F))
+            .and(ConditionBuilder.column("col5").isNotEqualToDouble(4.56))
+            .and(ConditionBuilder.column("col6").isNotEqualToText("text"))
+            .and(
+                ConditionBuilder.column("col7")
+                    .isNotEqualToBlob("blob1".getBytes(StandardCharsets.UTF_8)))
+            .and(
+                ConditionBuilder.column("col8")
+                    .isNotEqualToBlob(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(8);
+    assertThat(actual.getExpressions().get(0))
+        .isEqualTo(new ConditionalExpression("col1", true, Operator.NE));
+    assertThat(actual.getExpressions().get(1))
+        .isEqualTo(new ConditionalExpression("col2", 123, Operator.NE));
+    assertThat(actual.getExpressions().get(2))
+        .isEqualTo(new ConditionalExpression("col3", 456L, Operator.NE));
+    assertThat(actual.getExpressions().get(3))
+        .isEqualTo(new ConditionalExpression("col4", 1.23F, Operator.NE));
+    assertThat(actual.getExpressions().get(4))
+        .isEqualTo(new ConditionalExpression("col5", 4.56D, Operator.NE));
+    assertThat(actual.getExpressions().get(5))
+        .isEqualTo(new ConditionalExpression("col6", "text", Operator.NE));
+    assertThat(actual.getExpressions().get(6))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col7", "blob1".getBytes(StandardCharsets.UTF_8), Operator.NE));
+    assertThat(actual.getExpressions().get(7))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col8", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.NE));
+  }
+
+  @Test
+  public void updateIf_WithIsGreaterThanConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isGreaterThanBoolean(true))
+            .and(ConditionBuilder.column("col2").isGreaterThanInt(123))
+            .and(ConditionBuilder.column("col3").isGreaterThanBigInt(456L))
+            .and(ConditionBuilder.column("col4").isGreaterThanFloat(1.23F))
+            .and(ConditionBuilder.column("col5").isGreaterThanDouble(4.56))
+            .and(ConditionBuilder.column("col6").isGreaterThanText("text"))
+            .and(
+                ConditionBuilder.column("col7")
+                    .isGreaterThanBlob("blob1".getBytes(StandardCharsets.UTF_8)))
+            .and(
+                ConditionBuilder.column("col8")
+                    .isGreaterThanBlob(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(8);
+    assertThat(actual.getExpressions().get(0))
+        .isEqualTo(new ConditionalExpression("col1", true, Operator.GT));
+    assertThat(actual.getExpressions().get(1))
+        .isEqualTo(new ConditionalExpression("col2", 123, Operator.GT));
+    assertThat(actual.getExpressions().get(2))
+        .isEqualTo(new ConditionalExpression("col3", 456L, Operator.GT));
+    assertThat(actual.getExpressions().get(3))
+        .isEqualTo(new ConditionalExpression("col4", 1.23F, Operator.GT));
+    assertThat(actual.getExpressions().get(4))
+        .isEqualTo(new ConditionalExpression("col5", 4.56D, Operator.GT));
+    assertThat(actual.getExpressions().get(5))
+        .isEqualTo(new ConditionalExpression("col6", "text", Operator.GT));
+    assertThat(actual.getExpressions().get(6))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col7", "blob1".getBytes(StandardCharsets.UTF_8), Operator.GT));
+    assertThat(actual.getExpressions().get(7))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col8", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.GT));
+  }
+
+  @Test
+  public void updateIf_WithIsGreaterThanOrEqualToConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(
+                ConditionBuilder.column("col1").isGreaterThanOrEqualToBoolean(true))
+            .and(ConditionBuilder.column("col2").isGreaterThanOrEqualToInt(123))
+            .and(ConditionBuilder.column("col3").isGreaterThanOrEqualToBigInt(456L))
+            .and(ConditionBuilder.column("col4").isGreaterThanOrEqualToFloat(1.23F))
+            .and(ConditionBuilder.column("col5").isGreaterThanOrEqualToDouble(4.56))
+            .and(ConditionBuilder.column("col6").isGreaterThanOrEqualToText("text"))
+            .and(
+                ConditionBuilder.column("col7")
+                    .isGreaterThanOrEqualToBlob("blob1".getBytes(StandardCharsets.UTF_8)))
+            .and(
+                ConditionBuilder.column("col8")
+                    .isGreaterThanOrEqualToBlob(
+                        ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(8);
+    assertThat(actual.getExpressions().get(0))
+        .isEqualTo(new ConditionalExpression("col1", true, Operator.GTE));
+    assertThat(actual.getExpressions().get(1))
+        .isEqualTo(new ConditionalExpression("col2", 123, Operator.GTE));
+    assertThat(actual.getExpressions().get(2))
+        .isEqualTo(new ConditionalExpression("col3", 456L, Operator.GTE));
+    assertThat(actual.getExpressions().get(3))
+        .isEqualTo(new ConditionalExpression("col4", 1.23F, Operator.GTE));
+    assertThat(actual.getExpressions().get(4))
+        .isEqualTo(new ConditionalExpression("col5", 4.56D, Operator.GTE));
+    assertThat(actual.getExpressions().get(5))
+        .isEqualTo(new ConditionalExpression("col6", "text", Operator.GTE));
+    assertThat(actual.getExpressions().get(6))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col7", "blob1".getBytes(StandardCharsets.UTF_8), Operator.GTE));
+    assertThat(actual.getExpressions().get(7))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col8", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.GTE));
+  }
+
+  @Test
+  public void updateIf_WithIsLessThanConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isLessThanBoolean(true))
+            .and(ConditionBuilder.column("col2").isLessThanInt(123))
+            .and(ConditionBuilder.column("col3").isLessThanBigInt(456L))
+            .and(ConditionBuilder.column("col4").isLessThanFloat(1.23F))
+            .and(ConditionBuilder.column("col5").isLessThanDouble(4.56))
+            .and(ConditionBuilder.column("col6").isLessThanText("text"))
+            .and(
+                ConditionBuilder.column("col7")
+                    .isLessThanBlob("blob1".getBytes(StandardCharsets.UTF_8)))
+            .and(
+                ConditionBuilder.column("col8")
+                    .isLessThanBlob(ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(8);
+    assertThat(actual.getExpressions().get(0))
+        .isEqualTo(new ConditionalExpression("col1", true, Operator.LT));
+    assertThat(actual.getExpressions().get(1))
+        .isEqualTo(new ConditionalExpression("col2", 123, Operator.LT));
+    assertThat(actual.getExpressions().get(2))
+        .isEqualTo(new ConditionalExpression("col3", 456L, Operator.LT));
+    assertThat(actual.getExpressions().get(3))
+        .isEqualTo(new ConditionalExpression("col4", 1.23F, Operator.LT));
+    assertThat(actual.getExpressions().get(4))
+        .isEqualTo(new ConditionalExpression("col5", 4.56D, Operator.LT));
+    assertThat(actual.getExpressions().get(5))
+        .isEqualTo(new ConditionalExpression("col6", "text", Operator.LT));
+    assertThat(actual.getExpressions().get(6))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col7", "blob1".getBytes(StandardCharsets.UTF_8), Operator.LT));
+    assertThat(actual.getExpressions().get(7))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col8", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.LT));
+  }
+
+  @Test
+  public void updateIf_WithIsLessThanOrEqualToConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isLessThanOrEqualToBoolean(true))
+            .and(ConditionBuilder.column("col2").isLessThanOrEqualToInt(123))
+            .and(ConditionBuilder.column("col3").isLessThanOrEqualToBigInt(456L))
+            .and(ConditionBuilder.column("col4").isLessThanOrEqualToFloat(1.23F))
+            .and(ConditionBuilder.column("col5").isLessThanOrEqualToDouble(4.56))
+            .and(ConditionBuilder.column("col6").isLessThanOrEqualToText("text"))
+            .and(
+                ConditionBuilder.column("col7")
+                    .isLessThanOrEqualToBlob("blob1".getBytes(StandardCharsets.UTF_8)))
+            .and(
+                ConditionBuilder.column("col8")
+                    .isLessThanOrEqualToBlob(
+                        ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8))))
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(8);
+    assertThat(actual.getExpressions().get(0))
+        .isEqualTo(new ConditionalExpression("col1", true, Operator.LTE));
+    assertThat(actual.getExpressions().get(1))
+        .isEqualTo(new ConditionalExpression("col2", 123, Operator.LTE));
+    assertThat(actual.getExpressions().get(2))
+        .isEqualTo(new ConditionalExpression("col3", 456L, Operator.LTE));
+    assertThat(actual.getExpressions().get(3))
+        .isEqualTo(new ConditionalExpression("col4", 1.23F, Operator.LTE));
+    assertThat(actual.getExpressions().get(4))
+        .isEqualTo(new ConditionalExpression("col5", 4.56D, Operator.LTE));
+    assertThat(actual.getExpressions().get(5))
+        .isEqualTo(new ConditionalExpression("col6", "text", Operator.LTE));
+    assertThat(actual.getExpressions().get(6))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col7", "blob1".getBytes(StandardCharsets.UTF_8), Operator.LTE));
+    assertThat(actual.getExpressions().get(7))
+        .isEqualTo(
+            new ConditionalExpression(
+                "col8", ByteBuffer.wrap("blob2".getBytes(StandardCharsets.UTF_8)), Operator.LTE));
+  }
+
+  @Test
+  public void updateIf_WithIsNullConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isNullBoolean())
+            .and(ConditionBuilder.column("col2").isNullInt())
+            .and(ConditionBuilder.column("col3").isNullBigInt())
+            .and(ConditionBuilder.column("col4").isNullFloat())
+            .and(ConditionBuilder.column("col5").isNullDouble())
+            .and(ConditionBuilder.column("col6").isNullText())
+            .and(ConditionBuilder.column("col7").isNullBlob())
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(7);
+    assertThat(actual.getExpressions().get(0).getColumn()).isEqualTo(BooleanColumn.ofNull("col1"));
+    assertThat(actual.getExpressions().get(0).getOperator()).isEqualTo(Operator.IS_NULL);
+    assertThat(actual.getExpressions().get(1).getColumn()).isEqualTo(IntColumn.ofNull("col2"));
+    assertThat(actual.getExpressions().get(1).getOperator()).isEqualTo(Operator.IS_NULL);
+    assertThat(actual.getExpressions().get(2).getColumn()).isEqualTo(BigIntColumn.ofNull("col3"));
+    assertThat(actual.getExpressions().get(2).getOperator()).isEqualTo(Operator.IS_NULL);
+    assertThat(actual.getExpressions().get(3).getColumn()).isEqualTo(FloatColumn.ofNull("col4"));
+    assertThat(actual.getExpressions().get(3).getOperator()).isEqualTo(Operator.IS_NULL);
+    assertThat(actual.getExpressions().get(4).getColumn()).isEqualTo(DoubleColumn.ofNull("col5"));
+    assertThat(actual.getExpressions().get(4).getOperator()).isEqualTo(Operator.IS_NULL);
+    assertThat(actual.getExpressions().get(5).getColumn()).isEqualTo(TextColumn.ofNull("col6"));
+    assertThat(actual.getExpressions().get(5).getOperator()).isEqualTo(Operator.IS_NULL);
+    assertThat(actual.getExpressions().get(6).getColumn()).isEqualTo(BlobColumn.ofNull("col7"));
+    assertThat(actual.getExpressions().get(6).getOperator()).isEqualTo(Operator.IS_NULL);
+  }
+
+  @Test
+  public void updateIf_WithIsNotNullConditions_ShouldBuildProperly() {
+    // Arrange
+
+    // Act
+    UpdateIf actual =
+        ConditionBuilder.updateIf(ConditionBuilder.column("col1").isNotNullBoolean())
+            .and(ConditionBuilder.column("col2").isNotNullInt())
+            .and(ConditionBuilder.column("col3").isNotNullBigInt())
+            .and(ConditionBuilder.column("col4").isNotNullFloat())
+            .and(ConditionBuilder.column("col5").isNotNullDouble())
+            .and(ConditionBuilder.column("col6").isNotNullText())
+            .and(ConditionBuilder.column("col7").isNotNullBlob())
+            .build();
+
+    // Assert
+    assertThat(actual.getExpressions().size()).isEqualTo(7);
+    assertThat(actual.getExpressions().get(0).getColumn()).isEqualTo(BooleanColumn.ofNull("col1"));
+    assertThat(actual.getExpressions().get(0).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+    assertThat(actual.getExpressions().get(1).getColumn()).isEqualTo(IntColumn.ofNull("col2"));
+    assertThat(actual.getExpressions().get(1).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+    assertThat(actual.getExpressions().get(2).getColumn()).isEqualTo(BigIntColumn.ofNull("col3"));
+    assertThat(actual.getExpressions().get(2).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+    assertThat(actual.getExpressions().get(3).getColumn()).isEqualTo(FloatColumn.ofNull("col4"));
+    assertThat(actual.getExpressions().get(3).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+    assertThat(actual.getExpressions().get(4).getColumn()).isEqualTo(DoubleColumn.ofNull("col5"));
+    assertThat(actual.getExpressions().get(4).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+    assertThat(actual.getExpressions().get(5).getColumn()).isEqualTo(TextColumn.ofNull("col6"));
+    assertThat(actual.getExpressions().get(5).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+    assertThat(actual.getExpressions().get(6).getColumn()).isEqualTo(BlobColumn.ofNull("col7"));
+    assertThat(actual.getExpressions().get(6).getOperator()).isEqualTo(Operator.IS_NOT_NULL);
+  }
 }

--- a/core/src/test/java/com/scalar/db/api/InsertBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/InsertBuilderTest.java
@@ -1,0 +1,351 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class InsertBuilderTest {
+  private static final String NAMESPACE_1 = "namespace1";
+  private static final String NAMESPACE_2 = "namespace2";
+
+  private static final String TABLE_1 = "table1";
+  private static final String TABLE_2 = "table2";
+  @Mock private Key partitionKey1;
+  @Mock private Key partitionKey2;
+  @Mock private Key clusteringKey1;
+  @Mock private Key clusteringKey2;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void build_WithMandatoryParameters_ShouldBuildInsertWithMandatoryParameters() {
+    // Arrange Act
+    Insert actual = Insert.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
+
+    // Assert
+    assertThat(actual.forNamespace()).isEmpty();
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns()).isEmpty();
+  }
+
+  @Test
+  public void build_WithClusteringKey_ShouldBuildInsertWithClusteringKey() {
+    // Arrange Act
+    Insert actual =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(actual.getColumns()).isEmpty();
+  }
+
+  @Test
+  public void build_WithAllParameters_ShouldBuildInsertCorrectly() {
+    // Arrange Act
+    Insert actual =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(actual.getColumns().size()).isEqualTo(14);
+    assertThat(actual.getColumns().get("bigint1").getBigIntValue())
+        .isEqualTo(BigIntColumn.MAX_VALUE);
+    assertThat(actual.getColumns().get("bigint2").getBigIntValue())
+        .isEqualTo(Long.valueOf(BigIntColumn.MAX_VALUE));
+    assertThat(actual.getColumns().get("blob1").getBlobValueAsBytes())
+        .isEqualTo("blob".getBytes(StandardCharsets.UTF_8));
+    assertThat(actual.getColumns().get("blob2").getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.allocate(1));
+    assertThat(actual.getColumns().get("bool1").getBooleanValue()).isTrue();
+    assertThat(actual.getColumns().get("bool2").getBooleanValue()).isTrue();
+    assertThat(actual.getColumns().get("double1").getDoubleValue()).isEqualTo(Double.MAX_VALUE);
+    assertThat(actual.getColumns().get("double2").getDoubleValue())
+        .isEqualTo(Double.valueOf(Double.MAX_VALUE));
+    assertThat(actual.getColumns().get("float1").getFloatValue()).isEqualTo(Float.MAX_VALUE);
+    assertThat(actual.getColumns().get("float2").getFloatValue())
+        .isEqualTo(Float.valueOf(Float.MAX_VALUE));
+    assertThat(actual.getColumns().get("int1").getIntValue()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(actual.getColumns().get("int2").getIntValue())
+        .isEqualTo(Integer.valueOf(Integer.MAX_VALUE));
+    assertThat(actual.getColumns().get("text").getTextValue()).isEqualTo("a_value");
+    assertThat(actual.getColumns().get("text2").getTextValue()).isEqualTo("another_value");
+  }
+
+  @Test
+  public void build_WithAllValuesToNull_ShouldBuildInsertCorrectly() {
+    // Arrange Act
+    Insert actual =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .bigIntValue("bigint", null)
+            .blobValue("blob1", (byte[]) null)
+            .blobValue("blob2", (ByteBuffer) null)
+            .booleanValue("bool", null)
+            .doubleValue("double", null)
+            .floatValue("float", null)
+            .intValue("int", null)
+            .textValue("text", null)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns().size()).isEqualTo(8);
+    assertThat(actual.getColumns().get("bigint").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("blob1").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("blob2").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("bool").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("double").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("float").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("int").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("text").hasNullValue()).isTrue();
+  }
+
+  @Test
+  public void build_WithTwoValueUsingSameColumnName_ShouldBuildInsertCorrectly() {
+    // Arrange Act
+    Insert actual =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .bigIntValue("bigint", null)
+            .textValue("bigint", "a_value")
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns().size()).isEqualTo(1);
+    assertThat(actual.getColumns().get("bigint").getTextValue()).isEqualTo("a_value");
+  }
+
+  @Test
+  public void build_FromExistingWithoutChange_ShouldCopy() {
+    // Arrange
+    Insert existingInsert =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .build();
+
+    // Act
+    Insert newInsert = Insert.newBuilder(existingInsert).build();
+
+    // Assert
+    assertThat(newInsert).isEqualTo(existingInsert);
+  }
+
+  @Test
+  public void build_FromExistingAndUpdateAllParameters_ShouldBuildInsertWithUpdatedParameters() {
+    // Arrange
+    Insert existingInsert =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .build();
+
+    // Act
+    Insert newInsert =
+        Insert.newBuilder(existingInsert)
+            .namespace(NAMESPACE_2)
+            .table(TABLE_2)
+            .partitionKey(partitionKey2)
+            .clusteringKey(clusteringKey2)
+            .clearValues()
+            .bigIntValue("bigint1", BigIntColumn.MIN_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MIN_VALUE))
+            .blobValue("blob1", "foo".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(2))
+            .booleanValue("bool1", false)
+            .booleanValue("bool2", Boolean.FALSE)
+            .doubleValue("double1", Double.MIN_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MIN_VALUE))
+            .floatValue("float1", Float.MIN_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MIN_VALUE))
+            .intValue("int1", Integer.MIN_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MIN_VALUE))
+            .textValue("text", "another_value")
+            .value(TextColumn.of("text2", "foo"))
+            .build();
+
+    // Assert
+    assertThat(newInsert.forNamespace()).hasValue(NAMESPACE_2);
+    assertThat(newInsert.forTable()).hasValue(TABLE_2);
+    Assertions.<Key>assertThat(newInsert.getPartitionKey()).isEqualTo(partitionKey2);
+    assertThat(newInsert.getClusteringKey()).hasValue(clusteringKey2);
+    assertThat(newInsert.getColumns().size()).isEqualTo(14);
+    assertThat(newInsert.getColumns().get("bigint1").getBigIntValue())
+        .isEqualTo(BigIntColumn.MIN_VALUE);
+    assertThat(newInsert.getColumns().get("bigint2").getBigIntValue())
+        .isEqualTo(Long.valueOf(BigIntColumn.MIN_VALUE));
+    assertThat(newInsert.getColumns().get("blob1").getBlobValueAsBytes())
+        .isEqualTo("foo".getBytes(StandardCharsets.UTF_8));
+    assertThat(newInsert.getColumns().get("blob2").getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.allocate(2));
+    assertThat(newInsert.getColumns().get("bool1").getBooleanValue()).isFalse();
+    assertThat(newInsert.getColumns().get("bool2").getBooleanValue()).isFalse();
+    assertThat(newInsert.getColumns().get("double1").getDoubleValue()).isEqualTo(Double.MIN_VALUE);
+    assertThat(newInsert.getColumns().get("double2").getDoubleValue())
+        .isEqualTo(Double.valueOf(Double.MIN_VALUE));
+    assertThat(newInsert.getColumns().get("float1").getFloatValue()).isEqualTo(Float.MIN_VALUE);
+    assertThat(newInsert.getColumns().get("float2").getFloatValue())
+        .isEqualTo(Float.valueOf(Float.MIN_VALUE));
+    assertThat(newInsert.getColumns().get("int1").getIntValue()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(newInsert.getColumns().get("int2").getIntValue())
+        .isEqualTo(Integer.valueOf(Integer.MIN_VALUE));
+    assertThat(newInsert.getColumns().get("text").getTextValue()).isEqualTo("another_value");
+    assertThat(newInsert.getColumns().get("text2").getTextValue()).isEqualTo("foo");
+  }
+
+  @Test
+  public void build_FromExistingAndClearValue_ShouldBuildInsertWithoutClearedValues() {
+    // Arrange
+    Insert existingInsert =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .booleanValue("bool", Boolean.TRUE)
+            .doubleValue("double", Double.MIN_VALUE)
+            .build();
+
+    // Act
+    Insert newInsert =
+        Insert.newBuilder(existingInsert).clearValue("double").clearValue("unknown_column").build();
+
+    // Assert
+    assertThat(newInsert.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newInsert.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newInsert.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newInsert.getClusteringKey()).isEmpty();
+    assertThat(newInsert.getColumns().size()).isEqualTo(1);
+    assertThat(newInsert.getColumns().get("bool").getBooleanValue()).isTrue();
+  }
+
+  @Test
+  public void build_FromExistingAndClearClusteringKey_ShouldBuildInsertWithoutClusteringKey() {
+    // Arrange
+    Insert existingInsert =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Act
+    Insert newInsert = Insert.newBuilder(existingInsert).clearClusteringKey().build();
+
+    // Assert
+    assertThat(newInsert.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newInsert.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newInsert.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newInsert.getClusteringKey()).isEmpty();
+    assertThat(newInsert.getColumns()).isEmpty();
+  }
+
+  @Test
+  public void build_FromExistingAndClearNamespace_ShouldBuildInsertWithoutNamespace() {
+    // Arrange
+    Insert existingInsert =
+        Insert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Act
+    Insert newInsert = Insert.newBuilder(existingInsert).clearNamespace().build();
+
+    // Assert
+    assertThat(newInsert.forNamespace()).isEmpty();
+    assertThat(newInsert.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newInsert.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newInsert.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(newInsert.getColumns()).isEmpty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/api/InsertTest.java
+++ b/core/src/test/java/com/scalar/db/api/InsertTest.java
@@ -1,0 +1,154 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class InsertTest {
+  private static final String ANY_NAMESPACE = "ns";
+  private static final String ANY_TABLE = "tbl";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+
+  private Insert prepareInsert() {
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    return Insert.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE)
+        .partitionKey(partitionKey)
+        .clusteringKey(clusteringKey)
+        .textValue(ANY_NAME_1, ANY_TEXT_1)
+        .textValue(ANY_NAME_2, ANY_TEXT_2)
+        .build();
+  }
+
+  @Test
+  public void getPartitionKey_ProperKeyGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(expected)
+            .clusteringKey(clusteringKey)
+            .build();
+
+    // Act
+    Key actual = insert.getPartitionKey();
+
+    // Assert
+    Assertions.<Key>assertThat(expected).isEqualTo(actual);
+  }
+
+  @Test
+  public void getClusteringKey_ProperKeyGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_2);
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(expected)
+            .build();
+
+    // Act
+    Optional<Key> actual = insert.getClusteringKey();
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  public void getClusteringKey_ClusteringKeyNotGiven_ShouldReturnNull() {
+    // Arrange
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(partitionKey)
+            .build();
+
+    // Act
+    Optional<Key> actual = insert.getClusteringKey();
+
+    // Assert
+    assertThat(actual.isPresent()).isFalse();
+  }
+
+  @Test
+  public void getColumns_TryToModifyReturned_ShouldThrowException() {
+    // Arrange
+    Insert insert = prepareInsert();
+
+    // Act Assert
+    Map<String, Column<?>> values = insert.getColumns();
+    assertThatThrownBy(() -> values.put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3)))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void equals_SameInstanceGiven_ShouldReturnTrue() {
+    // Arrange
+    Insert insert = prepareInsert();
+
+    // Act
+    @SuppressWarnings("SelfEquals")
+    boolean ret = insert.equals(insert);
+
+    // Assert
+    assertThat(ret).isTrue();
+  }
+
+  @Test
+  public void equals_SameInsertGiven_ShouldReturnTrue() {
+    // Arrange
+    Insert insert = prepareInsert();
+    Insert another = prepareInsert();
+
+    // Act
+    boolean ret = insert.equals(another);
+
+    // Assert
+    assertThat(ret).isTrue();
+    assertThat(insert.hashCode()).isEqualTo(another.hashCode());
+  }
+
+  @Test
+  public void equals_InsertWithDifferentValuesGiven_ShouldReturnFalse() {
+    // Arrange
+    Insert insert = prepareInsert();
+    Insert another =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_1, ANY_TEXT_1)
+            .textValue(ANY_NAME_2, ANY_TEXT_3)
+            .build();
+
+    // Act
+    boolean ret = insert.equals(another);
+
+    // Assert
+    assertThat(ret).isFalse();
+    assertThat(insert.hashCode()).isNotEqualTo(another.hashCode());
+  }
+}

--- a/core/src/test/java/com/scalar/db/api/UpdateBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/UpdateBuilderTest.java
@@ -1,0 +1,389 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class UpdateBuilderTest {
+  private static final String NAMESPACE_1 = "namespace1";
+  private static final String NAMESPACE_2 = "namespace2";
+
+  private static final String TABLE_1 = "table1";
+  private static final String TABLE_2 = "table2";
+  @Mock private Key partitionKey1;
+  @Mock private Key partitionKey2;
+  @Mock private Key clusteringKey1;
+  @Mock private Key clusteringKey2;
+  @Mock private MutationCondition condition1;
+  @Mock private MutationCondition condition2;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void build_WithMandatoryParameters_ShouldBuildUpdateWithMandatoryParameters() {
+    // Arrange Act
+    Update actual = Update.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
+
+    // Assert
+    assertThat(actual.forNamespace()).isEmpty();
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns()).isEmpty();
+    assertThat(actual.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_WithClusteringKey_ShouldBuildUpdateWithClusteringKey() {
+    // Arrange Act
+    Update actual =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(actual.getColumns()).isEmpty();
+    assertThat(actual.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_WithAllParameters_ShouldBuildUpdateCorrectly() {
+    // Arrange Act
+    Update actual =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .condition(condition1)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(actual.getColumns().size()).isEqualTo(14);
+    assertThat(actual.getColumns().get("bigint1").getBigIntValue())
+        .isEqualTo(BigIntColumn.MAX_VALUE);
+    assertThat(actual.getColumns().get("bigint2").getBigIntValue())
+        .isEqualTo(Long.valueOf(BigIntColumn.MAX_VALUE));
+    assertThat(actual.getColumns().get("blob1").getBlobValueAsBytes())
+        .isEqualTo("blob".getBytes(StandardCharsets.UTF_8));
+    assertThat(actual.getColumns().get("blob2").getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.allocate(1));
+    assertThat(actual.getColumns().get("bool1").getBooleanValue()).isTrue();
+    assertThat(actual.getColumns().get("bool2").getBooleanValue()).isTrue();
+    assertThat(actual.getColumns().get("double1").getDoubleValue()).isEqualTo(Double.MAX_VALUE);
+    assertThat(actual.getColumns().get("double2").getDoubleValue())
+        .isEqualTo(Double.valueOf(Double.MAX_VALUE));
+    assertThat(actual.getColumns().get("float1").getFloatValue()).isEqualTo(Float.MAX_VALUE);
+    assertThat(actual.getColumns().get("float2").getFloatValue())
+        .isEqualTo(Float.valueOf(Float.MAX_VALUE));
+    assertThat(actual.getColumns().get("int1").getIntValue()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(actual.getColumns().get("int2").getIntValue())
+        .isEqualTo(Integer.valueOf(Integer.MAX_VALUE));
+    assertThat(actual.getColumns().get("text").getTextValue()).isEqualTo("a_value");
+    assertThat(actual.getColumns().get("text2").getTextValue()).isEqualTo("another_value");
+    assertThat(actual.getCondition()).hasValue(condition1);
+  }
+
+  @Test
+  public void build_WithAllValuesToNull_ShouldBuildUpdateCorrectly() {
+    // Arrange Act
+    Update actual =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .bigIntValue("bigint", null)
+            .blobValue("blob1", (byte[]) null)
+            .blobValue("blob2", (ByteBuffer) null)
+            .booleanValue("bool", null)
+            .doubleValue("double", null)
+            .floatValue("float", null)
+            .intValue("int", null)
+            .textValue("text", null)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns().size()).isEqualTo(8);
+    assertThat(actual.getColumns().get("bigint").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("blob1").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("blob2").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("bool").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("double").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("float").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("int").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("text").hasNullValue()).isTrue();
+    assertThat(actual.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_WithTwoValueUsingSameColumnName_ShouldBuildUpdateCorrectly() {
+    // Arrange Act
+    Update actual =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .bigIntValue("bigint", null)
+            .textValue("bigint", "a_value")
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns().size()).isEqualTo(1);
+    assertThat(actual.getColumns().get("bigint").getTextValue()).isEqualTo("a_value");
+    assertThat(actual.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_FromExistingWithoutChange_ShouldCopy() {
+    // Arrange
+    Update existingUpdate =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .condition(condition1)
+            .build();
+
+    // Act
+    Update newUpdate = Update.newBuilder(existingUpdate).build();
+
+    // Assert
+    assertThat(newUpdate).isEqualTo(existingUpdate);
+  }
+
+  @Test
+  public void build_FromExistingAndUpdateAllParameters_ShouldBuildUpdateWithUpdatedParameters() {
+    // Arrange
+    Update existingUpdate =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .condition(condition1)
+            .build();
+
+    // Act
+    Update newUpdate =
+        Update.newBuilder(existingUpdate)
+            .namespace(NAMESPACE_2)
+            .table(TABLE_2)
+            .partitionKey(partitionKey2)
+            .clusteringKey(clusteringKey2)
+            .clearValues()
+            .bigIntValue("bigint1", BigIntColumn.MIN_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MIN_VALUE))
+            .blobValue("blob1", "foo".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(2))
+            .booleanValue("bool1", false)
+            .booleanValue("bool2", Boolean.FALSE)
+            .doubleValue("double1", Double.MIN_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MIN_VALUE))
+            .floatValue("float1", Float.MIN_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MIN_VALUE))
+            .intValue("int1", Integer.MIN_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MIN_VALUE))
+            .textValue("text", "another_value")
+            .value(TextColumn.of("text2", "foo"))
+            .condition(condition2)
+            .build();
+
+    // Assert
+    assertThat(newUpdate.forNamespace()).hasValue(NAMESPACE_2);
+    assertThat(newUpdate.forTable()).hasValue(TABLE_2);
+    Assertions.<Key>assertThat(newUpdate.getPartitionKey()).isEqualTo(partitionKey2);
+    assertThat(newUpdate.getClusteringKey()).hasValue(clusteringKey2);
+    assertThat(newUpdate.getColumns().size()).isEqualTo(14);
+    assertThat(newUpdate.getColumns().get("bigint1").getBigIntValue())
+        .isEqualTo(BigIntColumn.MIN_VALUE);
+    assertThat(newUpdate.getColumns().get("bigint2").getBigIntValue())
+        .isEqualTo(Long.valueOf(BigIntColumn.MIN_VALUE));
+    assertThat(newUpdate.getColumns().get("blob1").getBlobValueAsBytes())
+        .isEqualTo("foo".getBytes(StandardCharsets.UTF_8));
+    assertThat(newUpdate.getColumns().get("blob2").getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.allocate(2));
+    assertThat(newUpdate.getColumns().get("bool1").getBooleanValue()).isFalse();
+    assertThat(newUpdate.getColumns().get("bool2").getBooleanValue()).isFalse();
+    assertThat(newUpdate.getColumns().get("double1").getDoubleValue()).isEqualTo(Double.MIN_VALUE);
+    assertThat(newUpdate.getColumns().get("double2").getDoubleValue())
+        .isEqualTo(Double.valueOf(Double.MIN_VALUE));
+    assertThat(newUpdate.getColumns().get("float1").getFloatValue()).isEqualTo(Float.MIN_VALUE);
+    assertThat(newUpdate.getColumns().get("float2").getFloatValue())
+        .isEqualTo(Float.valueOf(Float.MIN_VALUE));
+    assertThat(newUpdate.getColumns().get("int1").getIntValue()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(newUpdate.getColumns().get("int2").getIntValue())
+        .isEqualTo(Integer.valueOf(Integer.MIN_VALUE));
+    assertThat(newUpdate.getColumns().get("text").getTextValue()).isEqualTo("another_value");
+    assertThat(newUpdate.getColumns().get("text2").getTextValue()).isEqualTo("foo");
+    assertThat(newUpdate.getCondition()).hasValue(condition2);
+  }
+
+  @Test
+  public void build_FromExistingAndClearValue_ShouldBuildUpdateWithoutClearedValues() {
+    // Arrange
+    Update existingUpdate =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .booleanValue("bool", Boolean.TRUE)
+            .doubleValue("double", Double.MIN_VALUE)
+            .build();
+
+    // Act
+    Update newUpdate =
+        Update.newBuilder(existingUpdate).clearValue("double").clearValue("unknown_column").build();
+
+    // Assert
+    assertThat(newUpdate.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newUpdate.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpdate.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpdate.getClusteringKey()).isEmpty();
+    assertThat(newUpdate.getColumns().size()).isEqualTo(1);
+    assertThat(newUpdate.getColumns().get("bool").getBooleanValue()).isTrue();
+    assertThat(newUpdate.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_FromExistingAndClearCondition_ShouldBuildUpdateWithoutCondition() {
+    // Arrange
+    Update existingUpdate =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .condition(condition1)
+            .build();
+
+    // Act
+    Update newUpdate = Update.newBuilder(existingUpdate).clearCondition().build();
+
+    // Assert
+    assertThat(newUpdate.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newUpdate.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpdate.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpdate.getClusteringKey()).isEmpty();
+    assertThat(newUpdate.getColumns()).isEmpty();
+    assertThat(newUpdate.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_FromExistingAndClearClusteringKey_ShouldBuildUpdateWithoutClusteringKey() {
+    // Arrange
+    Update existingUpdate =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Act
+    Update newUpdate = Update.newBuilder(existingUpdate).clearClusteringKey().build();
+
+    // Assert
+    assertThat(newUpdate.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newUpdate.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpdate.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpdate.getClusteringKey()).isEmpty();
+    assertThat(newUpdate.getColumns()).isEmpty();
+    assertThat(newUpdate.getCondition()).isEmpty();
+  }
+
+  @Test
+  public void build_FromExistingAndClearNamespace_ShouldBuildUpdateWithoutNamespace() {
+    // Arrange
+    Update existingUpdate =
+        Update.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Act
+    Update newUpdate = Update.newBuilder(existingUpdate).clearNamespace().build();
+
+    // Assert
+    assertThat(newUpdate.forNamespace()).isEmpty();
+    assertThat(newUpdate.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpdate.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpdate.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(newUpdate.getColumns()).isEmpty();
+    assertThat(newUpdate.getCondition()).isEmpty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/api/UpdateTest.java
+++ b/core/src/test/java/com/scalar/db/api/UpdateTest.java
@@ -1,0 +1,186 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UpdateTest {
+  private static final String ANY_NAMESPACE = "ns";
+  private static final String ANY_TABLE = "tbl";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final String ANY_TEXT_4 = "text4";
+
+  private Update prepareUpdate() {
+    return Update.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .textValue(ANY_NAME_1, ANY_TEXT_1)
+        .textValue(ANY_NAME_2, ANY_TEXT_2)
+        .build();
+  }
+
+  @Test
+  public void getPartitionKey_ProperKeyGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(expected)
+            .clusteringKey(clusteringKey)
+            .build();
+
+    // Act
+    Key actual = update.getPartitionKey();
+
+    // Assert
+    Assertions.<Key>assertThat(expected).isEqualTo(actual);
+  }
+
+  @Test
+  public void getClusteringKey_ProperKeyGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_2);
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(expected)
+            .build();
+
+    // Act
+    Optional<Key> actual = update.getClusteringKey();
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  public void getClusteringKey_ClusteringKeyNotGiven_ShouldReturnNull() {
+    // Arrange
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(partitionKey)
+            .build();
+
+    // Act
+    Optional<Key> actual = update.getClusteringKey();
+
+    // Assert
+    assertThat(actual.isPresent()).isFalse();
+  }
+
+  @Test
+  public void getColumns_TryToModifyReturned_ShouldThrowException() {
+    // Arrange
+    Update update = prepareUpdate();
+
+    // Act Assert
+    Map<String, Column<?>> values = update.getColumns();
+    assertThatThrownBy(() -> values.put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3)))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void equals_SameInstanceGiven_ShouldReturnTrue() {
+    // Arrange
+    Update update = prepareUpdate();
+
+    // Act
+    @SuppressWarnings("SelfEquals")
+    boolean ret = update.equals(update);
+
+    // Assert
+    assertThat(ret).isTrue();
+  }
+
+  @Test
+  public void equals_SamePutGiven_ShouldReturnTrue() {
+    // Arrange
+    Update update = prepareUpdate();
+    Update another = prepareUpdate();
+
+    // Act
+    boolean ret = update.equals(another);
+
+    // Assert
+    assertThat(ret).isTrue();
+    assertThat(update.hashCode()).isEqualTo(another.hashCode());
+  }
+
+  @Test
+  public void equals_UpdateWithDifferentValuesGiven_ShouldReturnFalse() {
+    // Arrange
+    Update update = prepareUpdate();
+    Update another =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_1, ANY_TEXT_1)
+            .textValue(ANY_NAME_2, ANY_TEXT_3)
+            .build();
+
+    // Act
+    boolean ret = update.equals(another);
+
+    // Assert
+    assertThat(ret).isFalse();
+    assertThat(update.hashCode()).isNotEqualTo(another.hashCode());
+  }
+
+  @Test
+  public void equals_UpdateWithDifferentConditionsGiven_ShouldReturnFalse() {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+    Update another =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_4))
+                    .build())
+            .build();
+    // Act
+    boolean ret = update.equals(another);
+
+    // Assert
+    assertThat(ret).isFalse();
+    assertThat(update.hashCode()).isNotEqualTo(another.hashCode());
+  }
+}

--- a/core/src/test/java/com/scalar/db/api/UpsertBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/api/UpsertBuilderTest.java
@@ -1,0 +1,351 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class UpsertBuilderTest {
+  private static final String NAMESPACE_1 = "namespace1";
+  private static final String NAMESPACE_2 = "namespace2";
+
+  private static final String TABLE_1 = "table1";
+  private static final String TABLE_2 = "table2";
+  @Mock private Key partitionKey1;
+  @Mock private Key partitionKey2;
+  @Mock private Key clusteringKey1;
+  @Mock private Key clusteringKey2;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  @Test
+  public void build_WithMandatoryParameters_ShouldBuildUpsertWithMandatoryParameters() {
+    // Arrange Act
+    Upsert actual = Upsert.newBuilder().table(TABLE_1).partitionKey(partitionKey1).build();
+
+    // Assert
+    assertThat(actual.forNamespace()).isEmpty();
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns()).isEmpty();
+  }
+
+  @Test
+  public void build_WithClusteringKey_ShouldBuildUpsertWithClusteringKey() {
+    // Arrange Act
+    Upsert actual =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(actual.getColumns()).isEmpty();
+  }
+
+  @Test
+  public void build_WithAllParameters_ShouldBuildUpsertCorrectly() {
+    // Arrange Act
+    Upsert actual =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(actual.getColumns().size()).isEqualTo(14);
+    assertThat(actual.getColumns().get("bigint1").getBigIntValue())
+        .isEqualTo(BigIntColumn.MAX_VALUE);
+    assertThat(actual.getColumns().get("bigint2").getBigIntValue())
+        .isEqualTo(Long.valueOf(BigIntColumn.MAX_VALUE));
+    assertThat(actual.getColumns().get("blob1").getBlobValueAsBytes())
+        .isEqualTo("blob".getBytes(StandardCharsets.UTF_8));
+    assertThat(actual.getColumns().get("blob2").getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.allocate(1));
+    assertThat(actual.getColumns().get("bool1").getBooleanValue()).isTrue();
+    assertThat(actual.getColumns().get("bool2").getBooleanValue()).isTrue();
+    assertThat(actual.getColumns().get("double1").getDoubleValue()).isEqualTo(Double.MAX_VALUE);
+    assertThat(actual.getColumns().get("double2").getDoubleValue())
+        .isEqualTo(Double.valueOf(Double.MAX_VALUE));
+    assertThat(actual.getColumns().get("float1").getFloatValue()).isEqualTo(Float.MAX_VALUE);
+    assertThat(actual.getColumns().get("float2").getFloatValue())
+        .isEqualTo(Float.valueOf(Float.MAX_VALUE));
+    assertThat(actual.getColumns().get("int1").getIntValue()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(actual.getColumns().get("int2").getIntValue())
+        .isEqualTo(Integer.valueOf(Integer.MAX_VALUE));
+    assertThat(actual.getColumns().get("text").getTextValue()).isEqualTo("a_value");
+    assertThat(actual.getColumns().get("text2").getTextValue()).isEqualTo("another_value");
+  }
+
+  @Test
+  public void build_WithAllValuesToNull_ShouldBuildUpsertCorrectly() {
+    // Arrange Act
+    Upsert actual =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .bigIntValue("bigint", null)
+            .blobValue("blob1", (byte[]) null)
+            .blobValue("blob2", (ByteBuffer) null)
+            .booleanValue("bool", null)
+            .doubleValue("double", null)
+            .floatValue("float", null)
+            .intValue("int", null)
+            .textValue("text", null)
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns().size()).isEqualTo(8);
+    assertThat(actual.getColumns().get("bigint").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("blob1").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("blob2").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("bool").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("double").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("float").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("int").hasNullValue()).isTrue();
+    assertThat(actual.getColumns().get("text").hasNullValue()).isTrue();
+  }
+
+  @Test
+  public void build_WithTwoValueUsingSameColumnName_ShouldBuildUpsertCorrectly() {
+    // Arrange Act
+    Upsert actual =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .bigIntValue("bigint", null)
+            .textValue("bigint", "a_value")
+            .build();
+
+    // Assert
+    assertThat(actual.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(actual.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(actual.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(actual.getClusteringKey()).isEmpty();
+    assertThat(actual.getColumns().size()).isEqualTo(1);
+    assertThat(actual.getColumns().get("bigint").getTextValue()).isEqualTo("a_value");
+  }
+
+  @Test
+  public void build_FromExistingWithoutChange_ShouldCopy() {
+    // Arrange
+    Upsert existingUpsert =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .build();
+
+    // Act
+    Upsert newUpsert = Upsert.newBuilder(existingUpsert).build();
+
+    // Assert
+    assertThat(newUpsert).isEqualTo(existingUpsert);
+  }
+
+  @Test
+  public void build_FromExistingAndUpdateAllParameters_ShouldBuildUpsertWithUpdatedParameters() {
+    // Arrange
+    Upsert existingUpsert =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .bigIntValue("bigint1", BigIntColumn.MAX_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MAX_VALUE))
+            .blobValue("blob1", "blob".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(1))
+            .booleanValue("bool1", true)
+            .booleanValue("bool2", Boolean.TRUE)
+            .doubleValue("double1", Double.MAX_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MAX_VALUE))
+            .floatValue("float1", Float.MAX_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MAX_VALUE))
+            .intValue("int1", Integer.MAX_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MAX_VALUE))
+            .textValue("text", "a_value")
+            .value(TextColumn.of("text2", "another_value"))
+            .build();
+
+    // Act
+    Upsert newUpsert =
+        Upsert.newBuilder(existingUpsert)
+            .namespace(NAMESPACE_2)
+            .table(TABLE_2)
+            .partitionKey(partitionKey2)
+            .clusteringKey(clusteringKey2)
+            .clearValues()
+            .bigIntValue("bigint1", BigIntColumn.MIN_VALUE)
+            .bigIntValue("bigint2", Long.valueOf(BigIntColumn.MIN_VALUE))
+            .blobValue("blob1", "foo".getBytes(StandardCharsets.UTF_8))
+            .blobValue("blob2", ByteBuffer.allocate(2))
+            .booleanValue("bool1", false)
+            .booleanValue("bool2", Boolean.FALSE)
+            .doubleValue("double1", Double.MIN_VALUE)
+            .doubleValue("double2", Double.valueOf(Double.MIN_VALUE))
+            .floatValue("float1", Float.MIN_VALUE)
+            .floatValue("float2", Float.valueOf(Float.MIN_VALUE))
+            .intValue("int1", Integer.MIN_VALUE)
+            .intValue("int2", Integer.valueOf(Integer.MIN_VALUE))
+            .textValue("text", "another_value")
+            .value(TextColumn.of("text2", "foo"))
+            .build();
+
+    // Assert
+    assertThat(newUpsert.forNamespace()).hasValue(NAMESPACE_2);
+    assertThat(newUpsert.forTable()).hasValue(TABLE_2);
+    Assertions.<Key>assertThat(newUpsert.getPartitionKey()).isEqualTo(partitionKey2);
+    assertThat(newUpsert.getClusteringKey()).hasValue(clusteringKey2);
+    assertThat(newUpsert.getColumns().size()).isEqualTo(14);
+    assertThat(newUpsert.getColumns().get("bigint1").getBigIntValue())
+        .isEqualTo(BigIntColumn.MIN_VALUE);
+    assertThat(newUpsert.getColumns().get("bigint2").getBigIntValue())
+        .isEqualTo(Long.valueOf(BigIntColumn.MIN_VALUE));
+    assertThat(newUpsert.getColumns().get("blob1").getBlobValueAsBytes())
+        .isEqualTo("foo".getBytes(StandardCharsets.UTF_8));
+    assertThat(newUpsert.getColumns().get("blob2").getBlobValueAsByteBuffer())
+        .isEqualTo(ByteBuffer.allocate(2));
+    assertThat(newUpsert.getColumns().get("bool1").getBooleanValue()).isFalse();
+    assertThat(newUpsert.getColumns().get("bool2").getBooleanValue()).isFalse();
+    assertThat(newUpsert.getColumns().get("double1").getDoubleValue()).isEqualTo(Double.MIN_VALUE);
+    assertThat(newUpsert.getColumns().get("double2").getDoubleValue())
+        .isEqualTo(Double.valueOf(Double.MIN_VALUE));
+    assertThat(newUpsert.getColumns().get("float1").getFloatValue()).isEqualTo(Float.MIN_VALUE);
+    assertThat(newUpsert.getColumns().get("float2").getFloatValue())
+        .isEqualTo(Float.valueOf(Float.MIN_VALUE));
+    assertThat(newUpsert.getColumns().get("int1").getIntValue()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(newUpsert.getColumns().get("int2").getIntValue())
+        .isEqualTo(Integer.valueOf(Integer.MIN_VALUE));
+    assertThat(newUpsert.getColumns().get("text").getTextValue()).isEqualTo("another_value");
+    assertThat(newUpsert.getColumns().get("text2").getTextValue()).isEqualTo("foo");
+  }
+
+  @Test
+  public void build_FromExistingAndClearValue_ShouldBuildUpsertWithoutClearedValues() {
+    // Arrange
+    Upsert existingUpsert =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .booleanValue("bool", Boolean.TRUE)
+            .doubleValue("double", Double.MIN_VALUE)
+            .build();
+
+    // Act
+    Upsert newUpsert =
+        Upsert.newBuilder(existingUpsert).clearValue("double").clearValue("unknown_column").build();
+
+    // Assert
+    assertThat(newUpsert.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newUpsert.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpsert.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpsert.getClusteringKey()).isEmpty();
+    assertThat(newUpsert.getColumns().size()).isEqualTo(1);
+    assertThat(newUpsert.getColumns().get("bool").getBooleanValue()).isTrue();
+  }
+
+  @Test
+  public void build_FromExistingAndClearClusteringKey_ShouldBuildUpsertWithoutClusteringKey() {
+    // Arrange
+    Upsert existingUpsert =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Act
+    Upsert newUpsert = Upsert.newBuilder(existingUpsert).clearClusteringKey().build();
+
+    // Assert
+    assertThat(newUpsert.forNamespace()).hasValue(NAMESPACE_1);
+    assertThat(newUpsert.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpsert.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpsert.getClusteringKey()).isEmpty();
+    assertThat(newUpsert.getColumns()).isEmpty();
+  }
+
+  @Test
+  public void build_FromExistingAndClearNamespace_ShouldBuildUpsertWithoutNamespace() {
+    // Arrange
+    Upsert existingUpsert =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE_1)
+            .table(TABLE_1)
+            .partitionKey(partitionKey1)
+            .clusteringKey(clusteringKey1)
+            .build();
+
+    // Act
+    Upsert newUpsert = Upsert.newBuilder(existingUpsert).clearNamespace().build();
+
+    // Assert
+    assertThat(newUpsert.forNamespace()).isEmpty();
+    assertThat(newUpsert.forTable()).hasValue(TABLE_1);
+    Assertions.<Key>assertThat(newUpsert.getPartitionKey()).isEqualTo(partitionKey1);
+    assertThat(newUpsert.getClusteringKey()).hasValue(clusteringKey1);
+    assertThat(newUpsert.getColumns()).isEmpty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/api/UpsertTest.java
+++ b/core/src/test/java/com/scalar/db/api/UpsertTest.java
@@ -1,0 +1,152 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.io.Column;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UpsertTest {
+  private static final String ANY_NAMESPACE = "ns";
+  private static final String ANY_TABLE = "tbl";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+
+  private Upsert prepareUpsert() {
+    return Upsert.newBuilder()
+        .namespace(ANY_NAMESPACE)
+        .table(ANY_TABLE)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .textValue(ANY_NAME_1, ANY_TEXT_1)
+        .textValue(ANY_NAME_2, ANY_TEXT_2)
+        .build();
+  }
+
+  @Test
+  public void getPartitionKey_ProperKeyGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(expected)
+            .clusteringKey(clusteringKey)
+            .build();
+
+    // Act
+    Key actual = upsert.getPartitionKey();
+
+    // Assert
+    Assertions.<Key>assertThat(expected).isEqualTo(actual);
+  }
+
+  @Test
+  public void getClusteringKey_ProperKeyGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key expected = Key.ofText(ANY_NAME_1, ANY_TEXT_2);
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(expected)
+            .build();
+
+    // Act
+    Optional<Key> actual = upsert.getClusteringKey();
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  public void getClusteringKey_ClusteringKeyNotGiven_ShouldReturnNull() {
+    // Arrange
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(partitionKey)
+            .build();
+
+    // Act
+    Optional<Key> actual = upsert.getClusteringKey();
+
+    // Assert
+    assertThat(actual.isPresent()).isFalse();
+  }
+
+  @Test
+  public void getColumns_TryToModifyReturned_ShouldThrowException() {
+    // Arrange
+    Upsert upsert = prepareUpsert();
+
+    // Act Assert
+    Map<String, Column<?>> values = upsert.getColumns();
+    assertThatThrownBy(() -> values.put(ANY_NAME_3, TextColumn.of(ANY_NAME_3, ANY_TEXT_3)))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void equals_SameInstanceGiven_ShouldReturnTrue() {
+    // Arrange
+    Upsert upsert = prepareUpsert();
+
+    // Act
+    @SuppressWarnings("SelfEquals")
+    boolean ret = upsert.equals(upsert);
+
+    // Assert
+    assertThat(ret).isTrue();
+  }
+
+  @Test
+  public void equals_SameUpsertGiven_ShouldReturnTrue() {
+    // Arrange
+    Upsert upsert = prepareUpsert();
+    Upsert another = prepareUpsert();
+
+    // Act
+    boolean ret = upsert.equals(another);
+
+    // Assert
+    assertThat(ret).isTrue();
+    assertThat(upsert.hashCode()).isEqualTo(another.hashCode());
+  }
+
+  @Test
+  public void equals_UpsertWithDifferentValuesGiven_ShouldReturnFalse() {
+    // Arrange
+    Upsert upsert = prepareUpsert();
+    Upsert another =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_1, ANY_TEXT_1)
+            .textValue(ANY_NAME_2, ANY_TEXT_3)
+            .build();
+
+    // Act
+    boolean ret = upsert.equals(another);
+
+    // Assert
+    assertThat(ret).isFalse();
+    assertThat(upsert.hashCode()).isNotEqualTo(another.hashCode());
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/AbstractDistributedTransactionManagerTest.java
@@ -8,9 +8,12 @@ import static org.mockito.Mockito.mock;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
@@ -53,6 +56,9 @@ public class AbstractDistributedTransactionManagerTest {
       Delete delete = mock(Delete.class);
       @SuppressWarnings("unchecked")
       List<Delete> deletes = (List<Delete>) mock(List.class);
+      Insert insert = mock(Insert.class);
+      Upsert upsert = mock(Upsert.class);
+      Update update = mock(Update.class);
       @SuppressWarnings("unchecked")
       List<Mutation> mutations = (List<Mutation>) mock(List.class);
 
@@ -63,6 +69,9 @@ public class AbstractDistributedTransactionManagerTest {
       assertThatCode(() -> transaction.put(puts)).doesNotThrowAnyException();
       assertThatCode(() -> transaction.delete(delete)).doesNotThrowAnyException();
       assertThatCode(() -> transaction.delete(deletes)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.insert(insert)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.upsert(upsert)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.update(update)).doesNotThrowAnyException();
       assertThatCode(() -> transaction.mutate(mutations)).doesNotThrowAnyException();
     }
 
@@ -78,6 +87,9 @@ public class AbstractDistributedTransactionManagerTest {
       Delete delete = mock(Delete.class);
       @SuppressWarnings("unchecked")
       List<Delete> deletes = (List<Delete>) mock(List.class);
+      Insert insert = mock(Insert.class);
+      Upsert upsert = mock(Upsert.class);
+      Update update = mock(Update.class);
       @SuppressWarnings("unchecked")
       List<Mutation> mutations = (List<Mutation>) mock(List.class);
 
@@ -91,6 +103,12 @@ public class AbstractDistributedTransactionManagerTest {
       assertThatThrownBy(() -> transaction.delete(delete))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.insert(insert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.upsert(upsert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.update(update))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.mutate(mutations))
           .isInstanceOf(IllegalStateException.class);
@@ -107,6 +125,9 @@ public class AbstractDistributedTransactionManagerTest {
       Delete delete = mock(Delete.class);
       @SuppressWarnings("unchecked")
       List<Delete> deletes = (List<Delete>) mock(List.class);
+      Insert insert = mock(Insert.class);
+      Upsert upsert = mock(Upsert.class);
+      Update update = mock(Update.class);
       @SuppressWarnings("unchecked")
       List<Mutation> mutations = (List<Mutation>) mock(List.class);
 
@@ -120,6 +141,12 @@ public class AbstractDistributedTransactionManagerTest {
       assertThatThrownBy(() -> transaction.delete(delete))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.insert(insert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.upsert(upsert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.update(update))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.mutate(mutations))
           .isInstanceOf(IllegalStateException.class);

--- a/core/src/test/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/common/AbstractTwoPhaseCommitTransactionManagerTest.java
@@ -7,10 +7,13 @@ import static org.mockito.Mockito.mock;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
@@ -55,6 +58,9 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
       Delete delete = mock(Delete.class);
       @SuppressWarnings("unchecked")
       List<Delete> deletes = (List<Delete>) mock(List.class);
+      Insert insert = mock(Insert.class);
+      Upsert upsert = mock(Upsert.class);
+      Update update = mock(Update.class);
       @SuppressWarnings("unchecked")
       List<Mutation> mutations = (List<Mutation>) mock(List.class);
 
@@ -65,6 +71,9 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
       assertThatCode(() -> transaction.put(puts)).doesNotThrowAnyException();
       assertThatCode(() -> transaction.delete(delete)).doesNotThrowAnyException();
       assertThatCode(() -> transaction.delete(deletes)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.insert(insert)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.upsert(upsert)).doesNotThrowAnyException();
+      assertThatCode(() -> transaction.update(update)).doesNotThrowAnyException();
       assertThatCode(() -> transaction.mutate(mutations)).doesNotThrowAnyException();
     }
 
@@ -79,6 +88,9 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
       Delete delete = mock(Delete.class);
       @SuppressWarnings("unchecked")
       List<Delete> deletes = (List<Delete>) mock(List.class);
+      Insert insert = mock(Insert.class);
+      Upsert upsert = mock(Upsert.class);
+      Update update = mock(Update.class);
       @SuppressWarnings("unchecked")
       List<Mutation> mutations = (List<Mutation>) mock(List.class);
 
@@ -92,6 +104,12 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
       assertThatThrownBy(() -> transaction.delete(delete))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.insert(insert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.upsert(upsert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.update(update))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.mutate(mutations))
           .isInstanceOf(IllegalStateException.class);
@@ -108,6 +126,9 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
       Delete delete = mock(Delete.class);
       @SuppressWarnings("unchecked")
       List<Delete> deletes = (List<Delete>) mock(List.class);
+      Insert insert = mock(Insert.class);
+      Upsert upsert = mock(Upsert.class);
+      Update update = mock(Update.class);
       @SuppressWarnings("unchecked")
       List<Mutation> mutations = (List<Mutation>) mock(List.class);
 
@@ -121,6 +142,12 @@ public class AbstractTwoPhaseCommitTransactionManagerTest {
       assertThatThrownBy(() -> transaction.delete(delete))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.delete(deletes))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.insert(insert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.upsert(upsert))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> transaction.update(update))
           .isInstanceOf(IllegalStateException.class);
       assertThatThrownBy(() -> transaction.mutate(mutations))
           .isInstanceOf(IllegalStateException.class);

--- a/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/common/checker/OperationCheckerTest.java
@@ -12,6 +12,7 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
 import com.scalar.db.api.DeleteIfExists;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
@@ -21,6 +22,8 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -1366,6 +1369,46 @@ public class OperationCheckerTest {
 
     // Act Assert
     assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put, delete)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      whenCheckingMutateOperationWithMutationsWithUnsupportedMutations_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Key partitionKey = Key.of(PKEY1, 1, PKEY2, "val1");
+    Key clusteringKey = Key.of(CKEY1, 2, CKEY2, "val3");
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
+    Update update =
+        Update.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(COL1, 1)
+            .build();
+
+    // Act Assert
+    assertThatThrownBy(() -> operationChecker.check(Collections.singletonList(insert)))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(Collections.singletonList(upsert)))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(Collections.singletonList(update)))
         .isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -11,17 +11,23 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RecordNotFoundException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.io.Key;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,6 +48,7 @@ public class ConsensusCommitTest {
   private static final String ANY_TEXT_1 = "text1";
   private static final String ANY_TEXT_2 = "text2";
   private static final String ANY_TEXT_3 = "text3";
+  private static final String ANY_TEXT_4 = "text4";
 
   @Mock private Snapshot snapshot;
   @Mock private CrudHandler crud;
@@ -98,7 +105,7 @@ public class ConsensusCommitTest {
     TransactionResult result = mock(TransactionResult.class);
     when(crud.get(get)).thenReturn(Optional.of(result));
 
-    // Act Assert
+    // Act
     Optional<Result> actual = consensus.get(get);
 
     // Assert
@@ -120,7 +127,6 @@ public class ConsensusCommitTest {
     // Act Assert
     assertThatThrownBy(() -> consensus.get(get)).isInstanceOf(UncommittedRecordException.class);
 
-    // Assert
     verify(recovery).recover(get, result);
   }
 
@@ -132,7 +138,7 @@ public class ConsensusCommitTest {
     List<Result> results = Collections.singletonList(result);
     when(crud.scan(scan)).thenReturn(results);
 
-    // Act Assert
+    // Act
     List<Result> actual = consensus.scan(scan);
 
     // Assert
@@ -162,7 +168,7 @@ public class ConsensusCommitTest {
     Put put = preparePut();
     doNothing().when(crud).put(put);
 
-    // Act Assert
+    // Act
     consensus.put(put);
 
     // Assert
@@ -177,7 +183,7 @@ public class ConsensusCommitTest {
     Put put = preparePut();
     doNothing().when(crud).put(put);
 
-    // Act Assert
+    // Act
     consensus.put(Arrays.asList(put, put));
 
     // Assert
@@ -211,7 +217,7 @@ public class ConsensusCommitTest {
     Delete delete = prepareDelete();
     doNothing().when(crud).delete(delete);
 
-    // Act Assert
+    // Act
     consensus.delete(delete);
 
     // Assert
@@ -226,7 +232,7 @@ public class ConsensusCommitTest {
     Delete delete = prepareDelete();
     doNothing().when(crud).delete(delete);
 
-    // Act Assert
+    // Act
     consensus.delete(Arrays.asList(delete, delete));
 
     // Assert
@@ -249,6 +255,292 @@ public class ConsensusCommitTest {
 
     // Act Assert
     assertThatThrownBy(() -> consensus.delete(delete))
+        .isInstanceOf(UncommittedRecordException.class);
+
+    verify(recovery).recover(get, result);
+  }
+
+  @Test
+  public void insert_InsertGiven_ShouldCallCrudHandlerPut()
+      throws CrudException, ExecutionException {
+    // Arrange
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+
+    // Act
+    consensus.insert(insert);
+
+    // Assert
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .enableInsertMode()
+            .build();
+    verify(crud).put(expectedPut);
+    verify(mutationOperationChecker).check(expectedPut);
+  }
+
+  @Test
+  public void upsert_UpsertGiven_ShouldCallCrudHandlerPut()
+      throws CrudException, ExecutionException {
+    // Arrange
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+
+    // Act
+    consensus.upsert(upsert);
+
+    // Assert
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .enableImplicitPreRead()
+            .build();
+    verify(crud).put(expectedPut);
+    verify(mutationOperationChecker).check(expectedPut);
+  }
+
+  @Test
+  public void upsert_UpsertForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
+    // Arrange
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .enableImplicitPreRead()
+            .build();
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .build();
+
+    TransactionResult result = mock(TransactionResult.class);
+    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
+    doThrow(toThrow).when(crud).put(put);
+    when(toThrow.getSelection()).thenReturn(get);
+    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.upsert(upsert))
+        .isInstanceOf(UncommittedRecordException.class);
+
+    verify(recovery).recover(get, result);
+  }
+
+  @Test
+  public void update_UpdateWithoutConditionGiven_ShouldCallCrudHandlerPut()
+      throws CrudException, ExecutionException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+
+    // Act
+    consensus.update(update);
+
+    // Assert
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
+            .build();
+    verify(crud).put(expectedPut);
+    verify(mutationOperationChecker).check(expectedPut);
+  }
+
+  @Test
+  public void update_UpdateWithConditionGiven_ShouldCallCrudHandlerPut()
+      throws CrudException, ExecutionException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+
+    // Act
+    consensus.update(update);
+
+    // Assert
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .enableImplicitPreRead()
+            .build();
+    verify(crud).put(expectedPut);
+    verify(mutationOperationChecker).check(expectedPut);
+  }
+
+  @Test
+  public void
+      update_UpdateWithoutConditionGivenAndUnsatisfiedConditionExceptionThrownByCrudHandler_ShouldThrowRecordNotFoundException()
+          throws CrudException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
+            .build();
+
+    when(crud.getSnapshot()).thenReturn(snapshot);
+    when(snapshot.getId()).thenReturn("id");
+
+    doThrow(UnsatisfiedConditionException.class).when(crud).put(put);
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.update(update)).isInstanceOf(RecordNotFoundException.class);
+  }
+
+  @Test
+  public void
+      update_UpdateWithConditionGivenAndUnsatisfiedConditionExceptionThrownByCrudHandler_ShouldThrowUnsatisfiedConditionException()
+          throws CrudException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .enableImplicitPreRead()
+            .build();
+
+    when(crud.getSnapshot()).thenReturn(snapshot);
+    when(snapshot.getId()).thenReturn("id");
+
+    doThrow(UnsatisfiedConditionException.class).when(crud).put(put);
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.update(update))
+        .isInstanceOf(UnsatisfiedConditionException.class);
+  }
+
+  @Test
+  public void update_UpdateForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .enableImplicitPreRead()
+            .build();
+    Get get =
+        Get.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .build();
+
+    TransactionResult result = mock(TransactionResult.class);
+    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
+    doThrow(toThrow).when(crud).put(put);
+    when(toThrow.getSelection()).thenReturn(get);
+    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.update(update))
         .isInstanceOf(UncommittedRecordException.class);
 
     verify(recovery).recover(get, result);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -435,11 +435,11 @@ public class PrepareMutationComposerTest {
   }
 
   @Test
-  public void add_SelectionOtherThanGetGiven_ShouldThrowIllegalArgumentException() {
+  public void add_SelectionOtherThanGetGiven_ShouldThrowAssertionError() {
     // Arrange
     Scan scan = prepareScan();
 
     // Act Assert
-    assertThatThrownBy(() -> composer.add(scan, null)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> composer.add(scan, null)).isInstanceOf(AssertionError.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionTest.java
@@ -8,9 +8,15 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RecordNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.storage.jdbc.JdbcService;
@@ -27,7 +33,17 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class JdbcTransactionTest {
+  private static final String ANY_NAMESPACE = "namespace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final String ANY_TEXT_4 = "text4";
   private static final String ANY_TX_ID = "any_id";
+
   private static final Put ANY_PUT =
       Put.newBuilder()
           .namespace("ns")
@@ -42,6 +58,7 @@ public class JdbcTransactionTest {
           .partitionKey(Key.ofText("c1", "foo"))
           .condition(ConditionBuilder.deleteIfExists())
           .build();
+
   private JdbcTransaction transaction;
   @Mock private JdbcService jdbcService;
   @Mock private Connection connection;
@@ -164,5 +181,405 @@ public class JdbcTransactionTest {
         Arguments.of(
             ConditionBuilder.deleteIfExists(),
             "The DeleteIfExists condition of the Delete operation is not satisfied. Targeting column(s): null"));
+  }
+
+  @Test
+  public void insert_InsertGiven_WhenRecordDoesNotExist_ShouldCallJdbcServiceProperly()
+      throws CrudException, ExecutionException, SQLException {
+    // Arrange
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(true);
+
+    // Act
+    transaction.insert(insert);
+
+    // Assert
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void insert_InsertGiven_WhenRecordExists_ShouldThrowCrudConflictException()
+      throws ExecutionException, SQLException {
+    // Arrange
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.insert(insert)).isInstanceOf(CrudConflictException.class);
+
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void insert_InsertGiven_WhenSQLExceptionThrownByJdbcService_ShouldThrowCrudException()
+      throws SQLException, ExecutionException {
+    // Arrange
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
+
+    when(jdbcService.put(put, connection)).thenThrow(SQLException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.insert(insert)).isInstanceOf(CrudException.class);
+  }
+
+  @Test
+  public void
+      insert_InsertGiven_WhenExecutionExceptionThrownByJdbcService_ShouldThrowCrudException()
+          throws SQLException, ExecutionException {
+    // Arrange
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfNotExists())
+            .build();
+
+    when(jdbcService.put(put, connection)).thenThrow(ExecutionException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.insert(insert)).isInstanceOf(CrudException.class);
+  }
+
+  @Test
+  public void upsert_UpsertGiven_ShouldCallJdbcServiceProperly()
+      throws CrudException, ExecutionException, SQLException {
+    // Arrange
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(true);
+
+    // Act
+    transaction.upsert(upsert);
+
+    // Assert
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void upsert_UpsertGiven_WhenSQLExceptionThrownByJdbcService_ShouldThrowCrudException()
+      throws SQLException, ExecutionException {
+    // Arrange
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+
+    when(jdbcService.put(put, connection)).thenThrow(SQLException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.upsert(upsert)).isInstanceOf(CrudException.class);
+  }
+
+  @Test
+  public void
+      upsert_UpsertGiven_WhenExecutionExceptionThrownByJdbcService_ShouldThrowCrudException()
+          throws SQLException, ExecutionException {
+    // Arrange
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+
+    when(jdbcService.put(put, connection)).thenThrow(ExecutionException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.upsert(upsert)).isInstanceOf(CrudException.class);
+  }
+
+  @Test
+  public void update_UpdateWithoutConditionGiven_WhenRecordExists_ShouldCallJdbcServiceProperly()
+      throws CrudException, ExecutionException, SQLException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(true);
+
+    // Act
+    transaction.update(update);
+
+    // Assert
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void
+      update_UpdateWithoutConditionGiven_WhenRecordDoesNotExist_ShouldThrowRecordNotFoundException()
+          throws ExecutionException, SQLException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(update))
+        .isInstanceOf(RecordNotFoundException.class);
+
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void update_UpdateWithConditionGiven_WhenConditionSatisfied_ShouldCallJdbcServiceProperly()
+      throws CrudException, ExecutionException, SQLException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(true);
+
+    // Act
+    transaction.update(update);
+
+    // Assert
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void
+      update_UpdateWithConditionGiven_WhenConditionNotSatisfied_ShouldThrowUnsatisfiedConditionException()
+          throws ExecutionException, SQLException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+    Put expectedPut =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_4)
+            .condition(
+                ConditionBuilder.putIf(
+                        ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
+                    .build())
+            .build();
+
+    when(jdbcService.put(expectedPut, connection)).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(update))
+        .isInstanceOf(UnsatisfiedConditionException.class);
+
+    verify(jdbcService).put(expectedPut, connection);
+  }
+
+  @Test
+  public void update_UpdateGiven_WhenSQLExceptionThrownByJdbcService_ShouldThrowCrudException()
+      throws SQLException, ExecutionException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .build();
+
+    when(jdbcService.put(put, connection)).thenThrow(SQLException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(update)).isInstanceOf(CrudException.class);
+  }
+
+  @Test
+  public void
+      update_UpdateGiven_WhenExecutionExceptionThrownByJdbcService_ShouldThrowCrudException()
+          throws SQLException, ExecutionException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .build();
+    Put put =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+            .textValue(ANY_NAME_3, ANY_TEXT_3)
+            .condition(ConditionBuilder.putIfExists())
+            .build();
+
+    when(jdbcService.put(put, connection)).thenThrow(ExecutionException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(update)).isInstanceOf(CrudException.class);
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -3,6 +3,7 @@ package com.scalar.db.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.api.Scan.Ordering;
@@ -10,7 +11,9 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.exception.transaction.RecordNotFoundException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
@@ -1305,6 +1308,275 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
     // Act Assert
     assertThatThrownBy(() -> put(putIf)).isInstanceOf(UnsatisfiedConditionException.class);
+
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
+  }
+
+  @Test
+  public void insertAndCommit_InsertGivenForNonExisting_ShouldCreateRecord()
+      throws TransactionException {
+    // Arrange
+    int expected = INITIAL_BALANCE;
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.insert(insert);
+    transaction.commit();
+
+    // Assert
+    Get get = prepareGet(0, 0);
+    DistributedTransaction another = manager.start();
+    Optional<Result> result = another.get(get);
+    another.commit();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(getBalance(result.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void
+      insertAndCommit_InsertGivenForExisting_ShouldThrowCrudConflictExceptionOrCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    int expected = INITIAL_BALANCE + 100;
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+
+    try {
+      transaction.insert(insert);
+      transaction.commit();
+      fail("Should have thrown CrudConflictException or CommitConflictException");
+    } catch (CrudConflictException | CommitConflictException ignored) {
+      // Expected
+    }
+    transaction.rollback();
+  }
+
+  @Test
+  public void upsertAndCommit_UpsertGivenForNonExisting_ShouldCreateRecord()
+      throws TransactionException {
+    // Arrange
+    int expected = INITIAL_BALANCE;
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.upsert(upsert);
+    transaction.commit();
+
+    // Assert
+    Get get = prepareGet(0, 0);
+    DistributedTransaction another = manager.start();
+    Optional<Result> result = another.get(get);
+    another.commit();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(getBalance(result.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void upsertAndCommit_UpsertGivenForExisting_ShouldUpdateRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    int expected = INITIAL_BALANCE + 100;
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    transaction.upsert(upsert);
+    transaction.commit();
+
+    // Assert
+    DistributedTransaction another = manager.start();
+    Optional<Result> actual = another.get(prepareGet(0, 0));
+    another.commit();
+
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(getBalance(actual.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void updateAndCommit_UpdateGivenForNonExisting_ShouldThrowRecordNotFoundException()
+      throws TransactionException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    assertThatThrownBy(() -> transaction.update(update))
+        .isInstanceOf(RecordNotFoundException.class);
+    transaction.rollback();
+  }
+
+  @Test
+  public void updateAndCommit_UpsertGivenForExisting_ShouldUpdateRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    int expected = INITIAL_BALANCE + 100;
+    Update update =
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    transaction.update(update);
+    transaction.commit();
+
+    // Assert
+    DistributedTransaction another = manager.start();
+    Optional<Result> actual = another.get(prepareGet(0, 0));
+    another.commit();
+
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(getBalance(actual.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void update_withUpdateIfWithVerifiedCondition_shouldPutProperly()
+      throws TransactionException {
+    // Arrange
+    int someColumnValue = 10;
+    Put initialData =
+        Put.newBuilder(preparePut(0, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .intValue(SOME_COLUMN, someColumnValue)
+            .build();
+    put(initialData);
+
+    int updatedBalance = 2;
+    Update updateIf =
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, updatedBalance)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(updateIf);
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(updatedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(someColumnValue);
+  }
+
+  @Test
+  public void update_withUpdateIfWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException()
+      throws TransactionException {
+    // Arrange
+    Update updateIf =
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .condition(
+                ConditionBuilder.updateIf(ConditionBuilder.column(BALANCE).isNullInt()).build())
+            .build();
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(updateIf))
+        .isInstanceOf(UnsatisfiedConditionException.class);
+    transaction.rollback();
+
+    Optional<Result> result = get(prepareGet(0, 0));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void update_withUpdateIfWithNonVerifiedCondition_shouldThrowUnsatisfiedConditionException()
+      throws TransactionException {
+    // Arrange
+    Put initialData = Put.newBuilder(preparePut(0, 0)).intValue(BALANCE, INITIAL_BALANCE).build();
+    put(initialData);
+
+    Update updateIf =
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 2)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(updateIf))
+        .isInstanceOf(UnsatisfiedConditionException.class);
+    transaction.rollback();
 
     Optional<Result> optResult = get(prepareGet(0, 0));
     assertThat(optResult.isPresent()).isTrue();

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -3,14 +3,17 @@ package com.scalar.db.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitException;
+import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.RecordNotFoundException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
@@ -1559,6 +1562,298 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Act Assert
     assertThatThrownBy(() -> delete(deleteIfExists))
         .isInstanceOf(UnsatisfiedConditionException.class);
+  }
+
+  @Test
+  public void insertAndCommit_InsertGivenForNonExisting_ShouldCreateRecord()
+      throws TransactionException {
+    // Arrange
+    int expected = INITIAL_BALANCE;
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act
+    transaction.insert(insert);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction another = manager1.start();
+    Optional<Result> result = another.get(get);
+    another.prepare();
+    another.validate();
+    another.commit();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(getBalance(result.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void
+      insertAndCommit_InsertGivenForExisting_ShouldThrowCrudConflictExceptionOrPreparationConflictException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act Assert
+    int expected = INITIAL_BALANCE + 100;
+    Insert insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+
+    try {
+      transaction.insert(insert);
+      transaction.prepare();
+      transaction.validate();
+      transaction.commit();
+      fail("Should have thrown CrudConflictException or PreparationConflictException");
+    } catch (CrudConflictException | PreparationConflictException ignored) {
+      // Expected
+    }
+    transaction.rollback();
+  }
+
+  @Test
+  public void upsertAndCommit_UpsertGivenForNonExisting_ShouldCreateRecord()
+      throws TransactionException {
+    // Arrange
+    int expected = INITIAL_BALANCE;
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act
+    transaction.upsert(upsert);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction another = manager1.start();
+    Optional<Result> result = another.get(get);
+    another.prepare();
+    another.validate();
+    another.commit();
+    assertThat(result.isPresent()).isTrue();
+    assertThat(getBalance(result.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void upsertAndCommit_UpsertGivenForExisting_ShouldUpdateRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act
+    int expected = INITIAL_BALANCE + 100;
+    Upsert upsert =
+        Upsert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    transaction.upsert(upsert);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    TwoPhaseCommitTransaction another = manager1.start();
+    Optional<Result> actual = another.get(prepareGet(0, 0, namespace1, TABLE_1));
+    another.prepare();
+    another.validate();
+    another.commit();
+
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(getBalance(actual.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void updateAndCommit_UpdateGivenForNonExisting_ShouldThrowRecordNotFoundException()
+      throws TransactionException {
+    // Arrange
+    Update update =
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act
+    assertThatThrownBy(() -> transaction.update(update))
+        .isInstanceOf(RecordNotFoundException.class);
+    transaction.rollback();
+  }
+
+  @Test
+  public void updateAndCommit_UpsertGivenForExisting_ShouldUpdateRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act
+    int expected = INITIAL_BALANCE + 100;
+    Update update =
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expected)
+            .build();
+    transaction.update(update);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    TwoPhaseCommitTransaction another = manager1.start();
+    Optional<Result> actual = another.get(prepareGet(0, 0, namespace1, TABLE_1));
+    another.prepare();
+    another.validate();
+    another.commit();
+
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(getBalance(actual.get())).isEqualTo(expected);
+  }
+
+  @Test
+  public void update_withUpdateIfWithVerifiedCondition_shouldPutProperly()
+      throws TransactionException {
+    // Arrange
+    int someColumnValue = 10;
+    Put initialData =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .intValue(SOME_COLUMN, someColumnValue)
+            .build();
+    put(initialData);
+
+    int updatedBalance = 2;
+    Update updateIf =
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, updatedBalance)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act
+    transaction.update(updateIf);
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(updatedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(someColumnValue);
+  }
+
+  @Test
+  public void update_withUpdateIfWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException()
+      throws TransactionException {
+    // Arrange
+    Update updateIf =
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .condition(
+                ConditionBuilder.updateIf(ConditionBuilder.column(BALANCE).isNullInt()).build())
+            .build();
+
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(updateIf))
+        .isInstanceOf(UnsatisfiedConditionException.class);
+    transaction.rollback();
+
+    Optional<Result> result = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void update_withUpdateIfWithNonVerifiedCondition_shouldThrowUnsatisfiedConditionException()
+      throws TransactionException {
+    // Arrange
+    Put initialData =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build();
+    put(initialData);
+
+    Update updateIf =
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 2)
+            .condition(
+                ConditionBuilder.updateIf(
+                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
+                    .build())
+            .build();
+
+    TwoPhaseCommitTransaction transaction = manager1.start();
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.update(updateIf))
+        .isInstanceOf(UnsatisfiedConditionException.class);
+    transaction.rollback();
+
+    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    assertThat(optResult.isPresent()).isTrue();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    assertThat(result.isNull(SOME_COLUMN)).isTrue();
   }
 
   private Optional<Result> get(Get get) throws TransactionException {

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithServer.java
@@ -6,6 +6,8 @@ import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitIntegrationTestWithServer extends ConsensusCommitIntegrationTestBase {
 
@@ -40,4 +42,52 @@ public class ConsensusCommitIntegrationTestWithServer extends ConsensusCommitInt
       server.shutdown();
     }
   }
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void insertAndCommit_InsertGivenForNonExisting_ShouldCreateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndCommit_InsertGivenForExisting_ShouldThrowCrudConflictExceptionOrCommitConflictException() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndCommit_UpsertGivenForNonExisting_ShouldCreateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndCommit_UpsertGivenForExisting_ShouldUpdateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndCommit_UpdateGivenForNonExisting_ShouldThrowRecordNotFoundException() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndCommit_UpsertGivenForExisting_ShouldUpdateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void update_withUpdateIfWithVerifiedCondition_shouldPutProperly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      update_withUpdateIfWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      update_withUpdateIfWithNonVerifiedCondition_shouldThrowUnsatisfiedConditionException() {}
 }

--- a/server/src/integration-test/java/com/scalar/db/server/TwoPhaseConsensusCommitIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/TwoPhaseConsensusCommitIntegrationTestWithServer.java
@@ -6,6 +6,8 @@ import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitIntegrat
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TwoPhaseConsensusCommitIntegrationTestWithServer
     extends TwoPhaseConsensusCommitIntegrationTestBase {
@@ -57,4 +59,52 @@ public class TwoPhaseConsensusCommitIntegrationTestWithServer
       server2.shutdown();
     }
   }
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void insertAndCommit_InsertGivenForNonExisting_ShouldCreateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndCommit_InsertGivenForExisting_ShouldThrowCrudConflictExceptionOrPreparationConflictException() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndCommit_UpsertGivenForNonExisting_ShouldCreateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndCommit_UpsertGivenForExisting_ShouldUpdateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndCommit_UpdateGivenForNonExisting_ShouldThrowRecordNotFoundException() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndCommit_UpsertGivenForExisting_ShouldUpdateRecord() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void update_withUpdateIfWithVerifiedCondition_shouldPutProperly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      update_withUpdateIfWhenRecordDoesNotExist_shouldThrowUnsatisfiedConditionException() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      update_withUpdateIfWithNonVerifiedCondition_shouldThrowUnsatisfiedConditionException() {}
 }


### PR DESCRIPTION
## Description

This PR adds the Insert, Upsert, and Update operations to `TransactionCrudOperable`. For the specification of these operations, see the Javadoc of `TransactionCrudOperable`.

## Related issues and/or PRs

N/A

## Changes made

- Added the `Insert`, `Upsert`, and `Update` classes as subclasses of `Mutate`.
- Added the `insert()`, `upsert()`, and `update()` methods to `TransactionCrudOperable`.
- Deprecated the `put()` methods and some other methods in `TransactionCrudOperable`.
- Implemented the `insert()`, `upsert()`, and `update()` methods for Consensus Comment and JDBC transactions.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Documentation will be added in a separate PR.

## Release notes

Added the Insert, Upsert, and Update operations to the transactional API.
