### PR TITLE
Backport to branch(3) : Bump org.xerial:sqlite-jdbc from 3.45.3.0 to 3.46.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
         postgresqlDriverVersion = '42.7.3'
         oracleDriverVersion = '21.13.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
-        sqliteDriverVersion = '3.45.3.0'
+        sqliteDriverVersion = '3.46.0.0'
         yugabyteDriverVersion = '42.3.5-yb-4'
         grpcVersion = '1.60.0'
         protobufVersion = '3.21.12'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1789