### PR TITLE
Backport to branch(3) : Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-5 to 42.3.5-yb-6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
         oracleDriverVersion = '21.14.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
         sqliteDriverVersion = '3.46.0.0'
-        yugabyteDriverVersion = '42.3.5-yb-5'
+        yugabyteDriverVersion = '42.3.5-yb-6'
         grpcVersion = '1.60.0'
         protobufVersion = '3.21.12'
         annotationVersion = '1.3.2'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2078