### PR TITLE
Backport to branch (3.10), [3.7~3.11] Fix error in integration test with Java 21 as runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
         jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.9.3'
         commonsLangVersion = '3.12.0'
-        assertjVersion = '3.24.2'
+        assertjVersion = '3.26.0'
         mockitoVersion = '4.11.0'
         spotbugsVersion = '4.7.3'
         errorproneVersion = '2.10.0'


### PR DESCRIPTION
Backport of #1977 

CI check with Java 21: https://github.com/scalar-labs/scalardb/actions/runs/9705672866