### PR TITLE
Backport to branch(3.10): Reduce the number of concurrent DDLs from 10 to 1 for Cosmos DB in the integration tests

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
@@ -47,6 +47,11 @@ public class CosmosMultipleClusteringKeyScanIntegrationTest
   }
 
   @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
+  @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
@@ -25,6 +25,11 @@ public class CosmosMultiplePartitionKeyIntegrationTest
   }
 
   @Override
+  protected boolean isParallelDdlSupported() {
+    return false;
+  }
+
+  @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultipleClusteringKeyScanIntegrationTestBase.java
@@ -110,6 +110,10 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
     return THREAD_NUM;
   }
 
+  protected boolean isParallelDdlSupported() {
+    return true;
+  }
+
   private void createTables() throws java.util.concurrent.ExecutionException, InterruptedException {
     List<Callable<Void>> testCallables = new ArrayList<>();
 
@@ -139,8 +143,8 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
     // We firstly execute the first one and then the rest. This is because the first table creation
     // creates the metadata table, and this process can't be handled in multiple threads/processes
     // at the same time.
-    executeInParallel(testCallables.subList(0, 1));
-    executeInParallel(testCallables.subList(1, testCallables.size()));
+    executeDdls(testCallables.subList(0, 1));
+    executeDdls(testCallables.subList(1, testCallables.size()));
   }
 
   protected Map<String, String> getCreationOptions() {
@@ -210,8 +214,8 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
     // We firstly execute the callables without the last one. And then we execute the last one. This
     // is because the last table deletion deletes the metadata table, and this process can't be
     // handled in multiple threads/processes at the same time.
-    executeInParallel(testCallables.subList(0, testCallables.size() - 1));
-    executeInParallel(testCallables.subList(testCallables.size() - 1, testCallables.size()));
+    executeDdls(testCallables.subList(0, testCallables.size() - 1));
+    executeDdls(testCallables.subList(testCallables.size() - 1, testCallables.size()));
   }
 
   private void truncateTable(
@@ -2023,6 +2027,22 @@ public abstract class DistributedStorageMultipleClusteringKeyScanIntegrationTest
       }
     }
     executeInParallel(testCallables);
+  }
+
+  private void executeDdls(List<Callable<Void>> ddls)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    if (isParallelDdlSupported()) {
+      executeInParallel(ddls);
+    } else {
+      ddls.forEach(
+          ddl -> {
+            try {
+              ddl.call();
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
+    }
   }
 
   private void executeInParallel(List<Callable<Void>> testCallables)

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMultiplePartitionKeyIntegrationTestBase.java
@@ -92,6 +92,10 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
     return THREAD_NUM;
   }
 
+  protected boolean isParallelDdlSupported() {
+    return true;
+  }
+
   private void createTables() throws java.util.concurrent.ExecutionException, InterruptedException {
     List<Callable<Void>> testCallables = new ArrayList<>();
 
@@ -111,8 +115,8 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
     // We firstly execute the first one and then the rest. This is because the first table creation
     // creates the metadata table, and this process can't be handled in multiple threads/processes
     // at the same time.
-    executeInParallel(testCallables.subList(0, 1));
-    executeInParallel(testCallables.subList(1, testCallables.size()));
+    executeDdls(testCallables.subList(0, 1));
+    executeDdls(testCallables.subList(1, testCallables.size()));
   }
 
   protected Map<String, String> getCreationOptions() {
@@ -162,8 +166,8 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
     // We firstly execute the callables without the last one. And then we execute the last one. This
     // is because the last table deletion deletes the metadata table, and this process can't be
     // handled in multiple threads/processes at the same time.
-    executeInParallel(testCallables.subList(0, testCallables.size() - 1));
-    executeInParallel(testCallables.subList(testCallables.size() - 1, testCallables.size()));
+    executeDdls(testCallables.subList(0, testCallables.size() - 1));
+    executeDdls(testCallables.subList(testCallables.size() - 1, testCallables.size()));
   }
 
   private void truncateTable(DataType firstPartitionKeyType, DataType secondPartitionKeyType)
@@ -179,6 +183,22 @@ public abstract class DistributedStorageMultiplePartitionKeyIntegrationTestBase 
 
   private String getNamespaceName(DataType firstPartitionKeyType) {
     return namespaceBaseName + firstPartitionKeyType;
+  }
+
+  private void executeDdls(List<Callable<Void>> ddls)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    if (isParallelDdlSupported()) {
+      executeInParallel(ddls);
+    } else {
+      ddls.forEach(
+          ddl -> {
+            try {
+              ddl.call();
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
+    }
   }
 
   private void executeInParallel(List<Callable<Void>> testCallables)


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1920 to branch(3.10).