### PR TITLE
Backport to branch(3) : Make CoordinatorGroupCommitKeyManipulator public to reuse the logic in other projects

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
@@ -35,7 +35,7 @@ public class CoordinatorGroupCommitter
     return config.isCoordinatorGroupCommitEnabled();
   }
 
-  static class CoordinatorGroupCommitKeyManipulator
+  public static class CoordinatorGroupCommitKeyManipulator
       implements KeyManipulator<String, String, String, String, String> {
     private static final int PRIMARY_KEY_SIZE = 24;
     private static final char DELIMITER = ':';


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1864