### PR TITLE
Backport to branch(3) : Bump dropwizardMetricsVersion from 4.2.25 to 4.2.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
         annotationVersion = '1.3.2'
         picocliVersion = '4.7.6'
         scalarAdminVersion = '2.2.0'
-        dropwizardMetricsVersion = '4.2.25'
+        dropwizardMetricsVersion = '4.2.26'
         prometheusVersion = '0.16.0'
         commonsTextVersion = '1.12.0'
         jettyVersion = '9.4.54.v20240208'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1893