### PR TITLE
Fix resource leaks in `integrationTestJdbc`

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
@@ -9,9 +9,13 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
     extends ConsensusCommitAdminImportTableIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.class);
 
   private JdbcAdminImportTestUtils testUtils;
 
@@ -20,6 +24,23 @@ public class ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
     Properties properties = JdbcEnv.getProperties(testName);
     testUtils = new JdbcAdminImportTestUtils(properties);
     return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  public void afterAll() {
+    try {
+      super.afterAll();
+    } catch (Exception e) {
+      logger.warn("Failed to call super.afterAll", e);
+    }
+
+    try {
+      if (testUtils != null) {
+        testUtils.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close test utils", e);
+    }
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
@@ -9,9 +9,13 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JdbcAdminImportTableIntegrationTest
     extends DistributedStorageAdminImportTableIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(JdbcAdminImportTableIntegrationTest.class);
 
   private JdbcAdminImportTestUtils testUtils;
 
@@ -23,9 +27,20 @@ public class JdbcAdminImportTableIntegrationTest
   }
 
   @Override
-  protected void afterAll() throws Exception {
-    super.afterAll();
-    testUtils.close();
+  public void afterAll() {
+    try {
+      super.afterAll();
+    } catch (Exception e) {
+      logger.warn("Failed to call super.afterAll", e);
+    }
+
+    try {
+      if (testUtils != null) {
+        testUtils.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close test utils", e);
+    }
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -6,8 +6,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(JdbcSchemaLoaderImportIntegrationTest.class);
 
   private JdbcAdminImportTestUtils testUtils;
   private RdbEngineStrategy rdbEngine;
@@ -65,9 +69,20 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
   }
 
   @Override
-  public void afterAll() throws Exception {
-    super.afterAll();
-    testUtils.close();
+  public void afterAll() {
+    try {
+      super.afterAll();
+    } catch (Exception e) {
+      logger.warn("Failed to call super.afterAll", e);
+    }
+
+    try {
+      if (testUtils != null) {
+        testUtils.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close test utils", e);
+    }
   }
 
   @SuppressWarnings("unused")

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':core')
     implementation project(':schema-loader')
     implementation "com.google.guava:guava:${guavaVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     implementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
     runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':schema-loader')
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
     implementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     implementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
     runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
@@ -16,9 +16,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageAdminImportTableIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_admin_import_table";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -67,9 +71,20 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
   }
 
   @AfterEach
-  protected void afterEach() throws Exception {
-    dropTable();
-    admin.close();
+  protected void afterEach() {
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -23,9 +23,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageAdminIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageAdminIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_admin";
   private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
@@ -121,8 +125,19 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminRepairIntegrationTestBase.java
@@ -15,9 +15,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageAdminRepairIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageAdminRepairIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_admin_repair";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -71,8 +75,21 @@ public abstract class DistributedStorageAdminRepairIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    admin.close();
-    adminTestUtils.close();
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (adminTestUtils != null) {
+        adminTestUtils.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin test utils", e);
+    }
   }
 
   protected abstract Properties getProperties(String testName);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -28,9 +28,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageColumnValueIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageColumnValueIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_col_val";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -105,9 +109,27 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTable();
-    admin.close();
-    storage.close();
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop table", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTable() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageConditionalMutationIntegrationTestBase.java
@@ -40,9 +40,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageConditionalMutationIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_cond_mutation";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -127,9 +131,27 @@ public abstract class DistributedStorageConditionalMutationIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTable();
-    admin.close();
-    storage.close();
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop table", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTable() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java
@@ -54,9 +54,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageCrossPartitionScanIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_cross_partition_scan";
   private static final String NAMESPACE_BASE_NAME = "int_test_" + TEST_NAME + "_";
@@ -643,11 +647,41 @@ public abstract class DistributedStorageCrossPartitionScanIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTablesForOrderingTests();
-    dropTableForConditionTests();
-    admin.close();
-    storage.close();
-    executorService.shutdown();
+    try {
+      dropTablesForOrderingTests();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables for ordering tests", e);
+    }
+
+    try {
+      dropTableForConditionTests();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables for condition tests", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
+
+    try {
+      if (executorService != null) {
+        executorService.shutdown();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to shutdown executor service", e);
+    }
   }
 
   private void dropTableForConditionTests() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -140,7 +140,7 @@ public abstract class DistributedStorageIntegrationTestBase {
         storage.close();
       }
     } catch (Exception e) {
-      logger.warn("Failed to storage", e);
+      logger.warn("Failed to close storage", e);
     }
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -40,9 +40,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -117,9 +121,27 @@ public abstract class DistributedStorageIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTable();
-    admin.close();
-    storage.close();
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop table", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to storage", e);
+    }
   }
 
   private void dropTable() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageJapaneseIntegrationTestBase.java
