### PR TITLE
Refactor ConcatenationVisitor to use ColumnVisitor

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
@@ -38,6 +38,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(BooleanColumn column) {
+    assert !column.hasNullValue();
     columns.add(String.valueOf(column.getBooleanValue()));
   }
 
@@ -48,6 +49,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(IntColumn column) {
+    assert !column.hasNullValue();
     columns.add(String.valueOf(column.getIntValue()));
   }
 
@@ -58,6 +60,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(BigIntColumn column) {
+    assert !column.hasNullValue();
     columns.add(String.valueOf(column.getBigIntValue()));
   }
 
@@ -68,6 +71,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(FloatColumn column) {
+    assert !column.hasNullValue();
     columns.add(String.valueOf(column.getFloatValue()));
   }
 
@@ -78,6 +82,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(DoubleColumn column) {
+    assert !column.hasNullValue();
     columns.add(String.valueOf(column.getDoubleValue()));
   }
 
@@ -88,6 +93,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(TextColumn column) {
+    assert !column.hasNullValue();
     column.getValue().ifPresent(columns::add);
   }
 
@@ -98,10 +104,9 @@ public class ConcatenationVisitor implements ColumnVisitor {
    */
   @Override
   public void visit(BlobColumn column) {
-    if (!column.hasNullValue()) {
-      // Use Base64 encoding
-      columns.add(
-          Base64.getUrlEncoder().withoutPadding().encodeToString(column.getBlobValueAsBytes()));
-    }
+    assert !column.hasNullValue();
+    // Use Base64 encoding
+    columns.add(
+        Base64.getUrlEncoder().withoutPadding().encodeToString(column.getBlobValueAsBytes()));
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
@@ -1,13 +1,13 @@
 package com.scalar.db.storage.cosmos;
 
-import com.scalar.db.io.BigIntValue;
-import com.scalar.db.io.BlobValue;
-import com.scalar.db.io.BooleanValue;
-import com.scalar.db.io.DoubleValue;
-import com.scalar.db.io.FloatValue;
-import com.scalar.db.io.IntValue;
-import com.scalar.db.io.TextValue;
-import com.scalar.db.io.ValueVisitor;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.ColumnVisitor;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.TextColumn;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -19,88 +19,89 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @author Yuji Ito
  */
 @NotThreadSafe
-public class ConcatenationVisitor implements ValueVisitor {
-  private final List<String> values;
+public class ConcatenationVisitor implements ColumnVisitor {
+  private final List<String> columns;
 
   public ConcatenationVisitor() {
-    values = new ArrayList<>();
+    columns = new ArrayList<>();
   }
 
   public String build() {
-    // TODO What if the string or blob value includes `:`?
-    return String.join(":", values);
+    // TODO What if the string or blob colum includes `:`?
+    return String.join(":", columns);
   }
 
   /**
-   * Sets the specified {@code BooleanValue} to the key string
+   * Sets the specified {@code BooleanColumn} to the key string
    *
-   * @param value a {@code BooleanValue} to be set
+   * @param column a {@code BooleanColumn} to be set
    */
   @Override
-  public void visit(BooleanValue value) {
-    values.add(String.valueOf(value.get()));
+  public void visit(BooleanColumn column) {
+    columns.add(String.valueOf(column.getBooleanValue()));
   }
 
   /**
-   * Sets the specified {@code IntValue} to the key string
+   * Sets the specified {@code IntColumn} to the key string
    *
-   * @param value a {@code IntValue} to be set
+   * @param column a {@code IntColumn} to be set
    */
   @Override
-  public void visit(IntValue value) {
-    values.add(String.valueOf(value.get()));
+  public void visit(IntColumn column) {
+    columns.add(String.valueOf(column.getIntValue()));
   }
 
   /**
-   * Sets the specified {@code BigIntValue} to the key string
+   * Sets the specified {@code BigIntColumn} to the key string
    *
-   * @param value a {@code BigIntValue} to be set
+   * @param column a {@code BigIntColumn} to be set
    */
   @Override
-  public void visit(BigIntValue value) {
-    values.add(String.valueOf(value.get()));
+  public void visit(BigIntColumn column) {
+    columns.add(String.valueOf(column.getBigIntValue()));
   }
 
   /**
-   * Sets the specified {@code FloatValue} to the key string
+   * Sets the specified {@code FloatColumn} to the key string
    *
-   * @param value a {@code FloatValue} to be set
+   * @param column a {@code FloatColumn} to be set
    */
   @Override
-  public void visit(FloatValue value) {
-    values.add(String.valueOf(value.get()));
+  public void visit(FloatColumn column) {
+    columns.add(String.valueOf(column.getFloatValue()));
   }
 
   /**
-   * Sets the specified {@code DoubleValue} to the key string
+   * Sets the specified {@code DoubleColumn} to the key string
    *
-   * @param value a {@code DoubleValue} to be set
+   * @param column a {@code DoubleColumn} to be set
    */
   @Override
-  public void visit(DoubleValue value) {
-    values.add(String.valueOf(value.get()));
+  public void visit(DoubleColumn column) {
+    columns.add(String.valueOf(column.getDoubleValue()));
   }
 
   /**
-   * Sets the specified {@code TextValue} to the key string
+   * Sets the specified {@code TextColumn} to the key string
    *
-   * @param value a {@code TextValue} to be set
+   * @param column a {@code TextColumn} to be set
    */
   @Override
-  public void visit(TextValue value) {
-    value.get().ifPresent(values::add);
+  public void visit(TextColumn column) {
+    column.getValue().ifPresent(columns::add);
   }
 
   /**
-   * Sets the specified {@code BlobValue} to the key string
+   * Sets the specified {@code BlobColumn} to the key string
    *
-   * @param value a {@code BlobValue} to be set
+   * @param column a {@code BlobColumn} to be set
    */
   @Override
-  public void visit(BlobValue value) {
-    // Use Base64 encoding
-    value
-        .get()
-        .ifPresent(b -> values.add(Base64.getUrlEncoder().withoutPadding().encodeToString(b)));
+  public void visit(BlobColumn column) {
+    if (!column.hasNullValue()) {
+      // Use Base64 encoding
+      columns.add(
+          Base64.getUrlEncoder().withoutPadding().encodeToString(column.getBlobValueAsBytes()));
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
@@ -27,7 +27,7 @@ public class ConcatenationVisitor implements ColumnVisitor {
   }
 
   public String build() {
-    // TODO What if the string or blob colum includes `:`?
+    // TODO What if the string or blob column includes `:`?
     return String.join(":", columns);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperation.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperation.java
@@ -5,6 +5,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Streams;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.Column;
 import com.scalar.db.io.Value;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,8 +48,8 @@ public class CosmosOperation {
 
   @Nonnull
   public String getConcatenatedPartitionKey() {
-    Map<String, Value<?>> keyMap = new HashMap<>();
-    operation.getPartitionKey().get().forEach(v -> keyMap.put(v.getName(), v));
+    Map<String, Column<?>> keyMap = new HashMap<>();
+    operation.getPartitionKey().getColumns().forEach(c -> keyMap.put(c.getName(), c));
 
     ConcatenationVisitor visitor = new ConcatenationVisitor();
     metadata.getPartitionKeyNames().forEach(name -> keyMap.get(name).accept(visitor));
@@ -63,9 +64,11 @@ public class CosmosOperation {
 
   @Nonnull
   public String getId() {
-    Map<String, Value<?>> keyMap = new HashMap<>();
-    operation.getPartitionKey().get().forEach(v -> keyMap.put(v.getName(), v));
-    operation.getClusteringKey().ifPresent(k -> k.get().forEach(v -> keyMap.put(v.getName(), v)));
+    Map<String, Column<?>> keyMap = new HashMap<>();
+    operation.getPartitionKey().getColumns().forEach(c -> keyMap.put(c.getName(), c));
+    operation
+        .getClusteringKey()
+        .ifPresent(k -> k.getColumns().forEach(c -> keyMap.put(c.getName(), c)));
 
     ConcatenationVisitor visitor = new ConcatenationVisitor();
     Streams.concat(

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
@@ -43,10 +43,8 @@ public class ConcatenationVisitorTest {
     // Act
     visitor.visit(ANY_BOOLEAN_COLUMN);
     visitor.visit(ANY_INT_COLUMN);
-    visitor.visit(BlobColumn.ofNull("any_blob"));
     visitor.visit(ANY_BIGINT_COLUMN);
     visitor.visit(ANY_FLOAT_COLUMN);
-    visitor.visit(TextColumn.ofNull("any_text"));
     visitor.visit(ANY_DOUBLE_COLUMN);
     visitor.visit(ANY_TEXT_COLUMN);
     visitor.visit(ANY_BLOB_COLUMN);
@@ -120,15 +118,6 @@ public class ConcatenationVisitorTest {
   }
 
   @Test
-  public void visit_NullTextColumnAcceptCalled_ShouldDoNothing() {
-    // Act
-    TextColumn.ofNull("any_text").accept(visitor);
-
-    // Assert
-    assertThat(visitor.build()).isEqualTo("");
-  }
-
-  @Test
   public void visit_BlobColumnAcceptCalled_ShouldBuildBlobAsString() {
     // Act
     ANY_BLOB_COLUMN.accept(visitor);
@@ -136,14 +125,5 @@ public class ConcatenationVisitorTest {
     // Assert
     assertThat(visitor.build())
         .isEqualTo(Base64.getUrlEncoder().withoutPadding().encodeToString(ANY_BLOB));
-  }
-
-  @Test
-  public void visit_NullBlobColumnAcceptCalled_ShouldDoNothing() {
-    // Act
-    BlobColumn.ofNull("any_blob").accept(visitor);
-
-    // Assert
-    assertThat(visitor.build()).isEqualTo("");
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
@@ -2,13 +2,14 @@ package com.scalar.db.storage.cosmos;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.scalar.db.io.BigIntColumn;
 import com.scalar.db.io.BigIntValue;
-import com.scalar.db.io.BlobValue;
-import com.scalar.db.io.BooleanValue;
-import com.scalar.db.io.DoubleValue;
-import com.scalar.db.io.FloatValue;
-import com.scalar.db.io.IntValue;
-import com.scalar.db.io.TextValue;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.TextColumn;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,20 +17,20 @@ import org.junit.jupiter.api.Test;
 
 public class ConcatenationVisitorTest {
   private static final boolean ANY_BOOLEAN = false;
-  private static final BooleanValue ANY_BOOLEAN_VALUE =
-      new BooleanValue("any_boolean", ANY_BOOLEAN);
+  private static final BooleanColumn ANY_BOOLEAN_COLUMN =
+      BooleanColumn.of("any_boolean", ANY_BOOLEAN);
   private static final int ANY_INT = Integer.MIN_VALUE;
-  private static final IntValue ANY_INT_VALUE = new IntValue("any_int", ANY_INT);
+  private static final IntColumn ANY_INT_COLUMN = IntColumn.of("any_int", ANY_INT);
   private static final long ANY_BIGINT = BigIntValue.MAX_VALUE;
-  private static final BigIntValue ANY_BIGINT_VALUE = new BigIntValue("any_bigint", ANY_BIGINT);
+  private static final BigIntColumn ANY_BIGINT_COLUMN = BigIntColumn.of("any_bigint", ANY_BIGINT);
   private static final float ANY_FLOAT = Float.MIN_NORMAL;
-  private static final FloatValue ANY_FLOAT_VALUE = new FloatValue("any_float", ANY_FLOAT);
+  private static final FloatColumn ANY_FLOAT_COLUMN = FloatColumn.of("any_float", ANY_FLOAT);
   private static final double ANY_DOUBLE = Double.MIN_NORMAL;
-  private static final DoubleValue ANY_DOUBLE_VALUE = new DoubleValue("any_double", ANY_DOUBLE);
+  private static final DoubleColumn ANY_DOUBLE_COLUMN = DoubleColumn.of("any_double", ANY_DOUBLE);
   private static final String ANY_TEXT = "test";
-  private static final TextValue ANY_TEXT_VALUE = new TextValue("any_text", ANY_TEXT);
+  private static final TextColumn ANY_TEXT_COLUMN = TextColumn.of("any_text", ANY_TEXT);
   private static final byte[] ANY_BLOB = "scalar".getBytes(StandardCharsets.UTF_8);
-  private static final BlobValue ANY_BLOB_VALUE = new BlobValue("any_blob", ANY_BLOB);
+  private static final BlobColumn ANY_BLOB_COLUMN = BlobColumn.of("any_blob", ANY_BLOB);
   private ConcatenationVisitor visitor;
 
   @BeforeEach
@@ -40,13 +41,15 @@ public class ConcatenationVisitorTest {
   @Test
   public void build_AllTypesGiven_ShouldBuildString() {
     // Act
-    visitor.visit(ANY_BOOLEAN_VALUE);
-    visitor.visit(ANY_INT_VALUE);
-    visitor.visit(ANY_BIGINT_VALUE);
-    visitor.visit(ANY_FLOAT_VALUE);
-    visitor.visit(ANY_DOUBLE_VALUE);
-    visitor.visit(ANY_TEXT_VALUE);
-    visitor.visit(ANY_BLOB_VALUE);
+    visitor.visit(ANY_BOOLEAN_COLUMN);
+    visitor.visit(ANY_INT_COLUMN);
+    visitor.visit(BlobColumn.ofNull("any_blob"));
+    visitor.visit(ANY_BIGINT_COLUMN);
+    visitor.visit(ANY_FLOAT_COLUMN);
+    visitor.visit(TextColumn.ofNull("any_text"));
+    visitor.visit(ANY_DOUBLE_COLUMN);
+    visitor.visit(ANY_TEXT_COLUMN);
+    visitor.visit(ANY_BLOB_COLUMN);
     String actual = visitor.build();
 
     // Assert
@@ -63,66 +66,84 @@ public class ConcatenationVisitorTest {
   }
 
   @Test
-  public void visit_BooleanValueAcceptCalled_ShouldBuildBooleanAsString() {
+  public void visit_BooleanColumnAcceptCalled_ShouldBuildBooleanAsString() {
     // Act
-    ANY_BOOLEAN_VALUE.accept(visitor);
+    ANY_BOOLEAN_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build()).isEqualTo(String.valueOf(ANY_BOOLEAN));
   }
 
   @Test
-  public void visit_IntValueAcceptCalled_ShouldBuildIntAsString() {
+  public void visit_IntColumnAcceptCalled_ShouldBuildIntAsString() {
     // Act
-    ANY_INT_VALUE.accept(visitor);
+    ANY_INT_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build()).isEqualTo(String.valueOf(ANY_INT));
   }
 
   @Test
-  public void visit_BigIntValueAcceptCalled_ShouldBuildBigIntAsString() {
+  public void visit_BigIntColumnAcceptCalled_ShouldBuildBigIntAsString() {
     // Act
-    ANY_BIGINT_VALUE.accept(visitor);
+    ANY_BIGINT_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build()).isEqualTo(String.valueOf(ANY_BIGINT));
   }
 
   @Test
-  public void visit_FloatValueAcceptCalled_ShouldBuildFloatAsString() {
+  public void visit_FloatColumnAcceptCalled_ShouldBuildFloatAsString() {
     // Act
-    ANY_FLOAT_VALUE.accept(visitor);
+    ANY_FLOAT_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build()).isEqualTo(String.valueOf(ANY_FLOAT));
   }
 
   @Test
-  public void visit_DoubleValueAcceptCalled_ShouldBuildDoubleAsString() {
+  public void visit_DoubleColumnAcceptCalled_ShouldBuildDoubleAsString() {
     // Act
-    ANY_DOUBLE_VALUE.accept(visitor);
+    ANY_DOUBLE_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build()).isEqualTo(String.valueOf(ANY_DOUBLE));
   }
 
   @Test
-  public void visit_TextValueAcceptCalled_ShouldBuildText() {
+  public void visit_TextColumnAcceptCalled_ShouldBuildText() {
     // Act
-    ANY_TEXT_VALUE.accept(visitor);
+    ANY_TEXT_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build()).isEqualTo(ANY_TEXT);
   }
 
   @Test
-  public void visit_BlobValueAcceptCalled_ShouldBuildBlobAsString() {
+  public void visit_NullTextColumnAcceptCalled_ShouldDoNothing() {
     // Act
-    ANY_BLOB_VALUE.accept(visitor);
+    TextColumn.ofNull("any_text").accept(visitor);
+
+    // Assert
+    assertThat(visitor.build()).isEqualTo("");
+  }
+
+  @Test
+  public void visit_BlobColumnAcceptCalled_ShouldBuildBlobAsString() {
+    // Act
+    ANY_BLOB_COLUMN.accept(visitor);
 
     // Assert
     assertThat(visitor.build())
         .isEqualTo(Base64.getUrlEncoder().withoutPadding().encodeToString(ANY_BLOB));
+  }
+
+  @Test
+  public void visit_NullBlobColumnAcceptCalled_ShouldBuildBlobAsString() {
+    // Act
+    BlobColumn.ofNull("any_blob").accept(visitor);
+
+    // Assert
+    assertThat(visitor.build()).isEqualTo("");
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/ConcatenationVisitorTest.java
@@ -139,7 +139,7 @@ public class ConcatenationVisitorTest {
   }
 
   @Test
-  public void visit_NullBlobColumnAcceptCalled_ShouldBuildBlobAsString() {
+  public void visit_NullBlobColumnAcceptCalled_ShouldDoNothing() {
     // Act
     BlobColumn.ofNull("any_blob").accept(visitor);
 


### PR DESCRIPTION
## Description

Refactor `ConcatenationVisitor` that uses the deprecated `ValueVisitor` to use the `ColumnVisitor` instead.

The background is I take care of some refactoring to facilitate the implementation of time-related types.

## Related issues and/or PRs

N/A

## Changes made

Refactor `ConcatenationVisitor` that uses the deprecated `ValueVisitor` to use the `ColumnVisitor` instead.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
