### PR TITLE
Revise feature names in error messages

### DIFF
--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -435,8 +435,7 @@ public interface Admin {
       String namespace, String table, String columnName, DataType columnType, boolean encrypted)
       throws ExecutionException {
     if (encrypted) {
-      throw new UnsupportedOperationException(
-          CoreError.TRANSPARENT_DATA_ENCRYPTION_NOT_ENABLED.buildMessage());
+      throw new UnsupportedOperationException(CoreError.ENCRYPTION_NOT_ENABLED.buildMessage());
     } else {
       addNewColumnToTable(namespace, table, columnName, columnType);
     }

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -57,8 +57,7 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
     }
 
     if (!metadata.getEncryptedColumnNames().isEmpty()) {
-      throw new UnsupportedOperationException(
-          CoreError.TRANSPARENT_DATA_ENCRYPTION_NOT_ENABLED.buildMessage());
+      throw new UnsupportedOperationException(CoreError.ENCRYPTION_NOT_ENABLED.buildMessage());
     }
 
     try {
@@ -257,8 +256,7 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
       String namespace, String table, TableMetadata metadata, Map<String, String> options)
       throws ExecutionException {
     if (!metadata.getEncryptedColumnNames().isEmpty()) {
-      throw new UnsupportedOperationException(
-          CoreError.TRANSPARENT_DATA_ENCRYPTION_NOT_ENABLED.buildMessage());
+      throw new UnsupportedOperationException(CoreError.ENCRYPTION_NOT_ENABLED.buildMessage());
     }
 
     try {

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -647,7 +647,7 @@ public enum CoreError implements ScalarDbError {
           + "If you want to modify a condition, please use clearConditions() to remove all existing conditions first",
       "",
       ""),
-  TRANSPARENT_DATA_ENCRYPTION_NOT_ENABLED(
+  ENCRYPTION_NOT_ENABLED(
       Category.USER_ERROR,
       "0143",
       "The encryption feature is not enabled. To encrypt data at rest, you must enable this feature. Note that this feature is supported only in the ScalarDB Enterprise edition",

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -650,7 +650,7 @@ public enum CoreError implements ScalarDbError {
   TRANSPARENT_DATA_ENCRYPTION_NOT_ENABLED(
       Category.USER_ERROR,
       "0143",
-      "ScalarDB Transparent Data Encryption is not enabled. To use ScalarDB Transparent Data Encryption, you must enable it. Note that this feature is supported only in the ScalarDB Enterprise edition",
+      "The encryption feature is not enabled. To encrypt data at rest, you must enable this feature. Note that this feature is supported only in the ScalarDB Enterprise edition",
       "",
       ""),
   INVALID_VARIABLE_KEY_COLUMN_SIZE(

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -118,7 +118,7 @@ public enum CoreError implements ScalarDbError {
   AUTH_NOT_ENABLED(
       Category.USER_ERROR,
       "0022",
-      "ScalarDB Auth is not enabled. To use ScalarDB Auth, you must enable it. Note that this feature is supported only in the ScalarDB Enterprise edition",
+      "The authentication and authorization feature is not enabled. To use this feature, you must enable it. Note that this feature is supported only in the ScalarDB Enterprise edition",
       "",
       ""),
   CONDITION_BUILD_ERROR_CONDITION_NOT_ALLOWED_FOR_PUT_IF(


### PR DESCRIPTION
## Description

This PR revises features names in error messages.

Since we decided to use generic feature names rather than branded feature names for the encryption feature and the authentication and authorization feature, the error messages should be consistent with how we officially refer to these features.

## Related issues and/or PRs

- **PR that introduces the feature names:** https://github.com/scalar-labs/scalardb/pull/2182

## Changes made

- Changed `ScalarDB Auth` to `authentication and authorization`.
- Changed `ScalarDB Transparent Data Encryption` to `encryption`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A