### PR TITLE
Backport to branch(3.13) : Add validation for primary key columns in Cosmos DB adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -647,6 +647,13 @@ public enum CoreError implements ScalarDbError {
           + "If you want to modify a condition, please use clearConditions() to remove all existing conditions first",
       "",
       ""),
+  COSMOS_PRIMARY_KEY_CONTAINS_ILLEGAL_CHARACTER(
+      Category.USER_ERROR,
+      "0145",
+      "The value of the column %s in the primary key contains an illegal character. "
+          + "Primary-key columns must not contain any of the following characters in Cosmos DB: ':', '/', '\\', '#', '?'. Value: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
@@ -14,7 +14,8 @@ import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A visitor class to make a concatenated key string for the partition key
+ * A visitor class to make a concatenated key string for the partition key. This uses a colon as a
+ * key separator, so the text column value should not contain colons.
  *
  * @author Yuji Ito
  */
@@ -27,7 +28,6 @@ public class ConcatenationVisitor implements ValueVisitor {
   }
 
   public String build() {
-    // TODO What if the string or blob value includes `:`?
     return String.join(":", values);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperationChecker.java
@@ -2,25 +2,105 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.ColumnVisitor;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.TextColumn;
 
 public class CosmosOperationChecker extends OperationChecker {
+
+  private static final char[] ILLEGAL_CHARACTERS_IN_PRIMARY_KEY = {
+    // Colons are not allowed in primary-key columns due to the `ConcatenationVisitor` limitation.
+    ':',
+
+    // The following characters are not allowed in primary-key columns because they are restricted
+    // and cannot be used in the `Id` property of a Cosmos DB document. For more information, see:
+    // https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.databaseproperties.id?view=azure-dotnet#remarks
+    '/',
+    '\\',
+    '#',
+    '?'
+  };
+
+  private static final ColumnVisitor PRIMARY_KEY_COLUMN_CHECKER =
+      new ColumnVisitor() {
+        @Override
+        public void visit(BooleanColumn column) {}
+
+        @Override
+        public void visit(IntColumn column) {}
+
+        @Override
+        public void visit(BigIntColumn column) {}
+
+        @Override
+        public void visit(FloatColumn column) {}
+
+        @Override
+        public void visit(DoubleColumn column) {}
+
+        @Override
+        public void visit(TextColumn column) {
+          String value = column.getTextValue();
+          assert value != null;
+
+          for (char illegalCharacter : ILLEGAL_CHARACTERS_IN_PRIMARY_KEY) {
+            if (value.indexOf(illegalCharacter) != -1) {
+              throw new IllegalArgumentException(
+                  CoreError.COSMOS_PRIMARY_KEY_CONTAINS_ILLEGAL_CHARACTER.buildMessage(
+                      column.getName(), value));
+            }
+          }
+        }
+
+        @Override
+        public void visit(BlobColumn column) {}
+      };
+
   public CosmosOperationChecker(
       DatabaseConfig databaseConfig, TableMetadataManager metadataManager) {
     super(databaseConfig, metadataManager);
   }
 
   @Override
+  public void check(Get get) throws ExecutionException {
+    super.check(get);
+    checkPrimaryKey(get);
+  }
+
+  @Override
+  public void check(Scan scan) throws ExecutionException {
+    super.check(scan);
+    checkPrimaryKey(scan);
+    scan.getStartClusteringKey()
+        .ifPresent(
+            c -> c.getColumns().forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER)));
+    scan.getEndClusteringKey()
+        .ifPresent(
+            c -> c.getColumns().forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER)));
+  }
+
+  @Override
   public void check(Put put) throws ExecutionException {
     super.check(put);
+    checkPrimaryKey(put);
+
     TableMetadata metadata = getTableMetadata(put);
     checkCondition(put, metadata);
   }
@@ -28,8 +108,21 @@ public class CosmosOperationChecker extends OperationChecker {
   @Override
   public void check(Delete delete) throws ExecutionException {
     super.check(delete);
+    checkPrimaryKey(delete);
+
     TableMetadata metadata = getTableMetadata(delete);
     checkCondition(delete, metadata);
+  }
+
+  private void checkPrimaryKey(Operation operation) {
+    operation
+        .getPartitionKey()
+        .getColumns()
+        .forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER));
+    operation
+        .getClusteringKey()
+        .ifPresent(
+            c -> c.getColumns().forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER)));
   }
 
   private void checkCondition(Mutation mutation, TableMetadata metadata) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
