### PR TITLE
Add JdbcTestUtils.isXxxxx() to decide RdbEngineStrategy class in more robust way

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminRepairIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminRepairIntegrationTestWithJdbcDatabase.java
@@ -26,7 +26,7 @@ public class ConsensusCommitAdminRepairIntegrationTestWithJdbcDatabase
 
   @Override
   protected void waitForDifferentSessionDdl() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       // This is needed to avoid schema or catalog version mismatch database errors.
       Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
       return;

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -125,13 +125,13 @@ public class JdbcAdminImportTestUtils {
   public Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes(String namespace)
       throws SQLException {
     execute(rdbEngine.createSchemaSqls(namespace));
-    if (rdbEngine instanceof RdbEngineMysql) {
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
       return createExistingMysqlDatabaseWithAllDataTypes(namespace);
-    } else if (rdbEngine instanceof RdbEnginePostgresql) {
+    } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
       return createExistingPostgresDatabaseWithAllDataTypes(namespace);
-    } else if (rdbEngine instanceof RdbEngineOracle) {
+    } else if (JdbcTestUtils.isOracle(rdbEngine)) {
       return createExistingOracleDatabaseWithAllDataTypes(namespace);
-    } else if (rdbEngine instanceof RdbEngineSqlServer) {
+    } else if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       return createExistingSqlServerDatabaseWithAllDataTypes(namespace);
     } else {
       throw new RuntimeException();

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminRepairIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminRepairIntegrationTest.java
@@ -26,7 +26,7 @@ public class JdbcAdminRepairIntegrationTest
 
   @Override
   protected void waitForDifferentSessionDdl() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       // This is needed to avoid schema or catalog version mismatch database errors.
       Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
       return;

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -105,16 +105,16 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   @Override
   public boolean namespaceExists(String namespace) throws SQLException {
     String sql;
-    if (rdbEngine instanceof RdbEngineMysql) {
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
       sql = "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?";
-    } else if (rdbEngine instanceof RdbEngineOracle) {
+    } else if (JdbcTestUtils.isOracle(rdbEngine)) {
       sql = "SELECT 1 FROM all_users WHERE username = ?";
-    } else if (rdbEngine instanceof RdbEnginePostgresql) {
+    } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
       sql = "SELECT 1 FROM pg_namespace WHERE nspname = ?";
-    } else if (rdbEngine instanceof RdbEngineSqlite) {
+    } else if (JdbcTestUtils.isSqlite(rdbEngine)) {
       // SQLite has no concept of namespace
       return true;
-    } else if (rdbEngine instanceof RdbEngineSqlServer) {
+    } else if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       sql = "SELECT 1 FROM sys.schemas WHERE name = ?";
     } else {
       throw new AssertionError("Unsupported engine : " + rdbEngine.getClass().getSimpleName());

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseColumnValueIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseColumnValueIntegrationTest.java
@@ -23,7 +23,7 @@ public class JdbcDatabaseColumnValueIntegrationTest
 
   @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
       }
@@ -35,7 +35,7 @@ public class JdbcDatabaseColumnValueIntegrationTest
 
   @Override
   protected Value<?> getMinValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMinOracleDoubleValue(columnName);
       }
@@ -47,12 +47,12 @@ public class JdbcDatabaseColumnValueIntegrationTest
 
   @Override
   protected Value<?> getMaxValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
       }
     }
-    if (rdbEngine instanceof RdbEngineSqlServer) {
+    if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       if (dataType == DataType.TEXT) {
         return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
       }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseConditionalMutationIntegrationTest.java
@@ -23,7 +23,7 @@ public class JdbcDatabaseConditionalMutationIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    if (rdbEngine instanceof RdbEngineMysql) {
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
       // Since Deadlock error sometimes happens in MySQL, change the concurrency to 1
       return 1;
     }
@@ -33,7 +33,7 @@ public class JdbcDatabaseConditionalMutationIntegrationTest
   @Override
   protected Column<?> getColumnWithRandomValue(
       Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleColumn(random, columnName);
       }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseCrossPartitionScanIntegrationTest.java
@@ -23,7 +23,7 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       return 1;
     }
     return super.getThreadNum();
