### PR TITLE
Fix CI issue of SQL Server (Check if the command exsits)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,1004 +44,1004 @@ env:
   INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT: '-Dscalardb.consensus_commit.coordinator.group_commit.enabled=true -Dscalardb.consensus_commit.coordinator.group_commit.old_group_abort_timeout_millis=15000 --tests "**.ConsensusCommit**"'
 
 jobs:
-  check:
-    name: Gradle check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Setup and execute Gradle 'check' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: check buildSrc:check
-
-      - name: Save Gradle test reports
-        if: always()
-        run: |
-          mkdir -p /tmp/gradle_test_reports/core
-          mkdir -p /tmp/gradle_test_reports/schema-loader
-          cp -a core/build/reports/tests/test /tmp/gradle_test_reports/core/
-          cp -a schema-loader/build/reports/tests/test /tmp/gradle_test_reports/schema-loader/
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gradle_check_reports
-          path: /tmp/gradle_test_reports
-
-      - name: Save SpotBugs reports
-        if: always()
-        run: |
-          mkdir -p /tmp/gradle_spotbugs_reports/core
-          mkdir -p /tmp/gradle_spotbugs_reports/schema-loader
-          mkdir -p /tmp/gradle_spotbugs_reports/integration-test
-          cp -a core/build/reports/spotbugs /tmp/gradle_spotbugs_reports/core/
-          cp -a schema-loader/build/reports/spotbugs /tmp/gradle_spotbugs_reports/schema-loader/
-          cp -a integration-test/build/reports/spotbugs /tmp/gradle_spotbugs_reports/integration-test/
-
-      - name: Upload Spotbugs reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gradle_spotbugs_reports
-          path: /tmp/gradle_spotbugs_reports
-
-  dockerfile-lint:
-    name: Lint dockerfiles
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Dockerfile Lint for ScalarDB Schema Loader
-        if: always()
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: ':schema-loader:dockerfileLint'
-
-  integration-test-for-cassandra-3-0:
-    name: Cassandra 3.0 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      cassandra:
-        image: cassandra:3.0
-        env:
-          MAX_HEAP_SIZE: 2048m
-          HEAP_NEWSIZE: 512m
-        ports:
-          - 9042:9042
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestCassandra' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cassandra_3.0_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestCassandra
-
-  integration-test-for-cassandra-3-11:
-    name: Cassandra 3.11 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      cassandra:
-        image: cassandra:3.11
-        env:
-          MAX_HEAP_SIZE: 2048m
-          HEAP_NEWSIZE: 512m
-        ports:
-          - 9042:9042
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestCassandra' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cassandra_3.11_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestCassandra
-
-  integration-test-for-cosmos:
-    name: Cosmos DB integration test (${{ matrix.mode.label }})
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          $container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-windows")
-          docker cp "${container_id}:oracle-jdk.exe" .
-          docker rm "$container_id"
-          Write-Host "Install Oracle JDK"
-          Start-Process "oracle-jdk.exe" -NoNewWindow -Wait -ArgumentList "/s"
-          Write-Host "Oracle JDK installation successful"
-          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
-            $jdk_root_dir = "jdk-1.8"
-          } else {
-            $jdk_root_dir = "jdk-11"
-          }
-          echo "JAVA_HOME=C:\Program Files\Java\${jdk_root_dir}" >> ${env:GITHUB_ENV}
-
-      - name: Start Azure Cosmos DB emulator
-        run: |
-          Write-Host "Launching Cosmos DB Emulator"
-          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-          Start-CosmosDbEmulator -Consistency Strong
-
-      - name: Install TLS/SSL certificate
-        run: |
-          $cert = Get-ChildItem Cert:\LocalMachine\My | where{$_.FriendlyName -eq 'DocumentDbEmulatorCertificate'}
-          $params = @{
-            Cert = $cert
-            Type = "CERT"
-            FilePath = "$home/tmp-cert.cer"
-            NoClobber = $true
-          }
-          Export-Certificate @params
-          certutil -encode $home/tmp-cert.cer $home/cosmosdbcert.cer
-          Remove-Item $home/tmp-cert.cer
-          # Setting the keystore option differs between Java 8 and Java 11+
-          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
-            $keystore = "-keystore", "${env:JAVA_HOME}/jre/lib/security/cacerts"
-          } else {
-            $keystore = "-cacerts"
-          }
-          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -importcert -noprompt -alias cosmos_emulator -file $home/cosmosdbcert.cer
-          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -list -alias cosmos_emulator
-
-      - name: Setup and execute Gradle 'integrationTestCosmos' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestCosmos -Dscalardb.cosmos.uri=https://localhost:8081/ -Dscalardb.cosmos.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw== -Dfile.encoding=UTF-8 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cosmos_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestCosmos
-
-  integration-test-for-dynamo:
-    name: DynamoDB integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      dynamodb:
-        image: amazon/dynamodb-local:1.17.0
-        ports:
-          - 8000:8000
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestDynamo' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestDynamo ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dynamo_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestDynamo
-
-  integration-test-for-jdbc-mysql-5-7:
-    name: MySQL 5.7 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Run MySQL 5.7
-        run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mysql_5.7_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-mysql-8-0:
-    name: MySQL 8.0 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Run MySQL 8.0
-        run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.0 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mysql_8.0_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-mysql-8-1:
-    name: MySQL 8.1 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Run MySQL 8.1
-        run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.1 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mysql_8.1_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-postgresql-12:
-    name: PostgreSQL 12 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:12-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: postgresql_12_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-postgresql-13:
-    name: PostgreSQL 13 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:13-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: postgresql_13_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-postgresql-14:
-    name: PostgreSQL 14 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:14-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: postgresql_14_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-postgresql-15:
-    name: PostgreSQL 15 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: postgresql_15_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-  
-  integration-test-for-jdbc-oracle-19:
-    name: Oracle 19 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      oracle:
-        image: ghcr.io/scalar-labs/oracle/db-prebuilt:19
-        credentials:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-        ports:
-          - 1521:1521
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/ORCLPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: oracle_19_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-oracle-21:
-    name: Oracle 21 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      oracle:
-        image: ghcr.io/scalar-labs/oracle/db-prebuilt:21
-        credentials:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-        env:
-          ORACLE_PWD: Oracle
-        ports:
-          - 1521:1521
-        options: >-
-          --health-cmd "/opt/oracle/checkDBStatus.sh"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 120
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: oracle_21_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-oracle-23:
-    name: Oracle 23 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Free up ~14GB of disk space by removing the Android SDK
-        run: |
-          echo "Storage available before deletion"
-          df -h /
-          echo
-          sudo rm -r /usr/local/lib/android
-          echo "Storage available after deletion"
-          df -h /
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Start Oracle 23 container
-        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23
-
-      - name: Wait for the container to be ready
-        timeout-minutes: 5
-        run : |
-          while [ "`docker inspect -f {{.State.Health.Status}} oracle-23`" != "healthy" ]
-          do
-            sleep 10
-            echo "Container is not yet ready"
-          done
-          echo "Container is ready"
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Stop Oracle 23 container
-        if: always()
-        run: docker stop oracle-23 | xargs docker rm
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: oracle_23_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
+#  check:
+#    name: Gradle check
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Setup and execute Gradle 'check' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: check buildSrc:check
+#
+#      - name: Save Gradle test reports
+#        if: always()
+#        run: |
+#          mkdir -p /tmp/gradle_test_reports/core
+#          mkdir -p /tmp/gradle_test_reports/schema-loader
+#          cp -a core/build/reports/tests/test /tmp/gradle_test_reports/core/
+#          cp -a schema-loader/build/reports/tests/test /tmp/gradle_test_reports/schema-loader/
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: gradle_check_reports
+#          path: /tmp/gradle_test_reports
+#
+#      - name: Save SpotBugs reports
+#        if: always()
+#        run: |
+#          mkdir -p /tmp/gradle_spotbugs_reports/core
+#          mkdir -p /tmp/gradle_spotbugs_reports/schema-loader
+#          mkdir -p /tmp/gradle_spotbugs_reports/integration-test
+#          cp -a core/build/reports/spotbugs /tmp/gradle_spotbugs_reports/core/
+#          cp -a schema-loader/build/reports/spotbugs /tmp/gradle_spotbugs_reports/schema-loader/
+#          cp -a integration-test/build/reports/spotbugs /tmp/gradle_spotbugs_reports/integration-test/
+#
+#      - name: Upload Spotbugs reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: gradle_spotbugs_reports
+#          path: /tmp/gradle_spotbugs_reports
+#
+#  dockerfile-lint:
+#    name: Lint dockerfiles
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Dockerfile Lint for ScalarDB Schema Loader
+#        if: always()
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: ':schema-loader:dockerfileLint'
+#
+#  integration-test-for-cassandra-3-0:
+#    name: Cassandra 3.0 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      cassandra:
+#        image: cassandra:3.0
+#        env:
+#          MAX_HEAP_SIZE: 2048m
+#          HEAP_NEWSIZE: 512m
+#        ports:
+#          - 9042:9042
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestCassandra' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: cassandra_3.0_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestCassandra
+#
+#  integration-test-for-cassandra-3-11:
+#    name: Cassandra 3.11 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      cassandra:
+#        image: cassandra:3.11
+#        env:
+#          MAX_HEAP_SIZE: 2048m
+#          HEAP_NEWSIZE: 512m
+#        ports:
+#          - 9042:9042
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestCassandra' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: cassandra_3.11_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestCassandra
+#
+#  integration-test-for-cosmos:
+#    name: Cosmos DB integration test (${{ matrix.mode.label }})
+#    runs-on: windows-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          $container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-windows")
+#          docker cp "${container_id}:oracle-jdk.exe" .
+#          docker rm "$container_id"
+#          Write-Host "Install Oracle JDK"
+#          Start-Process "oracle-jdk.exe" -NoNewWindow -Wait -ArgumentList "/s"
+#          Write-Host "Oracle JDK installation successful"
+#          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
+#            $jdk_root_dir = "jdk-1.8"
+#          } else {
+#            $jdk_root_dir = "jdk-11"
+#          }
+#          echo "JAVA_HOME=C:\Program Files\Java\${jdk_root_dir}" >> ${env:GITHUB_ENV}
+#
+#      - name: Start Azure Cosmos DB emulator
+#        run: |
+#          Write-Host "Launching Cosmos DB Emulator"
+#          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+#          Start-CosmosDbEmulator -Consistency Strong
+#
+#      - name: Install TLS/SSL certificate
+#        run: |
+#          $cert = Get-ChildItem Cert:\LocalMachine\My | where{$_.FriendlyName -eq 'DocumentDbEmulatorCertificate'}
+#          $params = @{
+#            Cert = $cert
+#            Type = "CERT"
+#            FilePath = "$home/tmp-cert.cer"
+#            NoClobber = $true
+#          }
+#          Export-Certificate @params
+#          certutil -encode $home/tmp-cert.cer $home/cosmosdbcert.cer
+#          Remove-Item $home/tmp-cert.cer
+#          # Setting the keystore option differs between Java 8 and Java 11+
+#          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
+#            $keystore = "-keystore", "${env:JAVA_HOME}/jre/lib/security/cacerts"
+#          } else {
+#            $keystore = "-cacerts"
+#          }
+#          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -importcert -noprompt -alias cosmos_emulator -file $home/cosmosdbcert.cer
+#          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -list -alias cosmos_emulator
+#
+#      - name: Setup and execute Gradle 'integrationTestCosmos' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestCosmos -Dscalardb.cosmos.uri=https://localhost:8081/ -Dscalardb.cosmos.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw== -Dfile.encoding=UTF-8 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: cosmos_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestCosmos
+#
+#  integration-test-for-dynamo:
+#    name: DynamoDB integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      dynamodb:
+#        image: amazon/dynamodb-local:1.17.0
+#        ports:
+#          - 8000:8000
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestDynamo' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestDynamo ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: dynamo_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestDynamo
+#
+#  integration-test-for-jdbc-mysql-5-7:
+#    name: MySQL 5.7 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Run MySQL 5.7
+#        run: |
+#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: mysql_5.7_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-mysql-8-0:
+#    name: MySQL 8.0 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Run MySQL 8.0
+#        run: |
+#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.0 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: mysql_8.0_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-mysql-8-1:
+#    name: MySQL 8.1 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Run MySQL 8.1
+#        run: |
+#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.1 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: mysql_8.1_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-postgresql-12:
+#    name: PostgreSQL 12 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      postgres:
+#        image: postgres:12-alpine
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#        ports:
+#          - 5432:5432
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: postgresql_12_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-postgresql-13:
+#    name: PostgreSQL 13 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      postgres:
+#        image: postgres:13-alpine
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#        ports:
+#          - 5432:5432
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: postgresql_13_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-postgresql-14:
+#    name: PostgreSQL 14 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      postgres:
+#        image: postgres:14-alpine
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#        ports:
+#          - 5432:5432
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: postgresql_14_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-postgresql-15:
+#    name: PostgreSQL 15 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      postgres:
+#        image: postgres:15-alpine
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#        ports:
+#          - 5432:5432
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: postgresql_15_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#  
+#  integration-test-for-jdbc-oracle-19:
+#    name: Oracle 19 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      oracle:
+#        image: ghcr.io/scalar-labs/oracle/db-prebuilt:19
+#        credentials:
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#        ports:
+#          - 1521:1521
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/ORCLPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: oracle_19_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-oracle-21:
+#    name: Oracle 21 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      oracle:
+#        image: ghcr.io/scalar-labs/oracle/db-prebuilt:21
+#        credentials:
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#        env:
+#          ORACLE_PWD: Oracle
+#        ports:
+#          - 1521:1521
+#        options: >-
+#          --health-cmd "/opt/oracle/checkDBStatus.sh"
+#          --health-interval 10s
+#          --health-timeout 5s
+#          --health-retries 120
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: oracle_21_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-oracle-23:
+#    name: Oracle 23 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Free up ~14GB of disk space by removing the Android SDK
+#        run: |
+#          echo "Storage available before deletion"
+#          df -h /
+#          echo
+#          sudo rm -r /usr/local/lib/android
+#          echo "Storage available after deletion"
+#          df -h /
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Start Oracle 23 container
+#        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23
+#
+#      - name: Wait for the container to be ready
+#        timeout-minutes: 5
+#        run : |
+#          while [ "`docker inspect -f {{.State.Health.Status}} oracle-23`" != "healthy" ]
+#          do
+#            sleep 10
+#            echo "Container is not yet ready"
+#          done
+#          echo "Container is ready"
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Stop Oracle 23 container
+#        if: always()
+#        run: docker stop oracle-23 | xargs docker rm
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: oracle_23_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
   integration-test-for-jdbc-sqlserver-2017:
     name: SQL Server 2017 integration test (${{ matrix.mode.label }})
     runs-on: ubuntu-latest
