### PR TITLE
Backport to branch(3) : Fix integration test failure because of conflicting use of table names 

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -19,7 +19,7 @@ public abstract class ConsensusCommitCrossPartitionScanIntegrationTestBase
 
   @Override
   protected String getTestName() {
-    return "tx_cc";
+    return "tx_cross_scan";
   }
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBase.java
@@ -19,7 +19,7 @@ public abstract class TwoPhaseConsensusCommitCrossPartitionScanIntegrationTestBa
 
   @Override
   protected String getTestName() {
-    return "tx_2pcc";
+    return "2pcc_cross_scan";
   }
 
   @Override


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1762