### PR TITLE
Backport to branch(3) : Bump com.oracle.database.jdbc:ojdbc8 from 21.14.0.0 to 21.15.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
         commonsDbcp2Version = '2.12.0'
         mysqlDriverVersion = '8.0.33'
         postgresqlDriverVersion = '42.7.3'
-        oracleDriverVersion = '21.14.0.0'
+        oracleDriverVersion = '21.15.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
         sqliteDriverVersion = '3.46.0.1'
         yugabyteDriverVersion = '42.3.5-yb-6'


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2172