### PR TITLE
Backport to branch(3.13) : Revisit behavior of multiple mutations for same record in transaction in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -654,6 +654,10 @@ public enum CoreError implements ScalarDbError {
           + "Primary-key columns must not contain any of the following characters in Cosmos DB: ':', '/', '\\', '#', '?'. Value: %s",
       "",
       ""),
+  CONSENSUS_COMMIT_INSERTING_ALREADY_WRITTEN_DATA_NOT_ALLOWED(
+      Category.USER_ERROR, "0146", "Inserting already-written data is not allowed", "", ""),
+  CONSENSUS_COMMIT_DELETING_ALREADY_INSERTED_DATA_NOT_ALLOWED(
+      Category.USER_ERROR, "0147", "Deleting already-inserted data is not allowed", "", ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -9,6 +9,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.PutBuilder;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -112,45 +114,62 @@ public class Snapshot {
 
   // Although this class is not thread-safe, this method is actually thread-safe because the readSet
   // is a concurrent map
-  public void put(Key key, Optional<TransactionResult> result) {
+  public void putIntoReadSet(Key key, Optional<TransactionResult> result) {
     readSet.put(key, result);
   }
 
   // Although this class is not thread-safe, this method is actually thread-safe because the getSet
   // is a concurrent map
-  public void put(Get get, Optional<TransactionResult> result) {
+  public void putIntoGetSet(Get get, Optional<TransactionResult> result) {
     getSet.put(get, result);
   }
 
-  public void put(Scan scan, Map<Key, TransactionResult> results) {
+  public void putIntoScanSet(Scan scan, Map<Key, TransactionResult> results) {
     scanSet.put(scan, results);
   }
 
-  public void put(Key key, Put put) {
+  public void putIntoWriteSet(Key key, Put put) {
     if (deleteSet.containsKey(key)) {
       throw new IllegalArgumentException(
           CoreError.CONSENSUS_COMMIT_WRITING_ALREADY_DELETED_DATA_NOT_ALLOWED.buildMessage());
     }
     if (writeSet.containsKey(key)) {
+      if (put.isInsertModeEnabled()) {
+        throw new IllegalArgumentException(
+            CoreError.CONSENSUS_COMMIT_INSERTING_ALREADY_WRITTEN_DATA_NOT_ALLOWED.buildMessage());
+      }
+
       // merge the previous put in the write set and the new put
       Put originalPut = writeSet.get(key);
-      put.getColumns().values().forEach(originalPut::withValue);
+      PutBuilder.BuildableFromExisting putBuilder = Put.newBuilder(originalPut);
+      put.getColumns().values().forEach(putBuilder::value);
+
+      // If the implicit pre-read is enabled for the new put, it should also be enabled for the
+      // merged put. However, if the previous put is in insert mode, this doesn’t apply. This is
+      // because, in insert mode, the read set is not used during the preparation phase. Therefore,
+      // we only need to enable the implicit pre-read if the previous put is not in insert mode
+      if (put.isImplicitPreReadEnabled() && !originalPut.isInsertModeEnabled()) {
+        putBuilder.enableImplicitPreRead();
+      }
+
+      writeSet.put(key, putBuilder.build());
     } else {
       writeSet.put(key, put);
     }
   }
 
-  public void put(Key key, Delete delete) {
-    writeSet.remove(key);
+  public void putIntoDeleteSet(Key key, Delete delete) {
+    Put put = writeSet.get(key);
+    if (put != null) {
+      if (put.isInsertModeEnabled()) {
+        throw new IllegalArgumentException(
+            CoreError.CONSENSUS_COMMIT_DELETING_ALREADY_INSERTED_DATA_NOT_ALLOWED.buildMessage());
+      }
+
+      writeSet.remove(key);
+    }
+
     deleteSet.put(key, delete);
-  }
-
-  public boolean containsKeyInReadSet(Key key) {
-    return readSet.containsKey(key);
-  }
-
-  public Optional<TransactionResult> getFromReadSet(Key key) {
-    return readSet.getOrDefault(key, Optional.empty());
   }
 
   public List<Put> getPutsInWriteSet() {
@@ -161,7 +180,39 @@ public class Snapshot {
     return new ArrayList<>(deleteSet.values());
   }
 
-  public Optional<TransactionResult> mergeResult(Key key, Optional<TransactionResult> result)
+  public boolean containsKeyInReadSet(Key key) {
+    return readSet.containsKey(key);
+  }
+
+  public boolean containsKeyInGetSet(Get get) {
+    return getSet.containsKey(get);
+  }
+
+  public Optional<TransactionResult> getResult(Key key) throws CrudException {
+    Optional<TransactionResult> result = readSet.getOrDefault(key, Optional.empty());
+    return mergeResult(key, result);
+  }
+
+  public Optional<TransactionResult> getResult(Key key, Get get) throws CrudException {
+    Optional<TransactionResult> result = getSet.getOrDefault(get, Optional.empty());
+    return mergeResult(key, result, get.getConjunctions());
+  }
+
+  public Optional<Map<Snapshot.Key, TransactionResult>> getResults(Scan scan) throws CrudException {
+    if (!scanSet.containsKey(scan)) {
+      return Optional.empty();
+    }
+
+    Map<Key, TransactionResult> results = new LinkedHashMap<>();
+    for (Entry<Snapshot.Key, TransactionResult> entry : scanSet.get(scan).entrySet()) {
+      mergeResult(entry.getKey(), Optional.of(entry.getValue()))
+          .ifPresent(result -> results.put(entry.getKey(), result));
+    }
+
+    return Optional.of(results);
+  }
+
+  private Optional<TransactionResult> mergeResult(Key key, Optional<TransactionResult> result)
       throws CrudException {
     if (deleteSet.containsKey(key)) {
       return Optional.empty();
@@ -175,7 +226,7 @@ public class Snapshot {
     }
   }
 
-  public Optional<TransactionResult> mergeResult(
+  private Optional<TransactionResult> mergeResult(
       Key key, Optional<TransactionResult> result, Set<Conjunction> conjunctions)
       throws CrudException {
     return mergeResult(key, result)
@@ -202,32 +253,6 @@ public class Snapshot {
     } catch (ExecutionException e) {
       throw new CrudException(e.getMessage(), e, id);
     }
-  }
-
-  private TableMetadata getTableMetadata(Scan scan) throws ExecutionException {
-    TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(scan);
-    if (metadata == null) {
-      throw new IllegalArgumentException(
-          CoreError.TABLE_NOT_FOUND.buildMessage(scan.forFullTableName().get()));
-    }
-    return metadata.getTableMetadata();
-  }
-
-  public boolean containsKeyInGetSet(Get get) {
-    return getSet.containsKey(get);
-  }
-
-  public Optional<TransactionResult> get(Get get) {
-    // We expect this method is called after putting the result of the get operation in the get set.
-    assert getSet.containsKey(get);
-    return getSet.get(get);
-  }
-
-  public Optional<Map<Key, TransactionResult>> get(Scan scan) {
-    if (scanSet.containsKey(scan)) {
-      return Optional.ofNullable(scanSet.get(scan));
-    }
-    return Optional.empty();
   }
 
   public void verify(Scan scan) {
@@ -529,6 +554,15 @@ public class Snapshot {
     }
 
     parallelExecutor.validate(tasks, getId());
+  }
+
+  private TableMetadata getTableMetadata(Scan scan) throws ExecutionException {
+    TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(scan);
+    if (metadata == null) {
+      throw new IllegalArgumentException(
+          CoreError.TABLE_NOT_FOUND.buildMessage(scan.forFullTableName().get()));
+    }
+    return metadata.getTableMetadata();
   }
 
   private boolean isChanged(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -119,8 +119,8 @@ public class CommitHandlerTest {
     // different partition
     Put put1 = preparePut1();
     Put put2 = preparePut2();
-    snapshot.put(new Snapshot.Key(put1), put1);
-    snapshot.put(new Snapshot.Key(put2), put2);
+    snapshot.putIntoWriteSet(new Snapshot.Key(put1), put1);
+    snapshot.putIntoWriteSet(new Snapshot.Key(put2), put2);
 
     return snapshot;
   }
@@ -137,8 +137,8 @@ public class CommitHandlerTest {
     // same partition
     Put put1 = preparePut1();
     Put put3 = preparePut3();
-    snapshot.put(new Snapshot.Key(put1), put1);
-    snapshot.put(new Snapshot.Key(put3), put3);
+    snapshot.putIntoWriteSet(new Snapshot.Key(put1), put1);
+    snapshot.putIntoWriteSet(new Snapshot.Key(put3), put3);
 
     return snapshot;
   }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/SnapshotTest.java
@@ -27,7 +27,6 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
-import com.scalar.db.api.Selection.Conjunction;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -46,9 +45,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -293,80 +292,205 @@ public class SnapshotTest {
   }
 
   @Test
-  public void put_ResultGiven_ShouldHoldWhatsGivenInReadSet() {
+  public void putIntoReadSet_ResultGiven_ShouldHoldWhatsGivenInReadSet() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Snapshot.Key key = new Snapshot.Key(prepareGet());
     TransactionResult result = prepareResult(ANY_ID);
 
     // Act
-    snapshot.put(key, Optional.of(result));
+    snapshot.putIntoReadSet(key, Optional.of(result));
 
     // Assert
     assertThat(readSet.get(key)).isEqualTo(Optional.of(result));
   }
 
   @Test
-  public void put_PutGiven_ShouldHoldWhatsGivenInWriteSet() {
+  public void putIntoGetSet_ResultGiven_ShouldHoldWhatsGivenInReadSet() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Get get = prepareGet();
+    TransactionResult result = prepareResult(ANY_ID);
+
+    // Act
+    snapshot.putIntoGetSet(get, Optional.of(result));
+
+    // Assert
+    assertThat(getSet.get(get)).isEqualTo(Optional.of(result));
+  }
+
+  @Test
+  public void putIntoWriteSet_PutGiven_ShouldHoldWhatsGivenInWriteSet() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Snapshot.Key key = new Snapshot.Key(put);
 
     // Act
-    snapshot.put(key, put);
+    snapshot.putIntoWriteSet(key, put);
 
     // Assert
     assertThat(writeSet.get(key)).isEqualTo(put);
   }
 
   @Test
-  public void put_PutGivenTwice_ShouldHoldMergedPut() {
+  public void putIntoWriteSet_PutGivenTwice_ShouldHoldMergedPut() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put1 = preparePut();
     Snapshot.Key key = new Snapshot.Key(put1);
 
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
     Put put2 =
-        new Put(partitionKey, clusteringKey)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withValue(ANY_NAME_3, ANY_TEXT_5)
-            .withTextValue(ANY_NAME_4, null);
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(ANY_NAME_3, ANY_TEXT_5)
+            .textValue(ANY_NAME_4, null)
+            .enableImplicitPreRead()
+            .build();
 
     // Act
-    snapshot.put(key, put1);
-    snapshot.put(key, put2);
+    snapshot.putIntoWriteSet(key, put1);
+    snapshot.putIntoWriteSet(key, put2);
 
     // Assert
-    assertThat(writeSet.get(key).getColumns())
+    Put mergedPut = writeSet.get(key);
+    assertThat(mergedPut.getColumns())
         .isEqualTo(
             ImmutableMap.of(
                 ANY_NAME_3,
                 TextColumn.of(ANY_NAME_3, ANY_TEXT_5),
                 ANY_NAME_4,
                 TextColumn.ofNull(ANY_NAME_4)));
+    assertThat(mergedPut.isImplicitPreReadEnabled()).isTrue();
   }
 
   @Test
-  public void put_DeleteGiven_ShouldHoldWhatsGivenInDeleteSet() {
+  public void putIntoWriteSet_PutGivenAfterDelete_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Delete delete = prepareDelete();
+    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
+    snapshot.putIntoDeleteSet(deleteKey, delete);
+
+    Put put = preparePut();
+    Snapshot.Key putKey = new Snapshot.Key(preparePut());
+
+    // Act Assert
+    assertThatThrownBy(() -> snapshot.putIntoWriteSet(putKey, put))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      putIntoWriteSet_PutWithInsertModeEnabledGivenAfterPut_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePut();
+    Put putWithInsertModeEnabled = Put.newBuilder(put).enableInsertMode().build();
+    Snapshot.Key key = new Snapshot.Key(put);
+
+    // Act Assert
+    snapshot.putIntoWriteSet(key, put);
+    assertThatThrownBy(() -> snapshot.putIntoWriteSet(key, putWithInsertModeEnabled))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      putIntoWriteSet_PutWithImplicitPreReadEnabledGivenAfterWithInsertModeEnabled_ShouldHoldMergedPutWithoutImplicitPreRead() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put putWithInsertModeEnabled = Put.newBuilder(preparePut()).enableInsertMode().build();
+
+    Key partitionKey = Key.ofText(ANY_NAME_1, ANY_TEXT_1);
+    Key clusteringKey = Key.ofText(ANY_NAME_2, ANY_TEXT_2);
+    Put putWithImplicitPreReadEnabled =
+        Put.newBuilder()
+            .namespace(ANY_NAMESPACE_NAME)
+            .table(ANY_TABLE_NAME)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .textValue(ANY_NAME_3, ANY_TEXT_5)
+            .textValue(ANY_NAME_4, null)
+            .enableImplicitPreRead()
+            .build();
+
+    Snapshot.Key key = new Snapshot.Key(putWithInsertModeEnabled);
+
+    // Act
+    snapshot.putIntoWriteSet(key, putWithInsertModeEnabled);
+    snapshot.putIntoWriteSet(key, putWithImplicitPreReadEnabled);
+
+    // Assert
+    Put mergedPut = writeSet.get(key);
+    assertThat(mergedPut.getColumns())
+        .isEqualTo(
+            ImmutableMap.of(
+                ANY_NAME_3,
+                TextColumn.of(ANY_NAME_3, ANY_TEXT_5),
+                ANY_NAME_4,
+                TextColumn.ofNull(ANY_NAME_4)));
+    assertThat(mergedPut.isInsertModeEnabled()).isTrue();
+    assertThat(mergedPut.isImplicitPreReadEnabled()).isFalse();
+  }
+
+  @Test
+  public void putIntoDeleteSet_DeleteGiven_ShouldHoldWhatsGivenInDeleteSet() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Delete delete = prepareDelete();
     Snapshot.Key key = new Snapshot.Key(delete);
 
     // Act
-    snapshot.put(key, delete);
+    snapshot.putIntoDeleteSet(key, delete);
 
     // Assert
     assertThat(deleteSet.get(key)).isEqualTo(delete);
   }
 
   @Test
-  public void put_ScanGiven_ShouldHoldWhatsGivenInScanSet() {
+  public void putIntoDeleteSet_DeleteGivenAfterPut_PutSupercedesDelete() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePut();
+    Snapshot.Key putKey = new Snapshot.Key(preparePut());
+    snapshot.putIntoWriteSet(putKey, put);
+
+    Delete delete = prepareDelete();
+    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
+
+    // Act
+    snapshot.putIntoDeleteSet(deleteKey, delete);
+
+    // Assert
+    assertThat(writeSet.size()).isEqualTo(0);
+    assertThat(deleteSet.size()).isEqualTo(1);
+    assertThat(deleteSet.get(deleteKey)).isEqualTo(delete);
+  }
+
+  @Test
+  public void
+      putIntoDeleteSet_DeleteGivenAfterPutWithInsertModeEnabled_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Delete delete = prepareDelete();
+    Snapshot.Key key = new Snapshot.Key(delete);
+
+    Put putWithInsertModeEnabled = Put.newBuilder(preparePut()).enableInsertMode().build();
+    snapshot.putIntoWriteSet(key, putWithInsertModeEnabled);
+
+    // Act Assert
+    assertThatThrownBy(() -> snapshot.putIntoDeleteSet(key, delete))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void putIntoScanSet_ScanGiven_ShouldHoldWhatsGivenInScanSet() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Scan scan = prepareScan();
@@ -375,33 +499,64 @@ public class SnapshotTest {
     Map<Snapshot.Key, TransactionResult> expected = Collections.singletonMap(key, result);
 
     // Act
-    snapshot.put(scan, expected);
+    snapshot.putIntoScanSet(scan, expected);
 
     // Assert
     assertThat(scanSet.get(scan)).isEqualTo(expected);
   }
 
   @Test
-  public void mergeResult_KeyGivenContainedInWriteSet_ShouldReturnMergedResult()
+  public void getResult_KeyNeitherContainedInWriteSetNorReadSet_ShouldReturnEmpty()
       throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    Put put =
-        new Put(partitionKey, clusteringKey)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME)
-            .withValue(ANY_NAME_3, ANY_TEXT_5)
-            .withTextValue(ANY_NAME_4, null);
     Snapshot.Key key = new Snapshot.Key(prepareGet());
-    TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(key, Optional.of(result));
-    snapshot.put(key, put);
 
     // Act
-    Optional<TransactionResult> actual = snapshot.mergeResult(key, Optional.of(result));
+    Optional<TransactionResult> actual = snapshot.getResult(key);
+
+    // Assert
+    assertThat(actual).isNotPresent();
+  }
+
+  @Test
+  public void getResult_KeyContainedInWriteSetButNotContainedInReadSet_ShouldReturnProperResult()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePut();
+    Snapshot.Key key = new Snapshot.Key(prepareGet());
+    snapshot.putIntoWriteSet(key, put);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key);
+
+    // Assert
+    assertThat(actual).isPresent();
+
+    assertThat(actual.get().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_1)).isEqualTo(ANY_TEXT_1);
+    assertThat(actual.get().contains(ANY_NAME_2)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_2)).isEqualTo(ANY_TEXT_2);
+    assertThat(actual.get().contains(ANY_NAME_3)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_3)).isEqualTo(ANY_TEXT_3);
+    assertThat(actual.get().contains(ANY_NAME_4)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_4)).isEqualTo(ANY_TEXT_4);
+  }
+
+  @Test
+  public void getResult_KeyContainedInWriteSetAndReadSetGiven_ShouldReturnMergedResult()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePutForMergeTest();
+    Snapshot.Key key = new Snapshot.Key(prepareGet());
+    TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoReadSet(key, Optional.of(result));
+    snapshot.putIntoWriteSet(key, put);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key);
 
     // Assert
     assertThat(actual).isPresent();
