### PR TITLE
Fix a bug that the importing table feature accesses tables in other namespace that have the same table name with MySQL storage

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -70,6 +70,14 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
     super.importTables_ImportableTablesGiven_ShouldImportProperly();
   }
 
+  @Test
+  @Override
+  @DisabledIf("isSqlite")
+  public void importTables_ImportableTablesAndNonRelatedSameNameTableGiven_ShouldImportProperly()
+      throws Exception {
+    super.importTables_ImportableTablesAndNonRelatedSameNameTableGiven_ShouldImportProperly();
+  }
+
   @Override
   public void afterAll() {
     try {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -505,13 +505,16 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
+      String rawCatalogName = rdbEngine.rawCatalogName(namespace);
+      String rawSchemaName = rdbEngine.rawSchemaName(namespace);
+
       if (!tableExistsInternal(connection, namespace, table)) {
         throw new IllegalArgumentException(
             CoreError.TABLE_NOT_FOUND.buildMessage(getFullTableName(namespace, table)));
       }
 
       DatabaseMetaData metadata = connection.getMetaData();
-      ResultSet resultSet = metadata.getPrimaryKeys(null, namespace, table);
+      ResultSet resultSet = metadata.getPrimaryKeys(rawCatalogName, rawSchemaName, table);
       while (resultSet.next()) {
         primaryKeyExists = true;
         String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
@@ -524,7 +527,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                 getFullTableName(namespace, table)));
       }
 
