### PR TITLE
Backport to branch (3.8), [3.7~3.11] Fix error in integration test with Java 21 as runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
         jettyVersion = '9.4.53.v20231009'
         junitVersion = '5.8.2'
         commonsLangVersion = '3.12.0'
-        assertjVersion = '3.22.0'
+        assertjVersion = '3.26.0'
         mockitoVersion = '3.12.4'
         spotbugsVersion = '4.6.0'
         errorproneVersion = '2.10.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/1977

CI check with Java 21: https://github.com/scalar-labs/scalardb/actions/runs/9705747417