### PR TITLE
Ignore Spotbugs warning CT_CONSTRUCTOR_THROW

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -118,10 +118,6 @@ public class JdbcAdminImportTestUtils {
     majorVersion = getMajorVersion();
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes(String namespace)
       throws SQLException {
     execute(rdbEngine.createSchemaSqls(namespace));

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -103,10 +103,6 @@ public abstract class ActiveTransactionManagedDistributedTransactionManager
       add(this);
     }
 
-    // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-    @Override
-    protected final void finalize() {}
-
     @Override
     public synchronized Optional<Result> get(Get get) throws CrudException {
       return super.get(get);

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -110,10 +110,6 @@ public abstract class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       add(this);
     }
 
-    // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-    @Override
-    protected final void finalize() {}
-
     @Override
     public synchronized Optional<Result> get(Get get) throws CrudException {
       return super.get(get);

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -84,10 +84,6 @@ public class DatabaseConfig {
     this(propertiesPath.toFile());
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public Properties getProperties() {
     Properties ret = new Properties();
     ret.putAll(props);

--- a/core/src/main/java/com/scalar/db/io/BigIntColumn.java
+++ b/core/src/main/java/com/scalar/db/io/BigIntColumn.java
@@ -40,10 +40,6 @@ public class BigIntColumn implements Column<Long> {
     this.hasNullValue = hasNullValue;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   public String getName() {
     return name;

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -88,10 +88,6 @@ public class Cassandra extends AbstractDistributedStorage {
     this.operationChecker = operationChecker;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraConfig.java
@@ -16,10 +16,6 @@ public class CassandraConfig {
     metadataKeyspace = databaseConfig.getSystemNamespaceName();
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public String getMetadataKeyspace() {
     return metadataKeyspace;
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -88,10 +88,6 @@ public class Cosmos extends AbstractDistributedStorage {
     this.operationChecker = operationChecker;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosConfig.java
@@ -58,10 +58,6 @@ public class CosmosConfig {
     consistencyLevel = getString(databaseConfig.getProperties(), CONSISTENCY_LEVEL, null);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public String getEndpoint() {
     return endpoint;
   }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -105,10 +105,6 @@ public class Dynamo extends AbstractDistributedStorage {
     this.operationChecker = operationChecker;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   @Nonnull
   public Optional<Result> get(Get get) throws ExecutionException {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoConfig.java
@@ -77,10 +77,6 @@ public class DynamoConfig {
     namespacePrefix = getString(databaseConfig.getProperties(), NAMESPACE_PREFIX, null);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public String getRegion() {
     return region;
   }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Namespace.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Namespace.java
@@ -17,10 +17,6 @@ public class Namespace {
     this.name = name;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public static Namespace of(String prefix, String name) {
     return new Namespace(prefix, name);
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/ConditionalMutator.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/ConditionalMutator.java
@@ -56,10 +56,6 @@ public class ConditionalMutator implements MutationConditionVisitor {
     this.queryBuilder = queryBuilder;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public boolean mutate() throws SQLException {
     mutation.getCondition().ifPresent(condition -> condition.accept(this));
     throwSQLExceptionIfOccurred();

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcConfig.java
@@ -227,10 +227,6 @@ public class JdbcConfig {
     }
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public String getJdbcUrl() {
     return jdbcUrl;
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectWithFetchFirstNRowsOnly.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectWithFetchFirstNRowsOnly.java
@@ -13,10 +13,6 @@ public class SelectWithFetchFirstNRowsOnly extends SimpleSelectQuery {
     this.limit = limit;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   public String sql() {
     return super.sql() + " FETCH FIRST " + limit + " ROWS ONLY";

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectWithLimitQuery.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectWithLimitQuery.java
@@ -13,10 +13,6 @@ public class SelectWithLimitQuery extends SimpleSelectQuery {
     this.limit = limit;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   public String sql() {
     return super.sql() + " LIMIT " + limit;

--- a/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectWithTop.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/query/SelectWithTop.java
@@ -13,10 +13,6 @@ public class SelectWithTop extends SimpleSelectQuery {
     this.limit = limit;
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @Override
   public String sql() {
     // This inserts "TOP ${limit}" clause, specific to SqlServer, right after the "SELECT" clause of

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageConfig.java
@@ -44,10 +44,6 @@ public class MultiStorageConfig {
     checkIfStorageExists(defaultStorage);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   private ImmutableMap<String, Properties> loadDatabasePropertiesMapping(Properties properties) {
     String[] storages = getStringArray(properties, STORAGES, null);
     if (storages == null) {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -189,10 +189,6 @@ public class ConsensusCommitConfig {
             false);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public Isolation getIsolation() {
     return isolation;
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Coordinator.java
@@ -332,10 +332,6 @@ public class Coordinator {
       this(id, state, System.currentTimeMillis());
     }
 
-    // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-    @Override
-    protected final void finalize() {}
-
     @VisibleForTesting
     State(String id, List<String> childIds, TransactionState state, long createdAt) {
       this.id = checkNotNull(id);

--- a/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/util/groupcommit/GroupCommitConfig.java
@@ -64,10 +64,6 @@ public class GroupCommitConfig {
         false);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public int slotCapacity() {
     return slotCapacity;
   }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -6,9 +6,10 @@
       <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
       <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
       <!-- Temporarily excluded. See https://github.com/spotbugs/spotbugs/issues/1694 -->
-      <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+      <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
       <!-- To exclude Lombok thrown warnings -->
       <Bug pattern="SAME_NAME_BUT_DIFFERENT"/>
+      <Bug pattern="CT_CONSTRUCTOR_THROW"/>
     </Or>
   </Match>
 

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportSchemaParser.java
@@ -30,10 +30,6 @@ public class ImportSchemaParser {
     this.options = ImmutableMap.copyOf(options);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public List<ImportTableSchema> parse() {
     List<ImportTableSchema> tableSchemaList = new ArrayList<>();
     for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
@@ -33,10 +33,6 @@ public class ImportTableSchema {
     this.options = buildOptions(tableDefinition, options);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   private ImmutableMap<String, String> buildOptions(
       JsonObject tableDefinition, Map<String, String> globalOptions) {
     ImmutableMap.Builder<String, String> optionsBuilder = ImmutableMap.builder();

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -45,10 +45,6 @@ public class SchemaOperator implements AutoCloseable {
     this(StorageFactory.create(properties), TransactionFactory.create(properties));
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   @VisibleForTesting
   SchemaOperator(StorageFactory storageFactory, TransactionFactory transactionFactory) {
     storageAdmin =

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaParser.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaParser.java
@@ -31,10 +31,6 @@ public class SchemaParser {
     this.options = ImmutableMap.copyOf(options);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   public List<TableSchema> parse() {
     List<TableSchema> tableSchemaList = new ArrayList<>();
     for (Map.Entry<String, JsonElement> entry : schemaJson.entrySet()) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
@@ -70,10 +70,6 @@ public class TableSchema {
     this.options = buildOptions(tableDefinition, options);
   }
 
-  // For the SpotBugs warning CT_CONSTRUCTOR_THROW
-  @Override
-  protected final void finalize() {}
-
   protected TableMetadata buildTableMetadata(String tableFullName, JsonObject tableDefinition) {
     TableMetadata.Builder tableBuilder = TableMetadata.newBuilder();
 


### PR DESCRIPTION
## Description

This PR updates the code to ignore the spotbugs warning `CT_CONSTRUCTOR_THROW`.

## Related issues and/or PRs

N/A

## Changes made

- Updated the code to ignore the spotbugs warning `CT_CONSTRUCTOR_THROW`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
