### PR TITLE
Create metadata namespace and table if they does not exist before creating user tables

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -228,6 +228,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
     Namespace namespace = Namespace.of(namespacePrefix, nonPrefixedNamespace);
     checkMetadata(metadata);
 
+    boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
+
+    // Create the metadata table first if it does not exist
+    createMetadataTableIfNotExists(noBackup);
+
     long ru = Long.parseLong(options.getOrDefault(REQUEST_UNIT, DEFAULT_REQUEST_UNIT));
 
     CreateTableRequest.Builder requestBuilder = CreateTableRequest.builder();
@@ -250,12 +255,10 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       enableAutoScaling(namespace, table, metadata.getSecondaryIndexNames(), ru);
     }
 
-    boolean noBackup = Boolean.parseBoolean(options.getOrDefault(NO_BACKUP, DEFAULT_NO_BACKUP));
     if (!noBackup) {
       enableContinuousBackup(namespace, table);
     }
 
-    createMetadataTableIfNotExists(noBackup);
     putTableMetadata(namespace, table, metadata);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -98,9 +98,12 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
+      // Create the metadata schema and table first if they do not exist
+      createMetadataSchemaAndTableIfNotExists(connection);
+
       createTableInternal(connection, namespace, table, metadata);
       createIndex(connection, namespace, table, metadata);
-      addTableMetadata(connection, namespace, table, metadata, true);
+      addTableMetadata(connection, namespace, table, metadata, false);
     } catch (SQLException e) {
       throw new ExecutionException(
           "Creating the table failed: " + getFullTableName(namespace, table), e);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -286,7 +286,7 @@ public abstract class DynamoAdminTestBase {
     List<CreateTableRequest> actualCreateTableRequests = createTableRequestCaptor.getAllValues();
 
     List<AttributeDefinition> attributeDefinitions =
-        actualCreateTableRequests.get(0).attributeDefinitions();
+        actualCreateTableRequests.get(1).attributeDefinitions();
     assertThat(attributeDefinitions.size()).isEqualTo(3);
     assertThat(attributeDefinitions.get(0).attributeName()).isEqualTo(DynamoAdmin.PARTITION_KEY);
     assertThat(attributeDefinitions.get(0).attributeType()).isEqualTo(ScalarAttributeType.B);
@@ -295,24 +295,24 @@ public abstract class DynamoAdminTestBase {
     assertThat(attributeDefinitions.get(2).attributeName()).isEqualTo("c4");
     assertThat(attributeDefinitions.get(2).attributeType()).isEqualTo(ScalarAttributeType.B);
 
-    assertThat(actualCreateTableRequests.get(0).keySchema().size()).isEqualTo(2);
-    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).attributeName())
+    assertThat(actualCreateTableRequests.get(1).keySchema().size()).isEqualTo(2);
+    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).attributeName())
         .isEqualTo(DynamoAdmin.PARTITION_KEY);
-    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).keyType())
+    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).keyType())
         .isEqualTo(KeyType.HASH);
-    assertThat(actualCreateTableRequests.get(0).keySchema().get(1).attributeName())
+    assertThat(actualCreateTableRequests.get(1).keySchema().get(1).attributeName())
         .isEqualTo(DynamoAdmin.CLUSTERING_KEY);
-    assertThat(actualCreateTableRequests.get(0).keySchema().get(1).keyType())
+    assertThat(actualCreateTableRequests.get(1).keySchema().get(1).keyType())
         .isEqualTo(KeyType.RANGE);
 
-    assertThat(actualCreateTableRequests.get(0).globalSecondaryIndexes().size()).isEqualTo(1);
-    assertThat(actualCreateTableRequests.get(0).globalSecondaryIndexes().get(0).indexName())
+    assertThat(actualCreateTableRequests.get(1).globalSecondaryIndexes().size()).isEqualTo(1);
+    assertThat(actualCreateTableRequests.get(1).globalSecondaryIndexes().get(0).indexName())
         .isEqualTo(getFullTableName() + ".global_index.c4");
