### PR TITLE
Change default value of metadata cache expiration time

### DIFF
--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -57,6 +57,7 @@ public class DatabaseConfig {
   public static final String CROSS_PARTITION_SCAN_ORDERING = SCAN_PREFIX + "ordering.enabled";
   public static final String SYSTEM_NAMESPACE_NAME = PREFIX + "system_namespace_name";
 
+  public static final int DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS = 60;
   public static final String DEFAULT_SYSTEM_NAMESPACE_NAME = "scalardb";
 
   public DatabaseConfig(File propertiesFile) throws IOException {
@@ -180,7 +181,10 @@ public class DatabaseConfig {
   }
 
   public static long getMetadataCacheExpirationTimeSecs(Properties properties) {
-    return getLong(properties, METADATA_CACHE_EXPIRATION_TIME_SECS, -1);
+    return getLong(
+        properties,
+        METADATA_CACHE_EXPIRATION_TIME_SECS,
+        DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
   }
 
   public static long getActiveTransactionManagementExpirationTimeMillis(Properties properties) {

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -35,7 +35,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -61,7 +62,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
@@ -88,7 +90,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isFalse();
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
@@ -117,7 +120,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();


### PR DESCRIPTION
## Description

This PR changes the default value of the metadata cache expiration time (`scalar.db.metadata.cache_expiration_time_secs`) to 60 seconds. Strictly speaking, this may be an incompatible change, but I don't expect it to cause any problems. If there are any objections, please let me know.

## Related issues and/or PRs

N/A

## Changes made

- Changed the default value of the metadata cache expiration time (`scalar.db.metadata.cache_expiration_time_secs`) to 60 seconds.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Changed the default value of the metadata cache expiration time (`scalar.db.metadata.cache_expiration_time_secs`) to 60 seconds.
