### PR TITLE
[Dependabot] Group update PR & update actions on all branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   # For Gradle, update dependencies and plugins to the latest non-major version
   - package-ecosystem: "gradle"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -12,10 +16,76 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "software.amazon.awssdk:*"
         update-types: [ "version-update:semver-patch" ]
-  # For GitHub Actions workflows, update all actions
+
+  # For GitHub Actions, update all actions on the default, support and release branches
   - package-ecosystem: "github-actions"
+    groups:
+      actions on branch master:
+        patterns:
+          - "*"
     directory: "/"
     schedule:
       interval: "weekly"
     reviewers:
       - "scalar-labs/scalardb"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3"
+    groups:
+      actions on branch 3:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.13"
+    groups:
+      actions on branch 3.13:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.12"
+    groups:
+      actions on branch 3.12:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.11"
+    groups:
+      actions on branch 3.11:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.10"
+    groups:
+      actions on branch 3.10:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.9"
+    groups:
+      actions on branch 3.9:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
## Description

GitHub actions versions on support and release branches were not updated, so triggering the CI raised several deprecation warnings. Because of this, we decided to update the action on all branches.
Also, to reduce the number of PR being created, we configure Dependabot to group updates by ecosystem and branches.

To see an example of what it will look like, please check the [PR created](https://github.com/Torch3333/scalardb/pulls) on this ScalarDB fork where I did some tests.

> [!IMPORTANT]  
> We will need to update the Dependabot configuration every time a new ScalarDB version is released and/or become EOL so that actions on respective branches are updated accordingly. 

## Related issues and/or PRs

N/A

## Changes made


Update Dependabot config:
- Add a config to update actions for all branches
- Update the config to group updates into single PR by ecosystem and branch

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Dependabot configuration only needs to be present on the master branch. We don't need to backport this PR.

## Release notes

N/A