@@ -409,16 +564,18 @@ public class SnapshotTest {
   }
 
   @Test
-  public void mergeResult_KeyGivenContainedInDeleteSet_ShouldReturnEmpty() throws CrudException {
+  public void getResult_KeyContainedInDeleteSetAndReadSetGiven_ShouldReturnEmpty()
+      throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Delete delete = prepareDelete();
     Snapshot.Key key = new Snapshot.Key(delete);
-    snapshot.put(key, delete);
     TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoReadSet(key, Optional.of(result));
+    snapshot.putIntoDeleteSet(key, delete);
 
     // Act
-    Optional<TransactionResult> actual = snapshot.mergeResult(key, Optional.of(result));
+    Optional<TransactionResult> actual = snapshot.getResult(key);
 
     // Assert
     assertThat(actual).isNotPresent();
@@ -426,15 +583,115 @@ public class SnapshotTest {
 
   @Test
   public void
-      mergeResult_KeyGivenNeitherContainedInDeleteSetNorWriteSet_ShouldReturnOriginalResult()
+      getResult_KeyNeitherContainedInDeleteSetNorWriteSetButContainedInAndReadSetGiven_ShouldReturnOriginalResult()
           throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Snapshot.Key key = new Snapshot.Key(prepareGet());
     TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoReadSet(key, Optional.of(result));
 
     // Act
-    Optional<TransactionResult> actual = snapshot.mergeResult(key, Optional.of(result));
+    Optional<TransactionResult> actual = snapshot.getResult(key);
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(result));
+  }
+
+  @Test
+  public void getResult_KeyContainedInWriteSetAndGetNotContainedInGetSet_ShouldReturnEmpty()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Get get = prepareGet();
+    Snapshot.Key key = new Snapshot.Key(get);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
+
+    // Assert
+    assertThat(actual).isNotPresent();
+  }
+
+  @Test
+  public void getResult_KeyContainedInWriteSetAndGetNotContainedInGetSet_ShouldReturnProperResult()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePut();
+    Get get = prepareGet();
+    Snapshot.Key key = new Snapshot.Key(get);
+    snapshot.putIntoWriteSet(key, put);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
+
+    // Assert
+    assertThat(actual).isPresent();
+
+    assertThat(actual.get().contains(ANY_NAME_1)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_1)).isEqualTo(ANY_TEXT_1);
+    assertThat(actual.get().contains(ANY_NAME_2)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_2)).isEqualTo(ANY_TEXT_2);
+    assertThat(actual.get().contains(ANY_NAME_3)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_3)).isEqualTo(ANY_TEXT_3);
+    assertThat(actual.get().contains(ANY_NAME_4)).isTrue();
+    assertThat(actual.get().getText(ANY_NAME_4)).isEqualTo(ANY_TEXT_4);
+  }
+
+  @Test
+  public void
+      getResult_KeyContainedInWriteSetAndGetContainedInGetSetGiven_ShouldReturnMergedResult()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePutForMergeTest();
+    Get get = prepareGet();
+    Snapshot.Key key = new Snapshot.Key(get);
+    TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoGetSet(get, Optional.of(result));
+    snapshot.putIntoWriteSet(key, put);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
+
+    // Assert
+    assertThat(actual).isPresent();
+    assertMergedResultIsEqualTo(actual.get());
+  }
+
+  @Test
+  public void getResult_KeyContainedInDeleteSetAndGetContainedInGetSetGiven_ShouldReturnEmpty()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Delete delete = prepareDelete();
+    Get get = prepareGet();
+    Snapshot.Key key = new Snapshot.Key(get);
+    TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoGetSet(get, Optional.of(result));
+    snapshot.putIntoDeleteSet(key, delete);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
+
+    // Assert
+    assertThat(actual).isNotPresent();
+  }
+
+  @Test
+  public void
+      getResult_KeyNeitherContainedInDeleteSetNorWriteSetAndGetContainedInGetSetGiven_ShouldReturnOriginalResult()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Get get = prepareGet();
+    Snapshot.Key key = new Snapshot.Key(get);
+    TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoGetSet(get, Optional.of(result));
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
 
     // Assert
     assertThat(actual).isEqualTo(Optional.of(result));