@@ -31,7 +31,7 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
 
   @Override
   protected Column<?> getRandomColumn(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return ScalarDbUtils.toColumn(JdbcTestUtils.getRandomOracleDoubleValue(random, columnName));
       }
@@ -41,7 +41,7 @@ public class JdbcDatabaseCrossPartitionScanIntegrationTest
 
   @Override
   protected boolean isParallelDdlSupported() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       return false;
     }
     return super.isParallelDdlSupported();

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseIntegrationTest.java
@@ -18,7 +18,7 @@ public class JdbcDatabaseIntegrationTest extends DistributedStorageIntegrationTe
 
   @Override
   protected int getLargeDataSizeInBytes() {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       // For Oracle, the max data size for BLOB is 2000 bytes
       return 2000;
     } else {

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
@@ -25,7 +25,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       return 1;
     }
     return super.getThreadNum();
@@ -33,7 +33,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
 
   @Override
   protected boolean isParallelDdlSupported() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -43,12 +43,12 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
   //       fix is released.
   @SuppressWarnings("unused")
   private boolean isYugabyteDb() {
-    return rdbEngine instanceof RdbEngineYugabyte;
+    return JdbcTestUtils.isYugabyte(rdbEngine);
   }
 
   @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
       }
@@ -58,7 +58,7 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
 
   @Override
   protected Value<?> getMinValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMinOracleDoubleValue(columnName);
       }
@@ -68,12 +68,12 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
 
   @Override
   protected Value<?> getMaxValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
       }
     }
-    if (rdbEngine instanceof RdbEngineSqlServer) {
+    if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       if (dataType == DataType.TEXT) {
         return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
       }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultiplePartitionKeyIntegrationTest.java
@@ -23,7 +23,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       return 1;
     }
     return super.getThreadNum();
@@ -31,7 +31,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected boolean isParallelDdlSupported() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       return false;
     }
     return super.isParallelDdlSupported();
@@ -39,7 +39,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected boolean isFloatTypeKeySupported() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       return false;
     }
     return super.isFloatTypeKeySupported();
@@ -47,7 +47,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
       }
@@ -57,7 +57,7 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected Value<?> getMinValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMinOracleDoubleValue(columnName);
       }
@@ -67,12 +67,12 @@ public class JdbcDatabaseMultiplePartitionKeyIntegrationTest
 
   @Override
   protected Value<?> getMaxValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
       }
     }
-    if (rdbEngine instanceof RdbEngineSqlServer) {
+    if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       if (dataType == DataType.TEXT) {
         return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
       }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSecondaryIndexIntegrationTest.java
@@ -23,7 +23,7 @@ public class JdbcDatabaseSecondaryIndexIntegrationTest
 
   @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
       }
@@ -35,7 +35,7 @@ public class JdbcDatabaseSecondaryIndexIntegrationTest
 
   @Override
   protected Value<?> getMinValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMinOracleDoubleValue(columnName);
       }
@@ -47,12 +47,12 @@ public class JdbcDatabaseSecondaryIndexIntegrationTest
 
   @Override
   protected Value<?> getMaxValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
       }
     }
-    if (rdbEngine instanceof RdbEngineSqlServer) {
+    if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       if (dataType == DataType.TEXT) {
         return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
       }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSingleClusteringKeyScanIntegrationTest.java
@@ -22,7 +22,7 @@ public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
 
   @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
       }
@@ -32,7 +32,7 @@ public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
 
   @Override
   protected Value<?> getMinValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMinOracleDoubleValue(columnName);
       }
