### PR TITLE
Backport to branch(3) : Bump org.assertj:assertj-core from 3.25.3 to 3.26.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
         jettyVersion = '9.4.54.v20240208'
         junitVersion = '5.10.2'
         commonsLangVersion = '3.14.0'
-        assertjVersion = '3.25.3'
+        assertjVersion = '3.26.0'
         mockitoVersion = '4.11.0'
         spotbugsVersion = '4.8.5'
         errorproneVersion = '2.10.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1791