### PR TITLE
Optimize `Coordinator#getStateForGroupCommit()` by first looking up the coordinator table with parent transaction ID

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -83,27 +83,6 @@ public class Coordinator {
 
   @VisibleForTesting
   Optional<Coordinator.State> getStateForGroupCommit(String fullId) throws CoordinatorException {
-    // Reading a coordinator state is likely to occur during lazy recovery, as follows:
-    // 1. Transaction T1 starts and creates PREPARED state records but hasn't committed or aborted
-    //    yet.
-    // 2. Transaction T2 starts and reads the PREPARED state records created by T1.
-    // 3. T2 reads the coordinator table record for T1 to decide whether to roll back or roll
-    //    forward.
-    //
-    // The likelihood of step 2 would increase if T1 is delayed.
-    //
-    // With the group commit feature enabled, delayed transactions are isolated from a normal group
-    // that is looked up by a parent ID into a delayed group that is looked up by a full ID.
-    // Therefore, looking up with the full transaction ID should be tried first to minimize read
-    // operations as much as possible.
-
-    // Scan with the full ID for a delayed group that contains only a single transaction.
-    // The normal lookup logic can be used as is.
-    Optional<State> stateOfDelayedTxn = get(createGetWith(fullId));
-    if (stateOfDelayedTxn.isPresent()) {
-      return stateOfDelayedTxn;
-    }
-
     // Scan with the parent ID for a normal group that contains multiple transactions.
     Keys<String, String, String> idForGroupCommit = keyManipulator.keysFromFullKey(fullId);
 
@@ -111,13 +90,22 @@ public class Coordinator {
     String childId = idForGroupCommit.childKey;
     Get get = createGetWith(parentId);
     Optional<State> state = get(get);
-    return state.flatMap(
-        s -> {
-          if (s.getChildIds().contains(childId)) {
-            return state;
-          }
-          return Optional.empty();
-        });
+    // The current implementation is optimized for cases where the target transaction is properly
+    // group-committed, by first checking with the parent ID. However, if the target transaction was
+    // delayed and committed individually, two read operations are required.
+    Optional<State> stateContainingTargetTxId =
+        state.flatMap(
+            s -> {
+              if (s.getChildIds().contains(childId)) {
+                return state;
+              }
+              return Optional.empty();
+            });
+    if (stateContainingTargetTxId.isPresent()) {
+      return stateContainingTargetTxId;
+    }
+
+    return get(createGetWith(fullId));
   }
 
   public void putState(Coordinator.State state) throws CoordinatorException {
@@ -246,7 +234,8 @@ public class Coordinator {
     putState(new Coordinator.State(id, TransactionState.ABORTED));
   }
 
-  private Get createGetWith(String id) {
+  @VisibleForTesting
+  Get createGetWith(String id) {
     return new Get(new Key(Attribute.toIdValue(id)))
         .withConsistency(Consistency.LINEARIZABLE)
         .forNamespace(coordinatorNamespace)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -90,9 +90,10 @@ public class Coordinator {
     String childId = idForGroupCommit.childKey;
     Get get = createGetWith(parentId);
     Optional<State> state = get(get);
-    // The current implementation is optimized for cases where the target transaction is properly
-    // group-committed, by first checking with the parent ID. However, if the target transaction was
-    // delayed and committed individually, two read operations are required.
+    // The current implementation is optimized for cases where most transactions are
+    // group-committed. It first looks up a transaction state by the parent ID with a single read
+    // operation. If no matching transaction state is found (i.e., the transaction was delayed and
+    // committed individually), it issues an additional read operation using the full ID.
     Optional<State> stateContainingTargetTxId =
         state.flatMap(
             s -> {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -91,7 +91,7 @@ public class Coordinator {
     Get get = createGetWith(parentId);
     Optional<State> state = get(get);
     // The current implementation is optimized for cases where most transactions are
-    // group-committed. It first looks up a transaction state by the parent ID with a single read
+    // group-committed. It first looks up a transaction state using the parent ID with a single read
     // operation. If no matching transaction state is found (i.e., the transaction was delayed and
     // committed individually), it issues an additional read operation using the full ID.
     Optional<State> stateContainingTargetTxId =

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CoordinatorTest.java
@@ -264,19 +264,9 @@ public class CoordinatorTest {
     // The IDs used to find the state are:
     // - parentId:childId1
     // - parentId:childId2
-    doReturn(
-            // For the first call,
-            // - The first get with the full ID shouldn't find a state.
-            Optional.empty(),
-            // - The second get with the parent ID should return the state.
-            Optional.of(resultForGroupCommitState),
-            // For the second call,
-            // - The first get with the full ID shouldn't find a state.
-            Optional.empty(),
-            // - The second get with the parent ID should return the state.
-            Optional.of(resultForGroupCommitState))
+    doReturn(Optional.of(resultForGroupCommitState))
         .when(storage)
-        .get(any(Get.class));
+        .get(coordinator.createGetWith(parentId));
 
     // Act
     Optional<Coordinator.State> state1 = spiedCoordinator.getState(fullId1);
@@ -291,9 +281,9 @@ public class CoordinatorTest {
     assertThat(state1.get().getCreatedAt()).isEqualTo(ANY_TIME_1);
     verify(spiedCoordinator).getStateForGroupCommit(fullId1);
     verify(spiedCoordinator).getStateForGroupCommit(fullId2);
-    verify(storage, times(4)).get(getArgumentCaptor.capture());
+    verify(storage, times(2)).get(getArgumentCaptor.capture());
     assertGetArgumentCaptorForGetState(
-        getArgumentCaptor.getAllValues(), Arrays.asList(fullId1, parentId, fullId2, parentId));
+        getArgumentCaptor.getAllValues(), Arrays.asList(parentId, parentId));
   }
 
   @ParameterizedTest
@@ -310,6 +300,20 @@ public class CoordinatorTest {
     String childId = UUID.randomUUID().toString();
     String fullId = keyManipulator.fullKey(parentId, childId);
     List<String> childIds = Collections.emptyList();
+    String dummyChildId1 = UUID.randomUUID().toString();
+    String dummyChildId2 = UUID.randomUUID().toString();
+    List<String> dummyChildIds = Arrays.asList(dummyChildId1, dummyChildId2);
+
+    Result resultForGroupCommitState = mock(Result.class);
+    when(resultForGroupCommitState.getValue(Attribute.ID))
+        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
+    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
+        .thenReturn(
+            Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(dummyChildIds))));
+    when(resultForGroupCommitState.getValue(Attribute.STATE))
+        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
+    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
+        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
 
     Result resultForSingleCommitState = mock(Result.class);
     when(resultForSingleCommitState.getValue(Attribute.ID))
@@ -323,13 +327,18 @@ public class CoordinatorTest {
 
     // Assuming these states exist:
     //
-    //         id        | child_ids |  state
-    // ------------------+-----------+----------
-    //  parentId:childId |    []     | COMMITTED
+    //         id        |       child_ids      |  state
+    // ------------------+----------------------+----------
+    //  parentId:childId | [childId1, childId2] | COMMITTED
     //
     // The IDs used to find the state are:
     // - parentId:childId
-    doReturn(Optional.of(resultForSingleCommitState)).when(storage).get(any(Get.class));
+    doReturn(Optional.of(resultForGroupCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(parentId));
+    doReturn(Optional.of(resultForSingleCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(fullId));
 
     // Act
     Optional<Coordinator.State> state = spiedCoordinator.getState(fullId);
@@ -341,9 +350,9 @@ public class CoordinatorTest {
     Assertions.assertThat(state.get().getState()).isEqualTo(transactionState);
     assertThat(state.get().getCreatedAt()).isEqualTo(ANY_TIME_1);
     verify(spiedCoordinator).getStateForGroupCommit(fullId);
-    verify(storage).get(getArgumentCaptor.capture());
+    verify(storage, times(2)).get(getArgumentCaptor.capture());
     assertGetArgumentCaptorForGetState(
-        getArgumentCaptor.getAllValues(), Collections.singletonList(fullId));
+        getArgumentCaptor.getAllValues(), Arrays.asList(parentId, fullId));
   }
 
   @ParameterizedTest
@@ -381,14 +390,11 @@ public class CoordinatorTest {
     //
     // The IDs used to find the state are:
     // - parentId:childIdX
-    doReturn(
-            // The first get with the full ID should return empty.
-            Optional.empty(),
-            // The second get with the parent ID should return a state, but it doesn't contain the
-            // child ID.
-            Optional.of(resultForGroupCommitState))
+    doReturn(Optional.of(resultForGroupCommitState))
         .when(storage)
-        .get(any(Get.class));
+        .get(coordinator.createGetWith(parentId));
+
+    doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(targetFullId));
 
     // Act
     Optional<Coordinator.State> state = spiedCoordinator.getState(targetFullId);
@@ -398,7 +404,7 @@ public class CoordinatorTest {
     verify(spiedCoordinator).getStateForGroupCommit(targetFullId);
     verify(storage, times(2)).get(getArgumentCaptor.capture());
     assertGetArgumentCaptorForGetState(
-        getArgumentCaptor.getAllValues(), Arrays.asList(targetFullId, parentId));
+        getArgumentCaptor.getAllValues(), Arrays.asList(parentId, targetFullId));
   }
 
   @ParameterizedTest
@@ -413,10 +419,22 @@ public class CoordinatorTest {
     CoordinatorGroupCommitKeyManipulator keyManipulator =
         new CoordinatorGroupCommitKeyManipulator();
     String parentId = keyManipulator.generateParentKey();
+    List<String> childIds =
+        Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
     // Look up with the same parent ID and a wrong child ID.
     // But the full ID matches the single committed state.
     String targetFullId = keyManipulator.fullKey(parentId, UUID.randomUUID().toString());
+
+    Result resultForGroupCommitState = mock(Result.class);
+    when(resultForGroupCommitState.getValue(Attribute.ID))
+        .thenReturn(Optional.of(new TextValue(Attribute.ID, parentId)));
+    when(resultForGroupCommitState.getValue(Attribute.CHILD_IDS))
+        .thenReturn(Optional.of(new TextValue(Attribute.CHILD_IDS, Joiner.on(',').join(childIds))));
+    when(resultForGroupCommitState.getValue(Attribute.STATE))
+        .thenReturn(Optional.of(new IntValue(Attribute.STATE, transactionState.get())));
+    when(resultForGroupCommitState.getValue(Attribute.CREATED_AT))
+        .thenReturn(Optional.of(new BigIntValue(Attribute.CREATED_AT, ANY_TIME_1)));
 
     Result resultForSingleCommitState = mock(Result.class);
     when(resultForSingleCommitState.getValue(Attribute.ID))
@@ -437,7 +455,12 @@ public class CoordinatorTest {
     //
     // The IDs used to find the state are:
     // - parentId:childIdX
-    doReturn(Optional.of(resultForSingleCommitState)).when(storage).get(any(Get.class));
+    doReturn(Optional.of(resultForGroupCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(parentId));
+    doReturn(Optional.of(resultForSingleCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(targetFullId));
 
     // Act
     Optional<Coordinator.State> state = spiedCoordinator.getState(targetFullId);
@@ -449,9 +472,9 @@ public class CoordinatorTest {
     Assertions.assertThat(state.get().getState()).isEqualTo(transactionState);
     assertThat(state.get().getCreatedAt()).isEqualTo(ANY_TIME_1);
     verify(spiedCoordinator).getStateForGroupCommit(targetFullId);
-    verify(storage).get(getArgumentCaptor.capture());
+    verify(storage, times(2)).get(getArgumentCaptor.capture());
     assertGetArgumentCaptorForGetState(
-        getArgumentCaptor.getAllValues(), Collections.singletonList(targetFullId));
+        getArgumentCaptor.getAllValues(), Arrays.asList(parentId, targetFullId));
   }
 
   @ParameterizedTest
@@ -491,7 +514,10 @@ public class CoordinatorTest {
     //
     // The IDs used to find the state are:
     // - parentId:childIdY
-    when(storage.get(any(Get.class))).thenReturn(Optional.empty());
+    doReturn(Optional.of(resultForGroupCommitState))
+        .when(storage)
+        .get(coordinator.createGetWith(parentId));
+    doReturn(Optional.empty()).when(storage).get(coordinator.createGetWith(targetFullId));
 
     // Act
     Optional<Coordinator.State> state = spiedCoordinator.getState(targetFullId);
@@ -501,7 +527,7 @@ public class CoordinatorTest {
     verify(spiedCoordinator).getStateForGroupCommit(targetFullId);
     verify(storage, times(2)).get(getArgumentCaptor.capture());
     assertGetArgumentCaptorForGetState(
-        getArgumentCaptor.getAllValues(), Arrays.asList(targetFullId, parentId));
+        getArgumentCaptor.getAllValues(), Arrays.asList(parentId, targetFullId));
   }
 
   @Test


### PR DESCRIPTION
## Description

The current implementation of `Coordinator.getStateForGroupCommit()` checks transaction states that were stored with the Group Commit feature enabled in the following order:
1. First, it tries to find a record whose `tx_id` is the full transaction ID, returning the state if it's found. This record type is created when a transaction is delayed and committed individually.
2. Next, it tris to find a record whose `tx_id` is the parent transaction ID, returning the state if it's found and the `tx_sub_ids` contains the child transaction ID. This record type is created when a transaction gets commit-ready in time and group-committed.

This order is optimized for lazy-recovery, which is more likely to happen if the commit timing is delayed after PREPARE record is created. However, basically lazy-recovery doesn't happen so often.

We may create a new system that frequently looks up the coordinator table in the future. In that case, it might need to prioritize first finding group-committed transactions, not just delayed individually committed transaction. The current order doesn't fit this scenario.

This PR changes the lookup order to prioritize group-committed transactions first.

## Related issues and/or PRs

None

## Changes made

- Change the order of GET operations with full transaction ID and parent ID in `Coordinator#getStateForGroupCommit()`.
- Update the unit test along with the change.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A