### PR TITLE
Backport to branch(3) : Bump junitVersion from 5.10.2 to 5.10.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
         prometheusVersion = '0.16.0'
         commonsTextVersion = '1.12.0'
         jettyVersion = '9.4.54.v20240208'
-        junitVersion = '5.10.2'
+        junitVersion = '5.10.3'
         commonsLangVersion = '3.14.0'
         assertjVersion = '3.26.0'
         mockitoVersion = '4.11.0'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2017