### PR TITLE
Should add prefix to namespaces for Cosmos DB integration tests

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCrossPartitionScanIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCrossPartitionScanIntegrationTestWithCosmos.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.cosmos;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitCrossPartitionScanIntegrationTestBase;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,13 @@ public class ConsensusCommitCrossPartitionScanIntegrationTestWithCosmos
     Properties properties = CosmosEnv.getProperties(testName);
     properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "SERIALIZABLE");
     return properties;
+  }
+
+  @Override
+  protected String getNamespaceBaseName() {
+    String namespaceBaseName = super.getNamespaceBaseName();
+    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
+    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageCrossPartitionScanIntegrationTestBase;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,13 @@ public class CosmosCrossPartitionScanIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getNamespaceBaseName() {
+    String namespaceBaseName = super.getNamespaceBaseName();
+    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
+    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override


### PR DESCRIPTION
## Description

Currently, some integration tests for Cosmos DB are failing occasionally due to table name conflicts. To avoid these conflicts, we should add a prefix to the namespaces for the failed integration tests. This PR addresses the issue.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1682

## Changes made

- Add a prefix to namespaces for Cosmos DB integration tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
