### PR TITLE
Backport to branch(3) : Bump com.azure:azure-cosmos from 4.59.0 to 4.60.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         guavaVersion = '32.1.3-jre'
         slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.11.5'
-        azureCosmosVersion = '4.59.0'
+        azureCosmosVersion = '4.60.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.25.1'
         commonsDbcp2Version = '2.12.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1750