-      resultSet = metadata.getColumns(null, namespace, table, "%");
+      resultSet = metadata.getColumns(rawCatalogName, rawSchemaName, table, "%");
       while (resultSet.next()) {
         String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
         builder.addColumn(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -505,8 +505,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
-      String rawCatalogName = rdbEngine.getRawCatalogName(namespace);
-      String rawSchemaName = rdbEngine.getRawSchemaName(namespace);
+      String rawCatalogName = rdbEngine.getCatalogName(namespace);
+      String rawSchemaName = rdbEngine.getSchemaName(namespace);
 
       if (!tableExistsInternal(connection, namespace, table)) {
         throw new IllegalArgumentException(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -505,8 +505,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
-      String rawCatalogName = rdbEngine.getCatalogName(namespace);
-      String rawSchemaName = rdbEngine.getSchemaName(namespace);
+      String catalogName = rdbEngine.getCatalogName(namespace);
+      String schemaName = rdbEngine.getSchemaName(namespace);
 
       if (!tableExistsInternal(connection, namespace, table)) {
         throw new IllegalArgumentException(
@@ -514,7 +514,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
       }
 
       DatabaseMetaData metadata = connection.getMetaData();
-      ResultSet resultSet = metadata.getPrimaryKeys(rawCatalogName, rawSchemaName, table);
+      ResultSet resultSet = metadata.getPrimaryKeys(catalogName, schemaName, table);
       while (resultSet.next()) {
         primaryKeyExists = true;
         String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
@@ -527,7 +527,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                 getFullTableName(namespace, table)));
       }
 
-      resultSet = metadata.getColumns(rawCatalogName, rawSchemaName, table, "%");
+      resultSet = metadata.getColumns(catalogName, schemaName, table, "%");
       while (resultSet.next()) {
         String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
         builder.addColumn(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -505,8 +505,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
-      String rawCatalogName = rdbEngine.rawCatalogName(namespace);
-      String rawSchemaName = rdbEngine.rawSchemaName(namespace);
+      String rawCatalogName = rdbEngine.getRawCatalogName(namespace);
+      String rawSchemaName = rdbEngine.getRawSchemaName(namespace);
 
       if (!tableExistsInternal(connection, namespace, table)) {
         throw new IllegalArgumentException(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -358,13 +358,13 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Nullable
   @Override
-  public String getRawCatalogName(String namespace) {
+  public String getCatalogName(String namespace) {
     return namespace;
   }
 
   @Nullable
   @Override
-  public String getRawSchemaName(String namespace) {
+  public String getSchemaName(String namespace) {
     // This can be null. However, we return the namespace from this method just in case since users
     // might be able to set `databaseTerm` property to `SCHEMA` so that a return value from this
     // method is used for filtering.

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -358,13 +358,16 @@ class RdbEngineMysql implements RdbEngineStrategy {
 
   @Nullable
   @Override
-  public String rawCatalogName(String namespace) {
+  public String getRawCatalogName(String namespace) {
     return namespace;
   }
 
   @Nullable
   @Override
-  public String rawSchemaName(String namespace) {
+  public String getRawSchemaName(String namespace) {
+    // This can be null. However, we return the namespace from this method just in case since users
+    // might be able to set `databaseTerm` property to `SCHEMA` so that a return value from this
+    // method is used for filtering.
     return namespace;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -353,5 +354,17 @@ class RdbEngineMysql implements RdbEngineStrategy {
   @Override
   public String tryAddIfNotExistsToCreateIndexSql(String createIndexSql) {
     return createIndexSql;
+  }
+
+  @Nullable
+  @Override
+  public String rawCatalogName(String namespace) {
+    return namespace;
+  }
+
+  @Nullable
+  @Override
+  public String rawSchemaName(String namespace) {
+    return namespace;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -123,4 +123,12 @@ public interface RdbEngineStrategy {
   boolean isDuplicateIndexError(SQLException e);
 
   String tryAddIfNotExistsToCreateIndexSql(String createIndexSql);
+
+  default @Nullable String rawCatalogName(String namespace) {
+    return null;
+  }
+
+  default @Nullable String rawSchemaName(String namespace) {
+    return namespace;
+  }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -124,11 +124,11 @@ public interface RdbEngineStrategy {
 
   String tryAddIfNotExistsToCreateIndexSql(String createIndexSql);
 
-  default @Nullable String rawCatalogName(String namespace) {
+  default @Nullable String getRawCatalogName(String namespace) {
     return null;
   }
 
-  default @Nullable String rawSchemaName(String namespace) {
+  default @Nullable String getRawSchemaName(String namespace) {
     return namespace;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -124,11 +124,11 @@ public interface RdbEngineStrategy {
 
   String tryAddIfNotExistsToCreateIndexSql(String createIndexSql);
 
-  default @Nullable String getRawCatalogName(String namespace) {
+  default @Nullable String getCatalogName(String namespace) {
     return null;
   }
 
-  default @Nullable String getRawSchemaName(String namespace) {
+  default @Nullable String getSchemaName(String namespace) {
     return namespace;
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -2679,7 +2679,13 @@ public class JdbcAdminTest {
     when(connection.createStatement()).thenReturn(checkTableExistStatement);
     when(connection.getMetaData()).thenReturn(metadata);
     when(primaryKeyResults.next()).thenReturn(false);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    }
+
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
     String description = "database engine specific test failed: " + rdbEngine;
 
@@ -2721,8 +2727,16 @@ public class JdbcAdminTest {
     when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("timestamp");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
-    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(NAMESPACE, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    }
+
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
     String description = "database engine specific test failed: " + rdbEngine;
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -2589,8 +2589,14 @@ public class JdbcAdminTest {
         .thenReturn("");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0).thenReturn(0).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0).thenReturn(0).thenReturn(0);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
-    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(NAMESPACE, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    }
 
     Map<String, DataType> expectedColumns = new LinkedHashMap<>();
     expectedColumns.put("pk1", DataType.TEXT);

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -619,9 +619,9 @@ The following table shows the supported data types in ScalarDB and their mapping
 | ScalarDB  | Cassandra | Cosmos DB for NoSQL | DynamoDB | MySQL    | PostgreSQL/YugabyteDB | Oracle         | SQL Server      | SQLite  |
 |-----------|-----------|---------------------|----------|----------|-----------------------|----------------|-----------------|---------|
 | BOOLEAN   | boolean   | boolean (JSON)      | BOOL     | boolean  | boolean               | number(1)      | bit             | boolean |
-| INT       | int       | number (JSON)       | N        | int      | int                   | number(10)     | int             | int     |
+| INT       | int       | number (JSON)       | N        | int      | int                   | int            | int             | int     |
 | BIGINT    | bigint    | number (JSON)       | N        | bigint   | bigint                | number(19)     | bigint          | bigint  |
-| FLOAT     | float     | number (JSON)       | N        | real     | real                  | binary_float   | float(24)       | float   |
+| FLOAT     | float     | number (JSON)       | N        | double   | float                 | binary_float   | float(24)       | float   |
 | DOUBLE    | double    | number (JSON)       | N        | double   | double precision      | binary_double  | float           | double  |
 | TEXT      | text      | string (JSON)       | S        | longtext | text                  | varchar2(4000) | varchar(8000)   | text    |
 | BLOB      | blob      | string (JSON)       | B        | longblob | bytea                 | RAW(2000)      | varbinary(8000) | blob    |

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -619,9 +619,9 @@ The following table shows the supported data types in ScalarDB and their mapping
 | ScalarDB  | Cassandra | Cosmos DB for NoSQL | DynamoDB | MySQL    | PostgreSQL/YugabyteDB | Oracle         | SQL Server      | SQLite  |
 |-----------|-----------|---------------------|----------|----------|-----------------------|----------------|-----------------|---------|
 | BOOLEAN   | boolean   | boolean (JSON)      | BOOL     | boolean  | boolean               | number(1)      | bit             | boolean |
-| INT       | int       | number (JSON)       | N        | int      | int                   | int            | int             | int     |
+| INT       | int       | number (JSON)       | N        | int      | int                   | number(10)     | int             | int     |
 | BIGINT    | bigint    | number (JSON)       | N        | bigint   | bigint                | number(19)     | bigint          | bigint  |
-| FLOAT     | float     | number (JSON)       | N        | double   | float                 | binary_float   | float(24)       | float   |
+| FLOAT     | float     | number (JSON)       | N        | real     | real                  | binary_float   | float(24)       | float   |
 | DOUBLE    | double    | number (JSON)       | N        | double   | double precision      | binary_double  | float           | double  |
 | TEXT      | text      | string (JSON)       | S        | longtext | text                  | varchar2(4000) | varchar(8000)   | text    |
 | BLOB      | blob      | string (JSON)       | B        | longblob | bytea                 | RAW(2000)      | varbinary(8000) | blob    |

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -196,7 +196,9 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
     waitForDifferentSessionDdl();
     createImportableTable(namespace2, TABLE_2);
 
-    // Create a non-related table with the same name.
+    // Create non-related tables.
+    waitForDifferentSessionDdl();
+    createNonImportableTable(namespace1, TABLE_2);
     waitForDifferentSessionDdl();
     createNonImportableTable(namespace2, TABLE_1);
 
@@ -212,7 +214,17 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
       assertThat(storageAdmin.tableExists(namespace2, TABLE_2)).isTrue();
       assertThat(transactionAdmin.coordinatorTablesExist()).isFalse();
     } finally {
-      dropNonImportableTable(namespace2, TABLE_1);
+      try {
+        dropNonImportableTable(namespace1, TABLE_2);
+      } catch (Exception e) {
+        logger.warn("Failed to drop non-importable table. {}.{}", namespace1, TABLE_2, e);
+      }
+
+      try {
+        dropNonImportableTable(namespace2, TABLE_1);
+      } catch (Exception e) {
+        logger.warn("Failed to drop non-importable table. {}.{}", namespace2, TABLE_1, e);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

I found that the current implementation of the import-table feature could access tables in other namespace that have the same table name when using MySQL storage. For example, in the following situation, the metadata of the columns `pk_unexpected` and `col_unexpected` of `ns2.tbl1` are handled and the import-table feature fails due to unsupported data types.

| namespace | table | column |
|----|----|----|
| ns1 | tbl1 | pk1 INT |
|  |  | col2 TEXT |
| ns1 | tbl2 | pk2 INT |
|  |  | col2 TEXT |
| ns2 | tbl1 | pk_unexpected DATE |
|  |  | col_unexpected JSON |

https://bugs.mysql.com/bug.php?id=94223

> Actually, it was never working in c/J, schemaPattern is ignored.

This comment fits what I observed. And [the implementation](https://github.com/mysql/mysql-connector-j/blob/release/8.x/src/main/user-impl/java/com/mysql/cj/jdbc/DatabaseMetaData.java#L2084) seems to use `catalog` unless a special property `DatabaseTerm.SCHEMA` is set.

This PR takes care of the issue by introducing `com.scalar.db.storage.jdbc.RdbEngineStrategy.rawCatalogName()` and `rawSchemaName()`.

## Related issues and/or PRs

None

## Changes made

- Add `rawCatalogName()` and `rawSchemaName()` to `com.scalar.db.storage.jdbc.RdbEngineStrategy`
- Override the methods to pass ScalarDB namespace as `catalog` as well as `schema` in case of MySQL storage
- Use return values from `rawCatalogName()` and `rawSchemaName()` as the parameters of `java.sql.DatabaseMetaData#getPrimaryKeys` and `java.sql.DatabaseMetaData#getColumns`
- Update related unit tests
- Add an integration test case to reproduce the issue

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The integration test which is added in this PR fails without the fix https://github.com/scalar-labs/scalardb/actions/runs/9675571099.

## Release notes

Fix a bug of the import-table feature that it could access tables in other namespace that have the same table name when using MySQL storage. For example, in the following situation, the metadata of the columns `pk_unexpected` and `col_unexpected` of `ns2.tbl1` are handled and the import-table feature fails due to unsupported data types.

| namespace | table | column |
|----|----|----|
| ns1 | tbl1 | pk1 INT |
|  |  | col2 TEXT |
| ns1 | tbl2 | pk2 INT |
|  |  | col2 TEXT |
| ns2 | tbl1 | pk_unexpected DATE |
|  |  | col_unexpected JSON |
