### PR TITLE
Backport to branch(3.12): Fix a bug that the importing table feature accesses tables in other namespace that have the same table name with MySQL storage

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -75,6 +75,14 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
     super.importTables_ImportableTablesGiven_ShouldImportProperly();
   }
 
+  @Test
+  @Override
+  @DisabledIf("isSqlite")
+  public void importTables_ImportableTablesAndNonRelatedSameNameTableGiven_ShouldImportProperly()
+      throws Exception {
+    super.importTables_ImportableTablesAndNonRelatedSameNameTableGiven_ShouldImportProperly();
+  }
+
   @SuppressWarnings("unused")
   private boolean isSqlite() {
     return JdbcEnv.isSqlite();

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -453,13 +453,16 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
+      String catalogName = rdbEngine.getCatalogName(namespace);
+      String schemaName = rdbEngine.getSchemaName(namespace);
+
       if (!tableExistsInternal(connection, namespace, table)) {
         throw new IllegalArgumentException(
             CoreError.TABLE_NOT_FOUND.buildMessage(getFullTableName(namespace, table)));
       }
 
       DatabaseMetaData metadata = connection.getMetaData();
-      ResultSet resultSet = metadata.getPrimaryKeys(null, namespace, table);
+      ResultSet resultSet = metadata.getPrimaryKeys(catalogName, schemaName, table);
       while (resultSet.next()) {
         primaryKeyExists = true;
         String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
@@ -472,7 +475,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
                 getFullTableName(namespace, table)));
       }
 