@@ -38,7 +38,7 @@ public class CoordinatorGroupCommitter
   public static class CoordinatorGroupCommitKeyManipulator
       implements KeyManipulator<String, String, String, String, String> {
     private static final int PRIMARY_KEY_SIZE = 24;
-    private static final char DELIMITER = ':';
+    private static final char DELIMITER = '$';
     private static final int MAX_FULL_KEY_SIZE = 64;
     private static final int MAX_CHILD_KEY_SIZE =
         MAX_FULL_KEY_SIZE - PRIMARY_KEY_SIZE - 1 /* delimiter */;

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationCheckerTest.java
@@ -13,11 +13,14 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +37,26 @@ public class CosmosOperationCheckerTest {
   private static final String CKEY1 = "c1";
   private static final String COL1 = "v1";
   private static final String COL2 = "v2";
+
+  private static final TableMetadata TABLE_METADATA1 =
+      TableMetadata.newBuilder()
+          .addColumn(PKEY1, DataType.INT)
+          .addColumn(CKEY1, DataType.INT)
+          .addColumn(COL1, DataType.INT)
+          .addColumn(COL2, DataType.BLOB)
+          .addPartitionKey(PKEY1)
+          .addClusteringKey(CKEY1)
+          .addSecondaryIndex(COL1)
+          .build();
+
+  private static final TableMetadata TABLE_METADATA2 =
+      TableMetadata.newBuilder()
+          .addColumn(PKEY1, DataType.TEXT)
+          .addColumn(CKEY1, DataType.TEXT)
+          .addPartitionKey(PKEY1)
+          .addClusteringKey(CKEY1)
+          .build();
+
   @Mock private DatabaseConfig databaseConfig;
   @Mock private TableMetadataManager metadataManager;
   private CosmosOperationChecker operationChecker;
@@ -41,23 +64,14 @@ public class CosmosOperationCheckerTest {
   @BeforeEach
   public void setUp() throws Exception {
     openMocks(this).close();
-    TableMetadata tableMetadata =
-        TableMetadata.newBuilder()
-            .addColumn(PKEY1, DataType.INT)
-            .addColumn(CKEY1, DataType.INT)
-            .addColumn(COL1, DataType.INT)
-            .addColumn(COL2, DataType.BLOB)
-            .addPartitionKey(PKEY1)
-            .addClusteringKey(CKEY1)
-            .addSecondaryIndex(COL1)
-            .build();
-    when(metadataManager.getTableMetadata(any())).thenReturn(tableMetadata);
+
     operationChecker = new CosmosOperationChecker(databaseConfig, metadataManager);
   }
 
   @Test
-  public void check_ForPutWithCondition_ShouldBehaveProperly() {
+  public void check_ForPutWithCondition_ShouldBehaveProperly() throws ExecutionException {
     // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA1);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(buildPutWithCondition(putIfExists())))
@@ -128,8 +142,9 @@ public class CosmosOperationCheckerTest {
   }
 
   @Test
-  public void check_ForDeleteWithCondition_ShouldBehaveProperly() {
+  public void check_ForDeleteWithCondition_ShouldBehaveProperly() throws ExecutionException {
     // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA1);
 
     // Act Assert
     assertThatCode(() -> operationChecker.check(buildDeleteWithCondition(deleteIfExists())))
@@ -199,8 +214,11 @@ public class CosmosOperationCheckerTest {
   }
 
   @Test
-  public void check_ForMutationsWithPutWithCondition_ShouldBehaveProperly() {
+  public void check_ForMutationsWithPutWithCondition_ShouldBehaveProperly()
+      throws ExecutionException {
     // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA1);
+
     Put put =
         Put.newBuilder()
             .namespace(NAMESPACE_NAME)
@@ -298,8 +316,11 @@ public class CosmosOperationCheckerTest {
   }
 
   @Test
-  public void check_ForMutationsWithDeleteWithCondition_ShouldBehaveProperly() {
+  public void check_ForMutationsWithDeleteWithCondition_ShouldBehaveProperly()
+      throws ExecutionException {
     // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA1);
+
     Delete delete =
         Delete.newBuilder()
             .namespace(NAMESPACE_NAME)
@@ -394,6 +415,284 @@ public class CosmosOperationCheckerTest {
                                             "blob".getBytes(StandardCharsets.UTF_8)))
                                 .build()),
                         delete)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      check_GetGiven_WhenIllegalCharacterInPrimaryKeyColumn_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA2);
+
+    Get get1 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Get get2 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a:b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Get get3 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a:b"))
+            .build();
+    Get get4 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a/b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Get get5 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a/b"))
+            .build();
+    Get get6 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a\\b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Get get7 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a\\b"))
+            .build();
+    Get get8 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a#b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Get get9 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a#b"))
+            .build();
+    Get get10 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a?b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Get get11 =
+        Get.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a?b"))
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(get1)).doesNotThrowAnyException();
+    assertThatThrownBy(() -> operationChecker.check(get2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get3))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get4))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get5))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get6))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get7))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get8))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get9))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get10))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(get11))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      check_ScanGiven_WhenIllegalCharacterInPrimaryKeyColumn_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA2);
+
+    Scan scan1 =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .start(Key.ofText(CKEY1, "ab"))
+            .end(Key.ofText(CKEY1, "ab"))
+            .build();
+    Scan scan2 =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a:b"))
+            .start(Key.ofText(CKEY1, "ab"))
+            .end(Key.ofText(CKEY1, "ab"))
+            .build();
+    Scan scan3 =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .start(Key.ofText(CKEY1, "a:b"))
+            .end(Key.ofText(CKEY1, "ab"))
+            .build();
+    Scan scan4 =
+        Scan.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .start(Key.ofText(CKEY1, "ab"))
+            .end(Key.ofText(CKEY1, "a:b"))
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(scan1)).doesNotThrowAnyException();
+    assertThatThrownBy(() -> operationChecker.check(scan2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(scan3))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(scan4))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      check_PutGiven_WhenIllegalCharacterInPrimaryKeyColumn_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA2);
+
+    Put put1 =
+        Put.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a:b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Put put3 =
+        Put.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a:b"))
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(put1)).doesNotThrowAnyException();
+    assertThatThrownBy(() -> operationChecker.check(put2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(put3))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      check_DeleteGiven_WhenIllegalCharacterInPrimaryKeyColumn_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA2);
+
+    Delete delete1 =
+        Delete.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Delete delete2 =
+        Delete.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a:b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Delete delete3 =
+        Delete.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "a:b"))
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(delete1)).doesNotThrowAnyException();
+    assertThatThrownBy(() -> operationChecker.check(delete2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(delete3))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      check_MutationsGiven_WhenIllegalCharacterInPrimaryKeyColumn_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA2);
+
+    Put put1 =
+        Put.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a:b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Delete delete1 =
+        Delete.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "ab"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+    Delete delete2 =
+        Delete.newBuilder()
+            .namespace(NAMESPACE_NAME)
+            .table(TABLE_NAME)
+            .partitionKey(Key.ofText(PKEY1, "a:b"))
+            .clusteringKey(Key.ofText(CKEY1, "ab"))
+            .build();
+
+    // Act Assert
+    assertThatCode(() -> operationChecker.check(Arrays.asList(put1, delete1)))
+        .doesNotThrowAnyException();
+    assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put2, delete1)))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> operationChecker.check(Arrays.asList(put1, delete2)))
         .isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitterTest.java
