### PR TITLE
Fix Slf4j providers not found error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     ext {
         guiceVersion = '5.1.0'
         guavaVersion = '32.1.3-jre'
-        slf4jVersion = '1.7.36'
+        slf4jVersion = '2.0.16'
         cassandraDriverVersion = '3.11.5'
         azureCosmosVersion = '4.65.0'
         jooqVersion = '3.14.16'

--- a/build.gradle
+++ b/build.gradle
@@ -89,9 +89,5 @@ subprojects {
     installDist {
         duplicatesStrategy DuplicatesStrategy.EXCLUDE
     }
-
-    configurations.all {
-       resolutionStrategy.force "org.slf4j:slf4j-api:${slf4jVersion}", "org.slf4j:slf4j-simple:${slf4jVersion}"
-    }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     ext {
         guiceVersion = '5.1.0'
         guavaVersion = '32.1.3-jre'
-        slf4jVersion = '2.0.16'
+        slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.11.5'
         azureCosmosVersion = '4.65.0'
         jooqVersion = '3.14.16'
@@ -88,6 +88,10 @@ subprojects {
 
     installDist {
         duplicatesStrategy DuplicatesStrategy.EXCLUDE
+    }
+
+    configurations.all {
+       resolutionStrategy.force "org.slf4j:slf4j-api:${slf4jVersion}", "org.slf4j:slf4j-simple:${slf4jVersion}"
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -107,7 +107,9 @@ dependencies {
     implementation "com.microsoft.sqlserver:mssql-jdbc:${sqlserverDriverVersion}"
     implementation "org.xerial:sqlite-jdbc:${sqliteDriverVersion}"
     implementation "com.yugabyte:jdbc-yugabytedb:${yugabyteDriverVersion}"
-    implementation "org.mariadb.jdbc:mariadb-java-client:${mariadDbDriverVersion}"
+    implementation ("org.mariadb.jdbc:mariadb-java-client:${mariadDbDriverVersion}") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     implementation "org.apache.commons:commons-text:${commonsTextVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"


### PR DESCRIPTION
## Description

~~This updates slf4j to the latest version to resolve the following logger binding issue when running ScalarDB unit or integration test.~~
~~This forces Gradle to use the slf4j version defined by ScalarDB over any version pulled transitively.~~
This excludes the `slf4j-api` dependency from the maria-db driver to resolve the following logger binding issue when running ScalarDB unit or integration test.

```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/Users/vguilpain/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.36/a41f9cfe6faafb2eb83a1c7dd2d0dfd844e2a936/slf4j-simple-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

This problem appeared after adding the MariaDB driver dependency in https://github.com/scalar-labs/scalardb/pull/2391. This dependency pulls `slf4j-api` version 2.X, but `sl4j-simple` stays with version 1.7.X, causing a mismatch.

## Related issues and/or PRs

N/A

## Changes made

Update slf4j to the latest version.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release note

N/A