### PR TITLE
[3.7~3.11] Fix error in integration test with Java 21 as runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
         jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.10.1'
         commonsLangVersion = '3.14.0'
-        assertjVersion = '3.24.2'
+        assertjVersion = '3.26.0'
         mockitoVersion = '4.11.0'
         spotbugsVersion = '4.8.3'
         errorproneVersion = '2.10.0'


### PR DESCRIPTION
## Description

Integration tests [fail ](https://github.com/scalar-labs/scalardb/actions/runs/9594384574) when using Java 21 as the runtime because the `net.bytebuddy:byte-buddy` library current version is incompatible with Java 21. This library is a transitive dependency of `AsserJ` and `Mockito`. 
This PR updates this dependency to a version that supports Java 21.

## Related issues and/or PRs

N/A

## Changes made

I updated `AsserJ` so that its transitive dependency `net.bytebuddy:byte-buddy` is updated to a version that supports Java 21.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- CI run without the fix with Java 21 as runtime: https://github.com/scalar-labs/scalardb/actions/runs/9594384574
- CI run including the fix with Java 21 as runtime : https://github.com/scalar-labs/scalardb/actions/runs/9637838669

## Release notes

N/A