### PR TITLE
Backport to branch(3): Remove unnecessary `scalardb.cosmos.database_prefix` property

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class ConsensusCommitAdminIntegrationTestWithCosmos
@@ -11,13 +10,6 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   @Override
   protected Properties getProps(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminRepairTableIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminRepairTableIntegrationTestWithCosmos.java
@@ -6,7 +6,6 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminRepairTableIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -16,16 +15,6 @@ public class ConsensusCommitAdminRepairTableIntegrationTestWithCosmos
   @Override
   protected Properties getProps(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    return getNamespace(super.getNamespace());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.common.ConsensusCommitTestUtils;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public final class ConsensusCommitCosmosEnv {
@@ -11,10 +10,6 @@ public final class ConsensusCommitCosmosEnv {
   public static Properties getProperties(String testName) {
     Properties properties = CosmosEnv.getProperties(testName);
     return ConsensusCommitTestUtils.loadConsensusCommitProperties(properties);
-  }
-
-  public static Optional<String> getDatabasePrefix() {
-    return CosmosEnv.getDatabasePrefix();
   }
 
   public static Map<String, String> getCreationOptions() {

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCrossPartitionScanIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCrossPartitionScanIntegrationTestWithCosmos.java
@@ -3,7 +3,6 @@ package com.scalar.db.storage.cosmos;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitCrossPartitionScanIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -16,13 +15,6 @@ public class ConsensusCommitCrossPartitionScanIntegrationTestWithCosmos
     Properties properties = ConsensusCommitCosmosEnv.getProperties(testName);
     properties.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "SERIALIZABLE");
     return properties;
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class ConsensusCommitIntegrationTestWithCosmos extends ConsensusCommitIntegrationTestBase {
@@ -10,13 +9,6 @@ public class ConsensusCommitIntegrationTestWithCosmos extends ConsensusCommitInt
   @Override
   protected Properties getProps(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitNullMetadataIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitNullMetadataIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class ConsensusCommitNullMetadataIntegrationTestWithCosmos
@@ -11,21 +10,6 @@ public class ConsensusCommitNullMetadataIntegrationTestWithCosmos
   @Override
   protected Properties getProperties(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace1() {
-    return getNamespace(super.getNamespace1());
-  }
-
-  @Override
-  protected String getNamespace2() {
-    return getNamespace(super.getNamespace2());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitSpecificIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitSpecificIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class ConsensusCommitSpecificIntegrationTestWithCosmos
@@ -11,21 +10,6 @@ public class ConsensusCommitSpecificIntegrationTestWithCosmos
   @Override
   protected Properties getProperties(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace1() {
-    return getNamespace(super.getNamespace1());
-  }
-
-  @Override
-  protected String getNamespace2() {
-    return getNamespace(super.getNamespace2());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos
@@ -11,13 +10,6 @@ public class ConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos
   @Override
   protected Properties getProperties(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
@@ -10,26 +9,6 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace1() {
-    return getNamespace(super.getNamespace1());
-  }
-
-  @Override
-  protected String getNamespace2() {
-    return getNamespace(super.getNamespace2());
-  }
-
-  @Override
-  protected String getNamespace3() {
-    return getNamespace(super.getNamespace3());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminRepairTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminRepairTableIntegrationTest.java
@@ -6,7 +6,6 @@ import com.scalar.db.api.DistributedStorageAdminRepairTableIntegrationTestBase;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.util.AdminTestUtils;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -16,16 +15,6 @@ public class CosmosAdminRepairTableIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    return getNamespace(super.getNamespace());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosColumnValueIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosColumnValueIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageColumnValueIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosColumnValueIntegrationTest
@@ -10,13 +9,6 @@ public class CosmosColumnValueIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosConditionalMutationIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosConditionalMutationIntegrationTest.java
@@ -5,7 +5,6 @@ import com.scalar.db.api.DistributedStorageConditionalMutationIntegrationTestBas
 import com.scalar.db.io.DataType;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -14,13 +13,6 @@ public class CosmosConditionalMutationIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosCrossPartitionScanIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageCrossPartitionScanIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -13,13 +12,6 @@ public class CosmosCrossPartitionScanIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
@@ -2,16 +2,12 @@ package com.scalar.db.storage.cosmos;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public final class CosmosEnv {
   private static final String PROP_COSMOS_URI = "scalardb.cosmos.uri";
   private static final String PROP_COSMOS_PASSWORD = "scalardb.cosmos.password";
-  private static final String PROP_COSMOS_DATABASE_PREFIX = "scalardb.cosmos.database_prefix";
   private static final String PROP_COSMOS_CREATE_OPTIONS = "scalardb.cosmos.create_options";
 
   private static final ImmutableMap<String, String> DEFAULT_COSMOS_CREATE_OPTIONS =
@@ -22,7 +18,6 @@ public final class CosmosEnv {
   public static Properties getProperties(String testName) {
     String contactPoint = System.getProperty(PROP_COSMOS_URI);
     String password = System.getProperty(PROP_COSMOS_PASSWORD);
-    Optional<String> databasePrefix = getDatabasePrefix();
 
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, contactPoint);
@@ -32,26 +27,11 @@ public final class CosmosEnv {
     props.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_FILTERING, "true");
     props.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_ORDERING, "false");
 
-    if (databasePrefix.isPresent()) {
-      // Add the prefix and testName as a metadata database suffix
-      props.setProperty(
-          CosmosConfig.TABLE_METADATA_DATABASE,
-          databasePrefix.get() + CosmosAdmin.METADATA_DATABASE + "_" + testName);
-
-      props.setProperty(
-          ConsensusCommitConfig.COORDINATOR_NAMESPACE,
-          databasePrefix.get() + Coordinator.NAMESPACE);
-    } else {
-      // Add testName as a metadata database suffix
-      props.setProperty(
-          CosmosConfig.TABLE_METADATA_DATABASE, CosmosAdmin.METADATA_DATABASE + "_" + testName);
-    }
+    // Add testName as a metadata database suffix
+    props.setProperty(
+        CosmosConfig.TABLE_METADATA_DATABASE, CosmosAdmin.METADATA_DATABASE + "_" + testName);
 
     return props;
-  }
-
-  public static Optional<String> getDatabasePrefix() {
-    return Optional.ofNullable(System.getProperty(PROP_COSMOS_DATABASE_PREFIX));
   }
 
   public static Map<String, String> getCreationOptions() {

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosIntegrationTest extends DistributedStorageIntegrationTestBase {
@@ -10,13 +9,6 @@ public class CosmosIntegrationTest extends DistributedStorageIntegrationTestBase
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosJapaneseIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosJapaneseIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageJapaneseIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosJapaneseIntegrationTest extends DistributedStorageJapaneseIntegrationTestBase {
@@ -10,13 +9,6 @@ public class CosmosJapaneseIntegrationTest extends DistributedStorageJapaneseInt
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultipleClusteringKeyScanIntegrationTest.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ListMultimap;
 import com.scalar.db.api.DistributedStorageMultipleClusteringKeyScanIntegrationTestBase;
 import com.scalar.db.io.DataType;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosMultipleClusteringKeyScanIntegrationTest
@@ -14,13 +13,6 @@ public class CosmosMultipleClusteringKeyScanIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMultiplePartitionKeyIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageMultiplePartitionKeyIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosMultiplePartitionKeyIntegrationTest
@@ -10,13 +9,6 @@ public class CosmosMultiplePartitionKeyIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSchemaLoaderIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSchemaLoaderIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.schemaloader.SchemaLoaderIntegrationTestBase;
 import com.scalar.db.util.AdminTestUtils;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTestBase {
@@ -10,21 +9,6 @@ public class CosmosSchemaLoaderIntegrationTest extends SchemaLoaderIntegrationTe
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace1() {
-    return getNamespace(super.getNamespace1());
-  }
-
-  @Override
-  protected String getNamespace2() {
-    return getNamespace(super.getNamespace2());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSecondaryIndexIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSecondaryIndexIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageSecondaryIndexIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosSecondaryIndexIntegrationTest
@@ -10,13 +9,6 @@ public class CosmosSecondaryIndexIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSingleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSingleClusteringKeyScanIntegrationTest.java
@@ -4,7 +4,6 @@ import com.scalar.db.api.DistributedStorageSingleClusteringKeyScanIntegrationTes
 import com.scalar.db.io.DataType;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -13,13 +12,6 @@ public class CosmosSingleClusteringKeyScanIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSinglePartitionKeyIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosSinglePartitionKeyIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageSinglePartitionKeyIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosSinglePartitionKeyIntegrationTest
@@ -10,13 +9,6 @@ public class CosmosSinglePartitionKeyIntegrationTest
   @Override
   protected Properties getProperties(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosWithReservedKeywordIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosWithReservedKeywordIntegrationTest.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageWithReservedKeywordIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class CosmosWithReservedKeywordIntegrationTest
@@ -15,9 +14,7 @@ public class CosmosWithReservedKeywordIntegrationTest
 
   @Override
   protected String getNamespace() {
-    String namespace = "reserved_keyword_test";
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
+    return "reserved_keyword_test";
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionAdminIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class SingleCrudOperationTransactionAdminIntegrationTestWithCosmos
@@ -11,13 +10,6 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithCosmos
   @Override
   protected Properties getProps(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class SingleCrudOperationTransactionIntegrationTestWithCosmos
@@ -11,13 +10,6 @@ public class SingleCrudOperationTransactionIntegrationTestWithCosmos
   @Override
   protected Properties getProps(String testName) {
     return CosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = CosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class TwoPhaseConsensusCommitIntegrationTestWithCosmos
@@ -11,13 +10,6 @@ public class TwoPhaseConsensusCommitIntegrationTestWithCosmos
   @Override
   protected Properties getProps1(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespaceBaseName() {
-    String namespaceBaseName = super.getNamespaceBaseName();
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespaceBaseName).orElse(namespaceBaseName);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitSpecificIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos
@@ -11,21 +10,6 @@ public class TwoPhaseConsensusCommitSpecificIntegrationTestWithCosmos
   @Override
   protected Properties getProperties1(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace1() {
-    return getNamespace(super.getNamespace1());
-  }
-
-  @Override
-  protected String getNamespace2() {
-    return getNamespace(super.getNamespace2());
-  }
-
-  private String getNamespace(String namespace) {
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos.java
@@ -2,7 +2,6 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.transaction.consensuscommit.TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestBase;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 
 public class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWithCosmos
@@ -11,13 +10,6 @@ public class TwoPhaseConsensusCommitWithIncludeMetadataEnabledIntegrationTestWit
   @Override
   protected Properties getProperties(String testName) {
     return ConsensusCommitCosmosEnv.getProperties(testName);
-  }
-
-  @Override
-  protected String getNamespace() {
-    String namespace = super.getNamespace();
-    Optional<String> databasePrefix = ConsensusCommitCosmosEnv.getDatabasePrefix();
-    return databasePrefix.map(prefix -> prefix + namespace).orElse(namespace);
   }
 
   @Override


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1918 to branch(3)