@@ -270,12 +270,12 @@ class CoordinatorGroupCommitterTest {
 
       // Act
       // Assert
-      assertThat(keyManipulator.isFullKey("012345678901234567890123:" + childTxId)).isTrue();
-      assertThat(keyManipulator.isFullKey("abcdefghijklmnopqrstuvwx:" + childTxId)).isTrue();
-      assertThat(keyManipulator.isFullKey("cdefghijklmnopqrstuvwxyz:" + childTxId)).isTrue();
-      assertThat(keyManipulator.isFullKey("ABCDEFGHIJKLMNOPQRSTUVWX:" + childTxId)).isTrue();
-      assertThat(keyManipulator.isFullKey("CDEFGHIJKLMNOPQRSTUVWXYZ:" + childTxId)).isTrue();
-      assertThat(keyManipulator.isFullKey("0123456789abcdefghijWXYZ:" + childTxId)).isTrue();
+      assertThat(keyManipulator.isFullKey("012345678901234567890123$" + childTxId)).isTrue();
+      assertThat(keyManipulator.isFullKey("abcdefghijklmnopqrstuvwx$" + childTxId)).isTrue();
+      assertThat(keyManipulator.isFullKey("cdefghijklmnopqrstuvwxyz$" + childTxId)).isTrue();
+      assertThat(keyManipulator.isFullKey("ABCDEFGHIJKLMNOPQRSTUVWX$" + childTxId)).isTrue();
+      assertThat(keyManipulator.isFullKey("CDEFGHIJKLMNOPQRSTUVWXYZ$" + childTxId)).isTrue();
+      assertThat(keyManipulator.isFullKey("0123456789abcdefghijWXYZ$" + childTxId)).isTrue();
     }
 
     @Test
@@ -285,8 +285,8 @@ class CoordinatorGroupCommitterTest {
 
       // Act
       // Assert
-      assertThat(keyManipulator.isFullKey("01234567890123456789012:" + childTxId)).isFalse();
-      assertThat(keyManipulator.isFullKey("0123456789012345678901234:" + childTxId)).isFalse();
+      assertThat(keyManipulator.isFullKey("01234567890123456789012$" + childTxId)).isFalse();
+      assertThat(keyManipulator.isFullKey("0123456789012345678901234$" + childTxId)).isFalse();
       assertThat(keyManipulator.isFullKey("012345678901234567890123" + childTxId)).isFalse();
       assertThat(keyManipulator.isFullKey("0123456789012345678901234" + childTxId)).isFalse();
     }
@@ -331,7 +331,7 @@ class CoordinatorGroupCommitterTest {
 
       // Act
       // Assert
-      assertThat(keyManipulator.fullKey(parentKey, childKey)).isEqualTo(parentKey + ":" + childKey);
+      assertThat(keyManipulator.fullKey(parentKey, childKey)).isEqualTo(parentKey + "$" + childKey);
     }
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2292
- **Commit to backport:** b4170b4bb8185902baf44631affef4fe4d3be01d

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-2292 &&
git cherry-pick --no-rerere-autoupdate -m1 b4170b4bb8185902baf44631affef4fe4d3be01d
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!