-    assertThat(actualCreateTableRequests.get(0).globalSecondaryIndexes().get(0).keySchema().size())
+    assertThat(actualCreateTableRequests.get(1).globalSecondaryIndexes().get(0).keySchema().size())
         .isEqualTo(1);
     assertThat(
             actualCreateTableRequests
-                .get(0)
+                .get(1)
                 .globalSecondaryIndexes()
                 .get(0)
                 .keySchema()
@@ -321,7 +321,7 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo("c4");
     assertThat(
             actualCreateTableRequests
-                .get(0)
+                .get(1)
                 .globalSecondaryIndexes()
                 .get(0)
                 .keySchema()
@@ -330,7 +330,7 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo(KeyType.HASH);
     assertThat(
             actualCreateTableRequests
-                .get(0)
+                .get(1)
                 .globalSecondaryIndexes()
                 .get(0)
                 .projection()
@@ -338,7 +338,7 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo(ProjectionType.ALL);
     assertThat(
             actualCreateTableRequests
-                .get(0)
+                .get(1)
                 .globalSecondaryIndexes()
                 .get(0)
                 .provisionedThroughput()
@@ -346,39 +346,39 @@ public abstract class DynamoAdminTestBase {
         .isEqualTo(10);
     assertThat(
             actualCreateTableRequests
-                .get(0)
+                .get(1)
                 .globalSecondaryIndexes()
                 .get(0)
                 .provisionedThroughput()
                 .writeCapacityUnits())
         .isEqualTo(10);
 
-    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().writeCapacityUnits())
+    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().writeCapacityUnits())
         .isEqualTo(10);
-    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().readCapacityUnits())
+    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().readCapacityUnits())
         .isEqualTo(10);
 
-    assertThat(actualCreateTableRequests.get(0).tableName()).isEqualTo(getFullTableName());
+    assertThat(actualCreateTableRequests.get(1).tableName()).isEqualTo(getFullTableName());
 
     // for the table metadata table
-    attributeDefinitions = actualCreateTableRequests.get(1).attributeDefinitions();
+    attributeDefinitions = actualCreateTableRequests.get(0).attributeDefinitions();
     assertThat(attributeDefinitions.size()).isEqualTo(1);
     assertThat(attributeDefinitions.get(0).attributeName())
         .isEqualTo(DynamoAdmin.METADATA_ATTR_TABLE);
     assertThat(attributeDefinitions.get(0).attributeType()).isEqualTo(ScalarAttributeType.S);
 
-    assertThat(actualCreateTableRequests.get(1).keySchema().size()).isEqualTo(1);
-    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).attributeName())
+    assertThat(actualCreateTableRequests.get(0).keySchema().size()).isEqualTo(1);
+    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).attributeName())
         .isEqualTo(DynamoAdmin.METADATA_ATTR_TABLE);
-    assertThat(actualCreateTableRequests.get(1).keySchema().get(0).keyType())
+    assertThat(actualCreateTableRequests.get(0).keySchema().get(0).keyType())
         .isEqualTo(KeyType.HASH);
 
-    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().writeCapacityUnits())
+    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().writeCapacityUnits())
         .isEqualTo(1);
-    assertThat(actualCreateTableRequests.get(1).provisionedThroughput().readCapacityUnits())
+    assertThat(actualCreateTableRequests.get(0).provisionedThroughput().readCapacityUnits())
         .isEqualTo(1);
 
-    assertThat(actualCreateTableRequests.get(1).tableName()).isEqualTo(getFullMetadataTableName());
+    assertThat(actualCreateTableRequests.get(0).tableName()).isEqualTo(getFullMetadataTableName());
 
     ArgumentCaptor<PutItemRequest> putItemRequestCaptor =
         ArgumentCaptor.forClass(PutItemRequest.class);
