### PR TITLE
Fix CVE-2023-22102

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.27.4'
         commonsDbcp2Version = '2.12.0'
-        mysqlDriverVersion = '8.0.33'
+        mysqlDriverVersion = '9.0.0'
         postgresqlDriverVersion = '42.7.4'
         oracleDriverVersion = '21.15.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'software.amazon.awssdk:applicationautoscaling'
     implementation 'software.amazon.awssdk:dynamodb'
     implementation "org.apache.commons:commons-dbcp2:${commonsDbcp2Version}"
-    implementation "mysql:mysql-connector-java:${mysqlDriverVersion}"
+    implementation "com.mysql:mysql-connector-j:${mysqlDriverVersion}"
     implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
     implementation "com.oracle.database.jdbc:ojdbc8:${oracleDriverVersion}"
     implementation "com.microsoft.sqlserver:mssql-jdbc:${sqlserverDriverVersion}"


### PR DESCRIPTION
## Description

This PR fixes CVE-2023-22102 by bumping up the mysql driver to `9.0.0`.

## Related issues and/or PRs

N/A

## Changes made

- Bumped up the mysql driver to `9.0.0`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Upgraded the mysql driver to fix security issues. CVE-2023-22102
