### PR TITLE
Change hard-coded password for Oracle user in JDBC adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -27,7 +27,7 @@ class RdbEngineOracle implements RdbEngineStrategy {
   @Override
   public String[] createSchemaSqls(String fullSchema) {
     return new String[] {
-      "CREATE USER " + enclose(fullSchema) + " IDENTIFIED BY \"oracle\"",
+      "CREATE USER " + enclose(fullSchema) + " IDENTIFIED BY \"Oracle1234!@#$\"",
       "ALTER USER " + enclose(fullSchema) + " quota unlimited on USERS",
     };
   }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -334,11 +334,11 @@ public class JdbcAdminTest {
     createNamespace_forX_shouldExecuteCreateNamespaceStatement(
         RdbEngine.ORACLE,
         Arrays.asList(
-            "CREATE USER \"my_ns\" IDENTIFIED BY \"oracle\"",
+            "CREATE USER \"my_ns\" IDENTIFIED BY \"Oracle1234!@#$\"",
             "ALTER USER \"my_ns\" quota unlimited on USERS"),
         "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" FETCH FIRST 1 ROWS ONLY",
         Arrays.asList(
-            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"oracle\"",
+            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
             "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS"),
         "CREATE TABLE \""
             + METADATA_SCHEMA
@@ -838,7 +838,7 @@ public class JdbcAdminTest {
       throws Exception {
     addTableMetadata_createMetadataTableIfNotExistsForXAndOverwriteMetadata_ShouldWorkProperly(
         RdbEngine.ORACLE,
-        "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"oracle\"",
+        "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
         "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS",
         "CREATE TABLE \""
             + METADATA_SCHEMA
@@ -1041,7 +1041,7 @@ public class JdbcAdminTest {
       throws Exception {
     addTableMetadata_createMetadataTableIfNotExistsForX_ShouldWorkProperly(
         RdbEngine.ORACLE,
-        "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"oracle\"",
+        "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
         "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS",
         "CREATE TABLE \""
             + METADATA_SCHEMA
@@ -2926,11 +2926,11 @@ public class JdbcAdminTest {
     repairNamespace_forX_shouldWorkProperly(
         RdbEngine.ORACLE,
         Arrays.asList(
-            "CREATE USER \"my_ns\" IDENTIFIED BY \"oracle\"",
+            "CREATE USER \"my_ns\" IDENTIFIED BY \"Oracle1234!@#$\"",
             "ALTER USER \"my_ns\" quota unlimited on USERS"),
         "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" FETCH FIRST 1 ROWS ONLY",
         Arrays.asList(
-            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"oracle\"",
+            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
             "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS"),
         "CREATE TABLE \""
             + METADATA_SCHEMA
@@ -3058,7 +3058,7 @@ public class JdbcAdminTest {
         "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"metadata\" FETCH FIRST 1 ROWS ONLY",
         "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" FETCH FIRST 1 ROWS ONLY",
         ImmutableList.of(
-            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"oracle\"",
+            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
             "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS"),
         "CREATE TABLE \""
             + METADATA_SCHEMA
@@ -3280,7 +3280,7 @@ public class JdbcAdminTest {
         RdbEngine.ORACLE,
         "SELECT 1 FROM \"" + METADATA_SCHEMA + "\".\"namespaces\" FETCH FIRST 1 ROWS ONLY",
         Arrays.asList(
-            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"oracle\"",
+            "CREATE USER \"" + METADATA_SCHEMA + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
             "ALTER USER \"" + METADATA_SCHEMA + "\" quota unlimited on USERS"),
         "CREATE TABLE \""
             + METADATA_SCHEMA


### PR DESCRIPTION
## Description

This PR changes the hard-coded password for the Oracle user to a more secure one in the JDBC adapter. The primary goal of this change is to avoid violating password policies.

## Related issues and/or PRs

N/A

## Changes made

- Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Changed the hard-coded password for the Oracle user to a more secure one in the JDBC adapter.
