### PR TITLE
Add getCurrentUser() to AuthAdmin

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AuthAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AuthAdmin.java
@@ -137,6 +137,16 @@ public interface AuthAdmin {
   }
 
   /**
+   * Retrieves the current logged-in user.
+   *
+   * @return the current logged-in user
+   * @throws ExecutionException if the operation fails
+   */
+  default User getCurrentUser() throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.AUTH_NOT_ENABLED.buildMessage());
+  }
+
+  /**
    * Retrieves privileges for the given table for the given user.
    *
    * @param username the username

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -311,6 +311,11 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
+  public User getCurrentUser() throws ExecutionException {
+    return distributedTransactionAdmin.getCurrentUser();
+  }
+
+  @Override
   public Set<Privilege> getPrivileges(String username, String namespaceName)
       throws ExecutionException {
     return distributedTransactionAdmin.getPrivileges(username, namespaceName);


### PR DESCRIPTION
## Description

This PR adds the `getCurrentUser()` method to `AuthAdmin`, which retrieves the currently logged-in user.

## Related issues and/or PRs

N/A

## Changes made

- Added the `getCurrentUser()` method to `AuthAdmin`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
