### PR TITLE
Backport to branch(3) : Allow to specify global properties for all storages in multi-storage

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -54,9 +54,23 @@ public class MultiStorageConfig {
       return ImmutableMap.of();
     }
 
+    // Create a new Properties object for each storage
     ImmutableMap.Builder<String, Properties> builder = ImmutableMap.builder();
     for (String storage : storages) {
       Properties dbProps = new Properties();
+
+      // Put all properties unrelated to multi-storage first for global properties for all storages
+      for (String propertyName : properties.stringPropertyNames()) {
+        if (!propertyName.startsWith(PREFIX)) {
+          dbProps.put(propertyName, properties.getProperty(propertyName));
+        }
+      }
+
+      // Put all properties related to the current storage while removing
+      // `multi_storage.storages.<storage name>.` from the property name. For example, if the
+      // storage name is `cassandra`, and if the property name is
+      // `scalar.db.multi_storage.storages.cassandra.storage`, then we put the property with the key
+      // `scalar.db.storage`.
       for (String propertyName : properties.stringPropertyNames()) {
         if (propertyName.startsWith(STORAGES + "." + storage + ".")) {
           dbProps.put(
@@ -70,8 +84,10 @@ public class MultiStorageConfig {
             CoreError.MULTI_STORAGE_NESTED_MULTI_STORAGE_DEFINITION_NOT_SUPPORTED.buildMessage(
                 storage));
       }
+
       builder.put(storage, dbProps);
     }
+
     return builder.build();
   }
 

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageConfigTest.java
@@ -37,6 +37,9 @@ public class MultiStorageConfigTest {
 
     props.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "cassandra");
 
+    // Global properties for all storages
+    props.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN, "true");
+
     // Act
     MultiStorageConfig config = new MultiStorageConfig(new DatabaseConfig(props));
 
@@ -52,6 +55,7 @@ public class MultiStorageConfigTest {
     assertThat(c.getUsername().get()).isEqualTo("cassandra");
     assertThat(c.getPassword().isPresent()).isTrue();
     assertThat(c.getPassword().get()).isEqualTo("cassandra");
+    assertThat(c.isCrossPartitionScanEnabled()).isTrue();
 
     assertThat(config.getDatabasePropertiesMap().containsKey("mysql")).isTrue();
     c = new DatabaseConfig(config.getDatabasePropertiesMap().get("mysql"));
@@ -62,6 +66,7 @@ public class MultiStorageConfigTest {
     assertThat(c.getUsername().get()).isEqualTo("root");
     assertThat(c.getPassword().isPresent()).isTrue();
     assertThat(c.getPassword().get()).isEqualTo("mysql");
+    assertThat(c.isCrossPartitionScanEnabled()).isTrue();
 
     assertThat(config.getTableStorageMap().size()).isEqualTo(3);
     assertThat(config.getTableStorageMap().get("user.order")).isEqualTo("cassandra");


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1486
