### PR TITLE
Refactoring `CoordinatorGroupCommitKeyManipulator` by moving the implementation to `DefaultGroupCommitKeyManipulator` to improve the reusability

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -20,7 +20,7 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
-import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
+import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CoordinatorGroupCommitter.java
@@ -1,10 +1,9 @@
 package com.scalar.db.transaction.consensuscommit;
 
+import com.scalar.db.util.groupcommit.DefaultGroupCommitKeyManipulator;
 import com.scalar.db.util.groupcommit.GroupCommitConfig;
 import com.scalar.db.util.groupcommit.GroupCommitter;
-import com.scalar.db.util.groupcommit.KeyManipulator;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class CoordinatorGroupCommitter
     extends GroupCommitter<String, String, String, String, String, Snapshot> {
@@ -35,93 +34,7 @@ public class CoordinatorGroupCommitter
     return config.isCoordinatorGroupCommitEnabled();
   }
 
+  // The behavior of this class is completely the same as the parent class for now.
   public static class CoordinatorGroupCommitKeyManipulator
-      implements KeyManipulator<String, String, String, String, String> {
-    private static final int PRIMARY_KEY_SIZE = 24;
-    private static final char DELIMITER = '$';
-    private static final int MAX_FULL_KEY_SIZE = 64;
-    private static final int MAX_CHILD_KEY_SIZE =
-        MAX_FULL_KEY_SIZE - PRIMARY_KEY_SIZE - 1 /* delimiter */;
-    private static final char[] CHARS_FOR_PRIMARY_KEY;
-    private static final int CHARS_FOR_PRIMARY_KEY_SIZE;
-
-    static {
-      int digitsLen = '9' - '0' + 1;
-      int upperCasesLen = 'Z' - 'A' + 1;
-      int lowerCasesLen = 'z' - 'a' + 1;
-      CHARS_FOR_PRIMARY_KEY = new char[digitsLen + upperCasesLen + lowerCasesLen];
-
-      int index = 0;
-      for (char c = '0'; c <= '9'; c++) {
-        CHARS_FOR_PRIMARY_KEY[index++] = c;
-      }
-      for (char c = 'A'; c <= 'Z'; c++) {
-        CHARS_FOR_PRIMARY_KEY[index++] = c;
-      }
-      for (char c = 'a'; c <= 'z'; c++) {
-        CHARS_FOR_PRIMARY_KEY[index++] = c;
-      }
-
-      CHARS_FOR_PRIMARY_KEY_SIZE = CHARS_FOR_PRIMARY_KEY.length;
-    }
-
-    @Override
-    public String generateParentKey() {
-      char[] chars = new char[PRIMARY_KEY_SIZE];
-      for (int i = 0; i < PRIMARY_KEY_SIZE; i++) {
-        chars[i] =
-            CHARS_FOR_PRIMARY_KEY[ThreadLocalRandom.current().nextInt(CHARS_FOR_PRIMARY_KEY_SIZE)];
-      }
-      return new String(chars);
-    }
-
-    @Override
-    public String fullKey(String parentKey, String childKey) {
-      if (parentKey.length() != PRIMARY_KEY_SIZE) {
-        throw new IllegalArgumentException(
-            String.format(
-                "The length of parent key must be %d. ParentKey: %s", PRIMARY_KEY_SIZE, childKey));
-      }
-      if (childKey.length() > MAX_CHILD_KEY_SIZE) {
-        throw new IllegalArgumentException(
-            String.format(
-                "The length of child key must not exceed %d. ChildKey: %s",
-                MAX_CHILD_KEY_SIZE, childKey));
-      }
-      return parentKey + DELIMITER + childKey;
-    }
-
-    @Override
-    public boolean isFullKey(Object obj) {
-      if (!(obj instanceof String)) {
-        return false;
-      }
-      String key = (String) obj;
-      return key.length() > PRIMARY_KEY_SIZE && key.charAt(PRIMARY_KEY_SIZE) == DELIMITER;
-    }
-
-    @Override
-    public Keys<String, String, String> keysFromFullKey(String fullKey) {
-      if (!isFullKey(fullKey)) {
-        throw new IllegalArgumentException("Invalid full key. Key:" + fullKey);
-      }
-
-      return new Keys<>(
-          fullKey.substring(0, PRIMARY_KEY_SIZE),
-          fullKey.substring(PRIMARY_KEY_SIZE + 1 /* delimiter */),
-          fullKey);
-    }
-
-    @Override
-    public String emitFullKeyFromFullKey(String fullKey) {
-      // Return the string as is since the value is already String.
-      return fullKey;
-    }
-
-    @Override
-    public String emitParentKeyFromParentKey(String parentKey) {
-      // Return the string as is since the value is already String.
-      return parentKey;
-    }
-  }
+      extends DefaultGroupCommitKeyManipulator {}
 }

