### PR TITLE
Add build tests for `getting started` example projects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,8 +111,8 @@ jobs:
         with:
           arguments: ':schema-loader:dockerfileLint'
 
-  build-check-getting-started:
-    name: Build check for Getting Started project
+  build-check-example-project:
+    name: Build check for 'Getting Started' example project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -126,8 +126,8 @@ jobs:
       - name: Build Getting Started project
         run: cd docs/getting-started && ./gradlew assemble
 
-  build-check-getting-started-using-kotlin:
-    name: Build check for Getting Started project using Kotlin
+  build-check-example-project-for-kotlin:
+    name: Build check for 'Getting Started' example project for Kotlin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,36 @@ jobs:
         with:
           arguments: ':schema-loader:dockerfileLint'
 
+  build-check-getting-started:
+    name: Build check for Getting Started project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Build Getting Started project
+        run: cd docs/getting-started && ./gradlew assemble
+
+  build-check-getting-started-using-kotlin:
+    name: Build check for Getting Started project using Kotlin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Build Getting Started project
+        run: cd docs/getting-started-kotlin && ./gradlew assemble
+
   integration-test-for-cassandra-3-0:
     name: Cassandra 3.0 integration test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,11 @@ jobs:
   build-check-example-project:
     name: Build check for 'Getting Started' example project
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: docs/getting-started
+
     steps:
       - uses: actions/checkout@v4
 
@@ -123,12 +128,20 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_VENDOR }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Build Getting Started project
-        run: cd docs/getting-started && ./gradlew assemble
+        run: ./gradlew assemble
 
   build-check-example-project-for-kotlin:
     name: Build check for 'Getting Started' example project for Kotlin
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: docs/getting-started-kotlin
+
     steps:
       - uses: actions/checkout@v4
 
@@ -138,8 +151,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_VENDOR }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Build Getting Started project
-        run: cd docs/getting-started-kotlin && ./gradlew assemble
+        run: ./gradlew assemble
 
   integration-test-for-cassandra-3-0:
     name: Cassandra 3.0 integration test


### PR DESCRIPTION
## Description

We experienced [the build issue of the example project for getting started](https://github.com/scalar-labs/scalardb/pull/1852). This kind of issue likely happens without continuous build test. This PR adds tests for that.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1852

## Changes made

Add GitHub Actions Jobs to build the two example projects for getting started.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A