### PR TITLE
Fix integration test failure because of conflicting use of table names 

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -19,7 +19,7 @@ public abstract class ConsensusCommitCrossPartitionScanIntegrationTestBase
 
   @Override
   protected String getTestName() {
-    return "tx_cc";
+    return "tx_cross_scan";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -19,7 +19,7 @@ public abstract class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBa
 
   @Override
   protected String getTestName() {
-    return "tx_2pcc";
+    return "2pcc_cross_scan";
   }
 
   @Override


### PR DESCRIPTION
## Description

Some integration tests sometimes fail because they use the same coordinator and metadata table names. I noticed this happened for Dynamo integration test since they run in parallel, cf. https://github.com/scalar-labs/scalardb/actions/runs/9202754667
The CosmosDB integration test could fail in the same manner, too.

## Related issues and/or PRs

https://github.com/scalar-labs/scalardb/pull/1682

## Changes made

Use a unique namespace prefix to avoid conflicts between table names used by different integration test classes.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