@@ -428,8 +428,8 @@ public abstract class DynamoAdminTestBase {
     List<UpdateContinuousBackupsRequest> updateContinuousBackupsRequests =
         updateContinuousBackupsRequestCaptor.getAllValues();
     assertThat(updateContinuousBackupsRequests.size()).isEqualTo(2);
-    assertThat(updateContinuousBackupsRequests.get(0).tableName()).isEqualTo(getFullTableName());
-    assertThat(updateContinuousBackupsRequests.get(1).tableName())
+    assertThat(updateContinuousBackupsRequests.get(1).tableName()).isEqualTo(getFullTableName());
+    assertThat(updateContinuousBackupsRequests.get(0).tableName())
         .isEqualTo(getFullMetadataTableName());
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -364,9 +364,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.MYSQL,
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3`,`c1`,`c4`))",
-        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
-        "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "CREATE SCHEMA IF NOT EXISTS `" + tableMetadataSchemaName + "`",
         "CREATE TABLE IF NOT EXISTS `"
             + tableMetadataSchemaName
@@ -379,6 +376,9 @@ public abstract class JdbcAdminTestBase {
             + "`indexed` BOOLEAN NOT NULL,"
             + "`ordinal_position` INTEGER NOT NULL,"
             + "PRIMARY KEY (`full_table_name`, `column_name`))",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3`,`c1`,`c4`))",
+        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
+        "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,false,1)",
@@ -407,9 +407,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.POSTGRESQL,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "CREATE SCHEMA IF NOT EXISTS \"" + tableMetadataSchemaName + "\"",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
@@ -422,6 +419,9 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,false,1)",
@@ -450,10 +450,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.SQL_SERVER,
-        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
-            + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3],[c1],[c4]))",
-        "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
-        "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])",
         "CREATE SCHEMA [" + tableMetadataSchemaName + "]",
         "CREATE TABLE ["
             + tableMetadataSchemaName
@@ -466,6 +462,10 @@ public abstract class JdbcAdminTestBase {
             + "[indexed] BIT NOT NULL,"
             + "[ordinal_position] INTEGER NOT NULL,"
             + "PRIMARY KEY ([full_table_name], [column_name]))",
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
+            + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3],[c1],[c4]))",
+        "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
+        "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])",
         "INSERT INTO ["
             + tableMetadataSchemaName
             + "].[metadata] VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,0,1)",
@@ -494,15 +494,15 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.ORACLE,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
-        "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "CREATE USER \"" + tableMetadataSchemaName + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
         "ALTER USER \"" + tableMetadataSchemaName + "\" quota unlimited on USERS",
         "CREATE TABLE \""
             + tableMetadataSchemaName
             + "\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,0,1)",
@@ -531,9 +531,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_forX_shouldExecuteCreateTableStatement(
         RdbEngine.SQLITE,
-        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
             + "$metadata\"("
@@ -545,6 +542,9 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "$metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,FALSE,1)",
@@ -616,9 +616,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
         RdbEngine.MYSQL,
-        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
-        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
-        "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "CREATE SCHEMA IF NOT EXISTS `" + tableMetadataSchemaName + "`",
         "CREATE TABLE IF NOT EXISTS `"
             + tableMetadataSchemaName
@@ -631,6 +628,9 @@ public abstract class JdbcAdminTestBase {
             + "`indexed` BOOLEAN NOT NULL,"
             + "`ordinal_position` INTEGER NOT NULL,"
             + "PRIMARY KEY (`full_table_name`, `column_name`))",
+        "CREATE TABLE `my_ns`.`foo_table`(`c3` BOOLEAN,`c1` VARCHAR(64),`c4` VARBINARY(64),`c2` BIGINT,`c5` INT,`c6` DOUBLE,`c7` REAL, PRIMARY KEY (`c3` ASC,`c1` DESC,`c4` ASC))",
+        "CREATE INDEX `index_my_ns_foo_table_c4` ON `my_ns`.`foo_table` (`c4`)",
+        "CREATE INDEX `index_my_ns_foo_table_c1` ON `my_ns`.`foo_table` (`c1`)",
         "INSERT INTO `"
             + tableMetadataSchemaName
             + "`.`metadata` VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,false,1)",
@@ -659,10 +659,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
         RdbEngine.POSTGRESQL,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "CREATE SCHEMA IF NOT EXISTS \"" + tableMetadataSchemaName + "\"",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
@@ -675,6 +671,10 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" BOOLEAN,\"c1\" VARCHAR(10485760),\"c4\" BYTEA,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE PRECISION,\"c7\" REAL, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,false,1)",
@@ -703,10 +703,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
         RdbEngine.SQL_SERVER,
-        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
-            + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3] ASC,[c1] DESC,[c4] ASC))",
-        "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
-        "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])",
         "CREATE SCHEMA [" + tableMetadataSchemaName + "]",
         "CREATE TABLE ["
             + tableMetadataSchemaName
