### PR TITLE
Revert "Fix CVE-2023-22102 (#2227)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         jooqVersion = '3.14.16'
         awssdkVersion = '2.27.4'
         commonsDbcp2Version = '2.12.0'
-        mysqlDriverVersion = '9.0.0'
+        mysqlDriverVersion = '8.0.33'
         postgresqlDriverVersion = '42.7.4'
         oracleDriverVersion = '21.15.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'software.amazon.awssdk:applicationautoscaling'
     implementation 'software.amazon.awssdk:dynamodb'
     implementation "org.apache.commons:commons-dbcp2:${commonsDbcp2Version}"
-    implementation "com.mysql:mysql-connector-j:${mysqlDriverVersion}"
+    implementation "mysql:mysql-connector-java:${mysqlDriverVersion}"
     implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
     implementation "com.oracle.database.jdbc:ojdbc8:${oracleDriverVersion}"
     implementation "com.microsoft.sqlserver:mssql-jdbc:${sqlserverDriverVersion}"


### PR DESCRIPTION
## Description

This reverts commit 7792f170f1e44b11a98f9522e6249dbabc6efd04. This is because the change causes the following error in the ScalarDB Cluster:

```java
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/protobuf/GeneratedMessageV3
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at com.scalar.db.cluster.rpc.v1.sql.SqlTransactionGrpc.getBeginMethod(SqlTransactionGrpc.java:51)
        at com.scalar.db.cluster.rpc.v1.sql.SqlTransactionGrpc.getServiceDescriptor(SqlTransactionGrpc.java:631)
        at com.scalar.db.cluster.rpc.v1.sql.SqlTransactionGrpc.bindService(SqlTransactionGrpc.java:554)
        at com.scalar.db.cluster.rpc.v1.sql.SqlTransactionGrpc$SqlTransactionImplBase.bindService(SqlTransactionGrpc.java:277)
        at io.grpc.internal.ServerImplBuilder.addService(ServerImplBuilder.java:145)
        at io.grpc.internal.ServerImplBuilder.addService(ServerImplBuilder.java:57)
        at io.grpc.ForwardingServerBuilder.addService(ForwardingServerBuilder.java:77)
        at com.scalar.db.cluster.node.sql.SqlServerUtils.setUp(SqlServerUtils.java:30)
        at com.scalar.db.cluster.node.ClusterNodeServer.startGrpcServer(ClusterNodeServer.java:138)
        at com.scalar.db.cluster.node.ClusterNodeServer.start(ClusterNodeServer.java:84)
        at com.scalar.db.cluster.node.ClusterNodeServer.call(ClusterNodeServer.java:54)
        at com.scalar.db.cluster.node.ClusterNodeServer.call(ClusterNodeServer.java:25)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at com.scalar.db.cluster.node.ClusterNodeServer.main(ClusterNodeServer.java:60)
Caused by: java.lang.ClassNotFoundException: com.google.protobuf.GeneratedMessageV3
        at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        ... 33 more
```

It seems like the cause of the issue is the `protobuf` version depended by the mysql driver.

## Related issues and/or PRs

- #2227

## Changes made

- Reverted the change of #2227.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
