### PR TITLE
Fix delete behavior in Cosmos adapter

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/DeleteStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/DeleteStatementHandler.java
@@ -2,6 +2,7 @@ package com.scalar.db.storage.cosmos;
 
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
 import com.scalar.db.api.Delete;
@@ -42,7 +43,11 @@ public class DeleteStatementHandler extends MutateStatementHandler {
       PartitionKey partitionKey = cosmosMutation.getCosmosPartitionKey();
       CosmosItemRequestOptions options = new CosmosItemRequestOptions();
 
-      getContainer(mutation).deleteItem(id, partitionKey, options);
+      try {
+        getContainer(mutation).deleteItem(id, partitionKey, options);
+      } catch (NotFoundException ignored) {
+        // don't throw an exception if the item is not found
+      }
     } else {
       // clustering key is not fully specified
       executeStoredProcedure(mutation, tableMetadata);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/DeleteStatementHandlerTest.java
@@ -18,6 +18,7 @@ import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.CosmosScripts;
 import com.azure.cosmos.CosmosStoredProcedure;
+import com.azure.cosmos.implementation.NotFoundException;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosStoredProcedureRequestOptions;
@@ -119,6 +120,19 @@ public class DeleteStatementHandlerTest {
     assertThatThrownBy(() -> handler.handle(delete))
         .isInstanceOf(ExecutionException.class)
         .hasCause(toThrow);
+  }
+
+  @Test
+  public void handle_DeleteWithoutConditionsNotFoundExceptionThrown_ShouldNotThrowAnyException() {
+    // Arrange
+    doThrow(NotFoundException.class)
+        .when(container)
+        .deleteItem(anyString(), any(PartitionKey.class), any(CosmosItemRequestOptions.class));
+
+    Delete delete = prepareDelete();
+
+    // Act Assert
+    assertThatCode(() -> handler.handle(delete)).doesNotThrowAnyException();
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1500,6 +1500,17 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @Test
+  public void delete_ForNonExistingRecord_ShouldDoNothing() throws ExecutionException {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> storage.delete(prepareDeletes().get(0))).doesNotThrowAnyException();
+
+    Optional<Result> result = storage.get(prepareGet(0, 0));
+    assertThat(result).isNotPresent();
+  }
+
+  @Test
   public void mutate_MultiplePutGiven_ShouldStoreProperly() throws ExecutionException, IOException {
     // Arrange
     int pKey = 0;


### PR DESCRIPTION
## Description

This PR fixes the delete behavior in the Cosmos adapter. Currently, if we attempt to delete a non-existent record, the Cosmos adapter throws an `ExecutionException`. This behavior is inconsistent with other adapters. This PR adjusts it to ensure consistent behavior across adapters.

## Related issues and/or PRs

N/A

## Changes made

- Stop throwing an exception when attempting to delete a non-existent record in the Cosmos adapter.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed the behavior when deleting a non-existing record in the Cosmos adapter.