@@ -1251,307 +1251,307 @@ jobs:
         with:
           name: sqlserver_2022_integration_test_reports_${{ matrix.mode.label }}
           path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-sqlite-3:
-    name: SQLite 3 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Set up SQLite3
-        run: sudo apt-get install -y sqlite3
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: sqlite_3_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-mariadb-10:
-    name: MariaDB 10 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Run MariaDB 10.11
-        run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:10.11 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mariadb_10_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-mariadb-11-4:
-    name: MariaDB 11.4 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-
-    steps:
-      - name: Run MariaDB 11.4
-        run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:11.4 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mariadb_11.4_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-jdbc-yugabytedb-2:
-    name: YugabyteDB 2 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Run YugabyteDB 2
-        run: |
-          docker run -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.21.0.0-b545 bin/yugabyted start --background=false --master_flag="ysql_enable_db_catalog_version_mode=false" --tserver_flags="ysql_enable_db_catalog_version_mode=false"
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:yugabytedb://localhost:5433/ -Dscalardb.jdbc.username=yugabyte -Dscalardb.jdbc.password=yugabyte -Dscalar.db.jdbc.connection_pool.max_total=12 -Dscalar.db.jdbc.table_metadata.connection_pool.max_total=4 -Dscalar.db.jdbc.admin.connection_pool.max_total=4 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: yugabytedb_2_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestJdbc
-
-  integration-test-for-multi-storage:
-    name: Multi-storage integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
-
-    services:
-      cassandra:
-        image: cassandra:3.11
-        env:
-          MAX_HEAP_SIZE: 2048m
-          HEAP_NEWSIZE: 512m
-        ports:
-          - 9042:9042
-
-    strategy:
-      matrix:
-        mode:
-          - label: default
-            group_commit_enabled: false
-          - label: with_group_commit
-            group_commit_enabled: true
-
-    steps:
-      - name: Run MySQL 8
-        run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_VENDOR }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-        uses: actions/setup-java@v4
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-        with:
-          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-        run: |
-          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestMultiStorage' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestMultiStorage ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-
-      - name: Upload Gradle test reports
-        uses: actions/upload-artifact@v4
-        if : always()
-        with:
-          name: multi_storage_integration_test_reports_${{ matrix.mode.label }}
-          path: core/build/reports/tests/integrationTestMultiStorage
+#
+#  integration-test-for-jdbc-sqlite-3:
+#    name: SQLite 3 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Set up SQLite3
+#        run: sudo apt-get install -y sqlite3
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: sqlite_3_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-mariadb-10:
+#    name: MariaDB 10 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Run MariaDB 10.11
+#        run: |
+#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:10.11 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: mariadb_10_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-mariadb-11-4:
+#    name: MariaDB 11.4 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#
+#    steps:
+#      - name: Run MariaDB 11.4
+#        run: |
+#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:11.4 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: mariadb_11.4_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-jdbc-yugabytedb-2:
+#    name: YugabyteDB 2 integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Run YugabyteDB 2
+#        run: |
+#          docker run -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.21.0.0-b545 bin/yugabyted start --background=false --master_flag="ysql_enable_db_catalog_version_mode=false" --tserver_flags="ysql_enable_db_catalog_version_mode=false"
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestJdbc' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:yugabytedb://localhost:5433/ -Dscalardb.jdbc.username=yugabyte -Dscalardb.jdbc.password=yugabyte -Dscalar.db.jdbc.connection_pool.max_total=12 -Dscalar.db.jdbc.table_metadata.connection_pool.max_total=4 -Dscalar.db.jdbc.admin.connection_pool.max_total=4 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        if: always()
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: yugabytedb_2_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestJdbc
+#
+#  integration-test-for-multi-storage:
+#    name: Multi-storage integration test (${{ matrix.mode.label }})
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      cassandra:
+#        image: cassandra:3.11
+#        env:
+#          MAX_HEAP_SIZE: 2048m
+#          HEAP_NEWSIZE: 512m
+#        ports:
+#          - 9042:9042
+#
+#    strategy:
+#      matrix:
+#        mode:
+#          - label: default
+#            group_commit_enabled: false
+#          - label: with_group_commit
+#            group_commit_enabled: true
+#
+#    steps:
+#      - name: Run MySQL 8
+#        run: |
+#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#
+#      - uses: actions/checkout@v4
+#
+#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: ${{ env.JAVA_VERSION }}
+#          distribution: ${{ env.JAVA_VENDOR }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+#        uses: actions/setup-java@v4
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+#        with:
+#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.CR_PAT }}
+#
+#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+#        run: |
+#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+#
+#      - name: Setup and execute Gradle 'integrationTestMultiStorage' task
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: integrationTestMultiStorage ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+#
+#      - name: Upload Gradle test reports
+#        uses: actions/upload-artifact@v4
+#        if : always()
+#        with:
+#          name: multi_storage_integration_test_reports_${{ matrix.mode.label }}
+#          path: core/build/reports/tests/integrationTestMultiStorage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,1004 +44,1004 @@ env:
   INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT: '-Dscalardb.consensus_commit.coordinator.group_commit.enabled=true -Dscalardb.consensus_commit.coordinator.group_commit.old_group_abort_timeout_millis=15000 --tests "**.ConsensusCommit**"'
 
 jobs:
