### PR TITLE
Backport to branch(3.10) : Fix compilation error when using the JDK 21 for Getting Started with Kotlin

### DIFF
--- a/docs/getting-started-kotlin/build.gradle.kts
+++ b/docs/getting-started-kotlin/build.gradle.kts
@@ -25,6 +25,11 @@ tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 application {
     mainClass.set("MainKt")
 }


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2102