### PR TITLE
Use a proper coordinator table schema based on whether the group commit feature is enabled or not

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -2,13 +2,15 @@ package com.scalar.db.storage.cassandra;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Properties;
 
 public class ConsensusCommitAdminIntegrationTestWithCassandra
     extends ConsensusCommitAdminIntegrationTestBase {
   @Override
   protected Properties getProps(String testName) {
-    return CassandraEnv.getProperties(testName);
+    return ConsensusCommitCassandraEnv.getProperties(testName);
   }
 
   @Override
@@ -16,5 +18,18 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
     return new CassandraConfig(new DatabaseConfig(properties))
         .getSystemNamespaceName()
         .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+  }
+
+  @Override
+  protected String getCoordinatorNamespaceName(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .getCoordinatorNamespace()
+        .orElse(Coordinator.NAMESPACE);
+  }
+
+  @Override
+  protected boolean isGroupCommitEnabled(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .isCoordinatorGroupCommitEnabled();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -22,14 +22,14 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
 
   @Override
   protected String getCoordinatorNamespaceName(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
         .orElse(Coordinator.NAMESPACE);
   }
 
   @Override
   protected boolean isGroupCommitEnabled(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .isCoordinatorGroupCommitEnabled();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitAdminIntegrationTestWithCassandra.java
@@ -32,4 +32,7 @@ public class ConsensusCommitAdminIntegrationTestWithCassandra
     return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .isCoordinatorGroupCommitEnabled();
   }
+
+  @Override
+  protected void extraCheckOnCoordinatorTable() {}
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -29,14 +29,14 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
 
   @Override
   protected String getCoordinatorNamespaceName(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
         .orElse(Coordinator.NAMESPACE);
   }
 
   @Override
   protected boolean isGroupCommitEnabled(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .isCoordinatorGroupCommitEnabled();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitAdminIntegrationTestWithCosmos.java
@@ -2,6 +2,8 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Map;
 import java.util.Properties;
 
@@ -10,12 +12,12 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
 
   @Override
   protected Properties getProps(String testName) {
-    return CosmosEnv.getProperties(testName);
+    return ConsensusCommitCosmosEnv.getProperties(testName);
   }
 
   @Override
   protected Map<String, String> getCreationOptions() {
-    return CosmosEnv.getCreationOptions();
+    return ConsensusCommitCosmosEnv.getCreationOptions();
   }
 
   @Override
@@ -23,5 +25,18 @@ public class ConsensusCommitAdminIntegrationTestWithCosmos
     return new CosmosConfig(new DatabaseConfig(properties))
         .getTableMetadataDatabase()
         .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+  }
+
+  @Override
+  protected String getCoordinatorNamespaceName(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .getCoordinatorNamespace()
+        .orElse(Coordinator.NAMESPACE);
+  }
+
+  @Override
+  protected boolean isGroupCommitEnabled(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .isCoordinatorGroupCommitEnabled();
   }
 }

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -2,6 +2,8 @@ package com.scalar.db.storage.dynamo;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
@@ -12,12 +14,12 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
 
   @Override
   protected Properties getProps(String testName) {
-    return DynamoEnv.getProperties(testName);
+    return ConsensusCommitDynamoEnv.getProperties(testName);
   }
 
   @Override
   protected Map<String, String> getCreationOptions() {
-    return DynamoEnv.getCreationOptions();
+    return ConsensusCommitDynamoEnv.getCreationOptions();
   }
 
   @Override
@@ -30,6 +32,19 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
     return new DynamoConfig(new DatabaseConfig(properties))
         .getTableMetadataNamespace()
         .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+  }
