### PR TITLE
Backport to branch(3.13) : Use reusable vulnerability check workflow

### DIFF
--- a/.github/workflows/manual-vuln-check.yaml
+++ b/.github/workflows/manual-vuln-check.yaml
@@ -12,5 +12,3 @@ jobs:
       target-ref: ${{ github.ref_name }}
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -17,134 +17,16 @@ on:
       CR_PAT:
         required: true
       SLACK_SECURITY_WEBHOOK_URL:
-        required: true
+        required: false
 
-env:
-  TERM: dumb
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-
-    env:
-      GH_TOKEN: ${{ secrets.CR_PAT }}
-
-    steps:
-      # This first checkout is needed to use `ci/vuln-check/*`
-      - uses: actions/checkout@v4
-
-      - id: prepare-target-ref
-        name: Prepare target-ref
-        run: |
-          # Find the latest release name if `find-latest-release` is set to true. Use the value of `target-ref` as is otherwise.
-          if [[ ${{ inputs.find-latest-release }} = 'true' ]]; then
-            releases=$(ci/vuln-check/fetch_gh_releases "${{ github.event.repository.owner.login }}" "${{ github.event.repository.name }}")
-            echo -------------
-            echo "releases: $releases"
-            echo -------------
-            target_release=''
-            if [[ -n $releases ]]; then
-              target_release=$(ci/vuln-check/find_latest_release "${{ inputs.target-ref }}" $releases)
-            fi
-            if [[ -z $target_release ]]; then
-              echo "Can't find a target release"
-              exit 1
-            fi
-            echo $target_release
-            echo "target-ref=$target_release" >> $GITHUB_OUTPUT
-          else
-            echo "target-ref=${{ inputs.target-ref }}" >> $GITHUB_OUTPUT
-          fi
-
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.prepare-target-ref.outputs.target-ref }}
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-
-      - name: Login to GitHub Container Registry
-        if: always()
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Docker build
-        if: always()
-        run: ./gradlew docker
-
-      - name: Set version
-        if: always()
-        id: version
-        run: |
-          VERSION=$(./gradlew :core:properties -q | grep "version:" | awk '{print $2}')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Run Trivy vulnerability scanner for ScalarDB Server
-        if: always()
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/scalar-labs/scalardb-server:${{ steps.version.outputs.version }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-          timeout: '60m'
-
-      - name: Post Trivy vulnerability check failure for ScalarDB Server to Slack
-        if: failure()
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Server on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ steps.prepare-target-ref.outputs.target-ref }}`"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - name: Run Trivy vulnerability scanner for ScalarDB Schema Loader
-        if: always()
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-          timeout: '60m'
-
-      - name: Post Trivy vulnerability check failure for ScalarDB Schema Loader to Slack
-        if: failure()
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":octagonal_sign: The vulnerability check for ScalarDB Schema Loader on `${{ github.repository }}` <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|failed> with `${{ steps.prepare-target-ref.outputs.target-ref }}`"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  call-vuln-check:
+    uses: scalar-labs/actions/.github/workflows/vuln-check-reusable.yaml@main
+    with:
+      target-ref: ${{ inputs.target-ref }}
+      find-latest-release: ${{ inputs.find-latest-release }}
+      images: '[["ScalarDB Schema Loader", "scalardb-schema-loader"]]'
+      version-command: "./gradlew :core:properties -q | grep version: | awk '{print $2}'"
+    secrets:
+      CR_PAT: ${{ secrets.CR_PAT }}
+      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2288
- **Commit to backport:** de679ca7b576c22c53e40568ffaa5e33e0ca0681

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-2288 &&
git cherry-pick --no-rerere-autoupdate -m1 de679ca7b576c22c53e40568ffaa5e33e0ca0681
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!