### PR TITLE
Revert remove-untagged-images.yaml

### DIFF
--- a/.github/workflows/remove-untagged-images.yaml
+++ b/.github/workflows/remove-untagged-images.yaml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: scalardb-server
+        uses: camargo/delete-untagged-action@v1
+        with:
+          github-token: ${{ secrets.CR_PAT }}
+          package-name: scalardb-server
+
       - name: scalardb-schema-loader
         uses: camargo/delete-untagged-action@v1
         with:


### PR DESCRIPTION
## Description

This PR reverts the change of `remove-untagged-images.yaml` in https://github.com/scalar-labs/scalardb/pull/2050/files#diff-3866bab0e502310dd2b6495469023c0ae58669354b5672f0f3e659be24104f04

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2050

## Changes made

- Reverted `remove-untagged-images.yaml`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