+
+  @Override
+  protected String getCoordinatorNamespaceName(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .getCoordinatorNamespace()
+        .orElse(Coordinator.NAMESPACE);
+  }
+
+  @Override
+  protected boolean isGroupCommitEnabled(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .isCoordinatorGroupCommitEnabled();
   }
 
   // Since DynamoDB doesn't have the namespace concept, some behaviors around the namespace are

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitAdminIntegrationTestWithDynamo.java
@@ -36,14 +36,14 @@ public class ConsensusCommitAdminIntegrationTestWithDynamo
 
   @Override
   protected String getCoordinatorNamespaceName(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
         .orElse(Coordinator.NAMESPACE);
   }
 
   @Override
   protected boolean isGroupCommitEnabled(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .isCoordinatorGroupCommitEnabled();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -26,14 +26,14 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
 
   @Override
   protected String getCoordinatorNamespaceName(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .getCoordinatorNamespace()
         .orElse(Coordinator.NAMESPACE);
   }
 
   @Override
   protected boolean isGroupCommitEnabled(String testName) {
-    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+    return new ConsensusCommitConfig(new DatabaseConfig(getProperties(testName)))
         .isCoordinatorGroupCommitEnabled();
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminIntegrationTestWithJdbcDatabase.java
@@ -3,6 +3,8 @@ package com.scalar.db.storage.jdbc;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -12,7 +14,7 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
 
   @Override
   protected Properties getProps(String testName) {
-    return JdbcEnv.getProperties(testName);
+    return ConsensusCommitJdbcEnv.getProperties(testName);
   }
 
   @Override
@@ -20,6 +22,19 @@ public class ConsensusCommitAdminIntegrationTestWithJdbcDatabase
     return new JdbcConfig(new DatabaseConfig(properties))
         .getTableMetadataSchema()
         .orElse(DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+  }
+
+  @Override
+  protected String getCoordinatorNamespaceName(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .getCoordinatorNamespace()
+        .orElse(Coordinator.NAMESPACE);
+  }
+
+  @Override
+  protected boolean isGroupCommitEnabled(String testName) {
+    return new ConsensusCommitConfig(new DatabaseConfig(getProps(testName)))
+        .isCoordinatorGroupCommitEnabled();
   }
 
   // Since SQLite doesn't have persistent namespaces, some behaviors around the namespace are

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -37,7 +37,14 @@ import org.slf4j.LoggerFactory;
 public class Coordinator {
   public static final String NAMESPACE = "coordinator";
   public static final String TABLE = "state";
-  public static final TableMetadata TABLE_METADATA =
+  public static final TableMetadata TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED =
+      TableMetadata.newBuilder()
+          .addColumn(Attribute.ID, DataType.TEXT)
+          .addColumn(Attribute.STATE, DataType.INT)
+          .addColumn(Attribute.CREATED_AT, DataType.BIGINT)
+          .addPartitionKey(Attribute.ID)
+          .build();
+  public static final TableMetadata TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED =
       TableMetadata.newBuilder()
           .addColumn(Attribute.ID, DataType.TEXT)
           .addColumn(Attribute.CHILD_IDS, DataType.TEXT)

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -47,6 +47,7 @@ public abstract class ConsensusCommitAdminTestBase {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     when(config.getCoordinatorNamespace()).thenReturn(getCoordinatorNamespaceConfig());
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(false);
     admin = new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
     coordinatorNamespaceName = getCoordinatorNamespaceConfig().orElse(Coordinator.NAMESPACE);
   }
@@ -68,7 +69,29 @@ public abstract class ConsensusCommitAdminTestBase {
         .createTable(
             coordinatorNamespaceName,
             Coordinator.TABLE,
-            Coordinator.TABLE_METADATA,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED,
+            Collections.emptyMap());
+  }
+
+  @Test
+  public void createCoordinatorTables_WithGroupCommitEnabled_shouldCreateCoordinatorTableProperly()
+      throws ExecutionException {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithGroupCommit =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    // Act
+    adminWithGroupCommit.createCoordinatorTables();
+
+    // Assert
+    verify(distributedStorageAdmin)
+        .createNamespace(coordinatorNamespaceName, Collections.emptyMap());
+    verify(distributedStorageAdmin)
+        .createTable(
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED,
             Collections.emptyMap());
   }
 
@@ -98,7 +121,34 @@ public abstract class ConsensusCommitAdminTestBase {
     verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, options);
     verify(distributedStorageAdmin)
         .createTable(
-            coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, options);
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED,
+            options);
+  }
+
+  @Test
+  public void
+      createCoordinatorTables_WithOptionsWithGroupCommitEnabled_shouldCreateCoordinatorTableProperly()
+          throws ExecutionException {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithGroupCommit =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    Map<String, String> options = ImmutableMap.of("name", "value");
+
+    // Act
+    adminWithGroupCommit.createCoordinatorTables(options);
+
+    // Assert
+    verify(distributedStorageAdmin).createNamespace(coordinatorNamespaceName, options);
+    verify(distributedStorageAdmin)
+        .createTable(
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED,
+            options);
   }
 
   @Test
@@ -570,7 +620,32 @@ public abstract class ConsensusCommitAdminTestBase {
     // Assert
     verify(distributedStorageAdmin)
         .repairTable(
-            coordinatorNamespaceName, Coordinator.TABLE, Coordinator.TABLE_METADATA, options);
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED,
+            options);
+  }
+
+  @Test
+  public void repairCoordinatorTables_WithGroupCommitEnabled_ShouldCallJdbcAdminProperly()
+      throws ExecutionException {
+    // Arrange
+    when(config.isCoordinatorGroupCommitEnabled()).thenReturn(true);
+    ConsensusCommitAdmin adminWithGroupCommit =
+        new ConsensusCommitAdmin(distributedStorageAdmin, config, false);
+
+    Map<String, String> options = ImmutableMap.of("foo", "bar");
+
+    // Act
+    adminWithGroupCommit.repairCoordinatorTables(options);
+
+    // Assert
+    verify(distributedStorageAdmin)
+        .repairTable(
+            coordinatorNamespaceName,
+            Coordinator.TABLE,
+            Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED,
+            options);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -8,7 +8,9 @@ import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
+import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
+import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,6 +71,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
           .build();
   protected TransactionFactory transactionFactory;
   protected DistributedTransactionAdmin admin;
+  protected DistributedStorageAdmin storageAdmin;
   protected String systemNamespaceName;
   protected String namespace1;
   protected String namespace2;
@@ -81,6 +84,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     Properties properties = getProperties(testName);
     transactionFactory = TransactionFactory.create(properties);
     admin = transactionFactory.getTransactionAdmin();
+    storageAdmin = StorageFactory.create(properties).getStorageAdmin();
     systemNamespaceName = getSystemNamespaceName(properties);
     namespace1 = getNamespaceBaseName() + testName + "1";
     namespace2 = getNamespaceBaseName() + testName + "2";
@@ -99,6 +103,14 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
   }
 
   protected abstract String getSystemNamespaceName(Properties properties);
