### PR TITLE
Fix snapshot management issues

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -95,9 +95,10 @@ public class CrudHandler {
     Optional<TransactionResult> result = getFromStorage(get);
     if (!result.isPresent() || result.get().isCommitted()) {
       if (result.isPresent() || get.getConjunctions().isEmpty()) {
-        // Keep the read set latest to create the before image using the latest record when the
-        // transaction writes or deletes this record. However, we update it only if a get operation
-        // has no conjunction or the result exists. This is because we don’t know whether the record
+        // Keep the read set latest to create before image by using the latest record (result)
+        // because another conflicting transaction might have updated the record after this
+        // transaction read it first. However, we update it only if a get operation has no
+        // conjunction or the result exists. This is because we don’t know whether the record
         // actually exists or not due to the conjunction.
         snapshot.put(key, result);
       }
@@ -164,8 +165,9 @@ public class CrudHandler {
 
         Snapshot.Key key = new Snapshot.Key(scan, r);
 
-        // We always update the read set to create before image using the latest result when the
-        // transaction writes or deletes this record.
+        // We always update the read set to create before image by using the latest record (result)
+        // because another conflicting transaction might have updated the record after this
+        // transaction read it first.
         snapshot.put(key, Optional.of(result));
 
         snapshot.mergeResult(key, Optional.of(result)).ifPresent(value -> results.put(key, value));

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -83,7 +83,7 @@ public class CrudHandler {
 
   @VisibleForTesting
   void readUnread(Snapshot.Key key, Get get) throws CrudException {
-    if (!snapshot.contains(get)) {
+    if (!snapshot.containsKeyInGetSet(get)) {
       read(key, get);
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -95,10 +95,10 @@ public class CrudHandler {
     Optional<TransactionResult> result = getFromStorage(get);
     if (!result.isPresent() || result.get().isCommitted()) {
       if (result.isPresent() || get.getConjunctions().isEmpty()) {
-        // Keep the read set latest to create the before image using it when the transaction writes
-        // or deletes this record. However, we update it only if a get operation has no conjunction
-        // or the result exists. This is because we don’t know whether the record actually does not
-        // exist due to the conjunction.
+        // Keep the read set latest to create the before image using the latest record when the
+        // transaction writes or deletes this record. However, we update it only if a get operation
+        // has no conjunction or the result exists. This is because we don’t know whether the record
+        // actually exists or not due to the conjunction.
         snapshot.put(key, result);
       }
       snapshot.put(get, result); // for re-read and validation

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -181,8 +181,10 @@ public class Snapshot {
     return mergeResult(key, result)
         .filter(
             r ->
-                conjunctions.isEmpty()
-                    || !r.isMergedResult()
+                // We need to apply conditions if it is a merged result. Of course, we can just
+                // return the result without the condition check if there is no condition.
+                !r.isMergedResult()
+                    || conjunctions.isEmpty()
                     || ScalarDbUtils.columnsMatchAnyOfConjunctions(r.getColumns(), conjunctions));
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -180,7 +180,7 @@ public class Snapshot {
         .filter(
             r ->
                 conjunctions.isEmpty()
-                    || !writeSet.containsKey(key)
+                    || !r.isMergedResult()
                     || ScalarDbUtils.columnsMatchAnyOfConjunctions(r.getColumns(), conjunctions));
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -163,11 +163,11 @@ public class Snapshot {
       throws CrudException {
     if (deleteSet.containsKey(key)) {
       return Optional.empty();
-    } else if (readSet.containsKey(key) && writeSet.containsKey(key)) {
+    } else if (writeSet.containsKey(key)) {
       // merge the result in the read set and the put in the write set
       return Optional.of(
           new TransactionResult(
-              new MergedResult(readSet.get(key), writeSet.get(key), getTableMetadata(key))));
+              new MergedResult(result, writeSet.get(key), getTableMetadata(key))));
     } else {
       return result;
     }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -181,8 +181,9 @@ public class Snapshot {
     return mergeResult(key, result)
         .filter(
             r ->
-                // We need to apply conditions if it is a merged result. Of course, we can just
-                // return the result without the condition check if there is no condition.
+                // We need to apply conditions if it is a merged result because the transaction’s
+                // write makes the record no longer match the conditions. Of course, we can just
+                // return the result without checking the condition if there is no condition.
                 !r.isMergedResult()
                     || conjunctions.isEmpty()
                     || ScalarDbUtils.columnsMatchAnyOfConjunctions(r.getColumns(), conjunctions));
@@ -212,7 +213,7 @@ public class Snapshot {
     return metadata.getTableMetadata();
   }
 
-  public boolean contains(Get get) {
+  public boolean containsKeyInGetSet(Get get) {
     return getSet.containsKey(get);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -217,7 +217,8 @@ public class Snapshot {
   }
 
   public Optional<TransactionResult> get(Get get) {
-    assert this.contains(get);
+    // We expect this method is called after putting the result of the get operation in the get set.
+    assert getSet.containsKey(get);
     return getSet.get(get);
   }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionResult.java
@@ -142,6 +142,10 @@ public class TransactionResult extends AbstractResult {
     return getId() == null;
   }
 
+  public boolean isMergedResult() {
+    return result instanceof MergedResult;
+  }
+
   public boolean hasBeforeImage() {
     // We need to check not only before_id but also before_version to determine if the record has
     // the before image or not since we set before_version to 0 for the prepared record when

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.ConditionalExpression;
+import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
@@ -66,6 +68,8 @@ public class CrudHandlerTest {
               .addPartitionKey(ANY_NAME_1)
               .addClusteringKey(ANY_NAME_2)
               .build());
+  private static final TransactionTableMetadata TRANSACTION_TABLE_METADATA =
+      new TransactionTableMetadata(TABLE_METADATA);
 
   private CrudHandler handler;
   @Mock private DistributedStorage storage;
@@ -103,6 +107,14 @@ public class CrudHandlerTest {
         .forTable(ANY_TABLE_NAME);
   }
 
+  private Get toGetForStorageFrom(Get get) {
+    return Get.newBuilder(get)
+        .clearProjections()
+        .projections(TRANSACTION_TABLE_METADATA.getAfterImageColumnNames())
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
   private Scan prepareScan() {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     return new Scan(partitionKey).forNamespace(ANY_NAMESPACE_NAME).forTable(ANY_TABLE_NAME);
@@ -114,6 +126,14 @@ public class CrudHandlerTest {
         .table(ANY_TABLE_NAME)
         .all()
         .where(ConditionBuilder.column("column").isEqualToInt(10))
+        .build();
+  }
+
+  private Scan toScanForStorageFrom(Scan scan) {
+    return Scan.newBuilder(scan)
+        .clearProjections()
+        .projections(TRANSACTION_TABLE_METADATA.getAfterImageColumnNames())
+        .consistency(Consistency.LINEARIZABLE)
         .build();
   }
 
@@ -136,12 +156,14 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void get_KeyExistsInSnapshot_ShouldReturnFromSnapshot() throws CrudException {
+  public void get_GetExistsInSnapshot_ShouldReturnFromSnapshot() throws CrudException {
     // Arrange
     Get get = prepareGet();
     Optional<TransactionResult> expected = Optional.of(prepareResult(TransactionState.COMMITTED));
-    when(snapshot.containsKeyInReadSet(new Snapshot.Key(get))).thenReturn(true);
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(expected);
+    when(snapshot.contains(get)).thenReturn(true);
+    when(snapshot.get(get)).thenReturn(expected);
+    when(snapshot.mergeResult(new Snapshot.Key(get), expected, Collections.emptySet()))
+        .thenReturn(expected);
 
     // Act
     Optional<Result> actual = handler.get(get);
@@ -156,18 +178,22 @@ public class CrudHandlerTest {
 
   @Test
   public void
-      get_KeyNotExistsInSnapshotAndRecordInStorageCommitted_ShouldReturnFromStorageAndUpdateSnapshot()
+      get_GetNotExistsInSnapshotAndRecordInStorageCommitted_ShouldReturnFromStorageAndUpdateSnapshot()
           throws CrudException, ExecutionException {
     // Arrange
     Get get = prepareGet();
+    Get getForStorage = toGetForStorageFrom(get);
     Optional<Result> expected = Optional.of(prepareResult(TransactionState.COMMITTED));
+    Optional<TransactionResult> transactionResult = expected.map(e -> (TransactionResult) e);
     Snapshot.Key key = new Snapshot.Key(get);
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(false);
+    when(snapshot.contains(get)).thenReturn(false);
     doNothing()
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
-    when(storage.get(get)).thenReturn(expected);
-    when(snapshot.get(key)).thenReturn(expected.map(e -> (TransactionResult) e));
+    when(storage.get(getForStorage)).thenReturn(expected);
+    when(snapshot.get(get)).thenReturn(transactionResult);
+    when(snapshot.mergeResult(key, transactionResult, Collections.emptySet()))
+        .thenReturn(transactionResult);
 
     // Act
     Optional<Result> result = handler.get(get);
@@ -178,20 +204,22 @@ public class CrudHandlerTest {
             Optional.of(
                 new FilteredResult(
                     expected.get(), Collections.emptyList(), TABLE_METADATA, false)));
-    verify(storage).get(get);
+    verify(storage).get(getForStorage);
     verify(snapshot).put(key, Optional.of((TransactionResult) expected.get()));
+    verify(snapshot).put(get, Optional.of((TransactionResult) expected.get()));
   }
 
   @Test
   public void
-      get_KeyNotExistsInSnapshotAndRecordInStorageNotCommitted_ShouldThrowUncommittedRecordException()
-          throws CrudException, ExecutionException {
+      get_GetNotExistsInSnapshotAndRecordInStorageNotCommitted_ShouldThrowUncommittedRecordException()
+          throws ExecutionException {
     // Arrange
     Get get = prepareGet();
+    Get getForStorage = toGetForStorageFrom(get);
     result = prepareResult(TransactionState.PREPARED);
     Optional<Result> expected = Optional.of(result);
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
-    when(storage.get(get)).thenReturn(expected);
+    when(snapshot.contains(get)).thenReturn(false);
+    when(storage.get(getForStorage)).thenReturn(expected);
 
     // Act Assert
     assertThatThrownBy(() -> handler.get(get))
@@ -209,11 +237,11 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void get_KeyNeitherExistsInSnapshotNorInStorage_ShouldReturnEmpty()
+  public void get_GetNotExistsInSnapshotAndRecordNotExistsInStorage_ShouldReturnEmpty()
       throws CrudException, ExecutionException {
     // Arrange
     Get get = prepareGet();
-    when(snapshot.get(new Snapshot.Key(get))).thenReturn(Optional.empty());
+    when(snapshot.contains(get)).thenReturn(false);
     when(storage.get(get)).thenReturn(Optional.empty());
 
     // Act
@@ -224,13 +252,14 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void get_KeyNotContainsInReadSetAndExceptionThrownInStorage_ShouldThrowCrudException()
+  public void get_GetNotExistsInSnapshotAndExceptionThrownInStorage_ShouldThrowCrudException()
       throws ExecutionException {
     // Arrange
     Get get = prepareGet();
-    when(snapshot.containsKeyInReadSet(new Snapshot.Key(get))).thenReturn(false);
+    Get getForStorage = toGetForStorageFrom(get);
+    when(snapshot.contains(get)).thenReturn(false);
     ExecutionException toThrow = mock(ExecutionException.class);
-    when(storage.get(get)).thenThrow(toThrow);
+    when(storage.get(getForStorage)).thenThrow(toThrow);
 
     // Act Assert
     assertThatThrownBy(() -> handler.get(get)).isInstanceOf(CrudException.class).hasCause(toThrow);
@@ -241,20 +270,21 @@ public class CrudHandlerTest {
       throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
+    TransactionResult expected = new TransactionResult(result);
     doNothing()
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+    when(snapshot.mergeResult(any(), any())).thenReturn(Optional.of(expected));
 
     // Act
     List<Result> results = handler.scan(scan);
 
     // Assert
-    TransactionResult expected = new TransactionResult(result);
     verify(snapshot).put(key, Optional.of(expected));
     verify(snapshot).verify(scan);
     assertThat(results.size()).isEqualTo(1);
@@ -268,9 +298,10 @@ public class CrudHandlerTest {
           throws ExecutionException {
     // Arrange
     Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.PREPARED);
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     // Act Assert
     assertThatThrownBy(() -> handler.scan(scan))
@@ -292,25 +323,25 @@ public class CrudHandlerTest {
       throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
+    TransactionResult expected = new TransactionResult(result);
     doNothing()
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
     Snapshot.Key key = new Snapshot.Key(scan, result);
     when(snapshot.get(scan))
         .thenReturn(Optional.empty())
-        .thenReturn(Optional.of(Collections.singletonList(key)));
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(false).thenReturn(true);
-    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
+        .thenReturn(Optional.of(Collections.singletonMap(key, expected)));
+    when(snapshot.mergeResult(any(), any())).thenReturn(Optional.of(expected));
 
     // Act
     List<Result> results1 = handler.scan(scan);
     List<Result> results2 = handler.scan(scan);
 
     // Assert
-    TransactionResult expected = new TransactionResult(result);
     verify(snapshot).put(key, Optional.of(expected));
     assertThat(results1.size()).isEqualTo(1);
     assertThat(results1.get(0))
@@ -323,12 +354,13 @@ public class CrudHandlerTest {
       throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
     snapshot =
         new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, null, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     // Act
     List<Result> results1 = handler.scan(scan);
@@ -343,47 +375,58 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void scan_GetCalledAfterScan_ShouldReturnFromSnapshot()
+  public void scan_GetCalledAfterScan_ShouldReturnFromStorage()
       throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
     doNothing()
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
-    Snapshot.Key key = new Snapshot.Key(scan, result);
-    when(snapshot.get(scan)).thenReturn(Optional.empty());
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(false).thenReturn(true);
-    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    Get get = prepareGet();
+    Get getForStorage = toGetForStorageFrom(get);
+    Optional<TransactionResult> transactionResult = Optional.of(new TransactionResult(result));
+    when(storage.get(getForStorage)).thenReturn(Optional.of(result));
+    when(snapshot.get(get)).thenReturn(transactionResult);
+    when(snapshot.mergeResult(any(), any())).thenReturn(transactionResult);
+    when(snapshot.mergeResult(new Snapshot.Key(get), transactionResult, Collections.emptySet()))
+        .thenReturn(transactionResult);
 
     // Act
     List<Result> results = handler.scan(scan);
-    Optional<Result> result = handler.get(prepareGet());
+    Optional<Result> result = handler.get(get);
 
     // Assert
-    verify(storage, never()).get(any(Get.class));
+    verify(storage).scan(scanForStorage);
+    verify(storage).get(getForStorage);
     assertThat(results.get(0)).isEqualTo(result.get());
   }
 
   @Test
-  public void scan_GetCalledAfterScanUnderRealSnapshot_ShouldReturnFromSnapshot()
+  public void scan_GetCalledAfterScanUnderRealSnapshot_ShouldReturnFromStorage()
       throws ExecutionException, CrudException {
     // Arrange
-    Scan scan = prepareScan();
+    Scan scan = toScanForStorageFrom(prepareScan());
     result = prepareResult(TransactionState.COMMITTED);
     snapshot =
         new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, null, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(scan)).thenReturn(scanner);
+    Get get = toGetForStorageFrom(prepareGet());
+    when(storage.get(get)).thenReturn(Optional.of(result));
 
     // Act
     List<Result> results = handler.scan(scan);
-    Optional<Result> result = handler.get(prepareGet());
+    Optional<Result> result = handler.get(get);
 
     // Assert
+    verify(storage).scan(scan);
+    verify(storage).get(get);
     assertThat(results.get(0)).isEqualTo(result.get());
   }
 
@@ -392,6 +435,7 @@ public class CrudHandlerTest {
       throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
 
     ImmutableMap<String, Column<?>> columns =
@@ -428,7 +472,7 @@ public class CrudHandlerTest {
             deleteSet);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
     when(scanner.iterator()).thenReturn(Arrays.asList(result, result2).iterator());
-    when(storage.scan(scan)).thenReturn(scanner);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     Delete delete =
         new Delete(new Key(ANY_NAME_1, ANY_TEXT_1), new Key(ANY_NAME_2, ANY_TEXT_3))
@@ -460,29 +504,30 @@ public class CrudHandlerTest {
 
   @Test
   public void
-      scan_CrossPartitionScanndResultFromStorageGiven_ShouldUpdateSnapshotAndValidateThenReturn()
+      scan_CrossPartitionScanAndResultFromStorageGiven_ShouldUpdateSnapshotAndValidateThenReturn()
           throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareCrossPartitionScan();
     result = prepareResult(TransactionState.COMMITTED);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    when(snapshot.get(key)).thenReturn(Optional.of((TransactionResult) result));
     doNothing()
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(any(ScanAll.class))).thenReturn(scanner);
+    TransactionResult transactionResult = new TransactionResult(result);
+    when(snapshot.mergeResult(any(), any())).thenReturn(Optional.of(transactionResult));
 
     // Act
     List<Result> results = handler.scan(scan);
 
     // Assert
-    TransactionResult expected = new TransactionResult(result);
-    verify(snapshot).put(key, Optional.of(expected));
+    verify(snapshot).put(key, Optional.of(transactionResult));
     verify(snapshot).verify(scan);
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
-        .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
+        .isEqualTo(
+            new FilteredResult(transactionResult, Collections.emptyList(), TABLE_METADATA, false));
   }
 
   @Test
@@ -561,7 +606,7 @@ public class CrudHandlerTest {
     spied.put(put);
 
     // Assert
-    verify(spied).readUnread(key, getForKey);
+    verify(spied, never()).readUnread(key, getForKey);
     verify(snapshot).getFromReadSet(key);
     verify(mutationConditionsValidator).checkIfConditionIsSatisfied(put, result);
     verify(snapshot).put(key, put);
@@ -714,7 +759,7 @@ public class CrudHandlerTest {
     spied.delete(delete);
 
     // Assert
-    verify(spied).readUnread(key, getForKey);
+    verify(spied, never()).readUnread(key, getForKey);
     verify(snapshot).getFromReadSet(key);
     verify(mutationConditionsValidator).checkIfConditionIsSatisfied(delete, result);
     verify(snapshot).put(key, delete);
@@ -757,50 +802,46 @@ public class CrudHandlerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void readUnread_ContainsKeyInReadSet_ShouldCallAppropriateMethods()
+  public void readUnread_GetContainedInGetSet_ShouldCallAppropriateMethods()
       throws CrudException, ExecutionException {
     // Arrange
     Snapshot.Key key = mock(Snapshot.Key.class);
     when(key.getNamespace()).thenReturn(ANY_NAMESPACE_NAME);
     when(key.getTable()).thenReturn(ANY_TABLE_NAME);
     when(key.getPartitionKey()).thenReturn(Key.ofText(ANY_NAME_1, ANY_TEXT_1));
-
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(true);
-
     Get getForKey =
         Get.newBuilder()
             .namespace(key.getNamespace())
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
+    when(snapshot.contains(getForKey)).thenReturn(true);
 
     // Act
     handler.readUnread(key, getForKey);
 
     // Assert
     verify(storage, never()).get(any());
-    verify(snapshot, never()).put(any(), any(Optional.class));
+    verify(snapshot, never()).put(any(Get.class), any(Optional.class));
   }
 
   @Test
   public void
-      readUnread_NotContainsKeyInReadSet_EmptyResultReturnedByStorage_ShouldCallAppropriateMethods()
+      readUnread_GetNotContainedInGetSet_EmptyResultReturnedByStorage_ShouldCallAppropriateMethods()
           throws CrudException, ExecutionException {
     // Arrange
     Snapshot.Key key = mock(Snapshot.Key.class);
     when(key.getNamespace()).thenReturn(ANY_NAMESPACE_NAME);
     when(key.getTable()).thenReturn(ANY_TABLE_NAME);
     when(key.getPartitionKey()).thenReturn(Key.ofText(ANY_NAME_1, ANY_TEXT_1));
-
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(false);
-    when(storage.get(any())).thenReturn(Optional.empty());
-
     Get getForKey =
         Get.newBuilder()
             .namespace(key.getNamespace())
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
+    when(snapshot.contains(getForKey)).thenReturn(false);
+    when(storage.get(any())).thenReturn(Optional.empty());
 
     // Act
     handler.readUnread(key, getForKey);
@@ -808,19 +849,46 @@ public class CrudHandlerTest {
     // Assert
     verify(storage).get(any());
     verify(snapshot).put(key, Optional.empty());
+    verify(snapshot).put(getForKey, Optional.empty());
   }
 
   @Test
   public void
-      readUnread_NotContainsKeyInReadSet_CommittedRecordReturnedByStorage_ShouldCallAppropriateMethods()
+      readUnread_GetWithConjunctionsNotContainedInGetSet_EmptyResultReturnedByStorage_ShouldCallAppropriateMethods()
           throws CrudException, ExecutionException {
     // Arrange
     Snapshot.Key key = mock(Snapshot.Key.class);
     when(key.getNamespace()).thenReturn(ANY_NAMESPACE_NAME);
     when(key.getTable()).thenReturn(ANY_TABLE_NAME);
     when(key.getPartitionKey()).thenReturn(Key.ofText(ANY_NAME_1, ANY_TEXT_1));
+    Get getForKey =
+        Get.newBuilder()
+            .namespace(key.getNamespace())
+            .table(key.getTable())
+            .partitionKey(key.getPartitionKey())
+            .where(mock(ConditionalExpression.class))
+            .build();
+    when(snapshot.contains(getForKey)).thenReturn(false);
+    when(storage.get(any())).thenReturn(Optional.empty());
 
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(false);
+    // Act
+    handler.readUnread(key, getForKey);
+
+    // Assert
+    verify(storage).get(any());
+    verify(snapshot, never()).put(key, Optional.empty());
+    verify(snapshot).put(getForKey, Optional.empty());
+  }
+
+  @Test
+  public void
+      readUnread_GetNotContainedInGetSet_CommittedRecordReturnedByStorage_ShouldCallAppropriateMethods()
+          throws CrudException, ExecutionException {
+    // Arrange
+    Snapshot.Key key = mock(Snapshot.Key.class);
+    when(key.getNamespace()).thenReturn(ANY_NAMESPACE_NAME);
+    when(key.getTable()).thenReturn(ANY_TABLE_NAME);
+    when(key.getPartitionKey()).thenReturn(Key.ofText(ANY_NAME_1, ANY_TEXT_1));
 
     Result result = mock(Result.class);
     when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.COMMITTED.get());
@@ -832,6 +900,7 @@ public class CrudHandlerTest {
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
+    when(snapshot.contains(getForKey)).thenReturn(false);
 
     // Act
     handler.readUnread(key, getForKey);
@@ -843,15 +912,13 @@ public class CrudHandlerTest {
 
   @Test
   public void
-      readUnread_NotContainsKeyInReadSet_UncommittedRecordReturnedByStorage_ShouldThrowUncommittedRecordException()
+      readUnread_GetNotContainedInGetSet_UncommittedRecordReturnedByStorage_ShouldThrowUncommittedRecordException()
           throws ExecutionException {
     // Arrange
     Snapshot.Key key = mock(Snapshot.Key.class);
     when(key.getNamespace()).thenReturn(ANY_NAMESPACE_NAME);
     when(key.getTable()).thenReturn(ANY_TABLE_NAME);
     when(key.getPartitionKey()).thenReturn(Key.ofText(ANY_NAME_1, ANY_TEXT_1));
-
-    when(snapshot.containsKeyInReadSet(key)).thenReturn(false);
 
     Result result = mock(Result.class);
     when(result.getInt(Attribute.STATE)).thenReturn(TransactionState.PREPARED.get());
@@ -863,6 +930,7 @@ public class CrudHandlerTest {
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
+    when(snapshot.contains(getForKey)).thenReturn(false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.readUnread(key, getForKey))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -161,7 +161,7 @@ public class CrudHandlerTest {
     Get get = prepareGet();
     Get getForStorage = toGetForStorageFrom(get);
     Optional<TransactionResult> expected = Optional.of(prepareResult(TransactionState.COMMITTED));
-    when(snapshot.contains(getForStorage)).thenReturn(true);
+    when(snapshot.containsKeyInGetSet(getForStorage)).thenReturn(true);
     when(snapshot.get(getForStorage)).thenReturn(expected);
     when(snapshot.mergeResult(new Snapshot.Key(getForStorage), expected, Collections.emptySet()))
         .thenReturn(expected);
@@ -187,7 +187,7 @@ public class CrudHandlerTest {
     Optional<Result> expected = Optional.of(prepareResult(TransactionState.COMMITTED));
     Optional<TransactionResult> transactionResult = expected.map(e -> (TransactionResult) e);
     Snapshot.Key key = new Snapshot.Key(getForStorage);
-    when(snapshot.contains(getForStorage)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForStorage)).thenReturn(false);
     doNothing()
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
@@ -219,7 +219,7 @@ public class CrudHandlerTest {
     Get getForStorage = toGetForStorageFrom(get);
     result = prepareResult(TransactionState.PREPARED);
     Optional<Result> expected = Optional.of(result);
-    when(snapshot.contains(getForStorage)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForStorage)).thenReturn(false);
     when(storage.get(getForStorage)).thenReturn(expected);
 
     // Act Assert
@@ -243,7 +243,7 @@ public class CrudHandlerTest {
     // Arrange
     Get get = prepareGet();
     Get getForStorage = toGetForStorageFrom(get);
-    when(snapshot.contains(getForStorage)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForStorage)).thenReturn(false);
     when(storage.get(getForStorage)).thenReturn(Optional.empty());
 
     // Act
@@ -259,7 +259,7 @@ public class CrudHandlerTest {
     // Arrange
     Get get = prepareGet();
     Get getForStorage = toGetForStorageFrom(get);
-    when(snapshot.contains(getForStorage)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForStorage)).thenReturn(false);
     ExecutionException toThrow = mock(ExecutionException.class);
     when(storage.get(getForStorage)).thenThrow(toThrow);
 
@@ -281,7 +281,7 @@ public class CrudHandlerTest {
         .when(snapshot)
         .put(any(Snapshot.Key.class), ArgumentMatchers.<Optional<TransactionResult>>any());
     Snapshot.Key key = new Snapshot.Key(getForStorage);
-    when(snapshot.contains(getForStorage)).thenReturn(false).thenReturn(true);
+    when(snapshot.containsKeyInGetSet(getForStorage)).thenReturn(false).thenReturn(true);
     when(snapshot.get(getForStorage)).thenReturn(expected).thenReturn(expected);
     when(snapshot.mergeResult(key, expected, Collections.emptySet()))
         .thenReturn(expected)
@@ -894,7 +894,7 @@ public class CrudHandlerTest {
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
-    when(snapshot.contains(getForKey)).thenReturn(true);
+    when(snapshot.containsKeyInGetSet(getForKey)).thenReturn(true);
 
     // Act
     handler.readUnread(key, getForKey);
@@ -919,7 +919,7 @@ public class CrudHandlerTest {
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
-    when(snapshot.contains(getForKey)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForKey)).thenReturn(false);
     when(storage.get(any())).thenReturn(Optional.empty());
 
     // Act
@@ -947,7 +947,7 @@ public class CrudHandlerTest {
             .partitionKey(key.getPartitionKey())
             .where(mock(ConditionalExpression.class))
             .build();
-    when(snapshot.contains(getForKey)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForKey)).thenReturn(false);
     when(storage.get(any())).thenReturn(Optional.empty());
 
     // Act
@@ -979,7 +979,7 @@ public class CrudHandlerTest {
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
-    when(snapshot.contains(getForKey)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForKey)).thenReturn(false);
 
     // Act
     handler.readUnread(key, getForKey);
@@ -1009,7 +1009,7 @@ public class CrudHandlerTest {
             .table(key.getTable())
             .partitionKey(key.getPartitionKey())
             .build();
-    when(snapshot.contains(getForKey)).thenReturn(false);
+    when(snapshot.containsKeyInGetSet(getForKey)).thenReturn(false);
 
     // Act Assert
     assertThatThrownBy(() -> handler.readUnread(key, getForKey))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -543,7 +543,7 @@ public class CrudHandlerTest {
             tableMetadataManager,
             parallelExecutor,
             readSet,
-            new HashMap<>(),
+            new ConcurrentHashMap<>(),
             new HashMap<>(),
             new HashMap<>(),
             deleteSet);
@@ -723,7 +723,7 @@ public class CrudHandlerTest {
     spied.put(put);
 
     // Assert
-    verify(spied).readUnread(key, getForKey);
+    verify(spied).read(key, getForKey);
     verify(snapshot).getFromReadSet(key);
     verify(mutationConditionsValidator).checkIfConditionIsSatisfied(put, result);
     verify(snapshot).put(key, put);
@@ -873,7 +873,7 @@ public class CrudHandlerTest {
     spied.delete(delete);
 
     // Assert
-    verify(spied).readUnread(key, getForKey);
+    verify(spied).read(key, getForKey);
     verify(snapshot).getFromReadSet(key);
     verify(mutationConditionsValidator).checkIfConditionIsSatisfied(delete, null);
     verify(snapshot).put(key, delete);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -94,7 +94,7 @@ public class SnapshotTest {
 
   private Snapshot snapshot;
   private ConcurrentMap<Snapshot.Key, Optional<TransactionResult>> readSet;
-  private Map<Get, Optional<TransactionResult>> getSet;
+  private ConcurrentMap<Get, Optional<TransactionResult>> getSet;
   private Map<Scan, Map<Snapshot.Key, TransactionResult>> scanSet;
   private Map<Snapshot.Key, Put> writeSet;
   private Map<Snapshot.Key, Delete> deleteSet;
@@ -122,7 +122,7 @@ public class SnapshotTest {
 
   private Snapshot prepareSnapshot(Isolation isolation, SerializableStrategy strategy) {
     readSet = new ConcurrentHashMap<>();
-    getSet = new HashMap<>();
+    getSet = new ConcurrentHashMap<>();
     scanSet = new HashMap<>();
     writeSet = new HashMap<>();
     deleteSet = new HashMap<>();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionSetBuilder;
+import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
@@ -26,6 +27,7 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
+import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -44,9 +46,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,8 +94,8 @@ public class SnapshotTest {
 
   private Snapshot snapshot;
   private ConcurrentMap<Snapshot.Key, Optional<TransactionResult>> readSet;
-  private Map<Get, Snapshot.Key> getSet;
-  private Map<Scan, List<Snapshot.Key>> scanSet;
+  private Map<Get, Optional<TransactionResult>> getSet;
+  private Map<Scan, Map<Snapshot.Key, TransactionResult>> scanSet;
   private Map<Snapshot.Key, Put> writeSet;
   private Map<Snapshot.Key, Delete> deleteSet;
 
@@ -252,6 +254,17 @@ public class SnapshotTest {
         .build();
   }
 
+  private Put preparePutForMergeTest() {
+    return Put.newBuilder()
+        .namespace(ANY_NAMESPACE_NAME)
+        .table(ANY_TABLE_NAME)
+        .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
+        .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
+        .textValue(ANY_NAME_3, ANY_TEXT_5)
+        .textValue(ANY_NAME_4, null)
+        .build();
+  }
+
   private Delete prepareDelete() {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
@@ -357,8 +370,9 @@ public class SnapshotTest {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Scan scan = prepareScan();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    List<Snapshot.Key> expected = Collections.singletonList(key);
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    Map<Snapshot.Key, TransactionResult> expected = Collections.singletonMap(key, result);
 
     // Act
     snapshot.put(scan, expected);
@@ -368,7 +382,7 @@ public class SnapshotTest {
   }
 
   @Test
-  public void get_KeyGivenContainedInWriteSetAndReadSet_ShouldReturnMergedResult()
+  public void mergeResult_KeyGivenContainedInWriteSet_ShouldReturnMergedResult()
       throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
@@ -387,11 +401,71 @@ public class SnapshotTest {
     snapshot.put(key, put);
 
     // Act
-    Optional<TransactionResult> actual = snapshot.get(key);
+    Optional<TransactionResult> actual = snapshot.mergeResult(key, Optional.of(result));
 
     // Assert
     assertThat(actual).isPresent();
-    assertThat(actual.get().getValues())
+    assertMergedResultIsEqualTo(actual.get());
+  }
+
+  @Test
+  public void mergeResult_KeyGivenContainedInDeleteSet_ShouldReturnEmpty() throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Delete delete = prepareDelete();
+    Snapshot.Key key = new Snapshot.Key(delete);
+    snapshot.put(key, delete);
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.mergeResult(key, Optional.of(result));
+
+    // Assert
+    assertThat(actual).isNotPresent();
+  }
+
+  @Test
+  public void
+      mergeResult_KeyGivenNeitherContainedInDeleteSetNorWriteSet_ShouldReturnOriginalResult()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Snapshot.Key key = new Snapshot.Key(prepareGet());
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.mergeResult(key, Optional.of(result));
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(result));
+  }
+
+  @Test
+  public void
+      mergeResult_MatchedConjunctionAndKeyContainedInWriteSetGiven_ShouldReturnMergedResult()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePutForMergeTest();
+    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_5);
+    Set<Conjunction> conjunctions = ImmutableSet.of(Conjunction.of(condition));
+    Get get = Get.newBuilder(prepareGet()).where(condition).build();
+    Snapshot.Key key = new Snapshot.Key(get);
+    TransactionResult result = prepareResult(ANY_ID);
+    snapshot.put(key, Optional.of(result));
+    snapshot.put(key, put);
+
+    // Act
+    Optional<TransactionResult> actual =
+        snapshot.mergeResult(key, Optional.of(result), conjunctions);
+
+    // Assert
+    assertThat(actual).isPresent();
+    assertMergedResultIsEqualTo(actual.get());
+  }
+
+  private void assertMergedResultIsEqualTo(TransactionResult result) {
+    assertThat(result.getValues())
         .isEqualTo(
             ImmutableMap.<String, Value<?>>builder()
                 .put(ANY_NAME_1, new TextValue(ANY_NAME_1, ANY_TEXT_1))
@@ -401,25 +475,22 @@ public class SnapshotTest {
                 .put(Attribute.ID, Attribute.toIdValue(ANY_ID))
                 .put(Attribute.VERSION, Attribute.toVersionValue(ANY_VERSION))
                 .build());
-    assertThat(actual.get().getValue(ANY_NAME_1).isPresent()).isTrue();
-    assertThat(actual.get().getValue(ANY_NAME_1).get())
-        .isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
-    assertThat(actual.get().getValue(ANY_NAME_2).isPresent()).isTrue();
-    assertThat(actual.get().getValue(ANY_NAME_2).get())
-        .isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
-    assertThat(actual.get().getValue(ANY_NAME_3).isPresent()).isTrue();
-    assertThat(actual.get().getValue(ANY_NAME_3).get())
-        .isEqualTo(new TextValue(ANY_NAME_3, ANY_TEXT_5));
-    assertThat(actual.get().getValue(ANY_NAME_4).isPresent()).isTrue();
-    assertThat(actual.get().getValue(ANY_NAME_4).get())
+    assertThat(result.getValue(ANY_NAME_1).isPresent()).isTrue();
+    assertThat(result.getValue(ANY_NAME_1).get()).isEqualTo(new TextValue(ANY_NAME_1, ANY_TEXT_1));
+    assertThat(result.getValue(ANY_NAME_2).isPresent()).isTrue();
+    assertThat(result.getValue(ANY_NAME_2).get()).isEqualTo(new TextValue(ANY_NAME_2, ANY_TEXT_2));
+    assertThat(result.getValue(ANY_NAME_3).isPresent()).isTrue();
+    assertThat(result.getValue(ANY_NAME_3).get()).isEqualTo(new TextValue(ANY_NAME_3, ANY_TEXT_5));
+    assertThat(result.getValue(ANY_NAME_4).isPresent()).isTrue();
+    assertThat(result.getValue(ANY_NAME_4).get())
         .isEqualTo(new TextValue(ANY_NAME_4, (String) null));
-    assertThat(actual.get().getValue(Attribute.ID).isPresent()).isTrue();
-    assertThat(actual.get().getValue(Attribute.ID).get()).isEqualTo(Attribute.toIdValue(ANY_ID));
-    assertThat(actual.get().getValue(Attribute.VERSION).isPresent()).isTrue();
-    assertThat(actual.get().getValue(Attribute.VERSION).get())
+    assertThat(result.getValue(Attribute.ID).isPresent()).isTrue();
+    assertThat(result.getValue(Attribute.ID).get()).isEqualTo(Attribute.toIdValue(ANY_ID));
+    assertThat(result.getValue(Attribute.VERSION).isPresent()).isTrue();
+    assertThat(result.getValue(Attribute.VERSION).get())
         .isEqualTo(Attribute.toVersionValue(ANY_VERSION));
 
-    assertThat(actual.get().getContainedColumnNames())
+    assertThat(result.getContainedColumnNames())
         .isEqualTo(
             new HashSet<>(
                 Arrays.asList(
@@ -430,105 +501,76 @@ public class SnapshotTest {
                     Attribute.ID,
                     Attribute.VERSION)));
 
-    assertThat(actual.get().contains(ANY_NAME_1)).isTrue();
-    assertThat(actual.get().isNull(ANY_NAME_1)).isFalse();
-    assertThat(actual.get().getText(ANY_NAME_1)).isEqualTo(ANY_TEXT_1);
-    assertThat(actual.get().getAsObject(ANY_NAME_1)).isEqualTo(ANY_TEXT_1);
+    assertThat(result.contains(ANY_NAME_1)).isTrue();
+    assertThat(result.isNull(ANY_NAME_1)).isFalse();
+    assertThat(result.getText(ANY_NAME_1)).isEqualTo(ANY_TEXT_1);
+    assertThat(result.getAsObject(ANY_NAME_1)).isEqualTo(ANY_TEXT_1);
 
-    assertThat(actual.get().contains(ANY_NAME_2)).isTrue();
-    assertThat(actual.get().isNull(ANY_NAME_2)).isFalse();
-    assertThat(actual.get().getText(ANY_NAME_2)).isEqualTo(ANY_TEXT_2);
-    assertThat(actual.get().getAsObject(ANY_NAME_2)).isEqualTo(ANY_TEXT_2);
+    assertThat(result.contains(ANY_NAME_2)).isTrue();
+    assertThat(result.isNull(ANY_NAME_2)).isFalse();
+    assertThat(result.getText(ANY_NAME_2)).isEqualTo(ANY_TEXT_2);
+    assertThat(result.getAsObject(ANY_NAME_2)).isEqualTo(ANY_TEXT_2);
 
-    assertThat(actual.get().contains(ANY_NAME_3)).isTrue();
-    assertThat(actual.get().isNull(ANY_NAME_3)).isFalse();
-    assertThat(actual.get().getText(ANY_NAME_3)).isEqualTo(ANY_TEXT_5);
-    assertThat(actual.get().getAsObject(ANY_NAME_3)).isEqualTo(ANY_TEXT_5);
+    assertThat(result.contains(ANY_NAME_3)).isTrue();
+    assertThat(result.isNull(ANY_NAME_3)).isFalse();
+    assertThat(result.getText(ANY_NAME_3)).isEqualTo(ANY_TEXT_5);
+    assertThat(result.getAsObject(ANY_NAME_3)).isEqualTo(ANY_TEXT_5);
 
-    assertThat(actual.get().contains(ANY_NAME_4)).isTrue();
-    assertThat(actual.get().isNull(ANY_NAME_4)).isTrue();
-    assertThat(actual.get().getText(ANY_NAME_4)).isNull();
-    assertThat(actual.get().getAsObject(ANY_NAME_4)).isNull();
+    assertThat(result.contains(ANY_NAME_4)).isTrue();
+    assertThat(result.isNull(ANY_NAME_4)).isTrue();
+    assertThat(result.getText(ANY_NAME_4)).isNull();
+    assertThat(result.getAsObject(ANY_NAME_4)).isNull();
 
-    assertThat(actual.get().contains(Attribute.ID)).isTrue();
-    assertThat(actual.get().isNull(Attribute.ID)).isFalse();
-    assertThat(actual.get().getText(Attribute.ID)).isEqualTo(ANY_ID);
-    assertThat(actual.get().getAsObject(Attribute.ID)).isEqualTo(ANY_ID);
+    assertThat(result.contains(Attribute.ID)).isTrue();
+    assertThat(result.isNull(Attribute.ID)).isFalse();
+    assertThat(result.getText(Attribute.ID)).isEqualTo(ANY_ID);
+    assertThat(result.getAsObject(Attribute.ID)).isEqualTo(ANY_ID);
 
-    assertThat(actual.get().contains(Attribute.VERSION)).isTrue();
-    assertThat(actual.get().isNull(Attribute.VERSION)).isFalse();
-    assertThat(actual.get().getInt(Attribute.VERSION)).isEqualTo(ANY_VERSION);
-    assertThat(actual.get().getAsObject(Attribute.VERSION)).isEqualTo(ANY_VERSION);
+    assertThat(result.contains(Attribute.VERSION)).isTrue();
+    assertThat(result.isNull(Attribute.VERSION)).isFalse();
+    assertThat(result.getInt(Attribute.VERSION)).isEqualTo(ANY_VERSION);
+    assertThat(result.getAsObject(Attribute.VERSION)).isEqualTo(ANY_VERSION);
   }
 
   @Test
-  public void get_KeyGivenContainedInReadSet_ShouldReturnFromReadSet() throws CrudException {
+  public void
+      mergeResult_UnmatchedConjunctionAndKeyNeitherContainedInDeleteSetNorWriteSet_ShouldReturnOriginalResult()
+          throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Snapshot.Key key = new Snapshot.Key(prepareGet());
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(key, Optional.of(result));
+    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_1).isEqualToText(ANY_TEXT_2);
+    Set<Conjunction> conjunctions = ImmutableSet.of(Conjunction.of(condition));
 
     // Act
-    Optional<TransactionResult> actual = snapshot.get(key);
+    Optional<TransactionResult> actual =
+        snapshot.mergeResult(key, Optional.of(result), conjunctions);
 
     // Assert
     assertThat(actual).isEqualTo(Optional.of(result));
   }
 
   @Test
-  public void get_KeyGivenNotContainedInSnapshot_ShouldThrowIllegalArgumentException() {
+  public void mergeResult_UnmatchedConjunctionAndKeyContainedInWriteSetGiven_ShouldReturnEmpty()
+      throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.get(key)).isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void get_KeyGivenContainedInWriteSet_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Snapshot.Key key = new Snapshot.Key(put);
-    snapshot.put(key, put);
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.get(key)).isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void get_KeyGivenContainedInDeleteSet_ShouldReturnEmpty() throws CrudException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Delete delete = prepareDelete();
-    Snapshot.Key key = new Snapshot.Key(delete);
-    snapshot.put(key, delete);
-
-    // Act
-    Optional<TransactionResult> actual = snapshot.get(key);
-
-    // Assert
-    assertThat(actual).isNotPresent();
-  }
-
-  @Test
-  public void get_KeyGivenContainedInReadSetAndDeleteSet_ShouldReturnEmpty() throws CrudException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
+    Put put = preparePutForMergeTest();
+    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3);
+    Set<Conjunction> conjunctions = ImmutableSet.of(Conjunction.of(condition));
+    Get get = Get.newBuilder(prepareGet()).where(condition).build();
+    Snapshot.Key key = new Snapshot.Key(get);
     TransactionResult result = prepareResult(ANY_ID);
     snapshot.put(key, Optional.of(result));
-
-    Delete delete = prepareDelete();
-    snapshot.put(key, delete);
+    snapshot.put(key, put);
 
     // Act
-    Optional<TransactionResult> actual = snapshot.get(key);
+    Optional<TransactionResult> actual =
+        snapshot.mergeResult(key, Optional.of(result), conjunctions);
 
     // Assert
-    assertThat(actual).isNotPresent();
+    assertThat(actual).isEmpty();
   }
 
   @Test
@@ -538,10 +580,10 @@ public class SnapshotTest {
     Scan scan = prepareScan();
 
     // Act
-    Optional<List<Snapshot.Key>> keys = snapshot.get(scan);
+    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.get(scan);
 
     // Assert
-    assertThat(keys.isPresent()).isFalse();
+    assertThat(results.isPresent()).isFalse();
   }
 
   @Test
@@ -692,7 +734,7 @@ public class SnapshotTest {
     TransactionResult result = prepareResult(ANY_ID);
     TransactionResult txResult = new TransactionResult(result);
     snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.of(txResult));
     snapshot.put(new Snapshot.Key(put), put);
 
     // Act Assert
@@ -719,7 +761,7 @@ public class SnapshotTest {
     Get get = prepareAnotherGet();
     Put put = preparePut();
     snapshot.put(new Snapshot.Key(get), Optional.empty());
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.empty());
     snapshot.put(new Snapshot.Key(put), put);
 
     // Act Assert
@@ -741,9 +783,11 @@ public class SnapshotTest {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Scan scan = prepareScan();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
+    TransactionResult txResult = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, txResult);
     Put put = preparePut();
-    snapshot.put(scan, Collections.singletonList(key));
+    snapshot.put(key, Optional.of(txResult));
+    snapshot.put(scan, Collections.singletonMap(key, txResult));
     snapshot.put(new Snapshot.Key(put), put);
 
     // Act Assert
@@ -763,7 +807,7 @@ public class SnapshotTest {
     TransactionResult result = prepareResult(ANY_ID);
     TransactionResult txResult = new TransactionResult(result);
     snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.of(txResult));
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Get getWithProjections =
@@ -786,7 +830,7 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult txResult = prepareResult(ANY_ID);
     snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.of(txResult));
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult changedTxResult = prepareResult(ANY_ID + "x");
@@ -810,7 +854,7 @@ public class SnapshotTest {
     Get get = prepareAnotherGet();
     Put put = preparePut();
     snapshot.put(new Snapshot.Key(get), Optional.empty());
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.empty());
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult txResult = prepareResult(ANY_ID);
@@ -836,7 +880,7 @@ public class SnapshotTest {
     TransactionResult txResult = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, txResult);
     snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonList(key));
+    snapshot.put(scan, Collections.singletonMap(key, txResult));
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Scanner scanner = mock(Scanner.class);
@@ -864,7 +908,7 @@ public class SnapshotTest {
     TransactionResult txResult = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, txResult);
     snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonList(key));
+    snapshot.put(scan, Collections.singletonMap(key, txResult));
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult changedTxResult = prepareResult(ANY_ID + "x");
@@ -893,7 +937,7 @@ public class SnapshotTest {
     Scan scan = prepareScan();
     Put put = preparePut();
     TransactionResult result = prepareResult(ANY_ID + "x");
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult txResult = new TransactionResult(result);
@@ -964,8 +1008,8 @@ public class SnapshotTest {
     Snapshot.Key key1 = new Snapshot.Key(scan1, result1);
     Snapshot.Key key2 = new Snapshot.Key(scan2, result2);
 
-    snapshot.put(scan1, Collections.singletonList(key1));
-    snapshot.put(scan2, Collections.singletonList(key2));
+    snapshot.put(scan1, Collections.singletonMap(key1, new TransactionResult(result1)));
+    snapshot.put(scan2, Collections.singletonMap(key2, new TransactionResult(result2)));
     snapshot.put(key1, Optional.of(new TransactionResult(result1)));
     snapshot.put(key2, Optional.of(new TransactionResult(result2)));
 
@@ -1010,7 +1054,7 @@ public class SnapshotTest {
     TransactionResult result = prepareResultWithNullMetadata();
     TransactionResult txResult = new TransactionResult(result);
     snapshot.put(new Snapshot.Key(get), Optional.of(result));
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Get getWithProjections =
@@ -1035,7 +1079,7 @@ public class SnapshotTest {
     TransactionResult result = prepareResultWithNullMetadata();
     TransactionResult changedResult = prepareResult(ANY_ID);
     snapshot.put(new Snapshot.Key(get), Optional.of(result));
-    snapshot.put(get, new Snapshot.Key(get));
+    snapshot.put(get, Optional.of(result));
     snapshot.put(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Get getWithProjections =
@@ -1060,7 +1104,7 @@ public class SnapshotTest {
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
     snapshot.put(key, Optional.of(result));
-    snapshot.put(scan, Collections.singletonList(key));
+    snapshot.put(scan, Collections.singletonMap(key, result));
     DistributedStorage storage = mock(DistributedStorage.class);
     Scan scanWithProjections =
         Scan.newBuilder(scan)
@@ -1164,8 +1208,10 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.put(putKey, put);
     Scan scan = prepareScan();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(key, Optional.of(result));
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1183,7 +1229,7 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.put(putKey, put);
     Scan scan = prepareScan();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1207,7 +1253,7 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1232,7 +1278,7 @@ public class SnapshotTest {
             .consistency(Consistency.LINEARIZABLE)
             .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_4))
             .build();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1275,11 +1321,11 @@ public class SnapshotTest {
             // ["text1", "text2")
             .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
             .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
-    snapshot.put(scan1, Collections.emptyList());
-    snapshot.put(scan2, Collections.emptyList());
-    snapshot.put(scan3, Collections.emptyList());
-    snapshot.put(scan4, Collections.emptyList());
-    snapshot.put(scan5, Collections.emptyList());
+    snapshot.put(scan1, Collections.emptyMap());
+    snapshot.put(scan2, Collections.emptyMap());
+    snapshot.put(scan3, Collections.emptyMap());
+    snapshot.put(scan4, Collections.emptyMap());
+    snapshot.put(scan5, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
@@ -1326,9 +1372,9 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    snapshot.put(scan1, Collections.emptyList());
-    snapshot.put(scan2, Collections.emptyList());
-    snapshot.put(scan3, Collections.emptyList());
+    snapshot.put(scan1, Collections.emptyMap());
+    snapshot.put(scan2, Collections.emptyMap());
+    snapshot.put(scan3, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
@@ -1371,9 +1417,9 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    snapshot.put(scan1, Collections.emptyList());
-    snapshot.put(scan2, Collections.emptyList());
-    snapshot.put(scan3, Collections.emptyList());
+    snapshot.put(scan1, Collections.emptyMap());
+    snapshot.put(scan2, Collections.emptyMap());
+    snapshot.put(scan3, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
@@ -1399,8 +1445,9 @@ public class SnapshotTest {
             .table(ANY_TABLE_NAME)
             .indexKey(Key.ofText(ANY_NAME_4, ANY_TEXT_4))
             .build();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1428,8 +1475,9 @@ public class SnapshotTest {
             .table(ANY_TABLE_NAME)
             .indexKey(Key.ofText(ANY_NAME_4, ANY_TEXT_4))
             .build();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1468,8 +1516,9 @@ public class SnapshotTest {
             .table(ANY_TABLE_NAME)
             .indexKey(Key.ofText(ANY_NAME_4, ANY_TEXT_4))
             .build();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1511,8 +1560,9 @@ public class SnapshotTest {
             .indexKey(Key.ofText(ANY_NAME_4, ANY_TEXT_4))
             .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3))
             .build();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1534,8 +1584,9 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    Snapshot.Key key = new Snapshot.Key(scanAll, prepareResult(ANY_ID));
-    snapshot.put(scanAll, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scanAll, result);
+    snapshot.put(scanAll, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scanAll));
@@ -1558,14 +1609,31 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME_2)
             .forTable(ANY_TABLE_NAME_2);
-    Snapshot.Key key = new Snapshot.Key(scanAll, prepareResult(ANY_ID));
-    snapshot.put(scanAll, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scanAll, result);
+    snapshot.put(scanAll, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scanAll));
 
     // Assert
     assertThat(thrown).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void get_GetGivenAndAlreadyPresentInGetSet_ShouldReturnResult() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Get get = prepareGet();
+    TransactionResult expected = prepareResult(ANY_ID);
+    snapshot.put(get, Optional.of(expected));
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.get(get);
+
+    // Assert
+    assertThat(actual).isPresent();
+    assertThat(actual.get()).isEqualTo(expected);
   }
 
   @Test
@@ -1582,15 +1650,17 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME_2)
             .forTable(ANY_TABLE_NAME_2);
-    Snapshot.Key aKey = mock(Snapshot.Key.class);
-    snapshot.put(scanAll, Collections.singletonList(aKey));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scanAll, result);
+    snapshot.put(scanAll, Collections.singletonMap(key, result));
 
     // Act Assert
-    Optional<List<Snapshot.Key>> keys = snapshot.get(scanAll);
+    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.get(scanAll);
 
     // Assert
-    assertThat(keys).isNotEmpty();
-    assertThat(keys.get()).containsExactly(aKey);
+    assertThat(results).isNotEmpty();
+    assertThat(results.get()).containsKey(key);
+    assertThat(results.get().get(key)).isEqualTo(result);
   }
 
   @Test
@@ -1601,8 +1671,9 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.put(putKey, put);
     Scan scan = prepareCrossPartitionScan();
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1619,8 +1690,9 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.put(putKey, put);
     Scan scan = prepareCrossPartitionScan(ANY_NAMESPACE_NAME_2, ANY_TABLE_NAME);
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1637,8 +1709,9 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.put(putKey, put);
     Scan scan = prepareCrossPartitionScan(ANY_NAMESPACE_NAME, ANY_TABLE_NAME_2);
-    Snapshot.Key key = new Snapshot.Key(scan, prepareResult(ANY_ID));
-    snapshot.put(scan, Collections.singletonList(key));
+    TransactionResult result = prepareResult(ANY_ID);
+    Snapshot.Key key = new Snapshot.Key(scan, result);
+    snapshot.put(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1672,7 +1745,7 @@ public class SnapshotTest {
                             ConditionBuilder.column(ANY_NAME_8).isNullInt()))
                     .build())
             .build();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1695,7 +1768,7 @@ public class SnapshotTest {
             .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_1))
             .or(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_4))
             .build();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1718,7 +1791,7 @@ public class SnapshotTest {
             .where(ConditionBuilder.column(ANY_NAME_3).isLikeText("text%"))
             .and(ConditionBuilder.column(ANY_NAME_4).isNotLikeText("text"))
             .build();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1741,7 +1814,7 @@ public class SnapshotTest {
             .where(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_1))
             .or(ConditionBuilder.column(ANY_NAME_5).isEqualToText(ANY_TEXT_1))
             .build();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1759,7 +1832,7 @@ public class SnapshotTest {
     Snapshot.Key putKey = new Snapshot.Key(put);
     snapshot.put(putKey, put);
     Scan scan = Scan.newBuilder(prepareCrossPartitionScan()).clearConditions().build();
-    snapshot.put(scan, Collections.emptyList());
+    snapshot.put(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -1213,7 +1213,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   }
 
   @Test
-  public void getAndScan_CommitHappenedInBetween_ShouldReadRepeatably()
+  public void getThenScanAndGet_CommitHappenedInBetween_OnlyGetShouldReadRepeatably()
       throws TransactionException, ExecutionException {
     // Arrange
     populateRecordsWithNullMetadata(namespace1, TABLE_1);
@@ -1233,7 +1233,8 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
 
     // Assert
     assertThat(result1).isPresent();
-    assertThat(result1.get()).isEqualTo(result2);
+    assertThat(result1.get()).isNotEqualTo(result2);
+    assertThat(result2.getInt(BALANCE)).isEqualTo(2);
     assertThat(result1).isEqualTo(result3);
   }
 

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -3158,6 +3158,24 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
+  public void scan_CalledTwice_ShouldReturnFromSnapshotInSecondTime()
+      throws TransactionException, ExecutionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+
+    // Act
+    List<Result> result1 = transaction.scan(scan);
+    List<Result> result2 = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    verify(storage).scan(any(Scan.class));
+    assertThat(result1).isEqualTo(result2);
+  }
+
+  @Test
   public void scan_CalledTwiceWithSameConditionsAndUpdateForHappenedInBetween_ShouldReadRepeatably()
       throws TransactionException {
     // Arrange

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -1056,7 +1056,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void getAndScan_CommitHappenedInBetween_ShouldReadRepeatably()
+  public void getThenScanAndGet_CommitHappenedInBetween_OnlyGetShouldReadRepeatably()
       throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
@@ -1078,7 +1078,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(result1).isPresent();
-    assertThat(result1.get()).isEqualTo(result2);
+    assertThat(result1.get()).isNotEqualTo(result2);
+    assertThat(result2.getInt(BALANCE)).isEqualTo(2);
     assertThat(result1).isEqualTo(result3);
   }
 
@@ -2464,7 +2465,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void get_PutCalledBefore_ShouldGet() throws TransactionException {
+  public void get_PutThenGetWithoutConjunctionReturnEmptyFromStorage_ShouldReturnResult()
+      throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
 
@@ -2477,6 +2479,71 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Assert
     assertThat(result).isPresent();
     assertThat(getBalance(result.get())).isEqualTo(1);
+  }
+
+  @Test
+  public void get_PutThenGetWithConjunctionReturnEmptyFromStorage_ShouldReturnEmpty()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    Get get =
+        Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
+            .where(ConditionBuilder.column(BALANCE).isEqualToInt(1))
+            .build();
+    Optional<Result> result = transaction.get(get);
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+
+    // Assert
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
+  public void
+      get_PutThenGetWithConjunctionReturnResultFromStorageAndMatchedWithPut_ShouldReturnResult()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1);
+    Get get =
+        Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
+            .where(ConditionBuilder.column(BALANCE).isLessThanOrEqualToInt(INITIAL_BALANCE))
+            .build();
+
+    // Act
+    transaction.put(put);
+    Optional<Result> result = transaction.get(get);
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+
+    // Assert
+    assertThat(result).isPresent();
+    assertThat(getBalance(result.get())).isEqualTo(1);
+  }
+
+  @Test
+  public void
+      get_PutThenGetWithConjunctionReturnResultFromStorageButUnmatchedWithPut_ShouldReturnEmpty()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin();
+    Put put = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1);
+    Get get =
+        Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
+            .where(ConditionBuilder.column(BALANCE).isEqualToInt(0))
+            .build();
+
+    // Act
+    transaction.put(put);
+    Optional<Result> result = transaction.get(get);
+    assertThat(catchThrowable(transaction::commit)).isInstanceOf(CommitConflictException.class);
+    transaction.rollback();
+
+    // Assert
+    assertThat(result).isNotPresent();
   }
 
   @Test
@@ -2787,6 +2854,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(results.size()).isEqualTo(1);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(1);
   }
 
   @Test
@@ -3064,6 +3133,85 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(result.isPresent()).isFalse();
+  }
+
+  @Test
+  public void scan_CalledTwiceWithSameConditionsAndUpdateForHappenedInBetween_ShouldReadRepeatably()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.commit();
+
+    DistributedTransaction transaction1 = manager.begin();
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .start(Key.ofInt(ACCOUNT_TYPE, 0))
+            .where(ConditionBuilder.column(BALANCE).isEqualToInt(1))
+            .build();
+    List<Result> result1 = transaction1.scan(scan);
+
+    DistributedTransaction transaction2 = manager.begin();
+    transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
+    transaction2.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 0));
+    transaction2.commit();
+
+    // Act
+    List<Result> result2 = transaction1.scan(scan);
+    transaction1.commit();
+
+    // Assert
+    assertThat(result1.size()).isEqualTo(1);
+    assertThat(result2.size()).isEqualTo(1);
+    assertThat(result1.get(0)).isEqualTo(result2.get(0));
+  }
+
+  @Test
+  public void
+      scan_CalledTwiceWithDifferentConditionsAndUpdateHappenedInBetween_ShouldNotReadRepeatably()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    transaction.commit();
+
+    DistributedTransaction transaction1 = manager.begin();
+    Scan scan1 =
+        Scan.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .start(Key.ofInt(ACCOUNT_TYPE, 0))
+            .where(ConditionBuilder.column(BALANCE).isEqualToInt(1))
+            .build();
+    Scan scan2 =
+        Scan.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .start(Key.ofInt(ACCOUNT_TYPE, 0))
+            .where(ConditionBuilder.column(BALANCE).isGreaterThanInt(1))
+            .build();
+    List<Result> result1 = transaction1.scan(scan1);
+
+    DistributedTransaction transaction2 = manager.begin();
+    transaction2.get(prepareGet(0, 0, namespace1, TABLE_1));
+    transaction2.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 2));
+    transaction2.commit();
+
+    // Act
+    List<Result> result2 = transaction1.scan(scan2);
+    transaction1.commit();
+
+    // Assert
+    assertThat(result1.size()).isEqualTo(1);
+    assertThat(result2.size()).isEqualTo(1);
+    assertThat(result1.get(0)).isNotEqualTo(result2.get(0));
+    assertThat(result1.get(0).getInt(BALANCE)).isEqualTo(1);
+    assertThat(result2.get(0).getInt(BALANCE)).isEqualTo(2);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -2482,8 +2482,9 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void get_PutThenGetWithConjunctionReturnEmptyFromStorage_ShouldReturnEmpty()
-      throws TransactionException {
+  public void
+      get_PutThenGetWithConjunctionReturnEmptyFromStorageAndMatchedWithPut_ShouldReturnResult()
+          throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
 
@@ -2492,6 +2493,27 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     Get get =
         Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
             .where(ConditionBuilder.column(BALANCE).isEqualToInt(1))
+            .build();
+    Optional<Result> result = transaction.get(get);
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+
+    // Assert
+    assertThat(result).isPresent();
+    assertThat(getBalance(result.get())).isEqualTo(1);
+  }
+
+  @Test
+  public void
+      get_PutThenGetWithConjunctionReturnEmptyFromStorageAndUnmatchedWithPut_ShouldReturnEmpty()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
+    Get get =
+        Get.newBuilder(prepareGet(0, 0, namespace1, TABLE_1))
+            .where(ConditionBuilder.column(BALANCE).isEqualToInt(0))
             .build();
     Optional<Result> result = transaction.get(get);
     assertThatCode(transaction::commit).doesNotThrowAnyException();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -1012,7 +1012,7 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void getAndScan_CommitHappenedInBetween_ShouldReadRepeatably()
+  public void getThenScanAndGet_CommitHappenedInBetween_OnlyGetShouldReadRepeatably()
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1037,7 +1037,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(result1).isPresent();
-    assertThat(result1.get()).isEqualTo(result2);
+    assertThat(result1.get()).isNotEqualTo(result2);
+    assertThat(result2.getInt(BALANCE)).isEqualTo(2);
     assertThat(result1).isEqualTo(result3);
   }
 


### PR DESCRIPTION
## Description

This PR fixes a snapshot management issue, which occurs when a transaction issues multiple different get or scan operations with different conditions, and another transaction updates and commits the related record in between those operations. See an example situation below.

| ID  | Balance |
|-----|---------|
| 1   | 5       |
| 2   | 10      |
| 3   | 15      |

1. A transaction (Tx1) scans with a condition where balance > 0, then the read set will be filled with all records.
2. Another transaction (Tx2) updates ID=2 with 5 and commits.
3. Ongoing Tx1 scans with a different condition where balance < 10.

Currently, Tx1’s snapshot returns results from the read set if the key returned from storage already exists in the read set. So, in the above example, the client will see the records (1, 5) and (2, 10), which are obviously inconsistent with the query.

This PR fixes this issue by making different get and scan operations always return results from storage, although if they are the same operations, then the transaction returns from the snapshot.

## Related issues and/or PRs

- #1834

## Changes made

- Introduce operation-based snapshot using `getSet` and`scanSet` instead of key-based snapshot using `readSet`
- Only use `readSet` to keep the latest results for creating the before image

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

See inline comments for details.

## Release notes

Fixed snapshot management issues.