### PR TITLE
Backport to branch(3) : Update ScalarDB dependency version to 3.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.12.2'
+    implementation 'com.scalar-labs:scalardb:3.13.0'
 }
 ```
 
@@ -20,7 +20,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.12.2</version>
+  <version>3.13.0</version>
 </dependency>
 ```
 

--- a/docs/getting-started-kotlin/build.gradle.kts
+++ b/docs/getting-started-kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.scalar-labs", "scalardb", "3.12.2")
+    implementation("com.scalar-labs", "scalardb", "3.13.0")
     testImplementation(kotlin("test"))
 }
 

--- a/docs/getting-started/build.gradle
+++ b/docs/getting-started/build.gradle
@@ -11,7 +11,7 @@ application {
 }
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.12.2'
+    implementation 'com.scalar-labs:scalardb:3.13.0'
     implementation 'org.slf4j:slf4j-simple:1.7.30'
 }
 


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2036