### PR TITLE
Support listing namespaces for ScalarDB v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,13 +104,13 @@ jobs:
       - name: Dockerfile Lint for ScalarDB Server
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: ':server:dockerfileLint'
+          arguments: :server:dockerfileLint
 
       - name: Dockerfile Lint for ScalarDB Schema Loader
         if: always()
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: ':schema-loader:dockerfileLint'
+          arguments: :schema-loader:dockerfileLint
 
   build-check-example-project:
     name: Build check for 'Getting Started' example project

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,13 +104,13 @@ jobs:
       - name: Dockerfile Lint for ScalarDB Server
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: :server:dockerfileLint
+          arguments: ':server:dockerfileLint'
 
       - name: Dockerfile Lint for ScalarDB Schema Loader
         if: always()
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: :schema-loader:dockerfileLint
+          arguments: ':schema-loader:dockerfileLint'
 
   build-check-example-project:
     name: Build check for 'Getting Started' example project

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraAdminIntegrationTest.java
@@ -1,11 +1,19 @@
 package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
 import java.util.Properties;
 
 public class CassandraAdminIntegrationTest extends DistributedStorageAdminIntegrationTestBase {
   @Override
   protected Properties getProperties(String testName) {
     return CassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new CassandraConfig(new DatabaseConfig(properties))
+        .getSystemNamespaceName()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.cassandra;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Properties;
 
@@ -8,5 +9,12 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
   @Override
   protected Properties getProps(String testName) {
     return CassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new CassandraConfig(new DatabaseConfig(properties))
+        .getSystemNamespaceName()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/SingleCrudOperationTransactionAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/SingleCrudOperationTransactionAdminIntegrationTestWithCassandra.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.cassandra;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Collections;
 import java.util.Map;
@@ -16,5 +17,10 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithCassandra
   @Override
   protected Map<String, String> getCreationOptions() {
     return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME;
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.cosmos;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Properties;
@@ -15,5 +16,12 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
   @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new CosmosConfig(new DatabaseConfig(properties))
+        .getTableMetadataDatabase()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
 import java.util.Map;
 import java.util.Properties;
 
@@ -14,5 +15,12 @@ public class CosmosAdminIntegrationTest extends DistributedStorageAdminIntegrati
   @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new CosmosConfig(new DatabaseConfig(properties))
+        .getTableMetadataDatabase()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosAdminTestUtils.java
@@ -35,7 +35,7 @@ public class CosmosAdminTestUtils extends AdminTestUtils {
     metadataDatabase =
         new CosmosConfig(new DatabaseConfig(properties))
             .getTableMetadataDatabase()
-            .orElse(CosmosAdmin.METADATA_DATABASE);
+            .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   @Override

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosEnv.java
@@ -29,7 +29,8 @@ public final class CosmosEnv {
 
     // Add testName as a metadata database suffix
     props.setProperty(
-        CosmosConfig.TABLE_METADATA_DATABASE, CosmosAdmin.METADATA_DATABASE + "_" + testName);
+        CosmosConfig.TABLE_METADATA_DATABASE,
+        DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME + "_" + testName);
 
     return props;
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/SingleCrudOperationTransactionAdminIntegrationTestWithCosmos.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.cosmos;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Properties;
@@ -15,5 +16,12 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithCosmos
   @Override
   protected Map<String, String> getCreationOptions() {
     return CosmosEnv.getCreationOptions();
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new CosmosConfig(new DatabaseConfig(properties))
+        .getTableMetadataDatabase()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.dynamo;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Properties;
@@ -22,6 +23,13 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
   @Override
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new DynamoConfig(new DatabaseConfig(properties))
+        .getTableMetadataNamespace()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
@@ -21,6 +22,13 @@ public class DynamoAdminIntegrationTest extends DistributedStorageAdminIntegrati
   @Override
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new DynamoConfig(new DatabaseConfig(properties))
+        .getTableMetadataNamespace()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoAdminTestUtils.java
@@ -48,7 +48,9 @@ public class DynamoAdminTestUtils extends AdminTestUtils {
             .build();
     metadataNamespace =
         config.getNamespacePrefix().orElse("")
-            + config.getTableMetadataNamespace().orElse(DynamoAdmin.METADATA_NAMESPACE);
+            + config
+                .getTableMetadataNamespace()
+                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     namespacePrefix = config.getNamespacePrefix().orElse("");
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoEnv.java
@@ -45,7 +45,8 @@ public final class DynamoEnv {
 
     // Add testName as a metadata namespace suffix
     props.setProperty(
-        DynamoConfig.TABLE_METADATA_NAMESPACE, DynamoAdmin.METADATA_NAMESPACE + "_" + testName);
+        DynamoConfig.TABLE_METADATA_NAMESPACE,
+        DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME + "_" + testName);
 
     return props;
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/SingleCrudOperationTransactionAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/SingleCrudOperationTransactionAdminIntegrationTestWithDynamo.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.dynamo;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Map;
 import java.util.Properties;
@@ -22,6 +23,13 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithDynamo
   @Override
   protected boolean isIndexOnBooleanColumnSupported() {
     return false;
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new DynamoConfig(new DatabaseConfig(properties))
+        .getTableMetadataNamespace()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
 import java.util.Properties;
@@ -12,6 +13,13 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
   @Override
   protected Properties getProps(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new JdbcConfig(new DatabaseConfig(properties))
+        .getTableMetadataSchema()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,13 @@ public class JdbcAdminIntegrationTest extends DistributedStorageAdminIntegration
   @Override
   protected Properties getProperties(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new JdbcConfig(new DatabaseConfig(properties))
+        .getTableMetadataSchema()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminTestUtils.java
@@ -19,7 +19,8 @@ public class JdbcAdminTestUtils extends AdminTestUtils {
   public JdbcAdminTestUtils(Properties properties) {
     super(properties);
     config = new JdbcConfig(new DatabaseConfig(properties));
-    metadataSchema = config.getTableMetadataSchema().orElse(JdbcAdmin.METADATA_SCHEMA);
+    metadataSchema =
+        config.getTableMetadataSchema().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     rdbEngine = RdbEngineFactory.create(config);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcEnv.java
@@ -29,7 +29,9 @@ public final class JdbcEnv {
     props.setProperty(DatabaseConfig.CROSS_PARTITION_SCAN_ORDERING, "true");
 
     // Add testName as a metadata schema suffix
-    props.setProperty(JdbcConfig.TABLE_METADATA_SCHEMA, JdbcAdmin.METADATA_SCHEMA + "_" + testName);
+    props.setProperty(
+        JdbcConfig.TABLE_METADATA_SCHEMA,
+        DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME + "_" + testName);
 
     return props;
   }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionAdminIntegrationTestBase;
 import java.util.Properties;
@@ -12,6 +13,13 @@ public class SingleCrudOperationTransactionAdminIntegrationTestWithJdbcDatabase
   @Override
   protected Properties getProps(String testName) {
     return JdbcEnv.getProperties(testName);
+  }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new JdbcConfig(new DatabaseConfig(properties))
+        .getTableMetadataSchema()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTestUtils.java
@@ -28,7 +28,8 @@ public class MultiStorageAdminTestUtils extends AdminTestUtils {
     super(cassandraProperties);
 
     jdbcConfig = new JdbcConfig(new DatabaseConfig(jdbcProperties));
-    jdbcMetadataSchema = jdbcConfig.getTableMetadataSchema().orElse(JdbcAdmin.METADATA_SCHEMA);
+    jdbcMetadataSchema =
+        jdbcConfig.getTableMetadataSchema().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     rdbEngine = RdbEngineFactory.create(jdbcConfig);
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageEnv.java
@@ -1,7 +1,6 @@
 package com.scalar.db.storage.multistorage;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import java.util.Properties;
 
@@ -63,7 +62,8 @@ public final class MultiStorageEnv {
 
     // Add testName as a metadata schema suffix
     properties.setProperty(
-        JdbcConfig.TABLE_METADATA_SCHEMA, JdbcAdmin.METADATA_SCHEMA + "_" + testName);
+        JdbcConfig.TABLE_METADATA_SCHEMA,
+        DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME + "_" + testName);
 
     return properties;
   }

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminIntegrationTest.java
@@ -26,6 +26,13 @@ public class JdbcTransactionAdminIntegrationTest
     return properties;
   }
 
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    return new JdbcConfig(new DatabaseConfig(properties))
+        .getTableMetadataSchema()
+        .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+  }
+
   // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are
   // different from the other adapters. So disable several tests that check such behaviors.
 

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -415,4 +415,13 @@ public interface Admin {
    */
   void importTable(String namespace, String table, Map<String, String> options)
       throws ExecutionException;
+
+  /**
+   * Returns the names of the existing namespaces. Though, only namespace containing tables are
+   * returned. From ScalarDB 4.0, we plan to improve the design to suppress this limitation.
+   *
+   * @return a set of namespaces names, an empty set if no namespaces exist
+   * @throws ExecutionException if the operation fails
+   */
+  Set<String> getNamespaceNames() throws ExecutionException;
 }

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -417,7 +417,7 @@ public interface Admin {
       throws ExecutionException;
 
   /**
-   * Returns the names of the existing namespaces. Though, only namespace containing tables are
+   * Returns the names of the existing namespaces. However, only namespaces that contain tables are
    * returned. From ScalarDB 4.0, we plan to improve the design to suppress this limitation.
    *
    * @return a set of namespaces names, an empty set if no namespaces exist

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -41,7 +41,6 @@ import com.scalar.db.io.DataType;
  * }</pre>
  */
 public interface DistributedStorageAdmin extends Admin {
-
   /**
    * Get import table metadata in the ScalarDB format.
    *

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -41,6 +41,7 @@ import com.scalar.db.io.DataType;
  * }</pre>
  */
 public interface DistributedStorageAdmin extends Admin {
+  
   /**
    * Get import table metadata in the ScalarDB format.
    *

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -41,7 +41,7 @@ import com.scalar.db.io.DataType;
  * }</pre>
  */
 public interface DistributedStorageAdmin extends Admin {
-  
+
   /**
    * Get import table metadata in the ScalarDB format.
    *

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -321,6 +321,15 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    try {
+      return admin.getNamespaceNames();
+    } catch (ExecutionException e) {
+      throw new ExecutionException(CoreError.GETTING_NAMESPACE_NAMES_FAILED.buildMessage(), e);
+    }
+  }
+
+  @Override
   public void close() {
     admin.close();
   }

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -54,6 +54,7 @@ public class DatabaseConfig {
   public static final String CROSS_PARTITION_SCAN = SCAN_PREFIX + "enabled";
   public static final String CROSS_PARTITION_SCAN_FILTERING = SCAN_PREFIX + "filtering.enabled";
   public static final String CROSS_PARTITION_SCAN_ORDERING = SCAN_PREFIX + "ordering.enabled";
+  public static final String DEFAULT_SYSTEM_NAMESPACE_NAME = "scalardb";
 
   public DatabaseConfig(File propertiesFile) throws IOException {
     try (FileInputStream stream = new FileInputStream(propertiesFile)) {

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -113,6 +113,11 @@ public class AdminService implements DistributedStorageAdmin {
   }
 
   @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    return admin.getNamespaceNames();
+  }
+
+  @Override
   public void close() {
     admin.close();
   }

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
@@ -20,6 +20,7 @@ public class CassandraConfig {
   public CassandraConfig(DatabaseConfig databaseConfig) {
     systemNamespaceName = getString(databaseConfig.getProperties(), SYSTEM_NAMESPACE_NAME, null);
   }
+
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW
   @Override
   protected final void finalize() {}

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
@@ -1,6 +1,30 @@
 package com.scalar.db.storage.cassandra;
 
+import static com.scalar.db.config.ConfigUtils.getString;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Optional;
+
 public class CassandraConfig {
   // just hold the storage name for consistency with other storage
   public static final String STORAGE_NAME = "cassandra";
+  // We introduced this property so that `admin.getNamespaceNames()` can return the system namespace
+  // configured by ScalarDB Cluster.
+  // In ScalarDB core, storages besides Cassandra can define the system namespace with storage
+  // specific configuration. While ScalarDB Cluster can define the system namespace through this
+  // property below. To not introduce a new configuration for Cassandra to define the system
+  // namespace, we reuse the existing configuration defined by ScalarDB Cluster.
+  public static final String SYSTEM_NAMESPACE_NAME = "scalar.db.system_namespace_name";
+  private final String systemNamespaceName;
+
+  public CassandraConfig(DatabaseConfig databaseConfig) {
+    systemNamespaceName = getString(databaseConfig.getProperties(), SYSTEM_NAMESPACE_NAME, null);
+  }
+  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
+  @Override
+  protected final void finalize() {}
+
+  public Optional<String> getSystemNamespaceName() {
+    return Optional.ofNullable(systemNamespaceName);
+  }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -167,11 +167,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
             .build();
 
     applicationAutoScalingClient = createApplicationAutoScalingClient(config);
-    metadataNamespace =
-        config.getNamespacePrefix().orElse("")
-            + config
-                .getTableMetadataNamespace()
-                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+    metadataNamespace = getMetadataNamespace(config);
     namespacePrefix = config.getNamespacePrefix().orElse("");
     waitingDurationSecs = DEFAULT_WAITING_DURATION_SECS;
   }
@@ -180,11 +176,7 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   DynamoAdmin(DynamoDbClient client, DynamoConfig config) {
     this.client = client;
     applicationAutoScalingClient = createApplicationAutoScalingClient(config);
-    metadataNamespace =
-        config.getNamespacePrefix().orElse("")
-            + config
-                .getTableMetadataNamespace()
-                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+    metadataNamespace = getMetadataNamespace(config);
     namespacePrefix = config.getNamespacePrefix().orElse("");
     waitingDurationSecs = DEFAULT_WAITING_DURATION_SECS;
   }
@@ -196,13 +188,14 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       DynamoConfig config) {
     this.client = client;
     this.applicationAutoScalingClient = applicationAutoScalingClient;
-    metadataNamespace =
-        config.getNamespacePrefix().orElse("")
-            + config
-                .getTableMetadataNamespace()
-                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+    metadataNamespace = getMetadataNamespace(config);
     namespacePrefix = config.getNamespacePrefix().orElse("");
     waitingDurationSecs = 0;
+  }
+
+  private static String getMetadataNamespace(DynamoConfig config) {
+    return config.getNamespacePrefix().orElse("")
+        + config.getTableMetadataNamespace().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   private AwsCredentialsProvider createCredentialsProvider(DynamoConfig config) {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -15,6 +15,7 @@ import com.scalar.db.util.ScalarDbUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -106,7 +107,6 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   private static final String SCALING_TYPE_INDEX_READ = "index-read";
   private static final String SCALING_TYPE_INDEX_WRITE = "index-write";
 
-  public static final String METADATA_NAMESPACE = "scalardb";
   public static final String METADATA_TABLE = "metadata";
   @VisibleForTesting static final String METADATA_ATTR_PARTITION_KEY = "partitionKey";
   @VisibleForTesting static final String METADATA_ATTR_CLUSTERING_KEY = "clusteringKey";
@@ -169,7 +169,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     applicationAutoScalingClient = createApplicationAutoScalingClient(config);
     metadataNamespace =
         config.getNamespacePrefix().orElse("")
-            + config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+            + config
+                .getTableMetadataNamespace()
+                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     namespacePrefix = config.getNamespacePrefix().orElse("");
     waitingDurationSecs = DEFAULT_WAITING_DURATION_SECS;
   }
@@ -180,7 +182,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     applicationAutoScalingClient = createApplicationAutoScalingClient(config);
     metadataNamespace =
         config.getNamespacePrefix().orElse("")
-            + config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+            + config
+                .getTableMetadataNamespace()
+                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     namespacePrefix = config.getNamespacePrefix().orElse("");
     waitingDurationSecs = DEFAULT_WAITING_DURATION_SECS;
   }
@@ -194,7 +198,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     this.applicationAutoScalingClient = applicationAutoScalingClient;
     metadataNamespace =
         config.getNamespacePrefix().orElse("")
-            + config.getTableMetadataNamespace().orElse(METADATA_NAMESPACE);
+            + config
+                .getTableMetadataNamespace()
+                .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     namespacePrefix = config.getNamespacePrefix().orElse("");
     waitingDurationSecs = 0;
   }
@@ -1217,6 +1223,50 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   public void importTable(String namespace, String table, Map<String, String> options) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in DynamoDB");
+  }
+
+  @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    String nonPrefixedMetadataNamespace = metadataNamespace.substring(namespacePrefix.length());
+    if (!metadataTableExists()) {
+      return Collections.singleton(nonPrefixedMetadataNamespace);
+    }
+    try {
+      return new ImmutableSet.Builder<String>()
+          .addAll(getNamespacesOfExistingTables())
+          .add(nonPrefixedMetadataNamespace)
+          .build();
+    } catch (ExecutionException e) {
+      throw new ExecutionException("Retrieving the existing namespace names failed", e);
+    }
+  }
+
+  private Set<String> getNamespacesOfExistingTables() throws ExecutionException {
+    Set<String> nonPrefixedNamespaceNames = new HashSet<>();
+    Map<String, AttributeValue> lastEvaluatedKey = null;
+    do {
+      ScanResponse scanResponse;
+      try {
+        scanResponse =
+            client.scan(
+                ScanRequest.builder()
+                    .tableName(ScalarDbUtils.getFullTableName(metadataNamespace, METADATA_TABLE))
+                    .exclusiveStartKey(lastEvaluatedKey)
+                    .build());
+      } catch (RuntimeException e) {
+        throw new ExecutionException(
+            "Failed to retrieve the namespaces names of existing tables", e);
+      }
+      lastEvaluatedKey = scanResponse.lastEvaluatedKey();
+
+      for (Map<String, AttributeValue> tableMetadata : scanResponse.items()) {
+        String fullTableName = tableMetadata.get(METADATA_ATTR_TABLE).s();
+        String namespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
+        nonPrefixedNamespaceNames.add(namespaceName);
+      }
+    } while (!lastEvaluatedKey.isEmpty());
+
+    return nonPrefixedNamespaceNames;
   }
 
   private String getFullTableName(Namespace namespace, String table) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 @SuppressFBWarnings({"OBL_UNSATISFIED_OBLIGATION", "SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"})
 @ThreadSafe
 public class JdbcAdmin implements DistributedStorageAdmin {
-  public static final String METADATA_SCHEMA = "scalardb";
   public static final String METADATA_TABLE = "metadata";
 
   @VisibleForTesting static final String METADATA_COL_FULL_TABLE_NAME = "full_table_name";
@@ -67,14 +66,16 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     JdbcConfig config = new JdbcConfig(databaseConfig);
     rdbEngine = RdbEngineFactory.create(config);
     dataSource = JdbcUtils.initDataSourceForAdmin(config, rdbEngine);
-    metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);
+    metadataSchema =
+        config.getTableMetadataSchema().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public JdbcAdmin(BasicDataSource dataSource, JdbcConfig config) {
     rdbEngine = RdbEngineFactory.create(config);
     this.dataSource = dataSource;
-    metadataSchema = config.getTableMetadataSchema().orElse(METADATA_SCHEMA);
+    metadataSchema =
+        config.getTableMetadataSchema().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
   }
 
   @Override
@@ -771,6 +772,35 @@ public class JdbcAdmin implements DistributedStorageAdmin {
           String.format(
               "Adding the new column %s to the %s.%s table failed", columnName, namespace, table),
           e);
+    }
+  }
+
+  @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    String selectAllTableNames =
+        "SELECT DISTINCT "
+            + enclose(METADATA_COL_FULL_TABLE_NAME)
+            + " FROM "
+            + encloseFullTableName(metadataSchema, METADATA_TABLE);
+    try (Connection connection = dataSource.getConnection();
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(selectAllTableNames)) {
+      Set<String> namespaceOfExistingTables = new HashSet<>();
+      while (rs.next()) {
+        String fullTableName = rs.getString(METADATA_COL_FULL_TABLE_NAME);
+        String namespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
+        namespaceOfExistingTables.add(namespaceName);
+      }
+      namespaceOfExistingTables.add(metadataSchema);
+
+      return namespaceOfExistingTables;
+    } catch (SQLException e) {
+      // An exception will be thrown if the namespace table does not exist when executing the select
+      // query
+      if (rdbEngine.isUndefinedTableError(e)) {
+        return Collections.singleton(metadataSchema);
+      }
+      throw new ExecutionException("Getting the existing schema names failed", e);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/rpc/GrpcAdmin.java
@@ -345,6 +345,12 @@ public class GrpcAdmin implements DistributedStorageAdmin {
         "Import-related functionality is not supported in ScalarDB Server");
   }
 
+  @Override
+  public Set<String> getNamespaceNames() {
+    throw new UnsupportedOperationException(
+        "Retrieving the namespace names is not supported in ScalarDB Server");
+  }
+
   private static <T> T execute(ThrowableSupplier<T, ExecutionException> supplier)
       throws ExecutionException {
     try {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -255,6 +256,13 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
 
     // add ScalarDB metadata
     admin.repairTable(namespace, table, buildTransactionTableMetadata(tableMetadata), options);
+  }
+
+  @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    return admin.getNamespaceNames().stream()
+        .filter(namespace -> !namespace.equals(coordinatorNamespace))
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -162,6 +162,11 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    return jdbcAdmin.getNamespaceNames();
+  }
+
+  @Override
   public void close() {
     jdbcAdmin.close();
   }

--- a/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/rpc/GrpcTransactionAdmin.java
@@ -400,6 +400,12 @@ public class GrpcTransactionAdmin implements DistributedTransactionAdmin {
         "Import-related functionality is not supported in ScalarDB Server");
   }
 
+  @Override
+  public Set<String> getNamespaceNames() {
+    throw new UnsupportedOperationException(
+        "Retrieving the namespace names is not supported in ScalarDB Server");
+  }
+
   private static <T> T execute(ThrowableSupplier<T, ExecutionException> supplier)
       throws ExecutionException {
     try {

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdmin.java
@@ -105,6 +105,11 @@ public class SingleCrudOperationTransactionAdmin implements DistributedTransacti
     distributedStorageAdmin.addNewColumnToTable(namespace, table, columnName, columnType);
   }
 
+  @Override
+  public Set<String> getNamespaceNames() throws ExecutionException {
+    return distributedStorageAdmin.getNamespaceNames();
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.cassandra.CassandraAdmin.CompactionStrategy;
@@ -36,10 +37,13 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -613,5 +617,65 @@ public class CassandraAdminTest {
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"my_system_ns", ""})
+  public void getNamespaceNames_withExistingTables_ShouldWorkProperly(String systemNamespaceName)
+      throws ExecutionException {
+    // Arrange
+    Properties properties = new Properties();
+    properties.setProperty(CassandraConfig.SYSTEM_NAMESPACE_NAME, systemNamespaceName);
+    cassandraAdmin = new CassandraAdmin(clusterManager, new DatabaseConfig(properties));
+
+    Cluster cluster = mock(Cluster.class);
+    Metadata metadata = mock(Metadata.class);
+    KeyspaceMetadata keyspace1 = mock(KeyspaceMetadata.class);
+    KeyspaceMetadata keyspace3 = mock(KeyspaceMetadata.class);
+    KeyspaceMetadata keyspace4 = mock(KeyspaceMetadata.class);
+
+    when(cassandraSession.getCluster()).thenReturn(cluster);
+    when(cluster.getMetadata()).thenReturn(metadata);
+    when(metadata.getKeyspaces()).thenReturn(ImmutableList.of(keyspace1, keyspace3, keyspace4));
+    when(keyspace1.getName()).thenReturn("system_foo");
+    when(keyspace3.getName()).thenReturn("ks1");
+    when(keyspace4.getName()).thenReturn("ks2");
+
+    // Act
+    Set<String> actual = cassandraAdmin.getNamespaceNames();
+
+    // Assert
+    if (systemNamespaceName.isEmpty()) {
+      assertThat(actual).containsOnly("ks1", "ks2", DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+    } else {
+      assertThat(actual).containsOnly("ks1", "ks2", systemNamespaceName);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"my_system_ns", ""})
+  public void getNamespaceNames_withoutExistingTables_ShouldReturnSystemNamespaceOnly(
+      String systemNamespaceName) throws ExecutionException {
+    // Arrange
+    Properties properties = new Properties();
+    properties.setProperty(CassandraConfig.SYSTEM_NAMESPACE_NAME, systemNamespaceName);
+    cassandraAdmin = new CassandraAdmin(clusterManager, new DatabaseConfig(properties));
+
+    Cluster cluster = mock(Cluster.class);
+    Metadata metadata = mock(Metadata.class);
+
+    when(cassandraSession.getCluster()).thenReturn(cluster);
+    when(cluster.getMetadata()).thenReturn(metadata);
+    when(metadata.getKeyspaces()).thenReturn(Collections.emptyList());
+
+    // Act
+    Set<String> actual = cassandraAdmin.getNamespaceNames();
+
+    // Assert
+    if (systemNamespaceName.isEmpty()) {
+      assertThat(actual).containsOnly(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+    } else {
+      assertThat(actual).containsOnly(systemNamespaceName);
+    }
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraConfigTest.java
@@ -1,0 +1,38 @@
+package com.scalar.db.storage.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Optional;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class CassandraConfigTest {
+
+  private static final String ANY_SYSTEM_NAMESPACE = "any_namespace";
+
+  @Test
+  public void constructor_SystemNamespaceGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(CassandraConfig.SYSTEM_NAMESPACE_NAME, ANY_SYSTEM_NAMESPACE);
+
+    // Act
+    CassandraConfig config = new CassandraConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getSystemNamespaceName()).isEqualTo(Optional.of(ANY_SYSTEM_NAMESPACE));
+  }
+
+  @Test
+  public void constructor_NoPropertiesGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+
+    // Act
+    CassandraConfig config = new CassandraConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getSystemNamespaceName()).isEmpty();
+  }
+}

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -861,4 +861,56 @@ public abstract class CosmosAdminTestBase {
     assertThat(thrown2).isInstanceOf(UnsupportedOperationException.class);
     assertThat(thrown3).isInstanceOf(UnsupportedOperationException.class);
   }
+
+  @Test
+  public void getNamespaceNames_WithExistingTables_ShouldWorkProperly() throws ExecutionException {
+    // Arrange
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer tableMetadataContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(anyString())).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(tableMetadataContainer);
+    @SuppressWarnings("unchecked")
+    CosmosPagedIterable<CosmosTableMetadata> cosmosPagedIterable = mock(CosmosPagedIterable.class);
+    CosmosTableMetadata tableMetadata1 = CosmosTableMetadata.newBuilder().id("ns1.tbl1").build();
+    CosmosTableMetadata tableMetadata2 = CosmosTableMetadata.newBuilder().id("ns1.tbl2").build();
+    CosmosTableMetadata tableMetadata3 = CosmosTableMetadata.newBuilder().id("ns2.tbl3").build();
+    when(cosmosPagedIterable.stream())
+        .thenReturn(Stream.of(tableMetadata1, tableMetadata2, tableMetadata3));
+    when(tableMetadataContainer.queryItems(anyString(), any(), eq(CosmosTableMetadata.class)))
+        .thenReturn(cosmosPagedIterable);
+
+    // Act
+    Set<String> actual = admin.getNamespaceNames();
+
+    // Assert
+    verify(tableMetadataContainer).read();
+    verify(tableMetadataContainer)
+        .queryItems(
+            eq("SELECT container.id FROM container"),
+            any(CosmosQueryRequestOptions.class),
+            eq(CosmosTableMetadata.class));
+    assertThat(actual).containsOnly("ns1", "ns2", metadataDatabaseName);
+  }
+
+  @Test
+  public void getNamespaceNames_WithoutExistingTables_ShouldReturnMetadataDatabaseOnly()
+      throws ExecutionException {
+    // Arrange
+    CosmosDatabase metadataDatabase = mock(CosmosDatabase.class);
+    CosmosContainer tableMetadataContainer = mock(CosmosContainer.class);
+    when(client.getDatabase(anyString())).thenReturn(metadataDatabase);
+    when(metadataDatabase.getContainer(CosmosAdmin.METADATA_CONTAINER))
+        .thenReturn(tableMetadataContainer);
+    CosmosException cosmosException = mock(CosmosException.class);
+    when(cosmosException.getStatusCode()).thenReturn(CosmosErrorCode.NOT_FOUND.get());
+    when(tableMetadataContainer.read()).thenThrow(cosmosException);
+
+    // Act
+    Set<String> actual = admin.getNamespaceNames();
+
+    // Assert
+    verify(tableMetadataContainer).read();
+    assertThat(actual).containsOnly(metadataDatabaseName);
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/rpc/GrpcAdminTest.java
@@ -347,5 +347,7 @@ public class GrpcAdminTest {
         .isInstanceOf(UnsupportedOperationException.class);
     assertThatThrownBy(() -> admin.importTable(namespace, table, Collections.emptyMap()))
         .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> admin.getNamespaceNames())
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -735,4 +735,18 @@ public abstract class ConsensusCommitAdminTestBase {
             () -> admin.importTable(coordinatorNamespaceName, "tbl", Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void getNamespaceNames_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.getNamespaceNames())
+        .thenReturn(ImmutableSet.of("ns1", "ns2", coordinatorNamespaceName));
+
+    // Act
+    Set<String> actual = admin.getNamespaceNames();
+
+    // Assert
+    verify(distributedStorageAdmin).getNamespaceNames();
+    assertThat(actual).containsOnly("ns1", "ns2");
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -240,4 +240,18 @@ public class JdbcTransactionAdminTest {
     // Assert
     verify(jdbcAdmin).importTable(namespace, table, Collections.emptyMap());
   }
+
+  @Test
+  public void getNamespaceNames_ShouldCallJdbcAdminProperly() throws ExecutionException {
+    // Arrange
+    Set<String> namespaceNames = ImmutableSet.of("n1", "n2");
+    when(jdbcAdmin.getNamespaceNames()).thenReturn(namespaceNames);
+
+    // Act
+    Set<String> actualNamespaces = admin.getNamespaceNames();
+
+    // Assert
+    verify(jdbcAdmin).getNamespaceNames();
+    assertThat(actualNamespaces).containsOnly("n1", "n2");
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/rpc/GrpcTransactionAdminTest.java
@@ -422,5 +422,7 @@ public class GrpcTransactionAdminTest {
     // Act Assert
     assertThatThrownBy(() -> admin.importTable(namespace, table, Collections.emptyMap()))
         .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> admin.getNamespaceNames())
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdminTest.java
@@ -245,4 +245,19 @@ public class SingleCrudOperationTransactionAdminTest {
     // Assert
     verify(distributedStorageAdmin).importTable(namespace, table, Collections.emptyMap());
   }
+
+  @Test
+  public void getNamespaceNames_ShouldCallDistributedStorageAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    when(distributedStorageAdmin.getNamespaceNames())
+        .thenReturn(ImmutableSet.of("ns1", "ns2", "ns3"));
+
+    // Act
+    Set<String> actual = admin.getNamespaceNames();
+
+    // Assert
+    verify(distributedStorageAdmin).getNamespaceNames();
+    assertThat(actual).containsOnly("ns1", "ns2", "ns3");
+  }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -71,6 +71,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
           .build();
   private StorageFactory storageFactory;
   private DistributedStorageAdmin admin;
+  private String systemNamespaceName;
   private String namespace1;
   private String namespace2;
   private String namespace3;
@@ -78,8 +79,10 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   @BeforeAll
   public void beforeAll() throws Exception {
     initialize(TEST_NAME);
-    storageFactory = StorageFactory.create(getProperties(TEST_NAME));
+    Properties properties = getProperties(TEST_NAME);
+    storageFactory = StorageFactory.create(properties);
     admin = storageFactory.getAdmin();
+    systemNamespaceName = getSystemNamespaceName(properties);
     namespace1 = getNamespace1();
     namespace2 = getNamespace2();
     namespace3 = getNamespace3();
@@ -89,6 +92,8 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
   protected void initialize(String testName) throws Exception {}
 
   protected abstract Properties getProperties(String testName);
+
+  protected abstract String getSystemNamespaceName(Properties properties);
 
   protected String getNamespace1() {
     return NAMESPACE1;
@@ -763,6 +768,17 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     assertThatThrownBy(
             () -> admin.addNewColumnToTable(namespace1, TABLE1, COL_NAME2, DataType.TEXT))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getNamespaceNames_ShouldReturnCreatedNamespaces() throws ExecutionException {
+    // Arrange
+
+    // Act
+    Set<String> namespaces = admin.getNamespaceNames();
+
+    // Assert
+    assertThat(namespaces).containsOnly(namespace1, namespace2, systemNamespaceName);
   }
 
   protected boolean isIndexOnBooleanColumnSupported() {

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -69,6 +69,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
           .build();
   protected TransactionFactory transactionFactory;
   protected DistributedTransactionAdmin admin;
+  protected String systemNamespaceName;
   protected String namespace1;
   protected String namespace2;
   protected String namespace3;
@@ -80,6 +81,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     Properties properties = getProperties(testName);
     transactionFactory = TransactionFactory.create(properties);
     admin = transactionFactory.getTransactionAdmin();
+    systemNamespaceName = getSystemNamespaceName(properties);
     namespace1 = getNamespaceBaseName() + testName + "1";
     namespace2 = getNamespaceBaseName() + testName + "2";
     namespace3 = getNamespaceBaseName() + testName + "3";
@@ -95,6 +97,8 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   protected String getNamespaceBaseName() {
     return NAMESPACE_BASE_NAME;
   }
+
+  protected abstract String getSystemNamespaceName(Properties properties);
 
   private void createTables() throws ExecutionException {
     Map<String, String> options = getCreationOptions();
@@ -837,6 +841,17 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     } finally {
       admin.createCoordinatorTables(true, getCreationOptions());
     }
+  }
+
+  @Test
+  public void getNamespaceNames_ShouldReturnCreatedNamespaces() throws ExecutionException {
+    // Arrange
+
+    // Act
+    Set<String> namespaces = admin.getNamespaceNames();
+
+    // Assert
+    assertThat(namespaces).containsOnly(namespace1, namespace2, systemNamespaceName);
   }
 
   protected boolean isIndexOnBooleanColumnSupported() {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CosmosCommand.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/command/CosmosCommand.java
@@ -103,7 +103,7 @@ public class CosmosCommand extends StorageSpecificCommand implements Callable<In
     if (tableMetadataDatabasePrefix != null) {
       props.setProperty(
           CosmosConfig.TABLE_METADATA_DATABASE,
-          tableMetadataDatabasePrefix + CosmosAdmin.METADATA_DATABASE);
+          tableMetadataDatabasePrefix + DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     }
     if (coordinatorNamespacePrefix != null) {
       props.setProperty(

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
@@ -5,6 +5,8 @@ import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ConsensusCommitAdminIntegrationTestWithServer
     extends ConsensusCommitAdminIntegrationTestBase {
@@ -42,4 +44,15 @@ public class ConsensusCommitAdminIntegrationTestWithServer
       server.shutdown();
     }
   }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    // "Unused for ScalarDB server"
+    return null;
+  }
+
+  @Override
+  @Test
+  @Disabled("Retrieving the namespace names is not supported in ScalarDB server")
+  public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
@@ -47,12 +47,12 @@ public class ConsensusCommitAdminIntegrationTestWithServer
 
   @Override
   protected String getSystemNamespaceName(Properties properties) {
-    // "Unused for ScalarDB server"
+    // "Unused for ScalarDB Server"
     return null;
   }
 
   @Override
   @Test
-  @Disabled("Retrieving the namespace names is not supported in ScalarDB server")
+  @Disabled("Retrieving the namespace names is not supported in ScalarDB Server")
   public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
@@ -4,6 +4,8 @@ import com.scalar.db.api.DistributedStorageAdminIntegrationTestBase;
 import java.io.IOException;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class DistributedStorageAdminIntegrationTestWithServer
     extends DistributedStorageAdminIntegrationTestBase {
@@ -32,4 +34,15 @@ public class DistributedStorageAdminIntegrationTestWithServer
       server.shutdown();
     }
   }
+
+  @Override
+  protected String getSystemNamespaceName(Properties properties) {
+    // "Unused for ScalarDB server"
+    return null;
+  }
+
+  @Override
+  @Test
+  @Disabled("Retrieving the namespace names is not supported in ScalarDB server")
+  public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/DistributedStorageAdminIntegrationTestWithServer.java
@@ -37,12 +37,12 @@ public class DistributedStorageAdminIntegrationTestWithServer
 
   @Override
   protected String getSystemNamespaceName(Properties properties) {
-    // "Unused for ScalarDB server"
+    // "Unused for ScalarDB Server"
     return null;
   }
 
   @Override
   @Test
-  @Disabled("Retrieving the namespace names is not supported in ScalarDB server")
+  @Disabled("Retrieving the namespace names is not supported in ScalarDB Server")
   public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
 }

--- a/server/src/integration-test/java/com/scalar/db/server/ServerAdminTestUtils.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ServerAdminTestUtils.java
@@ -27,7 +27,8 @@ public class ServerAdminTestUtils extends AdminTestUtils {
   public ServerAdminTestUtils(Properties jdbcStorageProperties) {
     super(jdbcStorageProperties);
     config = new JdbcConfig(new DatabaseConfig(jdbcStorageProperties));
-    metadataNamespace = config.getTableMetadataSchema().orElse(JdbcAdmin.METADATA_SCHEMA);
+    metadataNamespace =
+        config.getTableMetadataSchema().orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
     metadataTable = JdbcAdmin.METADATA_TABLE;
     rdbEngine = RdbEngineFactory.create(config);
   }

--- a/server/src/integration-test/java/com/scalar/db/server/ServerEnv.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ServerEnv.java
@@ -1,7 +1,6 @@
 package com.scalar.db.server;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.jdbc.JdbcAdmin;
 import com.scalar.db.storage.jdbc.JdbcConfig;
 import java.util.Properties;
 
@@ -65,7 +64,8 @@ public final class ServerEnv {
 
     // Add testName as a metadata schema suffix
     properties.setProperty(
-        JdbcConfig.TABLE_METADATA_SCHEMA, JdbcAdmin.METADATA_SCHEMA + "_" + testName);
+        JdbcConfig.TABLE_METADATA_SCHEMA,
+        DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME + "_" + testName);
 
     return properties;
   }


### PR DESCRIPTION
## Description

In ScalardDB 4, we will introduce namespace management, which means a user will be able to list the existing namespace using the `Admin.getNamespaceNames()` method.

For ScalarDB 3, we introduce the same API with a simplistic approach. User namespaces are not managed in a dedicated table as we do for ScalarDB 4. `Admin.getNamespaceNames()` will extract on the fly the namespace names from the names of the user tables. This means this new API will not return a namespace if it does not contain tables.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/989

## Changes made

- Implemented the new API `Admin.getNamespaceNames()`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

There are a lot of changes but most of it are tests or due to moving a constant to another class. 
Please focus your review on the classes in the `core/src/main/java/com/scalar/db` folder. 

## Release notes

Added a new Admin API `admin.getNamespacesNames()` to list the user namespaces. Though, this API won't return a namespace that does not contain a table. From ScalarDB 4.0, we plan to improve the design to suppress this limitation.