--- a/core/src/main/java/com/scalar/db/util/groupcommit/DefaultGroupCommitKeyManipulator.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/DefaultGroupCommitKeyManipulator.java
@@ -1,0 +1,93 @@
+package com.scalar.db.util.groupcommit;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class DefaultGroupCommitKeyManipulator
+    implements GroupCommitKeyManipulator<String, String, String, String, String> {
+  private static final int PRIMARY_KEY_SIZE = 24;
+  private static final char DELIMITER = '$';
+  private static final int MAX_FULL_KEY_SIZE = 64;
+  private static final int MAX_CHILD_KEY_SIZE =
+      MAX_FULL_KEY_SIZE - PRIMARY_KEY_SIZE - 1 /* delimiter */;
+  private static final char[] CHARS_FOR_PRIMARY_KEY;
+  private static final int CHARS_FOR_PRIMARY_KEY_SIZE;
+
+  static {
+    int digitsLen = '9' - '0' + 1;
+    int upperCasesLen = 'Z' - 'A' + 1;
+    int lowerCasesLen = 'z' - 'a' + 1;
+    CHARS_FOR_PRIMARY_KEY = new char[digitsLen + upperCasesLen + lowerCasesLen];
+
+    int index = 0;
+    for (char c = '0'; c <= '9'; c++) {
+      CHARS_FOR_PRIMARY_KEY[index++] = c;
+    }
+    for (char c = 'A'; c <= 'Z'; c++) {
+      CHARS_FOR_PRIMARY_KEY[index++] = c;
+    }
+    for (char c = 'a'; c <= 'z'; c++) {
+      CHARS_FOR_PRIMARY_KEY[index++] = c;
+    }
+
+    CHARS_FOR_PRIMARY_KEY_SIZE = CHARS_FOR_PRIMARY_KEY.length;
+  }
+
+  @Override
+  public String generateParentKey() {
+    char[] chars = new char[PRIMARY_KEY_SIZE];
+    for (int i = 0; i < PRIMARY_KEY_SIZE; i++) {
+      chars[i] =
+          CHARS_FOR_PRIMARY_KEY[ThreadLocalRandom.current().nextInt(CHARS_FOR_PRIMARY_KEY_SIZE)];
+    }
+    return new String(chars);
+  }
+
+  @Override
+  public String fullKey(String parentKey, String childKey) {
+    if (parentKey.length() != PRIMARY_KEY_SIZE) {
+      throw new IllegalArgumentException(
+          String.format(
+              "The length of parent key must be %d. ParentKey: %s", PRIMARY_KEY_SIZE, childKey));
+    }
+    if (childKey.length() > MAX_CHILD_KEY_SIZE) {
+      throw new IllegalArgumentException(
+          String.format(
+              "The length of child key must not exceed %d. ChildKey: %s",
+              MAX_CHILD_KEY_SIZE, childKey));
+    }
+    return parentKey + DELIMITER + childKey;
+  }
+
+  @Override
+  public boolean isFullKey(Object obj) {
+    if (!(obj instanceof String)) {
+      return false;
+    }
+    String key = (String) obj;
+    return key.length() > PRIMARY_KEY_SIZE && key.charAt(PRIMARY_KEY_SIZE) == DELIMITER;
+  }
+
+  @Override
+  public Keys<String, String, String> keysFromFullKey(String fullKey) {
+    if (!isFullKey(fullKey)) {
+      throw new IllegalArgumentException("Invalid full key. Key:" + fullKey);
+    }
+
+    return new Keys<>(
+        fullKey.substring(0, PRIMARY_KEY_SIZE),
+        fullKey.substring(PRIMARY_KEY_SIZE + 1 /* delimiter */),
+        fullKey);
+  }
+
+  @Override
+  public String emitFullKeyFromFullKey(String fullKey) {
+    // Return the string as is since the value is already String.
+    return fullKey;
+  }
+
+  @Override
+  public String emitParentKeyFromParentKey(String parentKey) {
+    // Return the string as is since the value is already String.
+    return parentKey;
+  }
+}

