### PR TITLE
Backport to branch(3): Add utility setter methods for ImmutableMap to AbacOperationAttributes (#2448)

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AbacOperationAttributes.java
+++ b/core/src/main/java/com/scalar/db/api/AbacOperationAttributes.java
@@ -1,5 +1,6 @@
 package com.scalar.db.api;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -16,6 +17,11 @@ public final class AbacOperationAttributes {
     attributes.put(READ_TAG_PREFIX + policyName, readTag);
   }
 
+  public static void setReadTag(
+      ImmutableMap.Builder<String, String> attributesBuilder, String policyName, String readTag) {
+    attributesBuilder.put(READ_TAG_PREFIX + policyName, readTag);
+  }
+
   public static void clearReadTag(Map<String, String> attributes, String policyName) {
     attributes.remove(READ_TAG_PREFIX + policyName);
   }
@@ -27,6 +33,11 @@ public final class AbacOperationAttributes {
   public static void setWriteTag(
       Map<String, String> attributes, String policyName, String writeTag) {
     attributes.put(WRITE_TAG_PREFIX + policyName, writeTag);
+  }
+
+  public static void setWriteTag(
+      ImmutableMap.Builder<String, String> attributesBuilder, String policyName, String writeTag) {
+    attributesBuilder.put(WRITE_TAG_PREFIX + policyName, writeTag);
   }
 
   public static void clearWriteTag(Map<String, String> attributes, String policyName) {

--- a/core/src/test/java/com/scalar/db/api/AbacOperationAttributesTest.java
+++ b/core/src/test/java/com/scalar/db/api/AbacOperationAttributesTest.java
@@ -2,6 +2,7 @@ package com.scalar.db.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.scalar.db.io.Key;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class AbacOperationAttributesTest {
 
   @Test
-  public void setReadTag_ShouldSetReadTag() {
+  public void setReadTag_MapGiven_ShouldSetReadTag() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
     String policyName = "policyName";
@@ -22,6 +23,21 @@ public class AbacOperationAttributesTest {
 
     // Assert
     assertThat(attributes)
+        .containsEntry(AbacOperationAttributes.READ_TAG_PREFIX + policyName, readTag);
+  }
+
+  @Test
+  public void setReadTag_ImmutableMapBuilderGiven_ShouldSetReadTag() {
+    // Arrange
+    ImmutableMap.Builder<String, String> attributesBuilder = ImmutableMap.builder();
+    String policyName = "policyName";
+    String readTag = "readTag";
+
+    // Act
+    AbacOperationAttributes.setReadTag(attributesBuilder, policyName, readTag);
+
+    // Assert
+    assertThat(attributesBuilder.build())
         .containsEntry(AbacOperationAttributes.READ_TAG_PREFIX + policyName, readTag);
   }
 
@@ -60,7 +76,7 @@ public class AbacOperationAttributesTest {
   }
 
   @Test
-  public void setWriteTag_ShouldSetWriteTag() {
+  public void setWriteTag_MapGiven_ShouldSetWriteTag() {
     // Arrange
     Map<String, String> attributes = new HashMap<>();
     String policyName = "policyName";
@@ -71,6 +87,21 @@ public class AbacOperationAttributesTest {
 
     // Assert
     assertThat(attributes)
+        .containsEntry(AbacOperationAttributes.WRITE_TAG_PREFIX + policyName, writeTag);
+  }
+
+  @Test
+  public void setWriteTag_ImmutableMapBuilderGiven_ShouldSetWriteTag() {
+    // Arrange
+    ImmutableMap.Builder<String, String> attributesBuilder = ImmutableMap.builder();
+    String policyName = "policyName";
+    String writeTag = "writeTag";
+
+    // Act
+    AbacOperationAttributes.setWriteTag(attributesBuilder, policyName, writeTag);
+
+    // Assert
+    assertThat(attributesBuilder.build())
         .containsEntry(AbacOperationAttributes.WRITE_TAG_PREFIX + policyName, writeTag);
   }
 


### PR DESCRIPTION
Backport of https://github.com/scalar-labs/scalardb/pull/2448