+
+  protected String getCoordinatorNamespaceName(String testName) {
+    throw new AssertionError("Shouldn't be called");
+  }
+
+  protected boolean isGroupCommitEnabled(String testName) {
+    return false;
+  }
 
   private void createTables() throws ExecutionException {
     Map<String, String> options = getCreationOptions();
@@ -121,6 +133,14 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
       dropTables();
     } catch (Exception e) {
       logger.warn("Failed to drop tables", e);
+    }
+
+    try {
+      if (storageAdmin != null) {
+        storageAdmin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage admin", e);
     }
 
     try {
@@ -775,6 +795,17 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
 
     // Assert
     assertThat(admin.coordinatorTablesExist()).isTrue();
+
+    TableMetadata expectedMetadata;
+    if (isGroupCommitEnabled(getTestName())) {
+      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED;
+    } else {
+      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED;
+    }
+    assertThat(
+            storageAdmin.getTableMetadata(
+                getCoordinatorNamespaceName(getTestName()), Coordinator.TABLE))
+        .isEqualTo(expectedMetadata);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminIntegrationTestBase.java
@@ -784,6 +784,19 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  protected void extraCheckOnCoordinatorTable() throws ExecutionException {
+    TableMetadata expectedMetadata;
+    if (isGroupCommitEnabled(getTestName())) {
+      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED;
+    } else {
+      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED;
+    }
+    assertThat(
+            storageAdmin.getTableMetadata(
+                getCoordinatorNamespaceName(getTestName()), Coordinator.TABLE))
+        .isEqualTo(expectedMetadata);
+  }
+
   @Test
   public void createCoordinatorTables_ShouldCreateCoordinatorTablesCorrectly()
       throws ExecutionException {
@@ -796,16 +809,7 @@ public abstract class DistributedTransactionAdminIntegrationTestBase {
     // Assert
     assertThat(admin.coordinatorTablesExist()).isTrue();
 
-    TableMetadata expectedMetadata;
-    if (isGroupCommitEnabled(getTestName())) {
-      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED;
-    } else {
-      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED;
-    }
-    assertThat(
-            storageAdmin.getTableMetadata(
-                getCoordinatorNamespaceName(getTestName()), Coordinator.TABLE))
-        .isEqualTo(expectedMetadata);
+    extraCheckOnCoordinatorTable();
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/util/AdminTestUtils.java
+++ b/integration-test/src/main/java/com/scalar/db/util/AdminTestUtils.java
@@ -49,10 +49,9 @@ public abstract class AdminTestUtils {
    * @throws Exception if an error occurs
    */
   public boolean areTableMetadataForCoordinatorTablesPresent() throws Exception {
-    String coordinatorNamespace =
-        new ConsensusCommitConfig(new DatabaseConfig(coordinatorStorageProperties))
-            .getCoordinatorNamespace()
-            .orElse(Coordinator.NAMESPACE);
+    ConsensusCommitConfig config =
+        new ConsensusCommitConfig(new DatabaseConfig(coordinatorStorageProperties));
+    String coordinatorNamespace = config.getCoordinatorNamespace().orElse(Coordinator.NAMESPACE);
     String coordinatorTable = Coordinator.TABLE;
     // Use the DistributedStorageAdmin instead of the DistributedTransactionAdmin because the latter
     // expects the table to hold transaction table metadata columns which is not the case for the
@@ -66,6 +65,12 @@ public abstract class AdminTestUtils {
     if (tableMetadata == null) {
       return false;
     }
-    return tableMetadata.equals(Coordinator.TABLE_METADATA);
+    TableMetadata expectedMetadata;
+    if (config.isCoordinatorGroupCommitEnabled()) {
+      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_ENABLED;
+    } else {
+      expectedMetadata = Coordinator.TABLE_METADATA_WITH_GROUP_COMMIT_DISABLED;
+    }
+    return tableMetadata.equals(expectedMetadata);
   }
 }

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitAdminIntegrationTestWithServer.java
@@ -55,4 +55,7 @@ public class ConsensusCommitAdminIntegrationTestWithServer
   @Test
   @Disabled("Retrieving the namespace names is not supported in ScalarDB Server")
   public void getNamespaceNames_ShouldReturnCreatedNamespaces() {}
+
+  @Override
+  protected void extraCheckOnCoordinatorTable() {}
 }


### PR DESCRIPTION
## Description

We added the group commit feature for the coordinator table commit in version `3.13` and `4.x`. It added a new column `tx_child_ids` in `coordinator.state` table. So, our plan was as follows:
- In version 3, users manually need to drop and re-create the coordinator table if they want to use the group commit feature
- In version 4, users can migrate their coordinator table to the new schema that contains `tx_child_ids` using `schema-loader --upgrade` command

But, we noticed `schema-loader --repair-all --coordinator` command with JDBC storage updates the ScalarDB metadata table by adding `tx_child_ids` column while the existing coordinator table in underlying RDB is left as-is. It results in the inconsistent state and will cause an issue that `schema-loader --upgrade` wouldn't work with version 4.

After some discussions, we changed our plan for version 3 as follows:

- If the group commit feature is disabled (default), the old coordinator table schema is used. No issue happens even if `schema-loader --repair-all` is executed. So, most users don't need to consider the issue.
- If the group commit feature is enabled, users need to drop and re-create their coordinator table if it exists in advance. 
**This must be documented in another PR later**

## Related issues and/or PRs

None

## Changes made

- Made `ConsensusCommitAdmin` use the existing coordinator table schema that doesn't have `tx_child_idx` column if the group commit feature is disabled, and use the new coordinator table schema that has `tx_child_idx`  column if the group commit feature is enabled
- Updated and added related unit tests and integration tests

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A