### PR TITLE
Reduce Cosmos DB log messages in the integration test

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -154,7 +154,13 @@ task integrationTestCosmos(type: Test) {
     options {
         systemProperties(System.getProperties().findAll{it.key.toString().startsWith("scalardb")})
     }
-    jvmArgs '-XX:MaxDirectMemorySize=4g', '-Xmx6g', '-Dorg.slf4j.simpleLogger.log.com.azure.cosmos.implementation.RxDocumentClientImpl=warn', '-Dorg.slf4j.simpleLogger.log.com.azure.cosmos.implementation.Configs=warn'
+    jvmArgs '-XX:MaxDirectMemorySize=4g', '-Xmx6g',
+            // INFO com.azure.cosmos.implementation.RxDocumentClientImpl - Initializing DocumentClient [3] with serviceEndpoint [https://localhost:8081/], ...
+            '-Dorg.slf4j.simpleLogger.log.com.azure.cosmos.implementation.RxDocumentClientImpl=warn',
+            // INFO com.azure.cosmos.implementation.Configs - AZURE_COSMOS_DISABLE_NON_STREAMING_ORDER_BY property is: null
+            '-Dorg.slf4j.simpleLogger.log.com.azure.cosmos.implementation.Configs=warn',
+            // ERROR com.scalar.db.storage.cosmos.MutateStatementHandler - {"innerErrorMessage":"[\"Encountered exception while executing Javascript. Exception = Error: no mutation...
+            '-Dorg.slf4j.simpleLogger.log.com.scalar.db.storage.cosmos.MutateStatementHandler=off'
 }
 
 task integrationTestDynamo(type: Test) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -154,7 +154,7 @@ task integrationTestCosmos(type: Test) {
     options {
         systemProperties(System.getProperties().findAll{it.key.toString().startsWith("scalardb")})
     }
-    jvmArgs '-XX:MaxDirectMemorySize=4g', '-Xmx6g'
+    jvmArgs '-XX:MaxDirectMemorySize=4g', '-Xmx6g', '-Dorg.slf4j.simpleLogger.log.com.azure.cosmos.implementation.RxDocumentClientImpl=warn', '-Dorg.slf4j.simpleLogger.log.com.azure.cosmos.implementation.Configs=warn'
 }
 
 task integrationTestDynamo(type: Test) {


### PR DESCRIPTION
## Description

The size of the integration test report for Cosmos DB is more than 9MB while other report sizes are about a few hundreds KB. This PR reduces the log size by filtering out a few types of log messages.

## Related issues and/or PRs

None

## Changes made

Filter out the following types of log message
1. `INFO com.azure.cosmos.implementation.RxDocumentClientImpl - Initializing DocumentClient [3] with serviceEndpoint [https://localhost:8081/],...`
2. `INFO com.azure.cosmos.implementation.Configs - AZURE_COSMOS_DISABLE_NON_STREAMING_ORDER_BY property is: null`
3. `ERROR com.scalar.db.storage.cosmos.MutateStatementHandler - {"innerErrorMessage":"[\"Encountered exception while executing Javascript. Exception = Error: no mutation`

3 is ERROR, but it accounts for most of log messages. So, it needs to be filtered out.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

With this change, the artifact size that contains log message was reduced down from 9MB to less than 300KB.
<img width="1162" alt="image" src="https://github.com/scalar-labs/scalardb/assets/59043/4d40d910-85f0-4b6f-959e-63300b3ca55e">

## Release notes

N/A