@@ -42,12 +42,12 @@ public class JdbcDatabaseSingleClusteringKeyScanIntegrationTest
 
   @Override
   protected Value<?> getMaxValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
       }
     }
-    if (rdbEngine instanceof RdbEngineSqlServer) {
+    if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       if (dataType == DataType.TEXT) {
         return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
       }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseSinglePartitionKeyIntegrationTest.java
@@ -22,7 +22,7 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
 
   @Override
   protected Value<?> getRandomValue(Random random, String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getRandomOracleDoubleValue(random, columnName);
       }
@@ -32,7 +32,7 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
 
   @Override
   protected Value<?> getMinValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMinOracleDoubleValue(columnName);
       }
@@ -42,12 +42,12 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
 
   @Override
   protected Value<?> getMaxValue(String columnName, DataType dataType) {
-    if (rdbEngine instanceof RdbEngineOracle) {
+    if (JdbcTestUtils.isOracle(rdbEngine)) {
       if (dataType == DataType.DOUBLE) {
         return JdbcTestUtils.getMaxOracleDoubleValue(columnName);
       }
     }
-    if (rdbEngine instanceof RdbEngineSqlServer) {
+    if (JdbcTestUtils.isSqlServer(rdbEngine)) {
       if (dataType == DataType.TEXT) {
         return JdbcTestUtils.getMaxSqlServerTextValue(columnName);
       }
@@ -57,7 +57,7 @@ public class JdbcDatabaseSinglePartitionKeyIntegrationTest
 
   @Override
   protected boolean isFloatTypeKeySupported() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       return false;
     }
     return super.isFloatTypeKeySupported();

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -94,7 +94,7 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
 
   @Override
   protected void waitForDifferentSessionDdl() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       // This is needed to avoid schema or catalog version mismatch database errors.
       Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
       return;

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderIntegrationTest.java
@@ -31,7 +31,7 @@ public class JdbcSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTest
 
   @Override
   protected void waitForCreationIfNecessary() {
-    if (rdbEngine instanceof RdbEngineYugabyte) {
+    if (JdbcTestUtils.isYugabyte(rdbEngine)) {
       // This wait is longer than usual. This is because only the case of
       // `createTablesThenDeleteTables_ShouldExecuteProperly()` requires long wait.
       // The long wait may affect total duration. The following options might be better in the

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcTestUtils.java
@@ -46,4 +46,28 @@ public final class JdbcTestUtils {
     IntStream.range(0, TestUtils.MAX_TEXT_COUNT).forEach(i -> builder.append('Z'));
     return new TextValue(columnName, builder.toString());
   }
+
+  public static boolean isPostgresql(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEnginePostgresql;
+  }
+
+  public static boolean isMysql(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEngineMysql;
+  }
+
+  public static boolean isOracle(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEngineOracle;
+  }
+
+  public static boolean isSqlServer(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEngineSqlServer;
+  }
+
+  public static boolean isSqlite(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEngineSqlite;
+  }
+
+  public static boolean isYugabyte(RdbEngineStrategy rdbEngine) {
+    return rdbEngine instanceof RdbEngineYugabyte;
+  }
 }


### PR DESCRIPTION
## Description

In the current implementation, some integration test codes use the return value of `RdbEngineStrategy.toString()` or equivalent to know the actual class (`RdbEngineXxxxxx`) that implements `RdbEngineStrategy` interface since `RdbEngineXxxxxx`s are package-private.
- https://github.com/scalar-labs/scalardb/blob/master/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java#L158
- https://github.com/scalar-labs/scalardb/blob/3/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminRepairTableIntegrationTest.java#L49

This PR replaces those workarounds with more robust implementation.

## Related issues and/or PRs

https://github.com/scalar-labs/scalardb/pull/1744/files#r1603305279

## Changes made

- Add `JdbcTestUtils.ixXxxxxx(RdbEngineStrategy)`
- Use the new utility function when checking the actual class that implements `RdbEngineStrategy` interface

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A