### PR TITLE
Add check for encrypted columns to repairTable()

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -256,6 +256,11 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
   public void repairTable(
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
+    if (!metadata.getEncryptedColumnNames().isEmpty()) {
+      throw new UnsupportedOperationException(
+          CoreError.ENCRYPTED_COLUMNS_NOT_SUPPORTED.buildMessage());
+    }
+
     try {
       admin.repairTable(namespace, table, metadata, options);
     } catch (ExecutionException e) {

--- a/core/src/test/java/com/scalar/db/common/CheckedDistributedStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/common/CheckedDistributedStorageAdminTest.java
@@ -119,4 +119,38 @@ public class CheckedDistributedStorageAdminTest {
     // Assert
     assertThat(actual).containsExactly(SYSTEM_NAMESPACE);
   }
+
+  @Test
+  public void repairTable_ShouldCallAdminProperly() throws ExecutionException {
+    // Arrange
+    String namespaceName = "ns";
+    String tableName = "tbl";
+
+    TableMetadata tableMetadata = mock(TableMetadata.class);
+    Map<String, String> options = ImmutableMap.of("name", "value");
+
+    // Act
+    checkedAdmin.repairTable(namespaceName, tableName, tableMetadata, options);
+
+    // Assert
+    verify(admin).repairTable(namespaceName, tableName, tableMetadata, options);
+  }
+
+  @Test
+  public void
+      repairTable_TableMetadataWithEncryptedColumns_ShouldThrowUnsupportedOperationException() {
+    // Arrange
+    String namespaceName = "ns";
+    String tableName = "tbl";
+
+    TableMetadata tableMetadata = mock(TableMetadata.class);
+    when(tableMetadata.getEncryptedColumnNames()).thenReturn(Collections.singleton("col"));
+
+    Map<String, String> options = ImmutableMap.of("name", "value");
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> checkedAdmin.repairTable(namespaceName, tableName, tableMetadata, options))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
 }


### PR DESCRIPTION
## Description

This PR adds check for encrypted columns to `repairTable()`.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/1907

## Changes made

- Added check for encrypted columns to `repairTable()`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
