### PR TITLE
Backport to branch(3.11) : Fix CVE-2024-24790, CVE-2023-45283, and CVE-2023-45288

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.22
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.28
 ENV DOCKERIZE_VERSION v0.6.1
 
 # Install grpc_health_probe for kubernetes.


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1980