### PR TITLE
Backport to branch(3) : Optimization: Avoid creating an internal index in RDBMS after creating ScalarDB table as much as possible

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -133,7 +133,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
 
     String[] sqls =
         rdbEngine.createTableInternalSqlsAfterCreateTable(
-            hasDescClusteringOrder, schema, table, metadata);
+            hasDifferentClusteringOrders(metadata), schema, table, metadata);
     execute(connection, sqls);
   }
 
@@ -601,9 +601,23 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private boolean hasDescClusteringOrder(TableMetadata metadata) {
+  private static boolean hasDescClusteringOrder(TableMetadata metadata) {
     return metadata.getClusteringKeyNames().stream()
         .anyMatch(c -> metadata.getClusteringOrder(c) == Order.DESC);
+  }
+
+  @VisibleForTesting
+  static boolean hasDifferentClusteringOrders(TableMetadata metadata) {
+    boolean hasAscOrder = false;
+    boolean hasDescOrder = false;
+    for (Order order : metadata.getClusteringOrders().values()) {
+      if (order == Order.ASC) {
+        hasAscOrder = true;
+      } else {
+        hasDescOrder = true;
+      }
+    }
+    return hasAscOrder && hasDescOrder;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -50,7 +50,7 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata) {
+      boolean hasDifferentClusteringOrders, String schema, String table, TableMetadata metadata) {
     // do nothing
     return new String[] {};
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -45,15 +45,17 @@ public class RdbEngineOracle implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata) {
+      boolean hasDifferentClusteringOrders, String schema, String table, TableMetadata metadata) {
     ArrayList<String> sqls = new ArrayList<>();
 
     // Set INITRANS to 3 and MAXTRANS to 255 for the table to improve the
     // performance
     sqls.add("ALTER TABLE " + encloseFullTableName(schema, table) + " INITRANS 3 MAXTRANS 255");
 
-    if (hasDescClusteringOrder) {
-      // Create a unique index for the clustering orders
+    if (hasDifferentClusteringOrders) {
+      // Create a unique index for the clustering orders only when both ASC and DESC are contained
+      // in the clustering keys. If all the clustering key orders are DESC, the PRIMARY KEY index
+      // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
               + enclose(getFullTableName(schema, table) + "_clustering_order_idx")

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -41,11 +41,13 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata) {
+      boolean hasDifferentClusteringOrders, String schema, String table, TableMetadata metadata) {
     ArrayList<String> sqls = new ArrayList<>();
 
-    if (hasDescClusteringOrder) {
-      // Create a unique index for the clustering orders
+    if (hasDifferentClusteringOrders) {
+      // Create a unique index for the clustering orders only when both ASC and DESC are contained
+      // in the clustering keys. If all the clustering key orders are DESC, the PRIMARY KEY index
+      // can be used.
       sqls.add(
           "CREATE UNIQUE INDEX "
               + enclose(getFullTableName(schema, table) + "_clustering_order_idx")

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlServer.java
@@ -50,7 +50,7 @@ class RdbEngineSqlServer implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata) {
+      boolean hasDifferentClusteringOrders, String schema, String table, TableMetadata metadata) {
     // do nothing
     return new String[0];
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -166,7 +166,7 @@ public class RdbEngineSqlite implements RdbEngineStrategy {
 
   @Override
   public String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata) {
+      boolean hasDifferentClusteringOrders, String schema, String table, TableMetadata metadata) {
     // do nothing
     return new String[] {};
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -48,7 +48,7 @@ public interface RdbEngineStrategy {
       boolean hasDescClusteringOrder, TableMetadata metadata);
 
   String[] createTableInternalSqlsAfterCreateTable(
-      boolean hasDescClusteringOrder, String schema, String table, TableMetadata metadata);
+      boolean hasDifferentClusteringOrders, String schema, String table, TableMetadata metadata);
 
   String tryAddIfNotExistsToCreateTableSql(String createTableSql);
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -5,6 +5,7 @@ import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_COLUMN_SIZE;
 import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_DATA_TYPE;
 import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_DECIMAL_DIGITS;
 import static com.scalar.db.storage.jdbc.JdbcAdmin.JDBC_COL_TYPE_NAME;
+import static com.scalar.db.storage.jdbc.JdbcAdmin.hasDifferentClusteringOrders;
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -2541,6 +2542,74 @@ public abstract class JdbcAdminTestBase {
 
     // Assert
     assertThat(thrown).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void hasDifferentClusteringOrders_GivenOnlyAscOrders_ShouldReturnFalse() {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.ASC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+
+    // Act
+    // Assert
+    assertThat(hasDifferentClusteringOrders(metadata)).isFalse();
+  }
+
+  @Test
+  void hasDifferentClusteringOrders_GivenOnlyDescOrders_ShouldReturnFalse() {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.DESC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+
+    // Act
+    // Assert
+    assertThat(hasDifferentClusteringOrders(metadata)).isFalse();
+  }
+
+  @Test
+  void hasDifferentClusteringOrders_GivenBothAscAndDescOrders_ShouldReturnTrue() {
+    // Arrange
+    TableMetadata metadata1 =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+    TableMetadata metadata2 =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.DESC)
+            .addClusteringKey("ck2", Order.ASC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .addColumn("value", DataType.TEXT)
+            .build();
+
+    // Act
+    // Assert
+    assertThat(hasDifferentClusteringOrders(metadata1)).isTrue();
+    assertThat(hasDifferentClusteringOrders(metadata2)).isTrue();
   }
 
   private PreparedStatement prepareStatementForNamespaceCheck() throws SQLException {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineOracleTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngineOracleTest.java
@@ -1,0 +1,59 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import org.junit.jupiter.api.Test;
+
+class RdbEngineOracleTest {
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenSameClusteringOrders_ShouldNotCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEngineOracle();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(false, "myschema", "mytable", metadata);
+
+    // Assert
+    assertThat(sqls).hasSize(1);
+    assertThat(sqls[0]).startsWith("ALTER TABLE ");
+  }
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenDifferentClusteringOrders_ShouldCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEngineOracle();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(true, "myschema", "mytable", metadata);
+
+    // Assert
+    assertThat(sqls).hasSize(2);
+    assertThat(sqls[0]).startsWith("ALTER TABLE ");
+    assertThat(sqls[1]).startsWith("CREATE UNIQUE INDEX ");
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEnginePostgresqlTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEnginePostgresqlTest.java
@@ -1,0 +1,56 @@
+package com.scalar.db.storage.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
+import org.junit.jupiter.api.Test;
+
+class RdbEnginePostgresqlTest {
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenSameClusteringOrders_ShouldNotCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(false, "myschema", "mytable", metadata);
+
+    // Assert
+    assertThat(sqls).hasSize(0);
+  }
+
+  @Test
+  void createTableInternalSqlsAfterCreateTable_GivenDifferentClusteringOrders_ShouldCreateIndex() {
+    // Arrange
+    RdbEngineStrategy rdbEngine = new RdbEnginePostgresql();
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("pk")
+            .addClusteringKey("ck1", Order.ASC)
+            .addClusteringKey("ck2", Order.DESC)
+            .addColumn("pk", DataType.INT)
+            .addColumn("ck1", DataType.INT)
+            .addColumn("ck2", DataType.INT)
+            .build();
+
+    // Act
+    String[] sqls =
+        rdbEngine.createTableInternalSqlsAfterCreateTable(true, "myschema", "mytable", metadata);
+
+    // Assert
+    assertThat(sqls).hasSize(1);
+    assertThat(sqls[0]).startsWith("CREATE UNIQUE INDEX ");
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1723