### PR TITLE
[CI] Increase CosmosDB emulator startup timeout to 10min

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -300,7 +300,8 @@ jobs:
         run: |
           Write-Host "Launching Cosmos DB Emulator"
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-          Start-CosmosDbEmulator -Consistency Strong
+          # Set startup timeout to 10min (600s), the default is 4min
+          Start-CosmosDbEmulator -Consistency Strong -Timeout 600
 
       - name: Install TLS/SSL certificate
         run: |


### PR DESCRIPTION
## Description

The CI for CosmosDB has been failing regularly (more than 50% some days) because the CosmosDB emulator fails to start within the default timeout of 4min.
![image](https://github.com/user-attachments/assets/d558ae37-d093-4e51-8753-d52751b636dd)

This PR increases the timeout to 10min as a workaround. If failure continues to occur, we can consider implementing a retry mechanism.

## Related issues and/or PRs

N/A

## Changes made

Update the emulator of the CosmosDB CI startup timeout to 10min

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
