### PR TITLE
Fix CVE-2024-24790, CVE-2023-45283, and CVE-2023-45288

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.22
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.28
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/


### PR DESCRIPTION
## Description

This PR fixes CVE-2024-24790, CVE-2023-45283, and CVE-2023-45288 by bumping up `grpc_health_probe` to `v0.4.28`.

## Related issues and/or PRs

N/A

## Changes made

- Bumped up `grpc_health_probe` to `v0.4.28`.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Upgraded `grpc_health_probe` to fix security issues. CVE-2024-24790, CVE-2023-45283, and CVE-2023-45288