@@ -442,26 +699,196 @@ public class SnapshotTest {
 
   @Test
   public void
-      mergeResult_MatchedConjunctionAndKeyContainedInWriteSetGiven_ShouldReturnMergedResult()
+      getResult_KeyContainedInWriteSetAndGetContainedInGetSetWithMatchedConjunctionGiven_ShouldReturnMergedResult()
           throws CrudException {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePutForMergeTest();
     ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_5);
-    Set<Conjunction> conjunctions = ImmutableSet.of(Conjunction.of(condition));
     Get get = Get.newBuilder(prepareGet()).where(condition).build();
     Snapshot.Key key = new Snapshot.Key(get);
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(key, Optional.of(result));
-    snapshot.put(key, put);
+    snapshot.putIntoGetSet(get, Optional.of(result));
+    snapshot.putIntoWriteSet(key, put);
 
     // Act
-    Optional<TransactionResult> actual =
-        snapshot.mergeResult(key, Optional.of(result), conjunctions);
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
 
     // Assert
     assertThat(actual).isPresent();
     assertMergedResultIsEqualTo(actual.get());
+  }
+
+  @Test
+  public void
+      getResult_KeyNeitherContainedInDeleteSetNorWriteSetAndGetContainedInGetSetWithUnmatchedConjunction_ShouldReturnOriginalResult()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Snapshot.Key key = new Snapshot.Key(prepareGet());
+    TransactionResult result = prepareResult(ANY_ID);
+    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_1).isEqualToText(ANY_TEXT_2);
+    Get get = Get.newBuilder(prepareGet()).where(condition).build();
+    snapshot.putIntoGetSet(get, Optional.of(result));
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
+
+    // Assert
+    assertThat(actual).isEqualTo(Optional.of(result));
+  }
+
+  @Test
+  public void
+      getResult_KeyContainedInWriteSetAndGetContainedInGetSetWithUnmatchedConjunctionGiven_ShouldReturnEmpty()
+          throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePutForMergeTest();
+    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3);
+    Get get = Get.newBuilder(prepareGet()).where(condition).build();
+    Snapshot.Key key = new Snapshot.Key(get);
+    TransactionResult result = prepareResult(ANY_ID);
+    snapshot.putIntoGetSet(get, Optional.of(result));
+    snapshot.putIntoWriteSet(key, put);
+
+    // Act
+    Optional<TransactionResult> actual = snapshot.getResult(key, get);
+
+    // Assert
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  public void getResults_ScanNotContainedInScanSetGiven_ShouldReturnEmpty() throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Scan scan = prepareScan();
+
+    // Act
+    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.getResults(scan);
+
+    // Assert
+    assertThat(results.isPresent()).isFalse();
+  }
+
+  @Test
+  public void getResults_ScanContainedInScanSetGiven_ShouldReturnProperResults()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Scan scan = prepareScan();
+
+    TransactionResult result1 = mock(TransactionResult.class);
+    TransactionResult result2 = mock(TransactionResult.class);
+    TransactionResult result3 = mock(TransactionResult.class);
+    Snapshot.Key key1 = mock(Snapshot.Key.class);
+    Snapshot.Key key2 = mock(Snapshot.Key.class);
+    Snapshot.Key key3 = mock(Snapshot.Key.class);
+    scanSet.put(scan, ImmutableMap.of(key1, result1, key2, result2, key3, result3));
+
+    // Act
+    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.getResults(scan);
+
+    // Assert
+    assertThat(results).isPresent();
+
+    Iterator<Map.Entry<Snapshot.Key, TransactionResult>> entryIterator =
+        results.get().entrySet().iterator();
+
+    Map.Entry<Snapshot.Key, TransactionResult> entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key1);
+    assertThat(entry.getValue()).isEqualTo(result1);
+
+    entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key2);
+    assertThat(entry.getValue()).isEqualTo(result2);
+
+    entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key3);
+    assertThat(entry.getValue()).isEqualTo(result3);
+
+    assertThat(entryIterator.hasNext()).isFalse();
+  }
+
+  @Test
+  public void getResults_ScanContainedInScanSetGivenAndPutInWriteSet_ShouldReturnProperResults()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Put put = preparePutForMergeTest();
+    Scan scan = prepareScan();
+
+    TransactionResult result1 = prepareResult(ANY_ID);
+    TransactionResult result2 = mock(TransactionResult.class);
+    TransactionResult result3 = mock(TransactionResult.class);
+    Snapshot.Key key1 = new Snapshot.Key(put);
+    Snapshot.Key key2 = mock(Snapshot.Key.class);
+    Snapshot.Key key3 = mock(Snapshot.Key.class);
+    scanSet.put(scan, ImmutableMap.of(key1, result1, key2, result2, key3, result3));
+
+    snapshot.putIntoWriteSet(key1, put);
+
+    // Act
+    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.getResults(scan);
+
+    // Assert
+    assertThat(results).isPresent();
+
+    Iterator<Map.Entry<Snapshot.Key, TransactionResult>> entryIterator =
+        results.get().entrySet().iterator();
+
+    Map.Entry<Snapshot.Key, TransactionResult> entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key1);
+    assertMergedResultIsEqualTo(entry.getValue());
+
+    entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key2);
+    assertThat(entry.getValue()).isEqualTo(result2);
+
+    entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key3);
+    assertThat(entry.getValue()).isEqualTo(result3);
+
+    assertThat(entryIterator.hasNext()).isFalse();
+  }
+
+  @Test
+  public void getResults_ScanContainedInScanSetGivenAndDeleteInDeleteSet_ShouldReturnProperResults()
+      throws CrudException {
+    // Arrange
+    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
+    Delete delete = prepareDelete();
+    Scan scan = prepareScan();
+
+    TransactionResult result1 = prepareResult(ANY_ID);
+    TransactionResult result2 = mock(TransactionResult.class);
+    TransactionResult result3 = mock(TransactionResult.class);
+    Snapshot.Key key1 = new Snapshot.Key(delete);
+    Snapshot.Key key2 = mock(Snapshot.Key.class);
+    Snapshot.Key key3 = mock(Snapshot.Key.class);
+    scanSet.put(scan, ImmutableMap.of(key1, result1, key2, result2, key3, result3));
+
+    snapshot.putIntoDeleteSet(key1, delete);
+
+    // Act
+    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.getResults(scan);
+
+    // Assert
+    assertThat(results).isPresent();
+
+    Iterator<Map.Entry<Snapshot.Key, TransactionResult>> entryIterator =
+        results.get().entrySet().iterator();
+
+    Map.Entry<Snapshot.Key, TransactionResult> entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key2);
+    assertThat(entry.getValue()).isEqualTo(result2);
+
+    entry = entryIterator.next();
+    assertThat(entry.getKey()).isEqualTo(key3);
+    assertThat(entry.getValue()).isEqualTo(result3);
+
+    assertThat(entryIterator.hasNext()).isFalse();
   }
 
   private void assertMergedResultIsEqualTo(TransactionResult result) {
@@ -533,60 +960,6 @@ public class SnapshotTest {
   }
 
   @Test
-  public void
-      mergeResult_UnmatchedConjunctionAndKeyNeitherContainedInDeleteSetNorWriteSet_ShouldReturnOriginalResult()
-          throws CrudException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Snapshot.Key key = new Snapshot.Key(prepareGet());
-    TransactionResult result = prepareResult(ANY_ID);
-    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_1).isEqualToText(ANY_TEXT_2);
-    Set<Conjunction> conjunctions = ImmutableSet.of(Conjunction.of(condition));
-
-    // Act
-    Optional<TransactionResult> actual =
-        snapshot.mergeResult(key, Optional.of(result), conjunctions);
-
-    // Assert
-    assertThat(actual).isEqualTo(Optional.of(result));
-  }
-
-  @Test
-  public void mergeResult_UnmatchedConjunctionAndKeyContainedInWriteSetGiven_ShouldReturnEmpty()
-      throws CrudException {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePutForMergeTest();
-    ConditionalExpression condition = ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_3);
-    Set<Conjunction> conjunctions = ImmutableSet.of(Conjunction.of(condition));
-    Get get = Get.newBuilder(prepareGet()).where(condition).build();
-    Snapshot.Key key = new Snapshot.Key(get);
-    TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(key, Optional.of(result));
-    snapshot.put(key, put);
-
-    // Act
-    Optional<TransactionResult> actual =
-        snapshot.mergeResult(key, Optional.of(result), conjunctions);
-
-    // Assert
-    assertThat(actual).isEmpty();
-  }
-
-  @Test
-  public void get_ScanNotContainedInSnapshotGiven_ShouldReturnEmptyList() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Scan scan = prepareScan();
-
-    // Act
-    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.get(scan);
-
-    // Assert
-    assertThat(results.isPresent()).isFalse();
-  }
-
-  @Test
   public void to_PrepareMutationComposerGivenAndSnapshotIsolationSet_ShouldCallComposerProperly()
       throws PreparationConflictException, ExecutionException {
     // Arrange
@@ -594,10 +967,10 @@ public class SnapshotTest {
     Put put = preparePut();
     Delete delete = prepareAnotherDelete();
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
     configureBehavior();
 
     // Act
@@ -616,9 +989,9 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Put put = preparePut();
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     configureBehavior();
 
     // Act
@@ -639,10 +1012,10 @@ public class SnapshotTest {
     Put put = preparePut();
     Delete delete = prepareAnotherDelete();
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
 
     // Act
     snapshot.to(commitComposer);
@@ -661,10 +1034,10 @@ public class SnapshotTest {
     Put put = preparePut();
     Delete delete = prepareAnotherDelete();
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
     configureBehavior();
 
     // Act
@@ -685,10 +1058,10 @@ public class SnapshotTest {
     Put put = preparePut();
     Delete delete = prepareAnotherDelete();
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
     configureBehavior();
 
     // Act
@@ -708,10 +1081,10 @@ public class SnapshotTest {
     Put put = preparePut();
     Delete delete = prepareAnotherDelete();
     TransactionResult result = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(prepareGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
-    snapshot.put(new Snapshot.Key(delete), delete);
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareGet()), Optional.of(result));
+    snapshot.putIntoReadSet(new Snapshot.Key(prepareAnotherGet()), Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
+    snapshot.putIntoDeleteSet(new Snapshot.Key(delete), delete);
     configureBehavior();
 
     // Act
@@ -733,9 +1106,9 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult result = prepareResult(ANY_ID);
     TransactionResult txResult = new TransactionResult(result);
-    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(get, Optional.of(txResult));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.of(txResult));
+    snapshot.putIntoGetSet(get, Optional.of(txResult));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
 
     // Act Assert
     assertThatCode(() -> snapshot.toSerializableWithExtraWrite(prepareComposer))
@@ -760,9 +1133,9 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
     Get get = prepareAnotherGet();
     Put put = preparePut();
-    snapshot.put(new Snapshot.Key(get), Optional.empty());
-    snapshot.put(get, Optional.empty());
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.empty());
+    snapshot.putIntoGetSet(get, Optional.empty());
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.toSerializableWithExtraWrite(prepareComposer));
@@ -786,9 +1159,9 @@ public class SnapshotTest {
     TransactionResult txResult = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, txResult);
     Put put = preparePut();
-    snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonMap(key, txResult));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(key, Optional.of(txResult));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, txResult));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.toSerializableWithExtraWrite(prepareComposer));
@@ -806,9 +1179,9 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult result = prepareResult(ANY_ID);
     TransactionResult txResult = new TransactionResult(result);
