### PR TITLE
Add warning message for getNamespaceNames()

### DIFF
--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -10,8 +10,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(CheckedDistributedStorageAdmin.class);
 
   private final DistributedStorageAdmin admin;
 
@@ -322,6 +327,11 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
 
   @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
+    logger.warn(
+        "getNamespaceNames() extracts the namespace names of user tables dynamically. As a result, "
+            + "only namespaces that contain tables are returned. Starting from ScalarDB 4.0, we "
+            + "plan to improve the design to remove this limitation.");
+
     try {
       return admin.getNamespaceNames();
     } catch (ExecutionException e) {


### PR DESCRIPTION
## Description

This is for the `3` branch.

Currently, the `getNamespaceNames()` method has a limitation where only namespaces that contain tables are returned, which can be confusing for users. This PR adds a warning message about this limitation to the `getNamespaceNames()` method.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2002

## Changes made

- Added a warning message for the `getNamespaceNames()` method.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
