### PR TITLE
Support encrypted columns in Schema Loader

### DIFF
--- a/core/src/main/java/com/scalar/db/api/TableMetadata.java
+++ b/core/src/main/java/com/scalar/db/api/TableMetadata.java
@@ -1,5 +1,6 @@
 package com.scalar.db.api;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Scan.Ordering.Order;
@@ -162,7 +163,8 @@ public class TableMetadata {
         && Objects.equals(partitionKeyNames, metadata.partitionKeyNames)
         && Objects.equals(clusteringKeyNames, metadata.clusteringKeyNames)
         && Objects.equals(clusteringOrders, metadata.clusteringOrders)
-        && Objects.equals(secondaryIndexNames, metadata.secondaryIndexNames);
+        && Objects.equals(secondaryIndexNames, metadata.secondaryIndexNames)
+        && Objects.equals(encryptedColumnNames, metadata.encryptedColumnNames);
   }
 
   @Override
@@ -173,7 +175,21 @@ public class TableMetadata {
         partitionKeyNames,
         clusteringKeyNames,
         clusteringOrders,
-        secondaryIndexNames);
+        secondaryIndexNames,
+        encryptedColumnNames);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("columnNames", columnNames)
+        .add("columnDataTypes", columnDataTypes)
+        .add("partitionKeyNames", partitionKeyNames)
+        .add("clusteringKeyNames", clusteringKeyNames)
+        .add("clusteringOrders", clusteringOrders)
+        .add("secondaryIndexNames", secondaryIndexNames)
+        .add("encryptedColumnNames", encryptedColumnNames)
+        .toString();
   }
 
   /** A builder class that creates a TableMetadata instance. */

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/TableSchemaTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/TableSchemaTest.java
@@ -140,12 +140,12 @@ public class TableSchemaTest {
   }
 
   @Test
-  public void buildTableMetadata_ProperFormatTableDefinitionGiven_ShouldReturnProperTableMetadata()
-      throws SchemaLoaderException {
+  public void
+      buildTableMetadata_ProperFormatTableDefinitionGiven_ShouldReturnProperTableMetadata() {
     String tableDefinitionJson =
         "{\"transaction\": false,"
             + "\"partition-key\": [\"c1\"],"
-            + "\"clustering-key\": [\"c3\",\"c4 ASC\",\"c6 DESC\"],"
+            + "\"clustering-key\": [\"c3\",\"c4 ASC\",\"c6  DESC\"],"
             + "\"columns\": {"
             + "  \"c1\": \"INT\","
             + "  \"c2\": \"TEXT\","
@@ -183,6 +183,44 @@ public class TableSchemaTest {
   }
 
   @Test
+  public void
+      buildTableMetadata_ProperFormatTableDefinitionWithEncryptedColumnsGiven_ShouldReturnProperTableMetadata() {
+    String tableDefinitionJson =
+        "{\"transaction\": false,"
+            + "\"partition-key\": [\"c1\"],"
+            + "\"clustering-key\": [\"c3\",\"c4 ASC\",\"c6  DESC\"],"
+            + "\"columns\": {"
+            + "  \"c1\": \"INT\","
+            + "  \"c2\": \"TEXT ENCRYPTED\","
+            + "  \"c3\": \"BLOB\","
+            + "  \"c4\": \"INT\","
+            + "  \"c5\": \"BOOLEAN  ENCRYPTED\","
+            + "  \"c6\": \"INT\""
+            + "}}";
+    JsonObject tableDefinition = JsonParser.parseString(tableDefinitionJson).getAsJsonObject();
+
+    TableMetadata.Builder tableBuilder = TableMetadata.newBuilder();
+    tableBuilder.addPartitionKey("c1");
+    tableBuilder.addClusteringKey("c3");
+    tableBuilder.addClusteringKey("c4");
+    tableBuilder.addClusteringKey("c6", Order.DESC);
+    tableBuilder.addColumn("c1", DataType.INT);
+    tableBuilder.addColumn("c2", DataType.TEXT, true);
+    tableBuilder.addColumn("c3", DataType.BLOB);
+    tableBuilder.addColumn("c4", DataType.INT);
+    tableBuilder.addColumn("c5", DataType.BOOLEAN, true);
+    tableBuilder.addColumn("c6", DataType.INT);
+    TableMetadata expectedTableMetadata = tableBuilder.build();
+
+    // Act
+    TableMetadata tableMetadata =
+        new TableSchema("ns.tb", tableDefinition, Collections.emptyMap()).getTableMetadata();
+
+    // Assert
+    Assertions.assertThat(tableMetadata).isEqualTo(expectedTableMetadata);
+  }
+
+  @Test
   public void Table_WrongFormatTableFullNameGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     String tableFullName = "namespace_and_table_without_dot_separator";
@@ -194,11 +232,11 @@ public class TableSchemaTest {
   }
 
   @Test
-  public void constructor_TableDefinitionWithoutTransactionGiven_ShouldConstructProperTableSchema()
-      throws SchemaLoaderException {
+  public void
+      constructor_TableDefinitionWithoutTransactionGiven_ShouldConstructProperTableSchema() {
     String tableDefinitionJson =
         "{\"partition-key\": [\"c1\"],"
-            + "\"clustering-key\": [\"c3\",\"c4 ASC\",\"c6 DESC\"],"
+            + "\"clustering-key\": [\"c3\",\"c4 ASC\",\"c6  DESC\"],"
             + "\"columns\": {"
             + "  \"c1\": \"INT\","
             + "  \"c2\": \"TEXT\","


### PR DESCRIPTION
## Description

This PR adds support for encrypted columns to Schema Loader. With this change, users can specify the `ENCRYPTED` flag in the column definition as follows:

```json
{
  "sample_db.sample_table": {
    "partition-key": [
      "c1"
    ],
    "clustering-key": [
      "c4 ASC",
      "c6 DESC"
    ],
    "columns": {
      "c1": "INT",
      "c2": "TEXT ENCRYPTED",
      "c3": "BLOB",
      "c4": "INT",
      "c5": "BOOLEAN ENCRYPTED",
      "c6": "INT"
    }
  }
}
```

In the above example, the `ENCRYPTED` flag is specified for the `c2` and `c5` columns:

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1907

## Changes made

- Added support for encrypted columns to Schema Loader.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added support for encrypted columns to Schema Loader.
