### PR TITLE
Refactoring the callbacks for the group commit error handling in `CommitHandler`

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -63,9 +63,9 @@ public class CommitHandler {
       return Optional.of(
           beforePreparationSnapshotHook.handle(tableMetadataManager, snapshot.getReadWriteSets()));
     } catch (Exception e) {
+      onFailureBeforeCommit(snapshot);
       abortState(snapshot.getId());
       rollbackRecords(snapshot);
-      onFailureBeforeCommit(snapshot);
       throw new CommitException(
           CoreError.HANDLING_BEFORE_PREPARATION_SNAPSHOT_HOOK_FAILED.buildMessage(e.getMessage()),
           e,
@@ -83,9 +83,9 @@ public class CommitHandler {
     try {
       snapshotHookFuture.get();
     } catch (Exception e) {
+      onFailureBeforeCommit(snapshot);
       abortState(snapshot.getId());
       rollbackRecords(snapshot);
-      onFailureBeforeCommit(snapshot);
       throw new CommitException(
           CoreError.HANDLING_BEFORE_PREPARATION_SNAPSHOT_HOOK_FAILED.buildMessage(e.getMessage()),
           e,
@@ -98,6 +98,7 @@ public class CommitHandler {
     try {
       prepare(snapshot);
     } catch (PreparationException e) {
+      onFailureBeforeCommit(snapshot);
       abortState(snapshot.getId());
       rollbackRecords(snapshot);
       if (e instanceof PreparationConflictException) {
@@ -112,6 +113,7 @@ public class CommitHandler {
     try {
       validate(snapshot);
     } catch (ValidationException e) {
+      onFailureBeforeCommit(snapshot);
       abortState(snapshot.getId());
       rollbackRecords(snapshot);
       if (e instanceof ValidationConflictException) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -51,9 +51,7 @@ public class CommitHandler {
     this.parallelExecutor = checkNotNull(parallelExecutor);
   }
 
-  protected void onPrepareFailure(Snapshot snapshot) {}
-
-  protected void onValidateFailure(Snapshot snapshot) {}
+  protected void onFailureBeforeCommit(Snapshot snapshot) {}
 
   private Optional<Future<Void>> invokeBeforePreparationSnapshotHook(Snapshot snapshot)
       throws UnknownTransactionStatusException, CommitException {
@@ -67,9 +65,7 @@ public class CommitHandler {
     } catch (Exception e) {
       abortState(snapshot.getId());
       rollbackRecords(snapshot);
-      // TODO: This method is actually a part of preparation phase. But the callback method name
-      //       `onPrepareFailure()` should be renamed to more reasonable one.
-      onPrepareFailure(snapshot);
+      onFailureBeforeCommit(snapshot);
       throw new CommitException(
           CoreError.HANDLING_BEFORE_PREPARATION_SNAPSHOT_HOOK_FAILED.buildMessage(e.getMessage()),
           e,
@@ -89,9 +85,7 @@ public class CommitHandler {
     } catch (Exception e) {
       abortState(snapshot.getId());
       rollbackRecords(snapshot);
-      // TODO: This method is actually a part of validation phase. But the callback method name
-      //       `onValidateFailure()` should be renamed to more reasonable one.
-      onValidateFailure(snapshot);
+      onFailureBeforeCommit(snapshot);
       throw new CommitException(
           CoreError.HANDLING_BEFORE_PREPARATION_SNAPSHOT_HOOK_FAILED.buildMessage(e.getMessage()),
           e,
@@ -111,7 +105,7 @@ public class CommitHandler {
       }
       throw new CommitException(e.getMessage(), e, e.getTransactionId().orElse(null));
     } catch (Exception e) {
-      onPrepareFailure(snapshot);
+      onFailureBeforeCommit(snapshot);
       throw e;
     }
 
@@ -125,7 +119,7 @@ public class CommitHandler {
       }
       throw new CommitException(e.getMessage(), e, e.getTransactionId().orElse(null));
     } catch (Exception e) {
-      onValidateFailure(snapshot);
+      onFailureBeforeCommit(snapshot);
       throw e;
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -51,6 +51,12 @@ public class CommitHandler {
     this.parallelExecutor = checkNotNull(parallelExecutor);
   }
 
+  /**
+   * A callback invoked when any exception occurs before committing transactions. This method must
+   * not throw any exception.
+   *
+   * @param snapshot the failed snapshot.
+   */
   protected void onFailureBeforeCommit(Snapshot snapshot) {}
 
   private Optional<Future<Void>> invokeBeforePreparationSnapshotHook(Snapshot snapshot)

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -72,7 +72,12 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   }
 
   private void cancelGroupCommitIfNeeded(String id) {
-    groupCommitter.remove(id);
+    try {
+      groupCommitter.remove(id);
+    } catch (Exception e) {
+      logger.warn(
+          "Unexpectedly failed to remove the snapshot ID from the group committer. ID: {}", id);
+    }
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -38,12 +38,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   }
 
   @Override
-  protected void onPrepareFailure(Snapshot snapshot) {
-    cancelGroupCommitIfNeeded(snapshot.getId());
-  }
-
-  @Override
-  protected void onValidateFailure(Snapshot snapshot) {
+  protected void onFailureBeforeCommit(Snapshot snapshot) {
     cancelGroupCommitIfNeeded(snapshot.getId());
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -228,6 +228,8 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(any());
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -250,6 +252,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -272,6 +275,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -301,6 +305,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -328,6 +333,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -355,6 +361,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -380,6 +387,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -403,6 +411,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -426,6 +435,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -456,6 +466,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -484,6 +495,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -512,6 +524,7 @@ public class CommitHandlerTest {
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -538,6 +551,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   @Test
@@ -562,6 +576,7 @@ public class CommitHandlerTest {
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -585,6 +600,7 @@ public class CommitHandlerTest {
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verify(coordinator).getState(anyId());
     verify(handler).rollbackRecords(snapshot);
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -607,6 +623,7 @@ public class CommitHandlerTest {
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -629,6 +646,7 @@ public class CommitHandlerTest {
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verify(coordinator).getState(anyId());
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -647,6 +665,7 @@ public class CommitHandlerTest {
     verify(storage, times(2)).mutate(anyList());
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verify(handler, never()).rollbackRecords(snapshot);
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -228,7 +228,6 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
-    verify(handler).onFailureBeforeCommit(any());
     verify(handler).onFailureBeforeCommit(snapshot);
   }
 

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -183,8 +183,7 @@ public class CommitHandlerTest {
     verify(storage, times(4)).mutate(anyList());
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verifySnapshotHook(withSnapshotHook, readWriteSets);
-    verify(handler, never()).onPrepareFailure(any());
-    verify(handler, never()).onValidateFailure(any());
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @ParameterizedTest
@@ -206,8 +205,7 @@ public class CommitHandlerTest {
     verify(storage, times(2)).mutate(anyList());
     verifyCoordinatorPutState(TransactionState.COMMITTED);
     verifySnapshotHook(withSnapshotHook, readWriteSets);
-    verify(handler, never()).onPrepareFailure(any());
-    verify(handler, never()).onValidateFailure(any());
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -687,8 +685,7 @@ public class CommitHandlerTest {
     // This means `commit()` waited until the callback was completed before throwing
     // an exception from `commitState()`.
     assertThat(Duration.between(start, end)).isGreaterThanOrEqualTo(Duration.ofSeconds(2));
-    verify(handler, never()).onPrepareFailure(any());
-    verify(handler, never()).onValidateFailure(any());
+    verify(handler, never()).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -710,8 +707,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
-    verify(handler).onPrepareFailure(any());
-    verify(handler, never()).onValidateFailure(any());
+    verify(handler).onFailureBeforeCommit(any());
   }
 
   @Test
@@ -735,8 +731,7 @@ public class CommitHandlerTest {
     verify(coordinator, never())
         .putState(new Coordinator.State(anyId(), TransactionState.COMMITTED));
     verify(handler).rollbackRecords(snapshot);
-    verify(handler, never()).onPrepareFailure(any());
-    verify(handler).onValidateFailure(snapshot);
+    verify(handler).onFailureBeforeCommit(snapshot);
   }
 
   protected void doThrowExceptionWhenCoordinatorPutState(


### PR DESCRIPTION
## Description

In the current implementation, `CommitHandler` has `onPrepareFailure()` and `onValidateFailure()`, but there is no need to separate them. This PR merges them to make it simpler.

## Related issues and/or PRs

None.

## Changes made

- Merge `onPrepareFailure()` and `onValidateFailure()` into `onFailureBeforeCommit()`
- Make the error handling more consistent

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A (No behavior changed)