### PR TITLE
Backport to branch(3) : Delay throwing an exception for the combination of two-phase commit interface and the group commit feature to when `begin()` is called

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -44,7 +44,6 @@ public class TwoPhaseConsensusCommitManager
     this.storage = storage;
     this.admin = admin;
     config = new ConsensusCommitConfig(databaseConfig);
-    throwIfGroupCommitIsEnabled(config);
     tableMetadataManager =
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
@@ -61,9 +60,7 @@ public class TwoPhaseConsensusCommitManager
     StorageFactory storageFactory = StorageFactory.create(databaseConfig.getProperties());
     storage = storageFactory.getStorage();
     admin = storageFactory.getStorageAdmin();
-
     config = new ConsensusCommitConfig(databaseConfig);
-    throwIfGroupCommitIsEnabled(config);
     tableMetadataManager =
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
@@ -90,7 +87,6 @@ public class TwoPhaseConsensusCommitManager
     this.storage = storage;
     this.admin = admin;
     this.config = config;
-    throwIfGroupCommitIsEnabled(config);
     tableMetadataManager =
         new TransactionTableMetadataManager(
             admin, databaseConfig.getMetadataCacheExpirationTimeSecs());
@@ -102,7 +98,7 @@ public class TwoPhaseConsensusCommitManager
     mutationOperationChecker = new ConsensusCommitMutationOperationChecker(tableMetadataManager);
   }
 
-  private void throwIfGroupCommitIsEnabled(ConsensusCommitConfig config) {
+  private void throwIfGroupCommitIsEnabled() {
     if (CoordinatorGroupCommitter.isEnabled(config)) {
       throw new IllegalArgumentException(
           CoreError.CONSENSUS_COMMIT_GROUP_COMMIT_WITH_TWO_PHASE_COMMIT_INTERFACE_NOT_ALLOWED
@@ -132,6 +128,7 @@ public class TwoPhaseConsensusCommitManager
   @VisibleForTesting
   TwoPhaseCommitTransaction begin(String txId, Isolation isolation, SerializableStrategy strategy)
       throws TransactionException {
+    throwIfGroupCommitIsEnabled();
     return createNewTransaction(txId, isolation, strategy);
   }
 
@@ -144,6 +141,7 @@ public class TwoPhaseConsensusCommitManager
   @VisibleForTesting
   TwoPhaseCommitTransaction join(String txId, Isolation isolation, SerializableStrategy strategy)
       throws TransactionException {
+    throwIfGroupCommitIsEnabled();
     // If the transaction associated with the specified transaction ID is active, resume it
     if (isTransactionActive(txId)) {
       return resume(txId);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -81,26 +81,6 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
-  public void constructor_GroupCommitEnabledGiven_ShouldThrowException() {
-    // Arrange
-    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
-
-    // Act Assert
-    assertThatThrownBy(
-            () ->
-                new TwoPhaseConsensusCommitManager(
-                    storage,
-                    admin,
-                    config,
-                    databaseConfig,
-                    coordinator,
-                    parallelExecutor,
-                    recovery,
-                    commit))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
   public void begin_NoArgumentGiven_ReturnWithSomeTxIdAndSnapshotIsolation()
       throws TransactionException {
     // Arrange
@@ -166,6 +146,24 @@ public class TwoPhaseConsensusCommitManagerTest {
     // Act Assert
     manager.begin(ANY_TX_ID);
     assertThatThrownBy(() -> manager.begin(ANY_TX_ID)).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
+  public void begin_NoArgumentGiven_WithGroupCommitEnabled_ShouldThrowException() {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.begin()).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void begin_TxIdGiven_WithGroupCommitEnabled_ShouldThrowException() {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.begin(ANY_TX_ID)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -237,6 +235,24 @@ public class TwoPhaseConsensusCommitManagerTest {
   }
 
   @Test
+  public void start_NoArgumentGiven_WithGroupCommitEnabled_ShouldThrowException() {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.start()).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void start_TxIdGiven_WithGroupCommitEnabled_ShouldThrowException() {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.start(ANY_TX_ID)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void join_TxIdGiven_ReturnWithSpecifiedTxIdAndSnapshotIsolation()
       throws TransactionException {
     // Arrange
@@ -263,6 +279,15 @@ public class TwoPhaseConsensusCommitManagerTest {
 
     // Assert
     assertThat(transaction1).isEqualTo(transaction2);
+  }
+
+  @Test
+  public void join_TxIdGiven_WithGroupCommitEnabled_ShouldThrowException() {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.join(ANY_TX_ID)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1903