### PR TITLE
Increase heap size for Cosmos DB integration test

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -150,7 +150,7 @@ task integrationTestCosmos(type: Test) {
         systemProperties(System.getProperties().findAll{it.key.toString().startsWith("scalardb")})
     }
     maxParallelForks = 3
-    jvmArgs '-XX:MaxDirectMemorySize=4g', '-Xmx4g'
+    jvmArgs '-XX:MaxDirectMemorySize=4g', '-Xmx6g'
 }
 
 task integrationTestDynamo(type: Test) {


### PR DESCRIPTION
## Description

Recently, the Cosmos DB integration test is very flaky, and it looks like one of the reason is the lack of the heap memory. This PR addresses this issue and increases the heap size for the Cosmos DB integration test.

## Related issues and/or PRs

N/A

## Changes made

- Increased the heap size for the Cosmos DB integration test

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