-#  check:
-#    name: Gradle check
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Setup and execute Gradle 'check' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: check buildSrc:check
-#
-#      - name: Save Gradle test reports
-#        if: always()
-#        run: |
-#          mkdir -p /tmp/gradle_test_reports/core
-#          mkdir -p /tmp/gradle_test_reports/schema-loader
-#          cp -a core/build/reports/tests/test /tmp/gradle_test_reports/core/
-#          cp -a schema-loader/build/reports/tests/test /tmp/gradle_test_reports/schema-loader/
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: gradle_check_reports
-#          path: /tmp/gradle_test_reports
-#
-#      - name: Save SpotBugs reports
-#        if: always()
-#        run: |
-#          mkdir -p /tmp/gradle_spotbugs_reports/core
-#          mkdir -p /tmp/gradle_spotbugs_reports/schema-loader
-#          mkdir -p /tmp/gradle_spotbugs_reports/integration-test
-#          cp -a core/build/reports/spotbugs /tmp/gradle_spotbugs_reports/core/
-#          cp -a schema-loader/build/reports/spotbugs /tmp/gradle_spotbugs_reports/schema-loader/
-#          cp -a integration-test/build/reports/spotbugs /tmp/gradle_spotbugs_reports/integration-test/
-#
-#      - name: Upload Spotbugs reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: gradle_spotbugs_reports
-#          path: /tmp/gradle_spotbugs_reports
-#
-#  dockerfile-lint:
-#    name: Lint dockerfiles
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Dockerfile Lint for ScalarDB Schema Loader
-#        if: always()
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: ':schema-loader:dockerfileLint'
-#
-#  integration-test-for-cassandra-3-0:
-#    name: Cassandra 3.0 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      cassandra:
-#        image: cassandra:3.0
-#        env:
-#          MAX_HEAP_SIZE: 2048m
-#          HEAP_NEWSIZE: 512m
-#        ports:
-#          - 9042:9042
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestCassandra' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cassandra_3.0_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestCassandra
-#
-#  integration-test-for-cassandra-3-11:
-#    name: Cassandra 3.11 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      cassandra:
-#        image: cassandra:3.11
-#        env:
-#          MAX_HEAP_SIZE: 2048m
-#          HEAP_NEWSIZE: 512m
-#        ports:
-#          - 9042:9042
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestCassandra' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cassandra_3.11_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestCassandra
-#
-#  integration-test-for-cosmos:
-#    name: Cosmos DB integration test (${{ matrix.mode.label }})
-#    runs-on: windows-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          $container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-windows")
-#          docker cp "${container_id}:oracle-jdk.exe" .
-#          docker rm "$container_id"
-#          Write-Host "Install Oracle JDK"
-#          Start-Process "oracle-jdk.exe" -NoNewWindow -Wait -ArgumentList "/s"
-#          Write-Host "Oracle JDK installation successful"
-#          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
-#            $jdk_root_dir = "jdk-1.8"
-#          } else {
-#            $jdk_root_dir = "jdk-11"
-#          }
-#          echo "JAVA_HOME=C:\Program Files\Java\${jdk_root_dir}" >> ${env:GITHUB_ENV}
-#
-#      - name: Start Azure Cosmos DB emulator
-#        run: |
-#          Write-Host "Launching Cosmos DB Emulator"
-#          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-#          Start-CosmosDbEmulator -Consistency Strong
-#
-#      - name: Install TLS/SSL certificate
-#        run: |
-#          $cert = Get-ChildItem Cert:\LocalMachine\My | where{$_.FriendlyName -eq 'DocumentDbEmulatorCertificate'}
-#          $params = @{
-#            Cert = $cert
-#            Type = "CERT"
-#            FilePath = "$home/tmp-cert.cer"
-#            NoClobber = $true
-#          }
-#          Export-Certificate @params
-#          certutil -encode $home/tmp-cert.cer $home/cosmosdbcert.cer
-#          Remove-Item $home/tmp-cert.cer
-#          # Setting the keystore option differs between Java 8 and Java 11+
-#          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
-#            $keystore = "-keystore", "${env:JAVA_HOME}/jre/lib/security/cacerts"
-#          } else {
-#            $keystore = "-cacerts"
-#          }
-#          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -importcert -noprompt -alias cosmos_emulator -file $home/cosmosdbcert.cer
-#          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -list -alias cosmos_emulator
-#
-#      - name: Setup and execute Gradle 'integrationTestCosmos' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestCosmos -Dscalardb.cosmos.uri=https://localhost:8081/ -Dscalardb.cosmos.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw== -Dfile.encoding=UTF-8 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cosmos_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestCosmos
-#
-#  integration-test-for-dynamo:
-#    name: DynamoDB integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      dynamodb:
-#        image: amazon/dynamodb-local:1.17.0
-#        ports:
-#          - 8000:8000
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestDynamo' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestDynamo ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: dynamo_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestDynamo
-#
-#  integration-test-for-jdbc-mysql-5-7:
-#    name: MySQL 5.7 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Run MySQL 5.7
-#        run: |
-#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: mysql_5.7_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-mysql-8-0:
-#    name: MySQL 8.0 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Run MySQL 8.0
-#        run: |
-#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.0 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: mysql_8.0_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-mysql-8-1:
-#    name: MySQL 8.1 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Run MySQL 8.1
-#        run: |
-#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.1 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: mysql_8.1_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-postgresql-12:
-#    name: PostgreSQL 12 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      postgres:
-#        image: postgres:12-alpine
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#        ports:
-#          - 5432:5432
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: postgresql_12_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-postgresql-13:
-#    name: PostgreSQL 13 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      postgres:
-#        image: postgres:13-alpine
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#        ports:
-#          - 5432:5432
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: postgresql_13_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-postgresql-14:
-#    name: PostgreSQL 14 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      postgres:
-#        image: postgres:14-alpine
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#        ports:
-#          - 5432:5432
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: postgresql_14_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-postgresql-15:
-#    name: PostgreSQL 15 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      postgres:
-#        image: postgres:15-alpine
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#        ports:
-#          - 5432:5432
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: postgresql_15_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#  
-#  integration-test-for-jdbc-oracle-19:
-#    name: Oracle 19 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      oracle:
-#        image: ghcr.io/scalar-labs/oracle/db-prebuilt:19
-#        credentials:
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#        ports:
-#          - 1521:1521
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/ORCLPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: oracle_19_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-oracle-21:
-#    name: Oracle 21 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      oracle:
-#        image: ghcr.io/scalar-labs/oracle/db-prebuilt:21
-#        credentials:
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#        env:
-#          ORACLE_PWD: Oracle
-#        ports:
-#          - 1521:1521
-#        options: >-
-#          --health-cmd "/opt/oracle/checkDBStatus.sh"
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 120
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: oracle_21_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-oracle-23:
-#    name: Oracle 23 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Free up ~14GB of disk space by removing the Android SDK
-#        run: |
-#          echo "Storage available before deletion"
-#          df -h /
-#          echo
-#          sudo rm -r /usr/local/lib/android
-#          echo "Storage available after deletion"
-#          df -h /
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Start Oracle 23 container
-#        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23
-#
-#      - name: Wait for the container to be ready
-#        timeout-minutes: 5
-#        run : |
-#          while [ "`docker inspect -f {{.State.Health.Status}} oracle-23`" != "healthy" ]
-#          do
-#            sleep 10
-#            echo "Container is not yet ready"
-#          done
-#          echo "Container is ready"
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Stop Oracle 23 container
-#        if: always()
-#        run: docker stop oracle-23 | xargs docker rm
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: oracle_23_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
+  check:
+    name: Gradle check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Setup and execute Gradle 'check' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: check buildSrc:check
+
+      - name: Save Gradle test reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_test_reports/core
+          mkdir -p /tmp/gradle_test_reports/schema-loader
+          cp -a core/build/reports/tests/test /tmp/gradle_test_reports/core/
+          cp -a schema-loader/build/reports/tests/test /tmp/gradle_test_reports/schema-loader/
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle_check_reports
+          path: /tmp/gradle_test_reports
+
+      - name: Save SpotBugs reports
+        if: always()
+        run: |
+          mkdir -p /tmp/gradle_spotbugs_reports/core
+          mkdir -p /tmp/gradle_spotbugs_reports/schema-loader
+          mkdir -p /tmp/gradle_spotbugs_reports/integration-test
+          cp -a core/build/reports/spotbugs /tmp/gradle_spotbugs_reports/core/
+          cp -a schema-loader/build/reports/spotbugs /tmp/gradle_spotbugs_reports/schema-loader/
+          cp -a integration-test/build/reports/spotbugs /tmp/gradle_spotbugs_reports/integration-test/
+
+      - name: Upload Spotbugs reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle_spotbugs_reports
+          path: /tmp/gradle_spotbugs_reports
+
+  dockerfile-lint:
+    name: Lint dockerfiles
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Dockerfile Lint for ScalarDB Schema Loader
+        if: always()
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: ':schema-loader:dockerfileLint'
+
+  integration-test-for-cassandra-3-0:
+    name: Cassandra 3.0 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      cassandra:
+        image: cassandra:3.0
+        env:
+          MAX_HEAP_SIZE: 2048m
+          HEAP_NEWSIZE: 512m
+        ports:
+          - 9042:9042
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestCassandra' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cassandra_3.0_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestCassandra
+
+  integration-test-for-cassandra-3-11:
+    name: Cassandra 3.11 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      cassandra:
+        image: cassandra:3.11
+        env:
+          MAX_HEAP_SIZE: 2048m
+          HEAP_NEWSIZE: 512m
+        ports:
+          - 9042:9042
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestCassandra' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestCassandra ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cassandra_3.11_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestCassandra
+
+  integration-test-for-cosmos:
+    name: Cosmos DB integration test (${{ matrix.mode.label }})
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          $container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-windows")
+          docker cp "${container_id}:oracle-jdk.exe" .
+          docker rm "$container_id"
+          Write-Host "Install Oracle JDK"
+          Start-Process "oracle-jdk.exe" -NoNewWindow -Wait -ArgumentList "/s"
+          Write-Host "Oracle JDK installation successful"
+          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
+            $jdk_root_dir = "jdk-1.8"
+          } else {
+            $jdk_root_dir = "jdk-11"
+          }
+          echo "JAVA_HOME=C:\Program Files\Java\${jdk_root_dir}" >> ${env:GITHUB_ENV}
+
+      - name: Start Azure Cosmos DB emulator
+        run: |
+          Write-Host "Launching Cosmos DB Emulator"
+          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+          Start-CosmosDbEmulator -Consistency Strong
+
+      - name: Install TLS/SSL certificate
+        run: |
+          $cert = Get-ChildItem Cert:\LocalMachine\My | where{$_.FriendlyName -eq 'DocumentDbEmulatorCertificate'}
+          $params = @{
+            Cert = $cert
+            Type = "CERT"
+            FilePath = "$home/tmp-cert.cer"
+            NoClobber = $true
+          }
+          Export-Certificate @params
+          certutil -encode $home/tmp-cert.cer $home/cosmosdbcert.cer
+          Remove-Item $home/tmp-cert.cer
+          # Setting the keystore option differs between Java 8 and Java 11+
+          if ( ${env:INT_TEST_JAVA_RUNTIME_VERSION} -eq '8' ) {
+            $keystore = "-keystore", "${env:JAVA_HOME}/jre/lib/security/cacerts"
+          } else {
+            $keystore = "-cacerts"
+          }
+          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -importcert -noprompt -alias cosmos_emulator -file $home/cosmosdbcert.cer
+          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -list -alias cosmos_emulator
+
+      - name: Setup and execute Gradle 'integrationTestCosmos' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestCosmos -Dscalardb.cosmos.uri=https://localhost:8081/ -Dscalardb.cosmos.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw== -Dfile.encoding=UTF-8 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosmos_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestCosmos
+
+  integration-test-for-dynamo:
+    name: DynamoDB integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:1.17.0
+        ports:
+          - 8000:8000
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestDynamo' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestDynamo ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dynamo_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestDynamo
+
+  integration-test-for-jdbc-mysql-5-7:
+    name: MySQL 5.7 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Run MySQL 5.7
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mysql_5.7_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-mysql-8-0:
+    name: MySQL 8.0 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Run MySQL 8.0
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.0 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mysql_8.0_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-mysql-8-1:
+    name: MySQL 8.1 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Run MySQL 8.1
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8.1 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mysql_8.1_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-12:
+    name: PostgreSQL 12 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgresql_12_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-13:
+    name: PostgreSQL 13 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgresql_13_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-14:
+    name: PostgreSQL 14 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgresql_14_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-postgresql-15:
+    name: PostgreSQL 15 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgresql_15_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+  
+  integration-test-for-jdbc-oracle-19:
+    name: Oracle 19 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      oracle:
+        image: ghcr.io/scalar-labs/oracle/db-prebuilt:19
+        credentials:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+        ports:
+          - 1521:1521
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/ORCLPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle_19_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-oracle-21:
+    name: Oracle 21 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      oracle:
+        image: ghcr.io/scalar-labs/oracle/db-prebuilt:21
+        credentials:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+        env:
+          ORACLE_PWD: Oracle
+        ports:
+          - 1521:1521
+        options: >-
+          --health-cmd "/opt/oracle/checkDBStatus.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 120
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle_21_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-oracle-23:
+    name: Oracle 23 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Free up ~14GB of disk space by removing the Android SDK
+        run: |
+          echo "Storage available before deletion"
+          df -h /
+          echo
+          sudo rm -r /usr/local/lib/android
+          echo "Storage available after deletion"
+          df -h /
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Start Oracle 23 container
+        run: docker run -d --name oracle-23 -p 1521:1521  ghcr.io/scalar-labs/oracle/db-prebuilt:23
+
+      - name: Wait for the container to be ready
+        timeout-minutes: 5
+        run : |
+          while [ "`docker inspect -f {{.State.Health.Status}} oracle-23`" != "healthy" ]
+          do
+            sleep 10
+            echo "Container is not yet ready"
+          done
+          echo "Container is ready"
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Stop Oracle 23 container
+        if: always()
+        run: docker stop oracle-23 | xargs docker rm
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle_23_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
   integration-test-for-jdbc-sqlserver-2017:
     name: SQL Server 2017 integration test (${{ matrix.mode.label }})
     runs-on: ubuntu-latest