@@ -719,6 +715,10 @@ public abstract class JdbcAdminTestBase {
             + "[indexed] BIT NOT NULL,"
             + "[ordinal_position] INTEGER NOT NULL,"
             + "PRIMARY KEY ([full_table_name], [column_name]))",
+        "CREATE TABLE [my_ns].[foo_table]([c3] BIT,[c1] VARCHAR(8000),"
+            + "[c4] VARBINARY(8000),[c2] BIGINT,[c5] INT,[c6] FLOAT,[c7] FLOAT(24), PRIMARY KEY ([c3] ASC,[c1] DESC,[c4] ASC))",
+        "CREATE INDEX [index_my_ns_foo_table_c4] ON [my_ns].[foo_table] ([c4])",
+        "CREATE INDEX [index_my_ns_foo_table_c1] ON [my_ns].[foo_table] ([c1])",
         "INSERT INTO ["
             + tableMetadataSchemaName
             + "].[metadata] VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,0,1)",
@@ -747,16 +747,16 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
         RdbEngine.ORACLE,
-        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
-        "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
-        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "CREATE USER \"" + tableMetadataSchemaName + "\" IDENTIFIED BY \"Oracle1234!@#$\"",
         "ALTER USER \"" + tableMetadataSchemaName + "\" quota unlimited on USERS",
         "CREATE TABLE \""
             + tableMetadataSchemaName
             + "\".\"metadata\"(\"full_table_name\" VARCHAR2(128),\"column_name\" VARCHAR2(128),\"data_type\" VARCHAR2(20) NOT NULL,\"key_type\" VARCHAR2(20),\"clustering_order\" VARCHAR2(10),\"indexed\" NUMBER(1) NOT NULL,\"ordinal_position\" INTEGER NOT NULL,PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "CREATE TABLE \"my_ns\".\"foo_table\"(\"c3\" NUMBER(1),\"c1\" VARCHAR2(64),\"c4\" RAW(64),\"c2\" NUMBER(19),\"c5\" NUMBER(10),\"c6\" BINARY_DOUBLE,\"c7\" BINARY_FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\")) ROWDEPENDENCIES",
+        "ALTER TABLE \"my_ns\".\"foo_table\" INITRANS 3 MAXTRANS 255",
+        "CREATE UNIQUE INDEX \"my_ns.foo_table_clustering_order_idx\" ON \"my_ns\".\"foo_table\" (\"c3\" ASC,\"c1\" DESC,\"c4\" ASC)",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns\".\"foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns\".\"foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "\".\"metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,0,1)",
@@ -785,9 +785,6 @@ public abstract class JdbcAdminTestBase {
       throws ExecutionException, SQLException {
     createTable_WithClusteringOrderForX_shouldExecuteCreateTableStatement(
         RdbEngine.SQLITE,
-        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
-        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
-        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "CREATE TABLE IF NOT EXISTS \""
             + tableMetadataSchemaName
             + "$metadata\"("
@@ -799,6 +796,9 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
+        "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "INSERT INTO \""
             + tableMetadataSchemaName
             + "$metadata\" VALUES ('my_ns.foo_table','c3','BOOLEAN','PARTITION',NULL,FALSE,1)",


### PR DESCRIPTION
## Description

This is for the `3` and `3.13` branches.

This PR changes to create the metadata namespace and table if they does not exist before creating user tables.

## Related issues and/or PRs

N/A

## Changes made

- Changed to create the metadata namespace and table if they does not exist before creating user tables.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
