### PR TITLE
Reduce the number of concurrent DDLs from 10 to 1 for Cosmos DB in the integration tests

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
@@ -29,7 +29,7 @@ public class CosmosCrossPartitionScanIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    return 3;
+    return 1;
   }
 
   @Test

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
@@ -29,7 +29,12 @@ public class CosmosCrossPartitionScanIntegrationTest
 
   @Override
   protected int getThreadNum() {
-    return 1;
+    return 3;
+  }
+
+  @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
   }
 
   @Test

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
@@ -27,6 +27,11 @@ public class CosmosCrossPartitionScanIntegrationTest
     return CosmosEnv.getCreationOptions();
   }
 
+  @Override
+  protected int getThreadNum() {
+    return 3;
+  }
+
   @Test
   @Override
   @Disabled("Cross partition scan with ordering is not supported in Cosmos DB")

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
@@ -47,6 +47,11 @@ public class CosmosMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
+  @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
@@ -25,6 +25,11 @@ public class CosmosMultiplePartitionKeyIntegrationTest
   }
 
   @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
+  @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }


### PR DESCRIPTION
## Description

After merging https://github.com/scalar-labs/scalardb/pull/1909, we observed the integration test often failed with the Cosmos DB emulator due to failing to create a namespace.

https://github.com/scalar-labs/scalardb/blob/6d43a3666ffccfedcc35f9c077a85c24800b0283/integration-test/src/main/java/com/scalar/db/api/DistributedStorageCrossPartitionScanIntegrationTestBase.java#L165

I noticed `CosmosCrossPartitionScanIntegrationTest` used the default thread number (10). So, this PR limits it to 1 as well as other tests.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1909

## Changes made

- Reduce the concurrency for DDL operations in `CosmosCrossPartitionScanIntegrationTest` from 10 to 3

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- I first tried to reduce the concurrency to 3. But it still failed, and I changed it to 1.
- If this change makes the integration test with Cosmos DB emulator more stable, we may be able to increase `maxParallelForks` to 2 or 3 later.

## Release notes

N/A