@@ -17,9 +17,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageJapaneseIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageJapaneseIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_jp";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -79,9 +83,27 @@ public abstract class DistributedStorageJapaneseIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTable();
-    admin.close();
-    storage.close();
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop table", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTable() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -36,9 +36,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.class);
 
   private enum OrderingType {
     BOTH_SPECIFIED,
@@ -176,10 +180,35 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    storage.close();
-    executorService.shutdown();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
+
+    try {
+      if (executorService != null) {
+        executorService.shutdown();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to shutdown executor service", e);
+    }
   }
 
   private void dropTables() throws java.util.concurrent.ExecutionException, InterruptedException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
@@ -28,9 +28,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageMultiplePartitionKeyIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_mul_pkey";
   private static final String NAMESPACE_BASE_NAME = "int_test_" + TEST_NAME + "_";
@@ -138,9 +142,27 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    storage.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTables() throws java.util.concurrent.ExecutionException, InterruptedException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSecondaryIndexIntegrationTestBase.java
@@ -21,9 +21,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageSecondaryIndexIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_secondary_idx";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -98,9 +102,27 @@ public abstract class DistributedStorageSecondaryIndexIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    storage.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -122,6 +122,7 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
     } catch (Exception e) {
       logger.warn("Failed to drop tables", e);
     }
+
     try {
       if (admin != null) {
         admin.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSingleClusteringKeyScanIntegrationTestBase.java
@@ -27,9 +27,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageSingleClusteringKeyScanIntegrationTestBase.class);
 
   private enum OrderingType {
     SPECIFIED,
@@ -113,9 +117,26 @@ public abstract class DistributedStorageSingleClusteringKeyScanIntegrationTestBa
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    storage.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
@@ -106,6 +106,7 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
     } catch (Exception e) {
       logger.warn("Failed to drop tables", e);
     }
+
     try {
       if (admin != null) {
         admin.close();
@@ -113,6 +114,7 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
     } catch (Exception e) {
       logger.warn("Failed to close admin", e);
     }
+
     try {
       if (storage != null) {
         storage.close();

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageSinglePartitionKeyIntegrationTestBase.java
@@ -24,9 +24,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageSinglePartitionKeyIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_single_pkey";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -97,9 +101,25 @@ public abstract class DistributedStorageSinglePartitionKeyIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    storage.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageWithReservedKeywordIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageWithReservedKeywordIntegrationTestBase.java
@@ -27,9 +27,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedStorageWithReservedKeywordIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageWithReservedKeywordIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_reserved_kw";
 
@@ -114,9 +118,27 @@ public abstract class DistributedStorageWithReservedKeywordIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTable();
-    admin.close();
-    storage.close();
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
   }
 
   private void dropTable() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
@@ -16,9 +16,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionAdminImportTableIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedTransactionAdminImportTableIntegrationTestBase.class);
 
   private static final String TEST_NAME = "tx_admin_import_table";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -67,9 +71,20 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
   }
 
   @AfterEach
-  protected void afterEach() throws Exception {
-    dropTable();
-    admin.close();
+  protected void afterEach() {
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop table", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
   }
 
   @AfterAll

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -24,9 +24,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionAdminIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedTransactionAdminIntegrationTestBase.class);
 
   protected static final String TEST_NAME = "tx_admin";
   protected static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
@@ -123,8 +127,19 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminRepairIntegrationTestBase.java
@@ -19,9 +19,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionAdminRepairIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedTransactionAdminRepairIntegrationTestBase.class);
 
   protected static final String TEST_NAME = "tx_admin_repair";
   protected static final String NAMESPACE = "int_test_" + TEST_NAME;
@@ -79,9 +83,29 @@ public abstract class DistributedTransactionAdminRepairIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    admin.close();
-    storageAdmin.close();
-    adminTestUtils.close();
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storageAdmin != null) {
+        storageAdmin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage admin", e);
+    }
+
+    try {
+      if (adminTestUtils != null) {
+        adminTestUtils.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin test utils", e);
+    }
   }
 
   protected abstract Properties getProperties(String testName);

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionCrossPartitionScanIntegrationTestBase.java
@@ -30,9 +30,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionCrossPartitionScanIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedTransactionCrossPartitionScanIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_cpscan_tx_test_";
   protected static final String TABLE = "test_table";
