### PR TITLE
Backport to branch(3) : Reduce the number of concurrent DDLs from 10 to 1 for Cosmos DB in the integration tests

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
@@ -27,6 +27,16 @@ public class CosmosCrossPartitionScanIntegrationTest
     return CosmosEnv.getCreationOptions();
   }
 
+  @Override
+  protected int getThreadNum() {
+    return 3;
+  }
+
+  @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
   @Test
   @Override
   @Disabled("Cross partition scan with ordering is not supported in Cosmos DB")

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
@@ -47,6 +47,11 @@ public class CosmosMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
+  @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
@@ -25,6 +25,11 @@ public class CosmosMultiplePartitionKeyIntegrationTest
   }
 
   @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
+  @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1920