### PR TITLE
Fix GetBuilder and ScanBuilder

### DIFF
--- a/core/src/main/java/com/scalar/db/api/GetBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/GetBuilder.java
@@ -1078,7 +1078,7 @@ public class GetBuilder extends SelectionBuilder {
   }
 
   public static class BuildableGetFromExistingWithOngoingWhereOr
-      extends BuildableGetFromExistingWithOngoingWhere
+      extends BuildableGetFromExistingWithWhere
       implements Or<BuildableGetFromExistingWithOngoingWhereOr> {
 
     private BuildableGetFromExistingWithOngoingWhereOr(
@@ -1114,7 +1114,7 @@ public class GetBuilder extends SelectionBuilder {
   }
 
   public static class BuildableGetFromExistingWithOngoingWhereAnd
-      extends BuildableGetFromExistingWithOngoingWhere
+      extends BuildableGetFromExistingWithWhere
       implements And<BuildableGetFromExistingWithOngoingWhereAnd> {
 
     private BuildableGetFromExistingWithOngoingWhereAnd(

--- a/core/src/main/java/com/scalar/db/api/GetBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/GetBuilder.java
@@ -1034,18 +1034,8 @@ public class GetBuilder extends SelectionBuilder {
           Or<BuildableGetFromExistingWithOngoingWhereOr> {
 
     private BuildableGetFromExistingWithOngoingWhere(
-        BuildableGetOrGetWithIndexFromExisting buildable) {
-      super(buildable);
-    }
-
-    private BuildableGetFromExistingWithOngoingWhere(
         BuildableGetOrGetWithIndexFromExisting buildable, ConditionalExpression condition) {
       super(buildable, condition);
-    }
-
-    private BuildableGetFromExistingWithOngoingWhere(
-        BuildableGetFromExistingWithOngoingWhere buildable) {
-      super(buildable);
     }
 
     @Override

--- a/core/src/main/java/com/scalar/db/api/ScanBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ScanBuilder.java
@@ -1669,7 +1669,7 @@ public class ScanBuilder extends SelectionBuilder {
   }
 
   public static class BuildableScanFromExistingWithOngoingWhereOr
-      extends BuildableScanFromExistingWithOngoingWhere
+      extends BuildableScanFromExistingWithWhere
       implements Or<BuildableScanFromExistingWithOngoingWhereOr> {
 
     private BuildableScanFromExistingWithOngoingWhereOr(
@@ -1705,7 +1705,7 @@ public class ScanBuilder extends SelectionBuilder {
   }
 
   public static class BuildableScanFromExistingWithOngoingWhereAnd
-      extends BuildableScanFromExistingWithOngoingWhere
+      extends BuildableScanFromExistingWithWhere
       implements And<BuildableScanFromExistingWithOngoingWhereAnd> {
 
     private BuildableScanFromExistingWithOngoingWhereAnd(

--- a/core/src/main/java/com/scalar/db/api/ScanBuilder.java
+++ b/core/src/main/java/com/scalar/db/api/ScanBuilder.java
@@ -1625,18 +1625,8 @@ public class ScanBuilder extends SelectionBuilder {
           Or<BuildableScanFromExistingWithOngoingWhereOr> {
 
     private BuildableScanFromExistingWithOngoingWhere(
-        BuildableScanOrScanAllFromExisting buildable) {
-      super(buildable);
-    }
-
-    private BuildableScanFromExistingWithOngoingWhere(
         BuildableScanOrScanAllFromExisting buildable, ConditionalExpression condition) {
       super(buildable, condition);
-    }
-
-    private BuildableScanFromExistingWithOngoingWhere(
-        BuildableScanFromExistingWithOngoingWhere buildable) {
-      super(buildable);
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR fixes bugs in GetBuilder and ScanBuilder, which wrongly enable where() to continue with “and” in the disjunctive normal form context and for “or” vice vasa. They were due to incorrect inheritance.

```java
// The following patterns should not be accepted.
Scan newScan = Scan.newBuilder(scan).where(andConditionSet).and(orConditionSet).build();
Scan newScan = Scan.newBuilder(scan).where(orConditionSet).or(andConditionSet).build();
// They should be the following.
Scan newScan = Scan.newBuilder(scan).where(orConditionSet).and(orConditionSet).build();
Scan newScan = Scan.newBuilder(scan).where(andConditionSet).or(andConditionSet).build();
```

## Related issues and/or PRs

The bugs were introduced in the following PRs.
- #1715
- #1834

So, the `ScanBuilder` fix should be included in the minor versions >= 3.10, I think.

## Changes made

- Change superclass not to inherit wrong interfaces.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes. **Unsupported APIs cannot be tested in CI, but I confirmed the APIs are not shown as the candidates in IntelliJ.**
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed bugs in GetBuilder and ScanBuilder.