### PR TITLE
Add TransactionExecutor

### DIFF
--- a/core/src/main/java/com/scalar/db/common/TransactionExecutor.java
+++ b/core/src/main/java/com/scalar/db/common/TransactionExecutor.java
@@ -1,0 +1,75 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.exception.transaction.RollbackException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionUtils;
+import com.scalar.db.util.ThrowableConsumer;
+import com.scalar.db.util.ThrowableFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class TransactionExecutor {
+
+  private static final Logger logger = LoggerFactory.getLogger(TransactionExecutor.class);
+
+  private TransactionExecutor() {}
+
+  public static <T> T execute(
+      DistributedTransactionManager transactionManager,
+      ThrowableFunction<CrudOperable<?>, T, TransactionException> throwableFunction)
+      throws TransactionException {
+    if (SingleCrudOperationTransactionUtils.isSingleCrudOperationTransactionManager(
+        transactionManager)) {
+      return throwableFunction.apply(transactionManager);
+    }
+
+    DistributedTransaction transaction = null;
+    try {
+      transaction = transactionManager.begin();
+      T result = throwableFunction.apply(transaction);
+      transaction.commit();
+      return result;
+    } catch (Exception e) {
+      if (transaction != null) {
+        rollback(transaction);
+      }
+
+      throw e;
+    }
+  }
+
+  public static void execute(
+      DistributedTransactionManager transactionManager,
+      ThrowableConsumer<CrudOperable<?>, TransactionException> throwableFunction)
+      throws TransactionException {
+    if (SingleCrudOperationTransactionUtils.isSingleCrudOperationTransactionManager(
+        transactionManager)) {
+      throwableFunction.accept(transactionManager);
+      return;
+    }
+
+    DistributedTransaction transaction = null;
+    try {
+      transaction = transactionManager.begin();
+      throwableFunction.accept(transaction);
+      transaction.commit();
+    } catch (Exception e) {
+      if (transaction != null) {
+        rollback(transaction);
+      }
+
+      throw e;
+    }
+  }
+
+  private static void rollback(DistributedTransaction transaction) {
+    try {
+      transaction.rollback();
+    } catch (RollbackException e) {
+      logger.warn("Failed to rollback a transaction", e);
+    }
+  }
+}

--- a/core/src/test/java/com/scalar/db/common/TransactionExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/common/TransactionExecutorTest.java
@@ -1,0 +1,155 @@
+package com.scalar.db.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.transaction.singlecrudoperation.SingleCrudOperationTransactionManager;
+import com.scalar.db.util.ThrowableConsumer;
+import com.scalar.db.util.ThrowableFunction;
+import org.junit.jupiter.api.Test;
+
+public class TransactionExecutorTest {
+
+  @Test
+  public void execute_WithSingleCrudOperationTransactionManager_ShouldExecuteFunction()
+      throws TransactionException {
+    // Arrange
+    DistributedTransactionManager transactionManager =
+        mock(SingleCrudOperationTransactionManager.class);
+
+    int expected = 10;
+
+    // Act Assert
+    Integer result =
+        TransactionExecutor.execute(
+            transactionManager,
+            t -> {
+              assertThat(t).isEqualTo(transactionManager);
+              return expected;
+            });
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void execute2_WithSingleCrudOperationTransactionManager_ShouldExecuteFunction()
+      throws TransactionException {
+    // Arrange
+    DistributedTransactionManager transactionManager =
+        mock(SingleCrudOperationTransactionManager.class);
+
+    // Act Assert
+    TransactionExecutor.execute(
+        transactionManager,
+        t -> {
+          assertThat(t).isEqualTo(transactionManager);
+        });
+  }
+
+  @Test
+  public void execute_WithDistributedTransactionManager_ShouldExecuteFunction()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    DistributedTransactionManager transactionManager = mock(DistributedTransactionManager.class);
+    when(transactionManager.begin()).thenReturn(transaction);
+
+    int expected = 10;
+
+    // Act Assert
+    Integer result =
+        TransactionExecutor.execute(
+            transactionManager,
+            t -> {
+              assertThat(t).isEqualTo(transaction);
+              return expected;
+            });
+
+    assertThat(result).isEqualTo(expected);
+
+    verify(transactionManager).begin();
+    verify(transaction).commit();
+  }
+
+  @Test
+  public void execute2_WithDistributedTransactionManager_ShouldExecuteFunction()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    DistributedTransactionManager transactionManager = mock(DistributedTransactionManager.class);
+    when(transactionManager.begin()).thenReturn(transaction);
+
+    // Act Assert
+    TransactionExecutor.execute(
+        transactionManager,
+        t -> {
+          assertThat(t).isEqualTo(transaction);
+        });
+
+    verify(transactionManager).begin();
+    verify(transaction).commit();
+  }
+
+  @Test
+  public void
+      execute_WithDistributedTransactionManager_TransactionExceptionThrown_ShouldThrowTransactionException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    DistributedTransactionManager transactionManager = mock(DistributedTransactionManager.class);
+    when(transactionManager.begin()).thenReturn(transaction);
+
+    TransactionException exception = mock(TransactionException.class);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                TransactionExecutor.execute(
+                    transactionManager,
+                    (ThrowableFunction<CrudOperable<?>, Object, TransactionException>)
+                        t -> {
+                          throw exception;
+                        }))
+        .isEqualTo(exception);
+
+    verify(transactionManager).begin();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      execute2_WithDistributedTransactionManager_TransactionExceptionThrown_ShouldThrowTransactionException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    DistributedTransactionManager transactionManager = mock(DistributedTransactionManager.class);
+    when(transactionManager.begin()).thenReturn(transaction);
+
+    TransactionException exception = mock(TransactionException.class);
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                TransactionExecutor.execute(
+                    transactionManager,
+                    (ThrowableConsumer<CrudOperable<?>, TransactionException>)
+                        t -> {
+                          throw exception;
+                        }))
+        .isEqualTo(exception);
+
+    verify(transactionManager).begin();
+    verify(transaction).rollback();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a utility class `TransactionExecutor` that is a `SingleCrudOperationTransactionManager`-aware transaction executor.

## Related issues and/or PRs

N/A

## Changes made

- Added a utility class `TransactionExecutor`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