@@ -1251,307 +1251,307 @@ jobs:
         with:
           name: sqlserver_2022_integration_test_reports_${{ matrix.mode.label }}
           path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-sqlite-3:
-#    name: SQLite 3 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Set up SQLite3
-#        run: sudo apt-get install -y sqlite3
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: sqlite_3_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-mariadb-10:
-#    name: MariaDB 10 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Run MariaDB 10.11
-#        run: |
-#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:10.11 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: mariadb_10_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-mariadb-11-4:
-#    name: MariaDB 11.4 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#
-#    steps:
-#      - name: Run MariaDB 11.4
-#        run: |
-#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:11.4 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: mariadb_11.4_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-jdbc-yugabytedb-2:
-#    name: YugabyteDB 2 integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Run YugabyteDB 2
-#        run: |
-#          docker run -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.21.0.0-b545 bin/yugabyted start --background=false --master_flag="ysql_enable_db_catalog_version_mode=false" --tserver_flags="ysql_enable_db_catalog_version_mode=false"
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestJdbc' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:yugabytedb://localhost:5433/ -Dscalardb.jdbc.username=yugabyte -Dscalardb.jdbc.password=yugabyte -Dscalar.db.jdbc.connection_pool.max_total=12 -Dscalar.db.jdbc.table_metadata.connection_pool.max_total=4 -Dscalar.db.jdbc.admin.connection_pool.max_total=4 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        if: always()
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: yugabytedb_2_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestJdbc
-#
-#  integration-test-for-multi-storage:
-#    name: Multi-storage integration test (${{ matrix.mode.label }})
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      cassandra:
-#        image: cassandra:3.11
-#        env:
-#          MAX_HEAP_SIZE: 2048m
-#          HEAP_NEWSIZE: 512m
-#        ports:
-#          - 9042:9042
-#
-#    strategy:
-#      matrix:
-#        mode:
-#          - label: default
-#            group_commit_enabled: false
-#          - label: with_group_commit
-#            group_commit_enabled: true
-#
-#    steps:
-#      - name: Run MySQL 8
-#        run: |
-#          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
-#
-#      - uses: actions/checkout@v4
-#
-#      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: ${{ env.JAVA_VERSION }}
-#          distribution: ${{ env.JAVA_VENDOR }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
-#        uses: actions/setup-java@v4
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
-#        with:
-#          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
-#          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.CR_PAT }}
-#
-#      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
-#        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
-#        run: |
-#          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
-#          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
-#          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-#
-#      - name: Setup and execute Gradle 'integrationTestMultiStorage' task
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: integrationTestMultiStorage ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
-#
-#      - name: Upload Gradle test reports
-#        uses: actions/upload-artifact@v4
-#        if : always()
-#        with:
-#          name: multi_storage_integration_test_reports_${{ matrix.mode.label }}
-#          path: core/build/reports/tests/integrationTestMultiStorage
+
+  integration-test-for-jdbc-sqlite-3:
+    name: SQLite 3 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Set up SQLite3
+        run: sudo apt-get install -y sqlite3
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlite_3_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-mariadb-10:
+    name: MariaDB 10 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Run MariaDB 10.11
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:10.11 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mariadb_10_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-mariadb-11-4:
+    name: MariaDB 11.4 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+
+    steps:
+      - name: Run MariaDB 11.4
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mariadb:11.4 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mariadb_11.4_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-jdbc-yugabytedb-2:
+    name: YugabyteDB 2 integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Run YugabyteDB 2
+        run: |
+          docker run -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.21.0.0-b545 bin/yugabyted start --background=false --master_flag="ysql_enable_db_catalog_version_mode=false" --tserver_flags="ysql_enable_db_catalog_version_mode=false"
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestJdbc' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:yugabytedb://localhost:5433/ -Dscalardb.jdbc.username=yugabyte -Dscalardb.jdbc.password=yugabyte -Dscalar.db.jdbc.connection_pool.max_total=12 -Dscalar.db.jdbc.table_metadata.connection_pool.max_total=4 -Dscalar.db.jdbc.admin.connection_pool.max_total=4 ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: yugabytedb_2_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestJdbc
+
+  integration-test-for-multi-storage:
+    name: Multi-storage integration test (${{ matrix.mode.label }})
+    runs-on: ubuntu-latest
+
+    services:
+      cassandra:
+        image: cassandra:3.11
+        env:
+          MAX_HEAP_SIZE: 2048m
+          HEAP_NEWSIZE: 512m
+        ports:
+          - 9042:9042
+
+    strategy:
+      matrix:
+        mode:
+          - label: default
+            group_commit_enabled: false
+          - label: with_group_commit
+            group_commit_enabled: true
+
+    steps:
+      - name: Run MySQL 8
+        run: |
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:8 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }} (${{ env.JAVA_VENDOR }})
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_VENDOR }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}) to run integration test
+        uses: actions/setup-java@v4
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_JDK_WHEN_NOT_ORACLE_8_OR_11 == 'true'}}
+        with:
+          java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
+          distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Set up JDK ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }} (oracle) to run the integration test
+        if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
+        run: |
+          container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
+          docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
+          tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
+
+      - name: Setup and execute Gradle 'integrationTestMultiStorage' task
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: integrationTestMultiStorage ${{ matrix.mode.group_commit_enabled && env.INT_TEST_GRADLE_OPTIONS_FOR_GROUP_COMMIT || '' }}
+
+      - name: Upload Gradle test reports
+        uses: actions/upload-artifact@v4
+        if : always()
+        with:
+          name: multi_storage_integration_test_reports_${{ matrix.mode.label }}
+          path: core/build/reports/tests/integrationTestMultiStorage

