### PR TITLE
Backport to branch(3.9) : Fix CVE-2023-22102

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.20.54'
         commonsDbcp2Version = '2.9.0'
-        mysqlDriverVersion = '8.0.33'
+        mysqlDriverVersion = '9.0.0'
         postgresqlDriverVersion = '42.7.2'
         oracleDriverVersion = '21.9.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation 'software.amazon.awssdk:applicationautoscaling'
     implementation 'software.amazon.awssdk:dynamodb'
     implementation "org.apache.commons:commons-dbcp2:${commonsDbcp2Version}"
-    implementation "mysql:mysql-connector-java:${mysqlDriverVersion}"
+    implementation "com.mysql:mysql-connector-j:${mysqlDriverVersion}"
     implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
     implementation "com.oracle.database.jdbc:ojdbc8:${oracleDriverVersion}"
     implementation "com.microsoft.sqlserver:mssql-jdbc:${sqlserverDriverVersion}"


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2227
- **Commit to backport:** 7792f170f1e44b11a98f9522e6249dbabc6efd04

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.9-pull-2227 &&
git cherry-pick --no-rerere-autoupdate -m1 7792f170f1e44b11a98f9522e6249dbabc6efd04
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!