### PR TITLE
Make DistributedStorage, DistributedTransactionAdmin, and DistributedStorageAdmin extend AutoCloseable

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -67,7 +67,7 @@ import java.util.Optional;
  *
  * @author Hiroyuki Yamada
  */
-public interface DistributedStorage {
+public interface DistributedStorage extends AutoCloseable {
   /**
    * Sets the specified namespace and the table name as default values in the instance.
    *
@@ -190,5 +190,6 @@ public interface DistributedStorage {
    * Closes connections to the cluster. The connections are shared among multiple services such as
    * StorageService and TransactionService, thus this should only be used when closing applications.
    */
+  @Override
   void close();
 }

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -40,7 +40,7 @@ import com.scalar.db.io.DataType;
  * admin.dropNamespace(NAMESPACE);
  * }</pre>
  */
-public interface DistributedStorageAdmin extends Admin {
+public interface DistributedStorageAdmin extends Admin, AutoCloseable {
 
   /**
    * Get import table metadata in the ScalarDB format.
@@ -68,5 +68,6 @@ public interface DistributedStorageAdmin extends Admin {
       throws ExecutionException;
 
   /** Closes connections to the storage. */
+  @Override
   void close();
 }

--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionAdmin.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * An administrative interface for distributed transaction implementations. The user can execute
  * administrative operations with it like createNamespace/createTable/getTableMetadata.
  */
-public interface DistributedTransactionAdmin extends Admin, AuthAdmin {
+public interface DistributedTransactionAdmin extends Admin, AuthAdmin, AutoCloseable {
 
   /**
    * Creates coordinator namespace and tables.
@@ -115,5 +115,6 @@ public interface DistributedTransactionAdmin extends Admin, AuthAdmin {
   void repairCoordinatorTables(Map<String, String> options) throws ExecutionException;
 
   /** Closes connections to the storage. */
+  @Override
   void close();
 }


### PR DESCRIPTION
## Description

This PR makes the `DistributedStorage`, `DistributedTransactionAdmin`, and `DistributedStorageAdmin` interfaces extend `AutoCloseable`.

## Related issues and/or PRs

N/A

## Changes made

- Made the `DistributedStorage`, `DistributedTransactionAdmin`, and `DistributedStorageAdmin` interfaces extend `AutoCloseable`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