--- a/core/src/main/java/com/scalar/db/util/groupcommit/DelayedGroup.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/DelayedGroup.java
@@ -15,7 +15,7 @@ class DelayedGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
       GroupCommitConfig config,
       FULL_KEY fullKey,
       Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter,
-      KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+      GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator) {
     super(emitter, keyManipulator, 1, config.oldGroupAbortTimeoutMillis());
     this.fullKey = fullKey;

--- a/core/src/main/java/com/scalar/db/util/groupcommit/Group.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/Group.java
@@ -14,7 +14,8 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
   private static final Logger logger = LoggerFactory.getLogger(Group.class);
 
   protected final Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter;
-  protected final KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+  protected final GroupCommitKeyManipulator<
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
       keyManipulator;
   private final int capacity;
   private final AtomicReference<Integer> size = new AtomicReference<>();
@@ -61,7 +62,7 @@ abstract class Group<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL
 
   Group(
       Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter,
-      KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+      GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator,
       int capacity,
       long oldGroupAbortTimeoutMillis) {

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitKeyManipulator.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitKeyManipulator.java
@@ -15,7 +15,8 @@ import javax.annotation.concurrent.Immutable;
  * @param <EMIT_FULL_KEY> A full-key type that Emitter can interpret.
  */
 @Immutable
-public interface KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY> {
+public interface GroupCommitKeyManipulator<
+    PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY> {
   class Keys<PARENT_KEY, CHILD_KEY, FULL_KEY> {
     public final PARENT_KEY parentKey;
     public final CHILD_KEY childKey;

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitter.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitter.java
@@ -2,7 +2,7 @@ package com.scalar.db.util.groupcommit;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
+import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import java.io.Closeable;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -46,7 +46,8 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
   @Nullable private final GroupCommitMonitor groupCommitMonitor;
 
   // This contains logics of how to treat keys.
-  private final KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+  private final GroupCommitKeyManipulator<
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
       keyManipulator;
 
   private final GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
@@ -62,7 +63,7 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
   public GroupCommitter(
       String label,
       GroupCommitConfig config,
-      KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+      GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator) {
     logger.info("Starting GroupCommitter. Label: {}, Config: {}", label, config);
     this.keyManipulator = keyManipulator;
@@ -209,7 +210,7 @@ public class GroupCommitter<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EM
   GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY, V>
       createGroupManager(
           GroupCommitConfig config,
-          KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+          GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
               keyManipulator) {
     return new GroupManager<>(config, keyManipulator);
   }

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupManager.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.LazyInit;
-import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
+import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +49,8 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
       groupCleanupWorker;
 
   // Custom operations injected by the client
-  private final KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+  private final GroupCommitKeyManipulator<
+          PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
       keyManipulator;
   @LazyInit private Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter;
 
@@ -57,7 +58,7 @@ class GroupManager<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_K
 
   GroupManager(
       GroupCommitConfig config,
-      KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+      GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator) {
     this.keyManipulator = keyManipulator;
     this.config = config;

--- a/core/src/main/java/com/scalar/db/util/groupcommit/NormalGroup.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/NormalGroup.java
@@ -27,7 +27,7 @@ class NormalGroup<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KE
   NormalGroup(
       GroupCommitConfig config,
       Emittable<EMIT_PARENT_KEY, EMIT_FULL_KEY, V> emitter,
-      KeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
+      GroupCommitKeyManipulator<PARENT_KEY, CHILD_KEY, FULL_KEY, EMIT_PARENT_KEY, EMIT_FULL_KEY>
           keyManipulator) {
     super(emitter, keyManipulator, config.slotCapacity(), config.oldGroupAbortTimeoutMillis());
     this.delayedSlotMoveTimeoutMillis = config.delayedSlotMoveTimeoutMillis();

--- a/core/src/test/java/com/scalar/db/util/groupcommit/DelayedGroupTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/DelayedGroupTest.java
@@ -26,13 +26,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DelayedGroupTest {
   @Mock private Emittable<String, String, Integer> emitter;
-  private TestableKeyManipulator keyManipulator;
+  private TestableGroupCommitKeyManipulator keyManipulator;
 
   @BeforeEach
   void setUp() {
     // This generates parent keys which start with "0000" and increment by one for each subsequent
     // key ("0001", "0002"...).
-    keyManipulator = new TestableKeyManipulator();
+    keyManipulator = new TestableGroupCommitKeyManipulator();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterConcurrentTest.java
@@ -30,7 +30,7 @@ class GroupCommitterConcurrentTest {
   }
 
   private static class MyKeyManipulator
-      implements KeyManipulator<String, String, String, String, String> {
+      implements GroupCommitKeyManipulator<String, String, String, String, String> {
     @Override
     public String generateParentKey() {
       return UUID.randomUUID().toString();

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupCommitterTest.java
@@ -61,14 +61,14 @@ class GroupCommitterTest {
 
     TestableGroupCommitter(
         GroupCommitConfig config,
-        KeyManipulator<String, String, String, String, String> keyManipulator) {
+        GroupCommitKeyManipulator<String, String, String, String, String> keyManipulator) {
       super("test", config, keyManipulator);
     }
 
     @Override
     GroupManager<String, String, String, String, String, Integer> createGroupManager(
         GroupCommitConfig config,
-        KeyManipulator<String, String, String, String, String> keyManipulator) {
+        GroupCommitKeyManipulator<String, String, String, String, String> keyManipulator) {
       testableGroupCommitterGroupManagerCreated.set(true);
       return groupManager;
     }
@@ -137,7 +137,7 @@ class GroupCommitterTest {
             delayedSlotMoveTimeoutMillis,
             OLD_GROUP_ABORT_TIMEOUT_MILLIS,
             TIMEOUT_CHECK_INTERVAL_MILLIS),
-        new TestableKeyManipulator());
+        new TestableGroupCommitKeyManipulator());
   }
 
   @Test
@@ -146,7 +146,8 @@ class GroupCommitterTest {
     // Act
     try (TestableGroupCommitter ignored =
         new TestableGroupCommitter(
-            new GroupCommitConfig(20, 100, 400, 60, 10, true), new TestableKeyManipulator())) {
+            new GroupCommitConfig(20, 100, 400, 60, 10, true),
+            new TestableGroupCommitKeyManipulator())) {
       // Assert
       assertThat(testableGroupCommitterGroupManagerCreated.get()).isTrue();
       assertThat(testableGroupCommitterGroupSizeFixWorkerCreated.get()).isTrue();
@@ -162,7 +163,8 @@ class GroupCommitterTest {
     // Act
     try (TestableGroupCommitter ignored =
         new TestableGroupCommitter(
-            new GroupCommitConfig(20, 100, 400, 60, 10, false), new TestableKeyManipulator())) {
+            new GroupCommitConfig(20, 100, 400, 60, 10, false),
+            new TestableGroupCommitKeyManipulator())) {
       // Assert
       assertThat(testableGroupCommitterGroupManagerCreated.get()).isTrue();
       assertThat(testableGroupCommitterGroupSizeFixWorkerCreated.get()).isTrue();
@@ -578,7 +580,8 @@ class GroupCommitterTest {
     doReturn(false).when(groupCommitMetrics).hasRemaining();
     TestableGroupCommitter groupCommitter =
         new TestableGroupCommitter(
-            new GroupCommitConfig(20, 100, 400, 60, 10, true), new TestableKeyManipulator());
+            new GroupCommitConfig(20, 100, 400, 60, 10, true),
+            new TestableGroupCommitKeyManipulator());
     // Act
     groupCommitter.close();
     TimeUnit.SECONDS.sleep(4);
@@ -597,7 +600,8 @@ class GroupCommitterTest {
     doReturn(false).when(groupCommitMetrics).hasRemaining();
     TestableGroupCommitter groupCommitter =
         new TestableGroupCommitter(
-            new GroupCommitConfig(20, 100, 400, 60, 10, false), new TestableKeyManipulator());
+            new GroupCommitConfig(20, 100, 400, 60, 10, false),
+            new TestableGroupCommitKeyManipulator());
     // Act
     groupCommitter.close();
     TimeUnit.SECONDS.sleep(4);
@@ -616,7 +620,8 @@ class GroupCommitterTest {
     doReturn(true).when(groupCommitMetrics).hasRemaining();
     TestableGroupCommitter groupCommitter =
         new TestableGroupCommitter(
-            new GroupCommitConfig(20, 100, 400, 60000, 10), new TestableKeyManipulator());
+            new GroupCommitConfig(20, 100, 400, 60000, 10),
+            new TestableGroupCommitKeyManipulator());
     ExecutorService executorService = Executors.newCachedThreadPool();
 
     // Act

--- a/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/GroupManagerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
+import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -20,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class GroupManagerTest {
   private static final int TIMEOUT_CHECK_INTERVAL_MILLIS = 10;
-  private TestableKeyManipulator keyManipulator;
+  private TestableGroupCommitKeyManipulator keyManipulator;
   @Mock private Emittable<String, String, Integer> emittable;
 
   @Mock
@@ -31,7 +31,7 @@ class GroupManagerTest {
 
   @BeforeEach
   void setUp() {
-    keyManipulator = new TestableKeyManipulator();
+    keyManipulator = new TestableGroupCommitKeyManipulator();
   }
 
   @AfterEach

--- a/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/NormalGroupTest.java
@@ -25,13 +25,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class NormalGroupTest {
   @Mock private Emittable<String, String, Integer> emitter;
-  private TestableKeyManipulator keyManipulator;
+  private TestableGroupCommitKeyManipulator keyManipulator;
 
   @BeforeEach
   void setUp() {
     // This generates parent keys which start with "0000" and increment by one for each subsequent
     // key ("0001", "0002"...).
-    keyManipulator = new TestableKeyManipulator();
+    keyManipulator = new TestableGroupCommitKeyManipulator();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/util/groupcommit/TestableGroupCommitKeyManipulator.java
+++ b/core/src/test/java/com/scalar/db/util/groupcommit/TestableGroupCommitKeyManipulator.java
@@ -4,7 +4,8 @@ import com.google.common.base.Splitter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class TestableKeyManipulator implements KeyManipulator<String, String, String, String, String> {
+class TestableGroupCommitKeyManipulator
+    implements GroupCommitKeyManipulator<String, String, String, String, String> {
   private final AtomicInteger counter = new AtomicInteger();
 
   @Override

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -44,7 +44,7 @@ import com.scalar.db.io.Key;
 import com.scalar.db.io.Value;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
-import com.scalar.db.util.groupcommit.KeyManipulator.Keys;
+import com.scalar.db.util.groupcommit.GroupCommitKeyManipulator.Keys;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
## Description

In the current implementation, `CoordinatorGroupCommitKeyManipulator` designed to manipulate GroupCommit keys that are all String. But, the functionality should be reusable in other use cases, not only for the Coordinator Group Commit feature. This PR moves the implementation of `CoordinatorGroupCommitKeyManipulator` to `DefaultGroupCommitKeyManipulator` to make the functionality easier to reuse.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb-cluster/pull/834

## Changes made

- Move the implementation of `CoordinatorGroupCommitKeyManipulator` to `DefaultGroupCommitKeyManipulator`. `CoordinatorGroupCommitKeyManipulator` inherits `DefaultGroupCommitKeyManipulator` now.
- Rename interface `KeyManipulator` to `GroupCommitKeyManipulator` to clarify what kind of keys the interface manipulate.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This changes addresses [this issue](https://github.com/scalar-labs/scalardb-cluster/pull/834/files#diff-13122ac37bebf857a9e456ce0fb266b09d457daa4bc2caa929ad575529af576bR23-R26).

## Release notes

N/A