@@ -107,9 +111,27 @@ public abstract class DistributedTransactionCrossPartitionScanIntegrationTestBas
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    manager.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (manager != null) {
+        manager.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close manager", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -37,9 +37,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class DistributedTransactionIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DistributedTransactionIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_test_";
   protected static final String TABLE = "test_table";
@@ -105,9 +109,27 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin.close();
-    manager.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (manager != null) {
+        manager.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close manager", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.java
@@ -29,9 +29,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(TwoPhaseCommitTransactionCrossPartitionScanIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_rscan_2pc_test_";
   protected static final String TABLE_1 = "test_table1";
@@ -117,11 +121,43 @@ public abstract class TwoPhaseCommitTransactionCrossPartitionScanIntegrationTest
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin1.close();
-    admin2.close();
-    manager1.close();
-    manager2.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin1 != null) {
+        admin1.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin#1", e);
+    }
+
+    try {
+      if (admin2 != null) {
+        admin2.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin#2", e);
+    }
+
+    try {
+      if (manager1 != null) {
+        manager1.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close manager#1", e);
+    }
+
+    try {
+      if (manager2 != null) {
+        manager2.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close manager#2", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -37,9 +37,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(TwoPhaseCommitTransactionIntegrationTestBase.class);
 
   protected static final String NAMESPACE_BASE_NAME = "int_test_";
   protected static final String TABLE_1 = "test_table1";
@@ -120,11 +124,43 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTables();
-    admin1.close();
-    admin2.close();
-    manager1.close();
-    manager2.close();
+    try {
+      dropTables();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (admin1 != null) {
+        admin1.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin#1", e);
+    }
+
+    try {
+      if (admin2 != null) {
+        admin2.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin#2", e);
+    }
+
+    try {
+      if (manager1 != null) {
+        manager1.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close manager#1", e);
+    }
+
+    try {
+      if (manager2 != null) {
+        manager2.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close manager#2", e);
+    }
   }
 
   private void dropTables() throws ExecutionException {

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -23,9 +23,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SchemaLoaderImportIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(SchemaLoaderImportIntegrationTestBase.class);
   private static final String TEST_NAME = "schema_loader_import";
   private static final Path CONFIG_FILE_PATH = Paths.get("config.properties").toAbsolutePath();
   private static final Path IMPORT_SCHEMA_FILE_PATH =
@@ -105,9 +109,27 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTablesIfExist();
-    transactionAdmin.close();
-    storageAdmin.close();
+    try {
+      dropTablesIfExist();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (transactionAdmin != null) {
+        transactionAdmin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close transaction admin", e);
+    }
+
+    try {
+      if (storageAdmin != null) {
+        storageAdmin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage admin", e);
+    }
 
     // Delete the files
     Files.delete(CONFIG_FILE_PATH);

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderIntegrationTestBase.java
@@ -31,9 +31,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SchemaLoaderIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(SchemaLoaderIntegrationTestBase.class);
   private static final String TEST_NAME = "schema_loader";
   private static final Path CONFIG_FILE_PATH = Paths.get("config.properties").toAbsolutePath();
   private static final Path SCHEMA_FILE_PATH = Paths.get("schema.json").toAbsolutePath();
@@ -270,10 +274,36 @@ public abstract class SchemaLoaderIntegrationTestBase {
 
   @AfterAll
   public void afterAll() throws Exception {
-    dropTablesIfExist();
-    storageAdmin.close();
-    transactionAdmin.close();
-    adminTestUtils.close();
+    try {
+      dropTablesIfExist();
+    } catch (Exception e) {
+      logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (storageAdmin != null) {
+        storageAdmin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage admin", e);
+    }
+
+    try {
+      if (transactionAdmin != null) {
+        transactionAdmin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close transaction admin", e);
+    }
+
+    try {
+      if (adminTestUtils != null) {
+        adminTestUtils.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin test utils", e);
+    }
+
     // Delete the files
     Files.delete(CONFIG_FILE_PATH);
     Files.delete(SCHEMA_FILE_PATH);


### PR DESCRIPTION
## Description

I found some resource leaks including potential ones while executing `integrationTestJdbc`.  Resource leaks can cause unexpected exceptions (e.g., no available connection) and make it difficult to find actual problems of the implementation. This PR is to fix the resource leaks.

## Related issues and/or PRs

None

## Changes made

This PR contains the following changes:
- Improve the error handling of the clean-up operations in `@AfterAll` and `@AfterEach` annotated methods
- Release the resources that are not released

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A