### PR TITLE
Enable integration test cases skipped for YugabyteDB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1520,7 +1520,7 @@ jobs:
     steps:
       - name: Run YugabyteDB 2
         run: |
-          docker run -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.21.0.0-b545 bin/yugabyted start --background=false --master_flag="ysql_enable_db_catalog_version_mode=false" --tserver_flags="ysql_enable_db_catalog_version_mode=false"
+          docker run -p 5433:5433 -e YSQL_USER=yugabyte -e YSQL_PASSWORD=yugabyte -d yugabytedb/yugabyte:2.20.4.0-b50 bin/yugabyted start --background=false --master_flag="ysql_enable_db_catalog_version_mode=false" --tserver_flags="ysql_enable_db_catalog_version_mode=false"
 
       - uses: actions/checkout@v4
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMultipleClusteringKeyScanIntegrationTest.java
@@ -7,8 +7,6 @@ import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
 import java.util.Properties;
 import java.util.Random;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
     extends DistributedStorageMultipleClusteringKeyScanIntegrationTestBase {
@@ -80,23 +78,5 @@ public class JdbcDatabaseMultipleClusteringKeyScanIntegrationTest
       }
     }
     return super.getColumnWithMaxValue(columnName, dataType);
-  }
-
-  // TODO: Remove this once https://github.com/yugabyte/yugabyte-db/issues/22140 is fixed and the
-  //       fix is released.
-  @DisabledIf("isYugabyteDb")
-  @Test
-  @Override
-  public void scan_WithSecondClusteringKeyRange_ShouldReturnProperResult()
-      throws java.util.concurrent.ExecutionException, InterruptedException {
-    super.scan_WithSecondClusteringKeyRange_ShouldReturnProperResult();
-  }
-
-  @DisabledIf("isYugabyteDb")
-  @Test
-  @Override
-  public void scan_WithSecondClusteringKeyRangeWithSameValues_ShouldReturnProperResult()
-      throws java.util.concurrent.ExecutionException, InterruptedException {
-    super.scan_WithSecondClusteringKeyRangeWithSameValues_ShouldReturnProperResult();
   }
 }


### PR DESCRIPTION
## Description

The current integration test disabled 2 test cases when the underlying database is YugabyteDB to avoid https://github.com/yugabyte/yugabyte-db/issues/22140. But, the bug is already fixed, so this PR enabled the skipped test cases.

Note: this PR doesn't use the latest version of YugabyteDB Docker image, since another issue that DDL statements fail after the schema has been changed frequently occurs with recent versions.

## Related issues and/or PRs

None

## Changes made

- Remove 2 overridden test cases that skip test when the underlying database is YugabyteDB
- Change the YugabyteDB Docker image that has a fix for https://github.com/yugabyte/yugabyte-db/issues/22140

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A