### PR TITLE
Backport to branch(3.9) : [Github actions] Fix the deprecation of `gradle-build-action`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,10 +55,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_VENDOR }}
 
-      - name: Setup and execute Gradle 'check' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: check buildSrc:check
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'check' task
+        run: ./gradlew check buildSrc:check
 
       - name: Save Gradle test reports
         if: always()
@@ -109,16 +110,14 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_VENDOR }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        
       - name: Dockerfile Lint for ScalarDB Server
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :server:dockerfileLint
-
+        run: ./gradlew server:dockerfileLint
+        
       - name: Dockerfile Lint for ScalarDB Schema Loader
-        if: always()
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :schema-loader:dockerfileLint
+        run: ./gradlew schema-loader:dockerfileLint
 
   integration-test-for-cassandra-3-0:
     name: Cassandra 3.0 integration test
@@ -164,10 +163,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestCassandra' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestCassandra
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestCassandra' task
+        run: ./gradlew integrationTestCassandra
 
       - name: Upload Gradle test reports
         if: always()
@@ -220,10 +220,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestCassandra' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestCassandra
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestCassandra' task
+        run: ./gradlew integrationTestCassandra
 
       - name: Upload Gradle test reports
         if: always()
@@ -303,10 +304,11 @@ jobs:
           & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -importcert -noprompt -alias cosmos_emulator -file $home/cosmosdbcert.cer
           & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -list -alias cosmos_emulator
 
-      - name: Setup and execute Gradle 'integrationTestCosmos' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestCosmos -Dscalardb.cosmos.uri=https://localhost:8081/ -Dscalardb.cosmos.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw== -Dfile.encoding=UTF-8
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestCosmos' task
+        run: ./gradlew.bat integrationTestCosmos "-Dscalardb.cosmos.uri=https://localhost:8081/" "-Dscalardb.cosmos.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" "-Dfile.encoding=UTF-8"
 
       - name: Upload Gradle test reports
         if: always()
@@ -356,10 +358,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestDynamo' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestDynamo
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestDynamo' task
+        run: ./gradlew integrationTestDynamo
 
       - name: Upload Gradle test reports
         if: always()
@@ -411,10 +414,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc
 
       - name: Upload Gradle test reports
         if: always()
@@ -466,10 +470,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc
 
       - name: Upload Gradle test reports
         if: always()
@@ -521,10 +526,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc
 
       - name: Upload Gradle test reports
         if: always()
@@ -577,10 +583,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
 
       - name: Upload Gradle test reports
         if: always()
@@ -633,10 +640,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
 
       - name: Upload Gradle test reports
         if: always()
@@ -689,10 +697,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
 
       - name: Upload Gradle test reports
         if: always()
@@ -746,10 +755,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:postgresql://localhost:5432/ -Dscalardb.jdbc.username=postgres -Dscalardb.jdbc.password=postgres
 
       - name: Upload Gradle test reports
         if: always()
@@ -802,10 +812,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/ORCLPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/ORCLPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
 
       - name: Upload Gradle test reports
         if: always()
@@ -849,7 +860,6 @@ jobs:
           java-version: ${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}
           distribution: ${{ env.INT_TEST_JAVA_RUNTIME_VENDOR }}
 
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: ${{ env.SET_UP_INT_TEST_RUNTIME_ORACLE_JDK_8_OR_11 == 'true'}}
@@ -865,10 +875,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
 
       - name: Upload Gradle test reports
         if: always()
@@ -933,10 +944,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1 -Dscalardb.jdbc.username=SYSTEM -Dscalardb.jdbc.password=Oracle
 
       - name: Stop Oracle 23 container
         if: always()
@@ -999,10 +1011,11 @@ jobs:
         run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver17 SqlServer17 10 3
         timeout-minutes: 1
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc "-Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true" -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -1061,10 +1074,11 @@ jobs:
         run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver19 SqlServer19 10 3
         timeout-minutes: 1
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc "-Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true" -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -1123,10 +1137,11 @@ jobs:
         run: ./ci/no-superuser/create-no-superuser-sqlserver.sh sqlserver22 SqlServer22 10 3
         timeout-minutes: 1
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc "-Dscalardb.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=test_db;encrypt=true;trustServerCertificate=true" -Dscalardb.jdbc.username=no_superuser -Dscalardb.jdbc.password=no_superuser_password
 
       - name: Upload Gradle test reports
         if: always()
@@ -1173,10 +1188,11 @@ jobs:
       - name: Set up SQLite3
         run: sudo apt-get install -y sqlite3
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc -Dscalardb.jdbc.url=jdbc:sqlite:integration.sqlite3?busy_timeout=50000
 
       - name: Upload Gradle test reports
         if: always()
@@ -1228,10 +1244,12 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestJdbc
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc
+
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v3
@@ -1278,10 +1296,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestJdbc' task
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: integrationTestJdbc
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestJdbc' task
+        run: ./gradlew integrationTestJdbc
 
       - name: Upload Gradle test reports
         if: always()
@@ -1339,11 +1358,12 @@ jobs:
           container_id=$(docker create "ghcr.io/scalar-labs/oracle/jdk:${{ env.INT_TEST_JAVA_RUNTIME_VERSION }}-linux")
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
-
-      - name: Setup and execute Gradle 'integrationTestMultiStorage' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestMultiStorage
+          
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        
+      - name: Execute Gradle 'integrationTestMultiStorage' task
+        run: ./gradlew integrationTestMultiStorage
 
       - name: Upload Gradle test reports
         uses: actions/upload-artifact@v3
@@ -1395,10 +1415,11 @@ jobs:
           docker cp "$container_id:oracle-jdk.tar.gz" . && docker rm "$container_id"
           tar -xzf oracle-jdk.tar.gz -C /usr/lib/jvm
 
-      - name: Setup and execute Gradle 'integrationTestScalarDbServer' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: integrationTestScalarDbServer
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle 'integrationTestScalarDbServer' task
+        run: ./gradlew integrationTestScalarDbServer
 
       - name: Upload Gradle test reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -62,6 +62,9 @@ jobs:
       - name: Checkout the current repository
         uses: actions/checkout@v4
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build scalardb-server zip
         run: ./gradlew :server:distZip
 

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -20,15 +20,8 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Set version
         id: version

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -50,15 +50,8 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -39,11 +39,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Docker build
         if: always()
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: docker
+        run: ./gradlew docker
 
       - name: Set version
         if: always()


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2164
- **Commit to backport:** 853627aa2e23d5bf830660409c5a621ed1fe1e05

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.9-pull-2164 &&
git cherry-pick --no-rerere-autoupdate -m1 853627aa2e23d5bf830660409c5a621ed1fe1e05
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!