### PR TITLE
Backport to branch(3) : Change default key column size and make it configurable for MySQL and Oracle

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -653,6 +653,12 @@ public enum CoreError implements ScalarDbError {
       "ScalarDB Transparent Data Encryption is not enabled. To use ScalarDB Transparent Data Encryption, you must enable it. Note that this feature is supported only in the ScalarDB Enterprise edition",
       "",
       ""),
+  INVALID_VARIABLE_KEY_COLUMN_SIZE(
+      Category.USER_ERROR,
+      "0144",
+      "The variable key column size must be greater than or equal to 64",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/storage/jdbc/ConditionalMutator.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/ConditionalMutator.java
@@ -46,14 +46,14 @@ public class ConditionalMutator implements MutationConditionVisitor {
       Mutation mutation,
       TableMetadata tableMetadata,
       Connection connection,
-      QueryBuilder queryBuilder)
-      throws SQLException {
+      RdbEngineStrategy rdbEngine,
+      QueryBuilder queryBuilder) {
     assert mutation.getCondition().isPresent();
     this.mutation = mutation;
     this.tableMetadata = tableMetadata;
     this.connection = connection;
+    this.rdbEngine = rdbEngine;
     this.queryBuilder = queryBuilder;
-    rdbEngine = RdbEngineFactory.create(connection);
   }
 
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -41,6 +41,11 @@ public class JdbcConfig {
   public static final String ADMIN_CONNECTION_POOL_MAX_TOTAL =
       PREFIX + "admin.connection_pool.max_total";
 
+  public static final String MYSQL_VARIABLE_KEY_COLUMN_SIZE =
+      PREFIX + "mysql.variable_key_column_size";
+  public static final String ORACLE_VARIABLE_KEY_COLUMN_SIZE =
+      PREFIX + "oracle.variable_key_column_size";
+
   public static final int DEFAULT_CONNECTION_POOL_MIN_IDLE = 20;
   public static final int DEFAULT_CONNECTION_POOL_MAX_IDLE = 50;
   public static final int DEFAULT_CONNECTION_POOL_MAX_TOTAL = 200;
@@ -54,6 +59,25 @@ public class JdbcConfig {
   public static final int DEFAULT_ADMIN_CONNECTION_POOL_MIN_IDLE = 5;
   public static final int DEFAULT_ADMIN_CONNECTION_POOL_MAX_IDLE = 10;
   public static final int DEFAULT_ADMIN_CONNECTION_POOL_MAX_TOTAL = 25;
+
+  // MySQL and Oracle have limitations regarding the total size of key columns. Thus, we should set
+  // a small but enough key column size so that users can create multiple key columns without
+  // exceeding the limit and changing the default. Since we found the old default size of 64 bytes
+  // was small for some applications, we changed it based on the following specifications. See the
+  // official documents for details.
+  // 1) In MySQL, the maximum total size of key columns is 3072 bytes in the default, and thus,
+  // depending on the charset, it can be up to 768 characters long. It can further be reduced if the
+  // different settings are used.
+  // 2) In Oracle, the maximum total size of key columns is approximately 75% of the database block
+  // size minus some overhead. The default block size is 8KB, and it is typically 4kB or 8kB. Thus,
+  // the maximum size can be similar to the MySQL.
+  // See the official documents for details.
+  // https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html
+  // https://docs.oracle.com/en/database/oracle/oracle-database/23/refrn/logical-database-limits.html
+  public static final int DEFAULT_VARIABLE_KEY_COLUMN_SIZE = 128;
+  // As the partition key `tx_id` of the coordinator state table, we need a UUID string plus a
+  // 25-byte prefix for the group commit feature; thus, we set 64 bytes as the minimum.
+  public static final int MINIMUM_VARIABLE_KEY_COLUMN_SIZE = 64;
 
   private final String jdbcUrl;
   @Nullable private final String username;
@@ -75,6 +99,9 @@ public class JdbcConfig {
   private final int adminConnectionPoolMinIdle;
   private final int adminConnectionPoolMaxIdle;
   private final int adminConnectionPoolMaxTotal;
+
+  private final int mysqlVariableKeyColumnSize;
+  private final int oracleVariableKeyColumnSize;
 
   public JdbcConfig(DatabaseConfig databaseConfig) {
     String storage = databaseConfig.getStorage();
@@ -161,6 +188,23 @@ public class JdbcConfig {
             databaseConfig.getProperties(),
             ADMIN_CONNECTION_POOL_MAX_TOTAL,
             DEFAULT_ADMIN_CONNECTION_POOL_MAX_TOTAL);
+
+    mysqlVariableKeyColumnSize =
+        getInt(
+            databaseConfig.getProperties(),
+            MYSQL_VARIABLE_KEY_COLUMN_SIZE,
+            DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
+
+    oracleVariableKeyColumnSize =
+        getInt(
+            databaseConfig.getProperties(),
+            ORACLE_VARIABLE_KEY_COLUMN_SIZE,
+            DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
+
+    if (mysqlVariableKeyColumnSize < MINIMUM_VARIABLE_KEY_COLUMN_SIZE
+        || oracleVariableKeyColumnSize < MINIMUM_VARIABLE_KEY_COLUMN_SIZE) {
+      throw new IllegalArgumentException(CoreError.INVALID_VARIABLE_KEY_COLUMN_SIZE.buildMessage());
+    }
   }
 
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW
@@ -229,5 +273,13 @@ public class JdbcConfig {
 
   public int getAdminConnectionPoolMaxTotal() {
     return adminConnectionPoolMaxTotal;
+  }
+
+  public int getMysqlVariableKeyColumnSize() {
+    return mysqlVariableKeyColumnSize;
+  }
+
+  public int getOracleVariableKeyColumnSize() {
+    return oracleVariableKeyColumnSize;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -18,7 +18,6 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
 import com.scalar.db.exception.storage.RetriableExecutionException;
-import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -60,8 +59,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
             databaseConfig.getMetadataCacheExpirationTimeSecs());
 
     OperationChecker operationChecker = new OperationChecker(databaseConfig, tableMetadataManager);
-    QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, queryBuilder);
+    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine);
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.jdbc;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
@@ -41,15 +42,26 @@ public class JdbcService {
 
   private final TableMetadataManager tableMetadataManager;
   private final OperationChecker operationChecker;
+  private final RdbEngineStrategy rdbEngine;
   private final QueryBuilder queryBuilder;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public JdbcService(
       TableMetadataManager tableMetadataManager,
       OperationChecker operationChecker,
+      RdbEngineStrategy rdbEngine) {
+    this(tableMetadataManager, operationChecker, rdbEngine, new QueryBuilder(rdbEngine));
+  }
+
+  @VisibleForTesting
+  JdbcService(
+      TableMetadataManager tableMetadataManager,
+      OperationChecker operationChecker,
+      RdbEngineStrategy rdbEngine,
       QueryBuilder queryBuilder) {
     this.tableMetadataManager = Objects.requireNonNull(tableMetadataManager);
     this.operationChecker = Objects.requireNonNull(operationChecker);
+    this.rdbEngine = Objects.requireNonNull(rdbEngine);
     this.queryBuilder = Objects.requireNonNull(queryBuilder);
   }
 
@@ -173,7 +185,8 @@ public class JdbcService {
         return true;
       }
     } else {
-      return new ConditionalMutator(put, tableMetadata, connection, queryBuilder).mutate();
+      return new ConditionalMutator(put, tableMetadata, connection, rdbEngine, queryBuilder)
+          .mutate();
     }
   }
 
@@ -199,7 +212,8 @@ public class JdbcService {
         return true;
       }
     } else {
-      return new ConditionalMutator(delete, tableMetadata, connection, queryBuilder).mutate();
+      return new ConditionalMutator(delete, tableMetadata, connection, rdbEngine, queryBuilder)
+          .mutate();
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineFactory.java
@@ -1,8 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.common.error.CoreError;
-import java.sql.Connection;
-import java.sql.SQLException;
 
 /** Factory class of subclasses of {@link RdbEngineStrategy} */
 public final class RdbEngineFactory {
@@ -11,21 +9,14 @@ public final class RdbEngineFactory {
   }
 
   public static RdbEngineStrategy create(JdbcConfig config) {
-    return create(config.getJdbcUrl());
-  }
+    String jdbcUrl = config.getJdbcUrl();
 
-  public static RdbEngineStrategy create(Connection connection) throws SQLException {
-    String jdbcUrl = connection.getMetaData().getURL();
-    return create(jdbcUrl);
-  }
-
-  static RdbEngineStrategy create(String jdbcUrl) {
     if (jdbcUrl.startsWith("jdbc:mysql:")) {
-      return new RdbEngineMysql();
+      return new RdbEngineMysql(config);
     } else if (jdbcUrl.startsWith("jdbc:postgresql:")) {
       return new RdbEnginePostgresql();
     } else if (jdbcUrl.startsWith("jdbc:oracle:")) {
-      return new RdbEngineOracle();
+      return new RdbEngineOracle(config);
     } else if (jdbcUrl.startsWith("jdbc:sqlserver:")) {
       return new RdbEngineSqlServer();
     } else if (jdbcUrl.startsWith("jdbc:sqlite:")) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -1,5 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.error.CoreError;
@@ -21,6 +22,16 @@ import org.slf4j.LoggerFactory;
 
 class RdbEngineMysql implements RdbEngineStrategy {
   private static final Logger logger = LoggerFactory.getLogger(RdbEngineMysql.class);
+  private final String keyColumnSize;
+
+  RdbEngineMysql(JdbcConfig config) {
+    keyColumnSize = String.valueOf(config.getMysqlVariableKeyColumnSize());
+  }
+
+  @VisibleForTesting
+  RdbEngineMysql() {
+    keyColumnSize = String.valueOf(JdbcConfig.DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
+  }
 
   @Override
   public String[] createNamespaceSqls(String fullNamespace) {
@@ -198,9 +209,9 @@ class RdbEngineMysql implements RdbEngineStrategy {
   public String getDataTypeForKey(DataType dataType) {
     switch (dataType) {
       case TEXT:
-        return "VARCHAR(64)";
+        return "VARCHAR(" + keyColumnSize + ")";
       case BLOB:
-        return "VARBINARY(64)";
+        return "VARBINARY(" + keyColumnSize + ")";
       default:
         return null;
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineOracle.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.jdbc;
 
 import static com.scalar.db.util.ScalarDbUtils.getFullTableName;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.LikeExpression;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.error.CoreError;
@@ -23,6 +24,16 @@ import org.slf4j.LoggerFactory;
 
 public class RdbEngineOracle implements RdbEngineStrategy {
   private static final Logger logger = LoggerFactory.getLogger(RdbEngineOracle.class);
+  private final String keyColumnSize;
+
+  RdbEngineOracle(JdbcConfig config) {
+    keyColumnSize = String.valueOf(config.getOracleVariableKeyColumnSize());
+  }
+
+  @VisibleForTesting
+  RdbEngineOracle() {
+    keyColumnSize = String.valueOf(JdbcConfig.DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
+  }
 
   @Override
   public String[] createNamespaceSqls(String fullNamespace) {
@@ -204,9 +215,9 @@ public class RdbEngineOracle implements RdbEngineStrategy {
   public String getDataTypeForKey(DataType dataType) {
     switch (dataType) {
       case TEXT:
-        return "VARCHAR2(64)";
+        return "VARCHAR2(" + keyColumnSize + ")";
       case BLOB:
-        return "RAW(64)";
+        return "RAW(" + keyColumnSize + ")";
       default:
         return null;
     }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEnginePostgresql.java
@@ -202,6 +202,8 @@ class RdbEnginePostgresql implements RdbEngineStrategy {
 
   @Override
   public String getDataTypeForKey(DataType dataType) {
+    // The number 10485760 is due to the maximum length of the character column.
+    // https://www.postgresql.org/docs/15/datatype-character.html
     if (dataType == DataType.TEXT) {
       return "VARCHAR(10485760)";
     }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -33,7 +33,6 @@ import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngineFactory;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
-import com.scalar.db.storage.jdbc.query.QueryBuilder;
 import com.scalar.db.util.ThrowableFunction;
 import java.sql.SQLException;
 import java.util.List;
@@ -68,8 +67,7 @@ public class JdbcTransactionManager extends ActiveTransactionManagedDistributedT
             databaseConfig.getMetadataCacheExpirationTimeSecs());
 
     OperationChecker operationChecker = new OperationChecker(databaseConfig, tableMetadataManager);
-    QueryBuilder queryBuilder = new QueryBuilder(rdbEngine);
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, queryBuilder);
+    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine);
   }
 
   @VisibleForTesting

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcConfigTest.java
@@ -36,6 +36,8 @@ public class JdbcConfigTest {
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MIN_IDLE, "50");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_IDLE, "150");
     props.setProperty(JdbcConfig.ADMIN_CONNECTION_POOL_MAX_TOTAL, "200");
+    props.setProperty(JdbcConfig.MYSQL_VARIABLE_KEY_COLUMN_SIZE, "64");
+    props.setProperty(JdbcConfig.ORACLE_VARIABLE_KEY_COLUMN_SIZE, "64");
 
     // Act
     JdbcConfig config = new JdbcConfig(new DatabaseConfig(props));
@@ -61,6 +63,8 @@ public class JdbcConfigTest {
     assertThat(config.getAdminConnectionPoolMinIdle()).isEqualTo(50);
     assertThat(config.getAdminConnectionPoolMaxIdle()).isEqualTo(150);
     assertThat(config.getAdminConnectionPoolMaxTotal()).isEqualTo(200);
+    assertThat(config.getMysqlVariableKeyColumnSize()).isEqualTo(64);
+    assertThat(config.getOracleVariableKeyColumnSize()).isEqualTo(64);
   }
 
   @Test
@@ -100,6 +104,10 @@ public class JdbcConfigTest {
         .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_IDLE);
     assertThat(config.getTableMetadataConnectionPoolMaxTotal())
         .isEqualTo(JdbcConfig.DEFAULT_TABLE_METADATA_CONNECTION_POOL_MAX_TOTAL);
+    assertThat(config.getMysqlVariableKeyColumnSize())
+        .isEqualTo(JdbcConfig.DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
+    assertThat(config.getOracleVariableKeyColumnSize())
+        .isEqualTo(JdbcConfig.DEFAULT_VARIABLE_KEY_COLUMN_SIZE);
   }
 
   @Test
@@ -216,6 +224,30 @@ public class JdbcConfigTest {
 
     // Act Assert
     assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_PropertiesWithSmallKeyColumnSizeGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props1 = new Properties();
+    props1.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_JDBC_URL);
+    props1.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
+    props1.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+    props1.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
+    props1.setProperty(JdbcConfig.MYSQL_VARIABLE_KEY_COLUMN_SIZE, "32");
+    Properties props2 = new Properties();
+    props2.setProperty(DatabaseConfig.CONTACT_POINTS, ANY_JDBC_URL);
+    props2.setProperty(DatabaseConfig.USERNAME, ANY_USERNAME);
+    props2.setProperty(DatabaseConfig.PASSWORD, ANY_PASSWORD);
+    props2.setProperty(DatabaseConfig.STORAGE, JDBC_STORAGE);
+    props2.setProperty(JdbcConfig.ORACLE_VARIABLE_KEY_COLUMN_SIZE, "32");
+
+    // Act Assert
+    assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props1)))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new JdbcConfig(new DatabaseConfig(props2)))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -53,6 +53,7 @@ public class JdbcServiceTest {
   @Mock private QueryBuilder queryBuilder;
   @Mock private OperationChecker operationChecker;
   @Mock private TableMetadataManager tableMetadataManager;
+  @Mock private RdbEngineStrategy rdbEngine;
 
   @Mock private SelectQuery.Builder selectQueryBuilder;
   @Mock private SelectQuery selectQuery;
@@ -77,7 +78,7 @@ public class JdbcServiceTest {
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, queryBuilder);
+    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine, queryBuilder);
 
     // Arrange
     when(tableMetadataManager.getTableMetadata(any(Operation.class)))
@@ -443,7 +444,7 @@ public class JdbcServiceTest {
     when(insertQueryBuilder.build()).thenReturn(insertQuery);
     when(connection.prepareStatement(any())).thenReturn(preparedStatement);
     when(preparedStatement.executeUpdate()).thenThrow(sqlException);
-    when(sqlException.getSQLState()).thenReturn("23000");
+    when(rdbEngine.isDuplicateKeyError(sqlException)).thenReturn(true);
 
     // Act
     Put put =


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2245
- **Commit to backport:** a4b2cf91488322391397c3ba1241cd43d6401108

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2245 &&
git cherry-pick --no-rerere-autoupdate -m1 a4b2cf91488322391397c3ba1241cd43d6401108
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!