### PR TITLE
Backport to branch(3) : Change default value of metadata cache expiration time

### DIFF
--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -54,6 +54,8 @@ public class DatabaseConfig {
   public static final String CROSS_PARTITION_SCAN = SCAN_PREFIX + "enabled";
   public static final String CROSS_PARTITION_SCAN_FILTERING = SCAN_PREFIX + "filtering.enabled";
   public static final String CROSS_PARTITION_SCAN_ORDERING = SCAN_PREFIX + "ordering.enabled";
+
+  public static final int DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS = 60;
   public static final String DEFAULT_SYSTEM_NAMESPACE_NAME = "scalardb";
 
   public DatabaseConfig(File propertiesFile) throws IOException {
@@ -171,7 +173,10 @@ public class DatabaseConfig {
   }
 
   public static long getMetadataCacheExpirationTimeSecs(Properties properties) {
-    return getLong(properties, METADATA_CACHE_EXPIRATION_TIME_SECS, -1);
+    return getLong(
+        properties,
+        METADATA_CACHE_EXPIRATION_TIME_SECS,
+        DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
   }
 
   public static long getActiveTransactionManagementExpirationTimeMillis(Properties properties) {

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -35,7 +35,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
@@ -61,7 +62,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
@@ -88,7 +90,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().isPresent()).isFalse();
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
@@ -117,7 +120,8 @@ public class DatabaseConfigTest {
     assertThat(config.getPassword().get()).isEqualTo(ANY_PASSWORD);
     assertThat(config.getStorage()).isEqualTo("cassandra");
     assertThat(config.getTransactionManager()).isEqualTo("consensus-commit");
-    assertThat(config.getMetadataCacheExpirationTimeSecs()).isEqualTo(-1);
+    assertThat(config.getMetadataCacheExpirationTimeSecs())
+        .isEqualTo(DatabaseConfig.DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS);
     assertThat(config.getActiveTransactionManagementExpirationTimeMillis()).isEqualTo(-1);
     assertThat(config.getDefaultNamespaceName()).isEmpty();
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2274
- **Commit to backport:** d3251d36bbd286642cb97189b50c64e8b48aad27

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2274 &&
git cherry-pick --no-rerere-autoupdate -m1 d3251d36bbd286642cb97189b50c64e8b48aad27
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!