-    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(get, Optional.of(txResult));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.of(txResult));
+    snapshot.putIntoGetSet(get, Optional.of(txResult));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Get getWithProjections =
         prepareAnotherGet().withProjection(Attribute.ID).withProjection(Attribute.VERSION);
@@ -829,9 +1202,9 @@ public class SnapshotTest {
     Get get = prepareAnotherGet();
     Put put = preparePut();
     TransactionResult txResult = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(get), Optional.of(txResult));
-    snapshot.put(get, Optional.of(txResult));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.of(txResult));
+    snapshot.putIntoGetSet(get, Optional.of(txResult));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult changedTxResult = prepareResult(ANY_ID + "x");
     Get getWithProjections =
@@ -853,9 +1226,9 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Get get = prepareAnotherGet();
     Put put = preparePut();
-    snapshot.put(new Snapshot.Key(get), Optional.empty());
-    snapshot.put(get, Optional.empty());
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.empty());
+    snapshot.putIntoGetSet(get, Optional.empty());
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult txResult = prepareResult(ANY_ID);
     Get getWithProjections =
@@ -879,9 +1252,9 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult txResult = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, txResult);
-    snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonMap(key, txResult));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(key, Optional.of(txResult));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, txResult));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Scanner scanner = mock(Scanner.class);
     when(scanner.iterator()).thenReturn(Collections.singletonList((Result) txResult).iterator());
