### PR TITLE
Optimization: Avoid creating an internal index in RDBMS after creating ScalarDB table as much as possible

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -266,7 +266,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       throws SQLException {
     String[] stmts =
         rdbEngine.createTableInternalSqlsAfterCreateTable(
-            hasDescClusteringOrder(metadata), schema, table, metadata, ifNotExists);
+            hasDifferentClusteringOrders(metadata), schema, table, metadata, ifNotExists);
     try {
       execute(connection, stmts);
     } catch (SQLException e) {
@@ -674,9 +674,23 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private boolean hasDescClusteringOrder(TableMetadata metadata) {
+  private static boolean hasDescClusteringOrder(TableMetadata metadata) {
     return metadata.getClusteringKeyNames().stream()
         .anyMatch(c -> metadata.getClusteringOrder(c) == Order.DESC);
+  }
+
+  @VisibleForTesting
+  static boolean hasDifferentClusteringOrders(TableMetadata metadata) {
+    boolean hasAscOrder = false;
+    boolean hasDescOrder = false;
+    for (Order order : metadata.getClusteringOrders().values()) {
+      if (order == Order.ASC) {
+        hasAscOrder = true;
+      } else {
+        hasDescOrder = true;
+      }
+    }
+    return hasAscOrder && hasDescOrder;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -55,7 +55,7 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder,
+      boolean hasDifferentClusteringOrders,
       String schema,
       String table,
       TableMetadata metadata,

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -50,7 +50,7 @@ class RdbEngineOracle implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder,
+      boolean hasDifferentClusteringOrders,
       String schema,
       String table,
       TableMetadata metadata,
@@ -61,8 +61,10 @@ class RdbEngineOracle implements RdbEngineStrategy {
     // performance
     sqls.add("ALTER TABLE " + encloseFullTableName(schema, table) + " INITRANS 3 MAXTRANS 255");
 
-    if (hasDescClusteringOrder) {
-      // Create a unique index for the clustering orders
+    if (hasDifferentClusteringOrders) {
+      // Create a unique index for the clustering orders only when both ASC and DESC are contained
+      // in the clustering keys. If all the clustering key orders are DESC, the PRIMARY KEY index
+      // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
               + enclose(getFullTableName(schema, table) + "_clustering_order_idx")

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -46,15 +46,17 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder,
+      boolean hasDifferentClusteringOrders,
       String schema,
       String table,
       TableMetadata metadata,
       boolean ifNotExists) {
     ArrayList<String> sqls = new ArrayList<>();
 
-    if (hasDescClusteringOrder) {
-      // Create a unique index for the clustering orders
+    if (hasDifferentClusteringOrders) {
+      // Create a unique index for the clustering orders only when both ASC and DESC are contained
+      // in the clustering keys. If all the clustering key orders are DESC, the PRIMARY KEY index
+      // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
               + (ifNotExists ? "IF NOT EXISTS " : "")

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -55,7 +55,7 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder,
+      boolean hasDifferentClusteringOrders,
       String schema,
       String table,
       TableMetadata metadata,

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -178,7 +178,7 @@ class RdbEngineSqlite implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder,
+      boolean hasDifferentClusteringOrders,
       String schema,
       String table,
       TableMetadata metadata,

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -50,7 +50,7 @@ public interface RdbEngineStrategy {
       boolean hasDescClusteringOrder, TableMetadata metadata);
 
   String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder,
+      boolean hasDifferentClusteringOrders,
       String schema,
       String table,
       TableMetadata metadata,

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -5,6 +5,7 @@ import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_COLUMN_SIZE;
 import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_DATA_TYPE;
 import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_DECIMAL_DIGITS;
 import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_TYPE_NAME;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.hasDifferentClusteringOrders;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -3424,6 +3425,74 @@ public class JdbcAdminTest {
                 + " VALUES (?)");
     verify(insertStatement).setString(1, NAMESPACE);
     verify(insertStatement).execute();
+  }
+
+  @Test
+  void hasDifferentClusteringOrders_GivenOnlyAscOrders_ShouldReturnFalse() {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.ASC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+
+    // Act
+    // Assert
+    assertThat(hasDifferentClusteringOrders(metadata)).isFalse();
+  }
+
+  @Test
+  void hasDifferentClusteringOrders_GivenOnlyDescOrders_ShouldReturnFalse() {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.DESC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+
+    // Act
+    // Assert
+    assertThat(hasDifferentClusteringOrders(metadata)).isFalse();
+  }
+
+  @Test
+  void hasDifferentClusteringOrders_GivenBothAscAndDescOrders_ShouldReturnTrue() {
+    // Arrange
+    TableMetadata metadata1 =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+    TableMetadata metadata2 =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.DESC)
+            .addClusteringKey("ck2", Order.ASC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+
+    // Act
+    // Assert
+    assertThat(hasDifferentClusteringOrders(metadata1)).isTrue();
+    assertThat(hasDifferentClusteringOrders(metadata2)).isTrue();
   }
 
   // Utility class used to mock ResultSet for a "select * from" query on the metadata table

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineOracleTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineOracleTest.java
@@ -1,0 +1,61 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import org.junit.jupiter.api.Test;
+
+class RdbEngineOracleTest {
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenSameClusteringOrders_ShouldNotCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEngineOracle();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(
+            false, "myschema", "mytable", metadata, false);
+
+    // Assert
+    assertThat(sqls).hasSize(1);
+    assertThat(sqls[0]).startsWith("ALTER TABLE ");
+  }
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenDifferentClusteringOrders_ShouldCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEngineOracle();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(
+            true, "myschema", "mytable", metadata, false);
+
+    // Assert
+    assertThat(sqls).hasSize(2);
+    assertThat(sqls[0]).startsWith("ALTER TABLE ");
+    assertThat(sqls[1]).startsWith("CREATE UNIQUE INDEX ");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEnginePostgresqlTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEnginePostgresqlTest.java
@@ -1,0 +1,58 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import org.junit.jupiter.api.Test;
+
+class RdbEnginePostgresqlTest {
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenSameClusteringOrders_ShouldNotCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(
+            false, "myschema", "mytable", metadata, false);
+
+    // Assert
+    assertThat(sqls).hasSize(0);
+  }
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenDifferentClusteringOrders_ShouldCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(
+            true, "myschema", "mytable", metadata, false);
+
+    // Assert
+    assertThat(sqls).hasSize(1);
+    assertThat(sqls[0]).startsWith("CREATE UNIQUE INDEX ");
+  }
+}


### PR DESCRIPTION
## Description

Current ScalarDB implementation internally creates a unique index after creating a ScalarDB table when using PostgreSQL or Oracle as an underlying RDBMS if any DESC order is contained in the clustering keys. But unique index isn't needed when all the clustering keys are DESC. This PR avoids unique index creation after creating ScalarDB table in such cases. This optimization is beneficial in terms of reducing resource consumption and improving table update. Also, it's necessary to reduce the long duration when using YugabyteDB (https://github.com/scalar-labs/scalardb/pull/1710#issuecomment-2102520549).

We've already confirmed if this optimization should work with PostgreSQL on https://github.com/scalar-labs/scalardb/pull/1710#issuecomment-2102520549.

Regarding Oracle, it also seems to work as follows

```
SQL> explain plan for select * from                                                                                                                                                                      
(select * from test_tbl where pk = 5 order by ck1 asc, ck2 asc)                                                                                                                                               
where rownum < 5;                                                                                                                                                                                             
                                                                                                                                                                                                              
  2    3                                                                                                                                                                                                      
Explained. 
SQL> SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY());
----------------------------------------------------------------------------------
| Id  | Operation          | Name        | Rows  | Bytes | Cost (%CPU)| Time     |
----------------------------------------------------------------------------------
|   0 | SELECT STATEMENT   |             |     1 |    39 |     1   (0)| 00:00:01 |
|*  1 |  COUNT STOPKEY     |             |       |       |            |          |
|   2 |   VIEW             |             |     1 |    39 |     1   (0)| 00:00:01 |
|*  3 |    INDEX RANGE SCAN| SYS_C007342 |     1 |    39 |     1   (0)| 00:00:01 |
----------------------------------------------------------------------------------

Predicate Information (identified by operation id):
---------------------------------------------------

   1 - filter(ROWNUM<5)
   3 - access("PK"=5)
   
SQL> explain plan for select * from
(select * from test_tbl where pk = 5 order by ck1 asc, ck2 desc)
where rownum < 5;

  2    3  
Explained.
SQL> SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY());
---------------------------------------------------------------------------------------
| Id  | Operation               | Name        | Rows  | Bytes | Cost (%CPU)| Time     |
---------------------------------------------------------------------------------------
|   0 | SELECT STATEMENT        |             |     1 |    39 |     2  (50)| 00:00:01 |
|*  1 |  COUNT STOPKEY          |             |       |       |            |          |
|   2 |   VIEW                  |             |     1 |    39 |     2  (50)| 00:00:01 |
|*  3 |    SORT ORDER BY STOPKEY|             |     1 |    39 |     2  (50)| 00:00:01 |
|*  4 |     INDEX RANGE SCAN    | SYS_C007342 |     1 |    39 |     1   (0)| 00:00:01 |
---------------------------------------------------------------------------------------
Predicate Information (identified by operation id):
---------------------------------------------------

   1 - filter(ROWNUM<5)
   3 - filter(ROWNUM<5)
   4 - access("PK"=5)

SQL> explain plan for select * from
(select * from test_tbl where pk = 5 order by ck1 desc, ck2 desc)
where rownum < 5;  2    3  

Explained.
SQL> SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY());
---------------------------------------------------------------------------------------------
| Id  | Operation                     | Name        | Rows  | Bytes | Cost (%CPU)| Time     |
---------------------------------------------------------------------------------------------
|   0 | SELECT STATEMENT              |             |     1 |    39 |     1   (0)| 00:00:01 |
|*  1 |  COUNT STOPKEY                |             |       |       |            |          |
|   2 |   VIEW                        |             |     1 |    39 |     1   (0)| 00:00:01 |
|*  3 |    INDEX RANGE SCAN DESCENDING| SYS_C007342 |     1 |    39 |     1   (0)| 00:00:01 |
---------------------------------------------------------------------------------------------
Predicate Information (identified by operation id):
---------------------------------------------------

   1 - filter(ROWNUM<5)
   3 - access("PK"=5)
```

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1710

## Changes made

- Modify `JdbcAdmin`, `RdbEnginePostgreSQL` and `RdbEngineOracle` to create a unique index only when both ASC and DESC are contains in the clustering keys

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

Avoided creating an internal unique index as much as possible to reduce resource consumption and improve performance.