### PR TITLE
Should return true for system namespace in namespaceExists()

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -256,6 +256,10 @@ public class CassandraAdmin implements DistributedStorageAdmin {
 
   @Override
   public boolean namespaceExists(String namespace) throws ExecutionException {
+    if (systemNamespace.equals(namespace)) {
+      return true;
+    }
+
     try {
       KeyspaceMetadata keyspace =
           clusterManager

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -461,6 +461,10 @@ public class CosmosAdmin implements DistributedStorageAdmin {
 
   @Override
   public boolean namespaceExists(String namespace) throws ExecutionException {
+    if (metadataDatabase.equals(namespace)) {
+      return true;
+    }
+
     return databaseExists(namespace);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1132,6 +1132,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   @Override
   public boolean namespaceExists(String nonPrefixedNamespace) throws ExecutionException {
+    Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
+    if (metadataNamespace.equals(namespace.prefixed())) {
+      return true;
+    }
+
     try {
       boolean namespaceExists = false;
       String lastEvaluatedTableName = null;
@@ -1141,7 +1146,6 @@ public class DynamoAdmin implements DistributedStorageAdmin {
         ListTablesResponse listTablesResponse = client.listTables(listTablesRequest);
         lastEvaluatedTableName = listTablesResponse.lastEvaluatedTableName();
         List<String> tableNames = listTablesResponse.tableNames();
-        Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
         for (String tableName : tableNames) {
           if (tableName.startsWith(namespace.prefixed() + ".")) {
             namespaceExists = true;

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -487,6 +487,15 @@ public class CassandraAdminTest {
   }
 
   @Test
+  public void namespaceExists_WithSystemNamespace_ShouldReturnTrue() throws ExecutionException {
+    // Arrange
+
+    // Act Assert
+    assertThat(cassandraAdmin.namespaceExists(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME))
+        .isTrue();
+  }
+
+  @Test
   public void createIndex_ShouldExecuteProperCql() throws ExecutionException {
     // Arrange
     String namespace = "sample_ns";

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -913,4 +913,26 @@ public abstract class CosmosAdminTestBase {
     verify(tableMetadataContainer).read();
     assertThat(actual).containsOnly(metadataDatabaseName);
   }
+
+  @Test
+  public void namespaceExists_WithExistingNamespace_ShouldReturnTrue() throws ExecutionException {
+    // Arrange
+    String namespace = "ns";
+    CosmosDatabase database = mock(CosmosDatabase.class);
+    when(client.getDatabase(namespace)).thenReturn(database);
+
+    // Act
+    boolean actual = admin.namespaceExists(namespace);
+
+    // Assert
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void namespaceExists_WithMetadataDatabase_ShouldReturnTrue() throws ExecutionException {
+    // Arrange
+
+    // Act Assert
+    assertThat(admin.namespaceExists(metadataDatabaseName)).isTrue();
+  }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -218,6 +218,18 @@ public abstract class DynamoAdminTestBase {
   }
 
   @Test
+  public void namespaceExists_WithMetadataNamespace_ShouldReturnTrue() throws ExecutionException {
+    // Arrange
+
+    // Act Assert
+    assertThat(
+            admin.namespaceExists(
+                getTableMetadataNamespaceConfig()
+                    .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME)))
+        .isTrue();
+  }
+
+  @Test
   public void createTable_WhenMetadataTableNotExist_ShouldCreateTableAndMetadataTable()
       throws ExecutionException {
     // Arrange

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -1360,6 +1360,25 @@ public abstract class JdbcAdminTestBase {
   }
 
   @Test
+  public void namespaceExists_WithMetadataSchema_ShouldReturnTrue() throws ExecutionException {
+    // Arrange
+    JdbcAdmin adminForMySql = createJdbcAdminFor(RdbEngine.MYSQL);
+    JdbcAdmin adminForPostgresql = createJdbcAdminFor(RdbEngine.POSTGRESQL);
+    JdbcAdmin adminForOracle = createJdbcAdminFor(RdbEngine.ORACLE);
+    JdbcAdmin adminForSqlServer = createJdbcAdminFor(RdbEngine.SQL_SERVER);
+    JdbcAdmin adminForSqlite = createJdbcAdminFor(RdbEngine.SQLITE);
+    JdbcAdmin adminForYugabyte = createJdbcAdminFor(RdbEngine.YUGABYTE);
+
+    // Act Assert
+    assertThat(adminForMySql.namespaceExists(tableMetadataSchemaName)).isTrue();
+    assertThat(adminForPostgresql.namespaceExists(tableMetadataSchemaName)).isTrue();
+    assertThat(adminForOracle.namespaceExists(tableMetadataSchemaName)).isTrue();
+    assertThat(adminForSqlServer.namespaceExists(tableMetadataSchemaName)).isTrue();
+    assertThat(adminForSqlite.namespaceExists(tableMetadataSchemaName)).isTrue();
+    assertThat(adminForYugabyte.namespaceExists(tableMetadataSchemaName)).isTrue();
+  }
+
+  @Test
   public void createIndex_ForColumnTypeWithoutRequiredAlterationForMysql_ShouldCreateIndexProperly()
       throws Exception {
     createIndex_ForColumnTypeWithoutRequiredAlterationForX_ShouldCreateIndexProperly(


### PR DESCRIPTION
## Description

This is for the `3` branch.

Currently, when the system namespace is not created yet, the `getNamespaceNames()` API returns the system namespace but the `namespaceExists()` API with the system namespace returns false. This PR addresses this issue.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2002

## Changes made

- Added check for the system namespace to `namespaceExists()` for each storage adaptor.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
