### PR TITLE
Backport to branch(3) : Bump slackapi/slack-github-action from 1.25.0 to 1.26.0

### DIFF
--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
         if: failure()
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {
@@ -130,7 +130,7 @@ jobs:
 
       - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
         if: failure()
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1688