### PR TITLE
[Dependabot] Set reviewers for actions group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
 
   - package-ecosystem: "github-actions"
     target-branch: "3.13"
@@ -48,6 +50,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
 
   - package-ecosystem: "github-actions"
     target-branch: "3.12"
@@ -58,6 +62,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
 
   - package-ecosystem: "github-actions"
     target-branch: "3.11"
@@ -68,6 +74,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
 
   - package-ecosystem: "github-actions"
     target-branch: "3.10"
@@ -78,6 +86,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
 
   - package-ecosystem: "github-actions"
     target-branch: "3.9"
@@ -88,4 +98,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardb"
 


### PR DESCRIPTION
## Description

In #2220 , I forgot to set the reviewers for the actions update on all branches in the Dependabot configuration.
The action update PRs were created [successfully](https://github.com/scalar-labs/scalardb/pull/2226) but no reviewers were added automatically.

## Related issues and/or PRs

- #2220 

## Changes made

Set reviewers for actions update on all branches.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
