### PR TITLE
Make OperationBuilder public

### DIFF
--- a/core/src/main/java/com/scalar/db/api/OperationBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/OperationBuilder.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
  * This class defines common interfaces used by {@link DeleteBuilder}, {@link PutBuilder}, {@link
  * GetBuilder} and {@link ScanBuilder}
  */
-class OperationBuilder {
+public class OperationBuilder {
   interface Namespace<T> {
     /**
      * Sets the specified target namespace for this operation


### PR DESCRIPTION
## Description

Using interfaces in `OperationBuilder` simplifies the code and allows us to remove redundant code. It's worth making `OperationBuilder` public.

## Related issues and/or PRs

N/A

## Changes made

- Made `OperationBuilder` public.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
