### PR TITLE
[CI] Fix SQLServer 2017 job 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -829,7 +829,7 @@ jobs:
         with:
           name: postgresql_15_integration_test_reports_${{ matrix.mode.label }}
           path: core/build/reports/tests/integrationTestJdbc
-  
+
   integration-test-for-jdbc-oracle-19:
     name: Oracle 19 integration test (${{ matrix.mode.label }})
     runs-on: ubuntu-latest
@@ -1055,7 +1055,7 @@ jobs:
 
   integration-test-for-jdbc-sqlserver-2017:
     name: SQL Server 2017 integration test (${{ matrix.mode.label }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       sqlserver:


### PR DESCRIPTION
## Description

The CI job for SQLServer 2017 has been failing since the end of last week. It appears the SQLServer 2017 Docker container fails to start properly, cf. the logs in the "Additional notes” section below.

As a workaround, I downgraded the Github runner Ubuntu version from 22 to 20.


## Related issues and/or PRs

- Related issue on the SQLServer docker container repo: https://github.com/microsoft/mssql-docker/issues/899

## Changes made

Downgraded the CI Github runner Ubuntu version from 22 to 20 for the SQLServer2017 job to fix a container startup issue.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The logs for the SQLServer2017 Docker container which fails to start:
 
``` /usr/bin/docker logs --details e10554f08e7076e63739056880a392e14e57d44332eaeb1cf01b9199be3e1398
 This program has encountered a fatal error and cannot continue running at Mon Sep 23 19:57:12 2024
 The following diagnostic information is available:
 
          Reason: 0x00000001
          Signal: SIGABRT - Aborted (6)
           Stack:
                  IP               Function
                  ---------------- --------------------------------------
                  00005602c59be49c <unknown>
                  00005602c59bdee2 <unknown>
                  00005602c59bd4f1 <unknown>
                  00007f110b8e5f10 killpg+0x40
                  00007f110b8e5e87 gsignal+0xc7
                  00007f110b8e77f1 abort+0x141
                  00005602c5944e42 <unknown>
                  00005602c59cbcb4 <unknown>
 SQL Server 2017 will run as non-root by default.
 This container is running as user root.
 To learn more visit https://go.microsoft.com/fwlink/?linkid=2099216.
 Capturing a dump of 9
 Successfully captured dump: /var/opt/mssql/log/core.sqlservr.9_23_2024_19_57_13.9
 Executing: /opt/mssql/bin/handle-crash.sh with parameters
      handle-crash.sh
      /opt/mssql/bin/sqlservr
      9
      /opt/mssql/bin
      /var/opt/mssql/log/
      
      0aec4be1-d47a-40d2-9415-c5eaae487283
      67b0f9db-2f8b-4e5e-becb-1881acf2cae1
      
      /var/opt/mssql/log/core.sqlservr.9_23_2024_19_57_13.9
 
 Ubuntu 18.04.6 LTS
 Capturing core dump and information to /var/opt/mssql/log...
 Mon Sep 23 19:57:14 UTC 2024 Capturing program information
 Dump already generated: /var/opt/mssql/log/core.sqlservr.9_23_2024_19_57_13.9, moving to /var/opt/mssql/log/core.sqlservr.9.temp/core.sqlservr.9.gdmp
 Moving logs to /var/opt/mssql/log/core.sqlservr.9.temp/log/paldumper-debug.log
 Mon Sep 23 19:57:14 UTC 2024 Capturing program binaries
 Mon Sep 23 19:57:14 UTC 2024 Not compressing the dump files, moving instead to: /var/opt/mssql/log/core.sqlservr.09_23_2024_19_57_13.9.d
                  00005602c59ff1f8 <unknown>
                  00005602c59fefda <unknown>
                  00005602c5950cba <unknown>
                  00005602c595090f <unknown>
         Process: 9 - sqlservr
          Thread: 81 (application thread 0x138)
     Instance Id: 0aec4be1-d47a-40d2-9415-c5eaae487283
        Crash Id: 67b0f9db-2f8b-4e5e-becb-1881acf2cae1
     Build stamp: a061e85be3fdd5c8d55a05c62bda0b9e1d6d267f3cac4d70d78ec1a9a6f57be0
    Distribution: Ubuntu 18.04.6 LTS
      Processors: 4
    Total Memory: 16766771200 bytes
       Timestamp: Mon Sep 23 19:57:12 2024
      Last errno: 2
 Last errno text: No such file or directory
 dmesg: read kernel buffer failed: Operation not permitted
 /usr/bin/timeout: failed to run command '/bin/journalctl': No such file or directory
 /usr/bin/timeout: failed to run command '/bin/journalctl': No such file or directory
Stop and remove container: ef9749a2c27d44508d87f3d840135caa_mcrmicrosoftcommssqlserver2017latest_a21999
/usr/bin/docker rm --force e10554f08e7076e63739056880a392e14e57d44332eaeb1cf01b9199be3e1398
e10554f08e7076e63739056880a392e14e57d44332eaeb1cf01b9199be3e1398
Remove container network: github_network_ae228a4c3233440c8321937a87f4f648
/usr/bin/docker network rm github_network_ae228a4c3233440c8321937a87f4f648
github_network_ae228a4c3233440c8321937a87f4f648
```

## Release notes

N/A