### PR TITLE
Backport to branch(3.10) : Add validation for primary key columns in Cosmos DB adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ConcatenationVisitor.java
@@ -14,7 +14,8 @@ import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A visitor class to make a concatenated key string for the partition key
+ * A visitor class to make a concatenated key string for the partition key. This uses a colon as a
+ * key separator, so the text column value should not contain colons.
  *
  * @author Yuji Ito
  */
@@ -27,7 +28,6 @@ public class ConcatenationVisitor implements ValueVisitor {
   }
 
   public String build() {
-    // TODO What if the string or blob value includes `:`?
     return String.join(":", values);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperationChecker.java
@@ -2,22 +2,104 @@ package com.scalar.db.storage.cosmos;
 
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.ColumnVisitor;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.TextColumn;
 
 public class CosmosOperationChecker extends OperationChecker {
+
+  private static final char[] ILLEGAL_CHARACTERS_IN_PRIMARY_KEY = {
+    // Colons are not allowed in primary-key columns due to the `ConcatenationVisitor` limitation.
+    ':',
+
+    // The following characters are not allowed in primary-key columns because they are restricted
+    // and cannot be used in the `Id` property of a Cosmos DB document. For more information, see:
+    // https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.databaseproperties.id?view=azure-dotnet#remarks
+    '/',
+    '\\',
+    '#',
+    '?'
+  };
+
+  private static final ColumnVisitor PRIMARY_KEY_COLUMN_CHECKER =
+      new ColumnVisitor() {
+        @Override
+        public void visit(BooleanColumn column) {}
+
+        @Override
+        public void visit(IntColumn column) {}
+
+        @Override
+        public void visit(BigIntColumn column) {}
+
+        @Override
+        public void visit(FloatColumn column) {}
+
+        @Override
+        public void visit(DoubleColumn column) {}
+
+        @Override
+        public void visit(TextColumn column) {
+          String value = column.getTextValue();
+          assert value != null;
+
+          for (char illegalCharacter : ILLEGAL_CHARACTERS_IN_PRIMARY_KEY) {
+            if (value.indexOf(illegalCharacter) != -1) {
+              throw new IllegalArgumentException(
+                  String.format(
+                      "The value of the column %s in the primary key contains an illegal character. "
+                          + "Primary-key columns must not contain any of the following characters in Cosmos DB: ':', '/', '\\', '#', '?'. Value: %s",
+                      column.getName(), value));
+            }
+          }
+        }
+
+        @Override
+        public void visit(BlobColumn column) {}
+      };
+
   public CosmosOperationChecker(TableMetadataManager metadataManager) {
     super(metadataManager);
   }
 
   @Override
+  public void check(Get get) throws ExecutionException {
+    super.check(get);
+    checkPrimaryKey(get);
+  }
+
+  @Override
+  public void check(Scan scan) throws ExecutionException {
+    super.check(scan);
+    checkPrimaryKey(scan);
+    scan.getStartClusteringKey()
+        .ifPresent(
+            c -> c.getColumns().forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER)));
+    scan.getEndClusteringKey()
+        .ifPresent(
+            c -> c.getColumns().forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER)));
+  }
+
+  @Override
   public void check(Put put) throws ExecutionException {
     super.check(put);
+    checkPrimaryKey(put);
+
     TableMetadata metadata = getTableMetadata(put);
     checkCondition(put, metadata);
   }
@@ -25,8 +107,21 @@ public class CosmosOperationChecker extends OperationChecker {
   @Override
   public void check(Delete delete) throws ExecutionException {
     super.check(delete);
+    checkPrimaryKey(delete);
+
     TableMetadata metadata = getTableMetadata(delete);
     checkCondition(delete, metadata);
+  }
+
+  private void checkPrimaryKey(Operation operation) {
+    operation
+        .getPartitionKey()
+        .getColumns()
+        .forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER));
+    operation
+        .getClusteringKey()
+        .ifPresent(
+            c -> c.getColumns().forEach(column -> column.accept(PRIMARY_KEY_COLUMN_CHECKER)));
   }
 
   private void checkCondition(Mutation mutation, TableMetadata metadata) {

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosTest.java
@@ -1,20 +1,27 @@
 package com.scalar.db.storage.cosmos;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import com.azure.cosmos.CosmosClient;
 import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class CosmosTest {
+
   private Cosmos cosmos;
   @Mock private DatabaseConfig config;
   @Mock private CosmosClient client;
@@ -23,6 +30,7 @@ public class CosmosTest {
   @Mock private DeleteStatementHandler delete;
   @Mock private BatchHandler batch;
   @Mock private OperationChecker operationChecker;
+  @Mock private Key partitionKey;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -56,5 +64,106 @@ public class CosmosTest {
 
     // Act Assert
     assertThatThrownBy(() -> cosmos.scan(scan)).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void
+      get_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Get get = Get.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    doThrow(IllegalArgumentException.class).when(operationChecker).check(get);
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.get(get)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      scan_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Scan scan = Scan.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    doThrow(IllegalArgumentException.class).when(operationChecker).check(scan);
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.scan(scan)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      put_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Put put = Put.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    doThrow(IllegalArgumentException.class).when(operationChecker).check(put);
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.put(put)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      put_MultiplePutsGiven_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Put put1 = Put.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    Put put2 = Put.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+
+    doThrow(IllegalArgumentException.class).when(operationChecker).check(Arrays.asList(put1, put2));
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.put(Arrays.asList(put1, put2)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      delete_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Delete delete =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    doThrow(IllegalArgumentException.class).when(operationChecker).check(delete);
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.delete(delete)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      delete_MultipleDeletesGiven_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Delete delete1 =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    Delete delete2 =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+
+    doThrow(IllegalArgumentException.class)
+        .when(operationChecker)
+        .check(Arrays.asList(delete1, delete2));
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.delete(Arrays.asList(delete1, delete2)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      mutate_IllegalArgumentExceptionThrownByOperationChecker_ShouldThrowIllegalArgumentException()
+          throws ExecutionException {
+    // Arrange
+    Put put = Put.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+    Delete delete =
+        Delete.newBuilder().namespace("ns").table("tbl").partitionKey(partitionKey).build();
+
+    doThrow(IllegalArgumentException.class)
+        .when(operationChecker)
+        .check(Arrays.asList(put, delete));
+
+    // Act Assert
+    assertThatThrownBy(() -> cosmos.mutate(Arrays.asList(put, delete)))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2292
- **Commit to backport:** b4170b4bb8185902baf44631affef4fe4d3be01d

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.10-pull-2292 &&
git cherry-pick --no-rerere-autoupdate -m1 b4170b4bb8185902baf44631affef4fe4d3be01d
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!