-      resultSet = metadata.getColumns(null, namespace, table, "%");
+      resultSet = metadata.getColumns(catalogName, schemaName, table, "%");
       while (resultSet.next()) {
         String columnName = resultSet.getString(JDBC_COL_COLUMN_NAME);
         builder.addColumn(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -345,5 +346,20 @@ class RdbEngineMysql implements RdbEngineStrategy {
   public String getEscape(LikeExpression likeExpression) {
     String escape = likeExpression.getEscape();
     return escape.isEmpty() ? "\\" : escape;
+  }
+
+  @Nullable
+  @Override
+  public String getCatalogName(String namespace) {
+    return namespace;
+  }
+
+  @Nullable
+  @Override
+  public String getSchemaName(String namespace) {
+    // This can be null. However, we return the namespace from this method just in case since users
+    // might be able to set `databaseTerm` property to `SCHEMA` so that a return value from this
+    // method is used for filtering.
+    return namespace;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -121,4 +121,12 @@ public interface RdbEngineStrategy {
   default @Nullable String getEscape(LikeExpression likeExpression) {
     return likeExpression.getEscape();
   }
+
+  default @Nullable String getCatalogName(String namespace) {
+    return null;
+  }
+
+  default @Nullable String getSchemaName(String namespace) {
+    return namespace;
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -2253,8 +2253,14 @@ public abstract class JdbcAdminTestBase {
         .thenReturn("");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0).thenReturn(0).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0).thenReturn(0).thenReturn(0);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
-    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(NAMESPACE, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    }
 
     Map<String, DataType> expectedColumns = new LinkedHashMap<>();
     expectedColumns.put("pk1", DataType.TEXT);
@@ -2337,7 +2343,13 @@ public abstract class JdbcAdminTestBase {
     when(connection.createStatement()).thenReturn(checkTableExistStatement);
     when(connection.getMetaData()).thenReturn(metadata);
     when(primaryKeyResults.next()).thenReturn(false);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+    }
+
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
     String description = "database engine specific test failed: " + rdbEngine;
 
@@ -2379,8 +2391,16 @@ public abstract class JdbcAdminTestBase {
     when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("timestamp");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
-    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(NAMESPACE, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    }
+
     JdbcAdmin admin = createJdbcAdminFor(rdbEngine);
     String description = "database engine specific test failed: " + rdbEngine;
 
@@ -2498,8 +2518,14 @@ public abstract class JdbcAdminTestBase {
     when(columnResults.getString(JDBC_COL_TYPE_NAME)).thenReturn("VARCHAR");
     when(columnResults.getInt(JDBC_COL_COLUMN_SIZE)).thenReturn(0);
     when(columnResults.getInt(JDBC_COL_DECIMAL_DIGITS)).thenReturn(0);
-    when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
-    when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    RdbEngineStrategy rdbEngineStrategy = getRdbEngineStrategy(rdbEngine);
+    if (rdbEngineStrategy instanceof RdbEngineMysql) {
+      when(metadata.getPrimaryKeys(NAMESPACE, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(NAMESPACE, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    } else {
+      when(metadata.getPrimaryKeys(null, NAMESPACE, TABLE)).thenReturn(primaryKeyResults);
+      when(metadata.getColumns(null, NAMESPACE, TABLE, "%")).thenReturn(columnResults);
+    }
     List<Statement> expectedStatements = new ArrayList<>();
     for (int i = 0; i < expectedSqlStatements.size(); i++) {
       Statement expectedStatement = mock(Statement.class);

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation project(':core')
     implementation project(':schema-loader')
     implementation "com.google.guava:guava:${guavaVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-simple:${slf4jVersion}"
     implementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     implementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
     runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -24,9 +24,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SchemaLoaderImportIntegrationTestBase {
+  private static final Logger logger =
+      LoggerFactory.getLogger(SchemaLoaderImportIntegrationTestBase.class);
   private static final String TEST_NAME = "schema_loader_import";
   private static final Path CONFIG_FILE_PATH = Paths.get("config.properties").toAbsolutePath();
   private static final Path IMPORT_SCHEMA_FILE_PATH =
@@ -155,27 +159,17 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
   public void importTables_ImportableTablesAndNonRelatedSameNameTableGiven_ShouldImportProperly()
       throws Exception {
     // Arrange
-    waitForDifferentSessionDdl();
     transactionAdmin.createNamespace(namespace1);
-
-    waitForDifferentSessionDdl();
     storageAdmin.createNamespace(namespace2);
-
-    waitForDifferentSessionDdl();
     createImportableTable(namespace1, TABLE_1);
-
-    waitForDifferentSessionDdl();
     createImportableTable(namespace2, TABLE_2);
 
     // Create non-related tables.
-    waitForDifferentSessionDdl();
     createNonImportableTable(namespace1, TABLE_2);
-    waitForDifferentSessionDdl();
     createNonImportableTable(namespace2, TABLE_1);
 
     try {
       // Act
-      waitForDifferentSessionDdl();
       int exitCode =
           executeWithArgs(getCommandArgsForImport(CONFIG_FILE_PATH, IMPORT_SCHEMA_FILE_PATH));
 

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -152,6 +152,54 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
   }
 
   @Test
+  public void importTables_ImportableTablesAndNonRelatedSameNameTableGiven_ShouldImportProperly()
+      throws Exception {
+    // Arrange
+    waitForDifferentSessionDdl();
+    transactionAdmin.createNamespace(namespace1);
+
+    waitForDifferentSessionDdl();
+    storageAdmin.createNamespace(namespace2);
+
+    waitForDifferentSessionDdl();
+    createImportableTable(namespace1, TABLE_1);
+
+    waitForDifferentSessionDdl();
+    createImportableTable(namespace2, TABLE_2);
+
+    // Create non-related tables.
+    waitForDifferentSessionDdl();
+    createNonImportableTable(namespace1, TABLE_2);
+    waitForDifferentSessionDdl();
+    createNonImportableTable(namespace2, TABLE_1);
+
+    try {
+      // Act
+      waitForDifferentSessionDdl();
+      int exitCode =
+          executeWithArgs(getCommandArgsForImport(CONFIG_FILE_PATH, IMPORT_SCHEMA_FILE_PATH));
+
+      // Assert
+      assertThat(exitCode).isEqualTo(0);
+      assertThat(transactionAdmin.tableExists(namespace1, TABLE_1)).isTrue();
+      assertThat(storageAdmin.tableExists(namespace2, TABLE_2)).isTrue();
+      assertThat(transactionAdmin.coordinatorTablesExist()).isFalse();
+    } finally {
+      try {
+        dropNonImportableTable(namespace1, TABLE_2);
+      } catch (Exception e) {
+        logger.warn("Failed to drop non-importable table. {}.{}", namespace1, TABLE_2, e);
+      }
+
+      try {
+        dropNonImportableTable(namespace2, TABLE_1);
+      } catch (Exception e) {
+        logger.warn("Failed to drop non-importable table. {}.{}", namespace2, TABLE_1, e);
+      }
+    }
+  }
+
+  @Test
   public void importTables_NonImportableTablesGiven_ShouldThrowIllegalArgumentException()
       throws Exception {
     // Arrange


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2001 to branch(3.12)