### PR TITLE
Make CoordinatorGroupCommitKeyManipulator public to reuse the logic in other projects

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
@@ -35,7 +35,7 @@ public class CoordinatorGroupCommitter
     return config.isCoordinatorGroupCommitEnabled();
   }
 
-  static class CoordinatorGroupCommitKeyManipulator
+  public static class CoordinatorGroupCommitKeyManipulator
       implements KeyManipulator<String, String, String, String, String> {
     private static final int PRIMARY_KEY_SIZE = 24;
     private static final char DELIMITER = ':';


### PR DESCRIPTION
## Description

`CoordinatorGroupCommitKeyManipulator` contains various logics (e.g., determining whether a given string is a full key) about the group commit related keys. The logics are sometimes required in other projects, but the visibility of the class is not `public` in the current implementation. This PR changes the visibility to `public`.

## Related issues and/or PRs

None

## Changes made

- Change the visibility of `CoordinatorGroupCommitKeyManipulator` to public

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A