### PR TITLE
Backport to branch(3.8) : Use eclipse-temurin base image in Dockerfile

### DIFF
--- a/ci/dockerfile_lint.sh
+++ b/ci/dockerfile_lint.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
-HADOLINT_VERSION="v1.19.0"
+HADOLINT_VERSION="v2.12.0"
 HADOLINT="${HADOLINT:-docker run --rm -i -v "$(pwd):/mnt" -w "/mnt" "hadolint/hadolint:${HADOLINT_VERSION}" hadolint}"
 
 exec ${HADOLINT} ./Dockerfile

--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -1,4 +1,7 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.16
+FROM eclipse-temurin:8-jre-jammy
+
+RUN apt-get update && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY scalardb-schema-loader-*.jar /app.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,10 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM ghcr.io/scalar-labs/jre8:1.1.16
+FROM eclipse-temurin:8-jre-jammy
+
+RUN apt-get update && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tools dockerize /usr/local/bin/
 COPY --from=tools grpc_health_probe /usr/local/bin/


### PR DESCRIPTION
Backport of #1826 .
This PR fixes #1842 .