--- a/ci/no-superuser/create-no-superuser-sqlserver.sh
+++ b/ci/no-superuser/create-no-superuser-sqlserver.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ue
+set -u
 
 # Get container name and password from arguments
 SQL_SERVER_CONTAINER_NAME=$1
@@ -8,9 +8,12 @@ MAX_RETRY_COUNT=$3
 RETRY_INTERVAL=$4
 COUNT=0
 
-if [[ "$SQL_SERVER_CONTAINER_NAME" = "sqlserver22" ]]; then
+# Check if the `/opt/mssql-tools18/bin/sqlcmd` command exists or not.
+docker exec -t ${SQL_SERVER_CONTAINER_NAME} ls /opt/mssql-tools18/bin/sqlcmd
+if [[ $? -eq 0 ]]; then
   SQLCMD=/opt/mssql-tools18/bin/sqlcmd
 else
+  # If there is no `/opt/mssql-tools18/bin/sqlcmd` command, we use old command.
   SQLCMD=/opt/mssql-tools/bin/sqlcmd
 fi
 


### PR DESCRIPTION
## Description

Note: This PR fixes a similar issue with #2084.

This PR fixes the following CI error.

- https://github.com/scalar-labs/scalardb/actions/runs/10210235162/job/28250229001?pr=2156

Recently, the container image of MS SQL Server was updated, and the file path in the container was changed from `/opt/mssql-tools/bin/sqlcmd` to `/opt/mssql-tools18/bin/sqlcmd`.

So, I updated the script `create-no-superuser-sqlserver.sh`:

- Check if the `/opt/mssql-tools18/bin/sqlcmd` command exists or not in the container image.
- Use `mssql-tools18` (new one) if the `/opt/mssql-tools18/bin/sqlcmd` command exists.
- Use `mssql-tools` (old one) if the `/opt/mssql-tools18/bin/sqlcmd` command does NOT exist.

Please take a look!

## Related issues and/or PRs

- #2084

## Changes made

- Update `create-no-superuser-sqlserver.sh`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

You can see the test result in the following URL.

- https://github.com/scalar-labs/scalardb/actions/runs/10213857887

## Release notes

N/A
