### PR TITLE
Change some JDBC data types to proper ones

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -184,8 +184,9 @@ class RdbEngineMysql implements RdbEngineStrategy {
       case BOOLEAN:
         return "BOOLEAN";
       case DOUBLE:
-      case FLOAT:
         return "DOUBLE";
+      case FLOAT:
+        return "REAL";
       case INT:
         return "INT";
       case TEXT:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -196,7 +196,7 @@ class RdbEngineOracle implements RdbEngineStrategy {
       case FLOAT:
         return "BINARY_FLOAT";
       case INT:
-        return "INT";
+        return "NUMBER(10)";
       case TEXT:
         return "VARCHAR2(4000)";
       default:

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -192,7 +192,7 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
       case DOUBLE:
         return "DOUBLE PRECISION";
       case FLOAT:
-        return "FLOAT";
+        return "REAL";
       case INT:
         return "INT";
       case TEXT:

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -451,7 +451,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_ForX_CreateTableAndIndexes(
         RdbEngine.MYSQL,
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` DOUBLE, PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
         "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
         "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)");
   }
@@ -461,7 +461,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_ForX_CreateTableAndIndexes(
         RdbEngine.POSTGRESQL,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
         "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
         "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
@@ -483,7 +483,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_ForX_CreateTableAndIndexes(
         RdbEngine.ORACLE,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" INT,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
         "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
         "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
@@ -548,7 +548,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_IfNotExistsForX_createTableAndIndexesIfNotExists(
         RdbEngine.MYSQL,
-        "CREATE TABLE IF NOT EXISTS `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` DOUBLE, PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
+        "CREATE TABLE IF NOT EXISTS `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
         "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
         "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)");
   }
@@ -558,7 +558,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_IfNotExistsForX_createTableAndIndexesIfNotExists(
         RdbEngine.POSTGRESQL,
-        "CREATE TABLE IF NOT EXISTS \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE TABLE IF NOT EXISTS \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
         "CREATE UNIQUE INDEX IF NOT EXISTS \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
         "CREATE INDEX IF NOT EXISTS \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
         "CREATE INDEX IF NOT EXISTS \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")");
@@ -580,7 +580,7 @@ public class JdbcAdminTest {
       throws ExecutionException, SQLException {
     createTableInternal_IfNotExistsForX_createTableAndIndexesIfNotExists(
         RdbEngine.ORACLE,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" INT,\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
         "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
         "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
         "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
@@ -2374,7 +2374,7 @@ public class JdbcAdminTest {
         "SELECT \"column_name\",\"data_type\",\"key_type\",\"clustering_order\",\"indexed\" FROM \""
             + METADATA_SCHEMA
             + "\".\"metadata\" WHERE \"full_table_name\"=? ORDER BY \"ordinal_position\" ASC",
-        "ALTER TABLE \"ns\".\"table\" ADD \"c2\" INT",
+        "ALTER TABLE \"ns\".\"table\" ADD \"c2\" NUMBER(10)",
         "DELETE FROM \""
             + METADATA_SCHEMA
             + "\".\"metadata\" WHERE \"full_table_name\" = 'ns.table'",
@@ -2867,11 +2867,18 @@ public class JdbcAdminTest {
 
   private String prepareSqlForAlterTableAddColumn(RdbEngine rdbEngine, String column) {
     RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    String intType;
+    if (rdbEngineStrategy instanceof RdbEngineOracle) {
+      intType = "NUMBER(10)";
+    } else {
+      intType = "INT";
+    }
     return "ALTER TABLE "
         + rdbEngineStrategy.encloseFullTableName(NAMESPACE, TABLE)
         + " ADD "
         + rdbEngineStrategy.enclose(column)
-        + " INT";
+        + " "
+        + intType;
   }
 
   private RdbEngineStrategy getRdbEngineStrategy(RdbEngine rdbEngine) {

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -619,9 +619,9 @@ The following table shows the supported data types in ScalarDB and their mapping
 | ScalarDB  | Cassandra | Cosmos DB for NoSQL | DynamoDB | MySQL    | PostgreSQL/YugabyteDB | Oracle         | SQL Server      | SQLite  |
 |-----------|-----------|---------------------|----------|----------|-----------------------|----------------|-----------------|---------|
 | BOOLEAN   | boolean   | boolean (JSON)      | BOOL     | boolean  | boolean               | number(1)      | bit             | boolean |
-| INT       | int       | number (JSON)       | N        | int      | int                   | int            | int             | int     |
+| INT       | int       | number (JSON)       | N        | int      | int                   | number(10)     | int             | int     |
 | BIGINT    | bigint    | number (JSON)       | N        | bigint   | bigint                | number(19)     | bigint          | bigint  |
-| FLOAT     | float     | number (JSON)       | N        | double   | float                 | binary_float   | float(24)       | float   |
+| FLOAT     | float     | number (JSON)       | N        | real     | real                  | binary_float   | float(24)       | float   |
 | DOUBLE    | double    | number (JSON)       | N        | double   | double precision      | binary_double  | float           | double  |
 | TEXT      | text      | string (JSON)       | S        | longtext | text                  | varchar2(4000) | varchar(8000)   | text    |
 | BLOB      | blob      | string (JSON)       | B        | longblob | bytea                 | RAW(2000)      | varbinary(8000) | blob    |


### PR DESCRIPTION
## Description

We noticed there was room to improve some JDBC storage column types.

The current data type mapping is as follows:
| RDBMS Storage Type | ScalarDB: INT | ScalarDB: BIGINT | ScalarDB: FLOAT | ScalarDB: DOUBLE |
|----|----|----|----|----|
| Oracle | Oracle:`INT` (==`NUMBER(38)`) | `NUMBER(19)` | - | - |
| PostgreSQL | - | - | PG:`FLOAT` (==`DOUBLE PRECISION`) | PG:`DOUBLE PRECISION` |
| MySQL | - | - | MySQL:`DOUBLE` | PG:`DOUBLE` |

ScalarDB's `INT` type is larger than `BIGINT` in Oracle. Also, ScalarDB's `FLOAT` and `DOUBLE` are the same data type in PostgreSQL and MySQL.

This PR changes the data type mapping as follows:
- In Oracle, ScalarDB `INT` type is changed from `INT` (`NUMBER(38)`) to `NUMBER(10)`
- In PostgreSQL, ScalarDB `FLOAT` type is changed from `FLOAT` (`DOUBLE PRECISION`) to `REAL` (single-precision floating-point value)
- In MySQL, ScalarDB `FLOAT` type is changed from `DOUBLE` to `REAL` (single-precision floating-point value)

Indeed, we need to consider the compatibility. But @brfrn169 and I discussed it, and concluded to fix the issue as early as possible.

## Related issues and/or PRs

None

## Changes made

- Update the data type mapping logic of `com.scalar.db.storage.jdbc.RdbEngineXxxx.getDataTypeForEngine()` to align with the above description
- Update related unit tests

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

Change some data types of JDBC storages:
- In Oracle, ScalarDB `INT` type is changed from `INT` (`NUMBER(38)`) to `NUMBER(10)`
- In PostgreSQL, ScalarDB `FLOAT` type is changed from `FLOAT` (`DOUBLE PRECISION`) to `REAL` (single-precision floating-point value)
- In MySQL, ScalarDB `FLOAT` type is changed from `DOUBLE` to `REAL` (single-precision floating-point value)