@@ -907,9 +1280,9 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult txResult = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, txResult);
-    snapshot.put(key, Optional.of(txResult));
-    snapshot.put(scan, Collections.singletonMap(key, txResult));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(key, Optional.of(txResult));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, txResult));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult changedTxResult = prepareResult(ANY_ID + "x");
     Scanner scanner = mock(Scanner.class);
@@ -937,8 +1310,8 @@ public class SnapshotTest {
     Scan scan = prepareScan();
     Put put = preparePut();
     TransactionResult result = prepareResult(ANY_ID + "x");
-    snapshot.put(scan, Collections.emptyMap());
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     TransactionResult txResult = new TransactionResult(result);
     Scanner scanner = mock(Scanner.class);
@@ -1008,10 +1381,10 @@ public class SnapshotTest {
     Snapshot.Key key1 = new Snapshot.Key(scan1, result1);
     Snapshot.Key key2 = new Snapshot.Key(scan2, result2);
 
-    snapshot.put(scan1, Collections.singletonMap(key1, new TransactionResult(result1)));
-    snapshot.put(scan2, Collections.singletonMap(key2, new TransactionResult(result2)));
-    snapshot.put(key1, Optional.of(new TransactionResult(result1)));
-    snapshot.put(key2, Optional.of(new TransactionResult(result2)));
+    snapshot.putIntoScanSet(scan1, Collections.singletonMap(key1, new TransactionResult(result1)));
+    snapshot.putIntoScanSet(scan2, Collections.singletonMap(key2, new TransactionResult(result2)));
+    snapshot.putIntoReadSet(key1, Optional.of(new TransactionResult(result1)));
+    snapshot.putIntoReadSet(key2, Optional.of(new TransactionResult(result2)));
 
     DistributedStorage storage = mock(DistributedStorage.class);
 
@@ -1053,9 +1426,9 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult result = prepareResultWithNullMetadata();
     TransactionResult txResult = new TransactionResult(result);
-    snapshot.put(new Snapshot.Key(get), Optional.of(result));
-    snapshot.put(get, Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.of(result));
+    snapshot.putIntoGetSet(get, Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Get getWithProjections =
         Get.newBuilder(get).projections(Attribute.ID, Attribute.VERSION).build();
@@ -1078,9 +1451,9 @@ public class SnapshotTest {
     Put put = preparePut();
     TransactionResult result = prepareResultWithNullMetadata();
     TransactionResult changedResult = prepareResult(ANY_ID);
-    snapshot.put(new Snapshot.Key(get), Optional.of(result));
-    snapshot.put(get, Optional.of(result));
-    snapshot.put(new Snapshot.Key(put), put);
+    snapshot.putIntoReadSet(new Snapshot.Key(get), Optional.of(result));
+    snapshot.putIntoGetSet(get, Optional.of(result));
+    snapshot.putIntoWriteSet(new Snapshot.Key(put), put);
     DistributedStorage storage = mock(DistributedStorage.class);
     Get getWithProjections =
         Get.newBuilder(get).projections(Attribute.ID, Attribute.VERSION).build();
@@ -1103,8 +1476,8 @@ public class SnapshotTest {
     Scan scan = prepareScan();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(key, Optional.of(result));
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoReadSet(key, Optional.of(result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
     DistributedStorage storage = mock(DistributedStorage.class);
     Scan scanWithProjections =
         Scan.newBuilder(scan)
@@ -1123,95 +1496,18 @@ public class SnapshotTest {
   }
 
   @Test
-  public void put_DeleteGivenAfterPut_PutSupercedesDelete() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(preparePut());
-    snapshot.put(putKey, put);
-
-    Delete delete = prepareDelete();
-    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
-
-    // Act
-    snapshot.put(deleteKey, delete);
-
-    // Assert
-    assertThat(writeSet.size()).isEqualTo(0);
-    assertThat(deleteSet.size()).isEqualTo(1);
-    assertThat(deleteSet.get(deleteKey)).isEqualTo(delete);
-  }
-
-  @Test
-  public void put_PutGivenAfterDelete_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Delete delete = prepareDelete();
-    Snapshot.Key deleteKey = new Snapshot.Key(prepareDelete());
-    snapshot.put(deleteKey, delete);
-
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(preparePut());
-
-    // Act Assert
-    assertThatThrownBy(() -> snapshot.put(putKey, put))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void get_ScanGivenAndPutInWriteSetNotOverlappedWithScan_ShouldNotThrowException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan =
-        new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
-            // ["text3", "text4"]
-            .withStart(new Key(ANY_NAME_2, ANY_TEXT_3), true)
-            .withEnd(new Key(ANY_NAME_2, ANY_TEXT_4), true)
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME)
-            .forTable(ANY_TABLE_NAME);
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
-
-    // Assert
-    assertThat(thrown).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void
-      get_ScanGivenAndPutWithSamePartitionKeyWithoutClusteringKeyInWriteSet_ShouldNotThrowException() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Put put = preparePutWithPartitionKeyOnly();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-    Scan scan = prepareScan();
-
-    // Act Assert
-    Throwable thrown = catchThrowable(() -> snapshot.get(scan));
-
-    // Assert
-    assertThat(thrown).doesNotThrowAnyException();
-  }
-
-  @Test
   public void
       verify_ScanGivenAndPutKeyAlreadyPresentInScanSet_ShouldThrowIllegalArgumentException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan = prepareScan();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(key, Optional.of(result));
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoReadSet(key, Optional.of(result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1227,9 +1523,9 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePutWithPartitionKeyOnly();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan = prepareScan();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1246,14 +1542,14 @@ public class SnapshotTest {
     // "text2"
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, infinite)
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1269,7 +1565,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SNAPSHOT);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder()
             .namespace(ANY_NAMESPACE_NAME)
@@ -1278,7 +1574,7 @@ public class SnapshotTest {
             .consistency(Consistency.LINEARIZABLE)
             .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_4))
             .build();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1295,7 +1591,7 @@ public class SnapshotTest {
     // "text2"
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
         prepareScan()
             // ["text1", "text3"]
@@ -1321,11 +1617,11 @@ public class SnapshotTest {
             // ["text1", "text2")
             .withStart(new Key(ANY_NAME_2, ANY_TEXT_1), true)
             .withEnd(new Key(ANY_NAME_2, ANY_TEXT_2), false);
-    snapshot.put(scan1, Collections.emptyMap());
-    snapshot.put(scan2, Collections.emptyMap());
-    snapshot.put(scan3, Collections.emptyMap());
-    snapshot.put(scan4, Collections.emptyMap());
-    snapshot.put(scan5, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan1, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan2, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan3, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan4, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan5, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
@@ -1350,7 +1646,7 @@ public class SnapshotTest {
     // "text2"
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
         new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
             // (-infinite, "text3"]
@@ -1372,9 +1668,9 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    snapshot.put(scan1, Collections.emptyMap());
-    snapshot.put(scan2, Collections.emptyMap());
-    snapshot.put(scan3, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan1, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan2, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan3, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
@@ -1395,7 +1691,7 @@ public class SnapshotTest {
     // "text2"
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan1 =
         new Scan(new Key(ANY_NAME_1, ANY_TEXT_1))
             // ["text1", infinite)
@@ -1417,9 +1713,9 @@ public class SnapshotTest {
             .withConsistency(Consistency.LINEARIZABLE)
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
-    snapshot.put(scan1, Collections.emptyMap());
-    snapshot.put(scan2, Collections.emptyMap());
-    snapshot.put(scan3, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan1, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan2, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan3, Collections.emptyMap());
 
     // Act Assert
     Throwable thrown1 = catchThrowable(() -> snapshot.verify(scan1));
@@ -1438,7 +1734,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder()
             .namespace(ANY_NAMESPACE_NAME)
@@ -1447,7 +1743,7 @@ public class SnapshotTest {
             .build();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1468,7 +1764,7 @@ public class SnapshotTest {
             .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
             .build();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder()
             .namespace(ANY_NAMESPACE_NAME)
@@ -1477,7 +1773,7 @@ public class SnapshotTest {
             .build();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1508,8 +1804,8 @@ public class SnapshotTest {
             .build();
     Snapshot.Key putKey1 = new Snapshot.Key(put1);
     Snapshot.Key putKey2 = new Snapshot.Key(put2);
-    snapshot.put(putKey1, put1);
-    snapshot.put(putKey2, put2);
+    snapshot.putIntoWriteSet(putKey1, put1);
+    snapshot.putIntoWriteSet(putKey2, put2);
     Scan scan =
         Scan.newBuilder()
             .namespace(ANY_NAMESPACE_NAME)
@@ -1518,7 +1814,7 @@ public class SnapshotTest {
             .build();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1551,8 +1847,8 @@ public class SnapshotTest {
             .build();
     Snapshot.Key putKey1 = new Snapshot.Key(put1);
     Snapshot.Key putKey2 = new Snapshot.Key(put2);
-    snapshot.put(putKey1, put1);
-    snapshot.put(putKey2, put2);
+    snapshot.putIntoWriteSet(putKey1, put1);
+    snapshot.putIntoWriteSet(putKey2, put2);
     Scan scan =
         Scan.newBuilder()
             .namespace(ANY_NAMESPACE_NAME)
@@ -1562,7 +1858,7 @@ public class SnapshotTest {
             .build();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1578,7 +1874,7 @@ public class SnapshotTest {
     // "text2"
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     ScanAll scanAll =
         new ScanAll()
             .withConsistency(Consistency.LINEARIZABLE)
@@ -1586,7 +1882,7 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME);
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scanAll, result);
-    snapshot.put(scanAll, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scanAll, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scanAll));
@@ -1603,7 +1899,7 @@ public class SnapshotTest {
     // "text2"
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     ScanAll scanAll =
         new ScanAll()
             .withConsistency(Consistency.LINEARIZABLE)
@@ -1611,7 +1907,7 @@ public class SnapshotTest {
             .forTable(ANY_TABLE_NAME_2);
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scanAll, result);
-    snapshot.put(scanAll, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scanAll, Collections.singletonMap(key, result));
 
     // Act Assert
     Throwable thrown = catchThrowable(() -> snapshot.verify(scanAll));
@@ -1621,59 +1917,16 @@ public class SnapshotTest {
   }
 
   @Test
-  public void get_GetGivenAndAlreadyPresentInGetSet_ShouldReturnResult() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    Get get = prepareGet();
-    TransactionResult expected = prepareResult(ANY_ID);
-    snapshot.put(get, Optional.of(expected));
-
-    // Act
-    Optional<TransactionResult> actual = snapshot.get(get);
-
-    // Assert
-    assertThat(actual).isPresent();
-    assertThat(actual.get()).isEqualTo(expected);
-  }
-
-  @Test
-  public void get_ScanAllGivenAndAlreadyPresentInScanSet_ShouldReturnKeys() {
-    // Arrange
-    snapshot = prepareSnapshot(Isolation.SNAPSHOT);
-    // "text2"
-    Put put = preparePut();
-    Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
-
-    ScanAll scanAll =
-        new ScanAll()
-            .withConsistency(Consistency.LINEARIZABLE)
-            .forNamespace(ANY_NAMESPACE_NAME_2)
-            .forTable(ANY_TABLE_NAME_2);
-    TransactionResult result = prepareResult(ANY_ID);
-    Snapshot.Key key = new Snapshot.Key(scanAll, result);
-    snapshot.put(scanAll, Collections.singletonMap(key, result));
-
-    // Act Assert
-    Optional<Map<Snapshot.Key, TransactionResult>> results = snapshot.get(scanAll);
-
-    // Assert
-    assertThat(results).isNotEmpty();
-    assertThat(results.get()).containsKey(key);
-    assertThat(results.get().get(key)).isEqualTo(result);
-  }
-
-  @Test
   public void verify_CrossPartitionScanGivenAndPutInSameTable_ShouldThrowException() {
     // Arrange
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan = prepareCrossPartitionScan();
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1688,11 +1941,11 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan = prepareCrossPartitionScan(ANY_NAMESPACE_NAME_2, ANY_TABLE_NAME);
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1707,11 +1960,11 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan = prepareCrossPartitionScan(ANY_NAMESPACE_NAME, ANY_TABLE_NAME_2);
     TransactionResult result = prepareResult(ANY_ID);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    snapshot.put(scan, Collections.singletonMap(key, result));
+    snapshot.putIntoScanSet(scan, Collections.singletonMap(key, result));
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1727,7 +1980,7 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePutWithIntColumns();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder(prepareCrossPartitionScan())
             .clearConditions()
@@ -1745,7 +1998,7 @@ public class SnapshotTest {
                             ConditionBuilder.column(ANY_NAME_8).isNullInt()))
                     .build())
             .build();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1761,14 +2014,14 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder(prepareCrossPartitionScan())
             .clearConditions()
             .where(ConditionBuilder.column(ANY_NAME_3).isEqualToText(ANY_TEXT_1))
             .or(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_4))
             .build();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1784,14 +2037,14 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder(prepareCrossPartitionScan())
             .clearConditions()
             .where(ConditionBuilder.column(ANY_NAME_3).isLikeText("text%"))
             .and(ConditionBuilder.column(ANY_NAME_4).isNotLikeText("text"))
             .build();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1807,14 +2060,14 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePut();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan =
         Scan.newBuilder(prepareCrossPartitionScan())
             .clearConditions()
             .where(ConditionBuilder.column(ANY_NAME_4).isEqualToText(ANY_TEXT_1))
             .or(ConditionBuilder.column(ANY_NAME_5).isEqualToText(ANY_TEXT_1))
             .build();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));
@@ -1830,9 +2083,9 @@ public class SnapshotTest {
     snapshot = prepareSnapshot(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
     Put put = preparePutWithIntColumns();
     Snapshot.Key putKey = new Snapshot.Key(put);
-    snapshot.put(putKey, put);
+    snapshot.putIntoWriteSet(putKey, put);
     Scan scan = Scan.newBuilder(prepareCrossPartitionScan()).clearConditions().build();
-    snapshot.put(scan, Collections.emptyMap());
+    snapshot.putIntoScanSet(scan, Collections.emptyMap());
 
     // Act
     Throwable thrown = catchThrowable(() -> snapshot.verify(scan));

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -1,7 +1,21 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionIntegrationTestBase;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Key;
+import java.util.Optional;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 public abstract class ConsensusCommitIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -23,4 +37,896 @@ public abstract class ConsensusCommitIntegrationTestBase
   }
 
   protected abstract Properties getProps(String testName);
+
+  @Test
+  public void
+      insertAndInsert_forSameRecord_whenRecordNotExists_shouldThrowIllegalArgumentExceptionOnSecondInsert()
+          throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.insert(
+                    Insert.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .intValue(BALANCE, INITIAL_BALANCE)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void
+      insertAndInsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnSecondInsert()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.insert(
+                    Insert.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .intValue(BALANCE, INITIAL_BALANCE)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void insertAndUpsert_forSameRecord_whenRecordNotExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void
+      insertAndUpsert_forSameRecord_whenRecordExists_shouldThrowCommitConflictExceptionOnCommit()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void insertAndUpdate_forSameRecord_whenRecordNotExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void
+      insertAndUpdate_forSameRecord_whenRecordExists_shouldThrowCommitConflictExceptionOnCommit()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      insertAndDelete_forSameRecord_whenRecordNotExists_shouldThrowIllegalArgumentExceptionOnDelete()
+          throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.delete(
+                    Delete.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void
+      insertAndDelete_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnDelete()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.delete(
+                    Delete.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void upsertAndInsert_forSameRecord_shouldThrowIllegalArgumentExceptionOnInsert()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.insert(
+                    Insert.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .intValue(BALANCE, INITIAL_BALANCE)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void upsertAndUpsert_forSameRecord_shouldWorkCorrectly() throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void upsertAndUpdate_forSameRecord_shouldWorkCorrectly() throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void upsertAndDelete_forSameRecord_shouldWorkCorrectly() throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isNotPresent();
+  }
+
+  @Test
+  public void updateAndInsert_forSameRecord_whenRecordNotExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void
+      updateAndInsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnInsert()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.insert(
+                    Insert.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .intValue(BALANCE, expectedBalance)
+                        .intValue(SOME_COLUMN, expectedSomeColumn)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void updateAndUpsert_forSameRecord_whenRecordNotExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void updateAndUpsert_forSameRecord_whenRecordExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.upsert(
+        Upsert.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void updateAndUpdate_forSameRecord_whenRecordNotExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isNotPresent();
+  }
+
+  @Test
+  public void updateAndUpdate_forSameRecord_whenRecordExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+    int expectedBalance = 100;
+    int expectedSomeColumn = 200;
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, expectedBalance)
+            .intValue(SOME_COLUMN, expectedSomeColumn)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isPresent();
+    Result result = optResult.get();
+    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.getInt(BALANCE)).isEqualTo(expectedBalance);
+    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(expectedSomeColumn);
+  }
+
+  @Test
+  public void updateAndDelete_forSameRecord_whenRecordNotExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isNotPresent();
+  }
+
+  @Test
+  public void updateAndDelete_forSameRecord_whenRecordExists_shouldWorkCorrectly()
+      throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isNotPresent();
+  }
+
+  @Test
+  public void
+      deleteAndInsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnInsert()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.insert(
+                    Insert.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .intValue(BALANCE, INITIAL_BALANCE)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void
+      deleteAndUpsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnUpsert()
+          throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act Assert
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+    assertThatThrownBy(
+            () ->
+                transaction.upsert(
+                    Upsert.newBuilder()
+                        .namespace(namespace)
+                        .table(TABLE)
+                        .partitionKey(partitionKey)
+                        .clusteringKey(clusteringKey)
+                        .intValue(BALANCE, INITIAL_BALANCE)
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    transaction.rollback();
+  }
+
+  @Test
+  public void deleteAndUpdate_forSameRecord_whenRecordExists_shouldDoNothing()
+      throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isNotPresent();
+  }
+
+  @Test
+  public void deleteAndDelete_forSameRecord_shouldWorkCorrectly() throws TransactionException {
+    // Arrange
+    put(preparePut(0, 0));
+
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, 0);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, 0);
+
+    DistributedTransaction transaction = manager.start();
+
+    // Act
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+    transaction.delete(
+        Delete.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> optResult = get(prepareGet(0, 0));
+    assertThat(optResult).isNotPresent();
+  }
 }

--- a/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithServer.java
+++ b/server/src/integration-test/java/com/scalar/db/server/ConsensusCommitIntegrationTestWithServer.java
@@ -181,4 +181,133 @@ public class ConsensusCommitIntegrationTestWithServer extends ConsensusCommitInt
   @Override
   @Test
   public void scan_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndInsert_forSameRecord_whenRecordNotExists_shouldThrowIllegalArgumentExceptionOnSecondInsert() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndInsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnSecondInsert() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void insertAndUpsert_forSameRecord_whenRecordNotExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndUpsert_forSameRecord_whenRecordExists_shouldThrowCommitConflictExceptionOnCommit() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void insertAndUpdate_forSameRecord_whenRecordNotExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndUpdate_forSameRecord_whenRecordExists_shouldThrowCommitConflictExceptionOnCommit() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndDelete_forSameRecord_whenRecordNotExists_shouldThrowIllegalArgumentExceptionOnDelete() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      insertAndDelete_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnDelete() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndInsert_forSameRecord_shouldThrowIllegalArgumentExceptionOnInsert() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndUpsert_forSameRecord_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndUpdate_forSameRecord_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void upsertAndDelete_forSameRecord_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndInsert_forSameRecord_whenRecordNotExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      updateAndInsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnInsert() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndUpsert_forSameRecord_whenRecordNotExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndUpsert_forSameRecord_whenRecordExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndUpdate_forSameRecord_whenRecordNotExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndUpdate_forSameRecord_whenRecordExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndDelete_forSameRecord_whenRecordNotExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void updateAndDelete_forSameRecord_whenRecordExists_shouldWorkCorrectly() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      deleteAndInsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnInsert() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void
+      deleteAndUpsert_forSameRecord_whenRecordExists_shouldThrowIllegalArgumentExceptionOnUpsert() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void deleteAndUpdate_forSameRecord_whenRecordExists_shouldDoNothing() {}
+
+  @Disabled("ScalarDB Server doesn't support insert(), upsert(), and update()")
+  @Override
+  @Test
+  public void deleteAndDelete_forSameRecord_shouldWorkCorrectly() {}
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2340
- **Commit to backport:** 3f20979c11a660dfb7b021809b727a69a0008bb9

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-2340 &&
git cherry-pick --no-rerere-autoupdate -m1 3f20979c11a660dfb7b021809b727a69a0008bb9
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!