### PR TITLE
Revise import table feature for time-related types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,7 +413,7 @@ jobs:
     steps:
       - name: Run MySQL 5.7
         run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --explicit-defaults-for-timestamp
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,7 +413,7 @@ jobs:
     steps:
       - name: Run MySQL 5.7
         run: |
-          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --explicit-defaults-for-timestamp
+          docker run -e MYSQL_ROOT_PASSWORD=mysql -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
 
       - uses: actions/checkout@v4
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase.java
@@ -1,10 +1,10 @@
 package com.scalar.db.storage.jdbc;
 
-import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.DistributedStorageAdminImportTableIntegrationTestBase.TestData;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitAdminImportTableIntegrationTestBase;
 import java.sql.SQLException;
-import java.util.Map;
+import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -44,8 +44,7 @@ public class ConsensusCommitAdminImportTableIntegrationTestWithJdbcDatabase
   }
 
   @Override
-  protected Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
-      throws SQLException {
+  protected List<TestData> createExistingDatabaseWithAllDataTypes() throws SQLException {
     return testUtils.createExistingDatabaseWithAllDataTypes(getNamespace());
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTableIntegrationTest.java
@@ -1,10 +1,9 @@
 package com.scalar.db.storage.jdbc;
 
 import com.scalar.db.api.DistributedStorageAdminImportTableIntegrationTestBase;
-import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import java.sql.SQLException;
-import java.util.Map;
+import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -44,8 +43,7 @@ public class JdbcAdminImportTableIntegrationTest
   }
 
   @Override
-  protected Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
-      throws SQLException {
+  protected List<TestData> createExistingDatabaseWithAllDataTypes() throws SQLException {
     return testUtils.createExistingDatabaseWithAllDataTypes(getNamespace());
   }
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -192,7 +192,11 @@ public class JdbcAdminImportTestUtils {
     columns.put("col23", "TIME(6)");
     columns.put("col24", "DATETIME(6)");
     columns.put("col25", "DATETIME(6)"); // override to TIMESTAMPTZ
-    columns.put("col26", "TIMESTAMP(6)");
+    // With Mysql 5.7, if a TIMESTAMP column is not explicitly declared with the NULL attribute, it
+    // is declared automatically with the NOT NULL attribute and assigned a default value equal to
+    // the current timestamp.
+    // cf. the "--explicit-defaults-for-timestamp" option documentation
+    columns.put("col26", "TIMESTAMP(6) NULL");
     if (isMariaDB()) {
       columns.put("col27", "JSON");
     }

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcAdminImportTestUtils.java
@@ -192,7 +192,7 @@ public class JdbcAdminImportTestUtils {
     columns.put("col23", "TIME(6)");
     columns.put("col24", "DATETIME(6)");
     columns.put("col25", "DATETIME(6)"); // override to TIMESTAMPTZ
-    // With Mysql 5.7, if a TIMESTAMP column is not explicitly declared with the NULL attribute, it
+    // With MySQL 5.7, if a TIMESTAMP column is not explicitly declared with the NULL attribute, it
     // is declared automatically with the NOT NULL attribute and assigned a default value equal to
     // the current timestamp.
     // cf. the "--explicit-defaults-for-timestamp" option documentation
@@ -757,6 +757,7 @@ public class JdbcAdminImportTestUtils {
       return new JdbcTestData(
           tableName, createTableSql, overrideColumnsType, tableMetadata, columns);
     }
+
     /**
      * Create test data for a table that cannot be imported.
      *

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcSchemaLoaderImportIntegrationTest.java
@@ -1,9 +1,14 @@
 package com.scalar.db.storage.jdbc;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.io.DataType;
 import com.scalar.db.schemaloader.SchemaLoaderImportIntegrationTestBase;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -12,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportIntegrationTestBase {
+
   private static final Logger logger =
       LoggerFactory.getLogger(JdbcSchemaLoaderImportIntegrationTest.class);
 
@@ -31,21 +37,111 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
   @SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
   @Override
   protected void createImportableTable(String namespace, String table) throws Exception {
-    testUtils.execute(
-        "CREATE TABLE "
-            + rdbEngine.encloseFullTableName(namespace, table)
-            + "("
-            + rdbEngine.enclose("pk")
-            + " CHAR(8),"
-            + rdbEngine.enclose("col")
-            + " CHAR(8), PRIMARY KEY("
-            + rdbEngine.enclose("pk")
-            + "))");
+    String sql;
+
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
+      sql =
+          "CREATE TABLE "
+              + rdbEngine.encloseFullTableName(namespace, table)
+              + "("
+              + rdbEngine.enclose("pk")
+              + " CHAR(8),"
+              + rdbEngine.enclose("col1")
+              + " CHAR(8),"
+              + rdbEngine.enclose("col2")
+              + " DATETIME,"
+              + "PRIMARY KEY("
+              + rdbEngine.enclose("pk")
+              + "))";
+    } else if (JdbcTestUtils.isOracle(rdbEngine)) {
+      sql =
+          "CREATE TABLE "
+              + rdbEngine.encloseFullTableName(namespace, table)
+              + "("
+              + rdbEngine.enclose("pk")
+              + " CHAR(8),"
+              + rdbEngine.enclose("col1")
+              + " CHAR(8),"
+              + rdbEngine.enclose("col2")
+              + " DATE,"
+              + "PRIMARY KEY("
+              + rdbEngine.enclose("pk")
+              + "))";
+    } else if (JdbcTestUtils.isPostgresql(rdbEngine) || JdbcTestUtils.isSqlServer(rdbEngine)) {
+      sql =
+          "CREATE TABLE "
+              + rdbEngine.encloseFullTableName(namespace, table)
+              + "("
+              + rdbEngine.enclose("pk")
+              + " CHAR(8),"
+              + rdbEngine.enclose("col1")
+              + " CHAR(8),"
+              + "PRIMARY KEY("
+              + rdbEngine.enclose("pk")
+              + "))";
+    } else {
+      throw new AssertionError();
+    }
+
+    testUtils.execute(sql);
+  }
+
+  @Override
+  protected Map<String, DataType> getImportableTableOverrideColumnsType() {
+    // col1 type override confirms overriding with the default data type mapping does not fail
+    // col2 really performs a type override
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
+      return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIMESTAMPTZ);
+    } else if (JdbcTestUtils.isOracle(rdbEngine)) {
+      return ImmutableMap.of("col1", DataType.TEXT, "col2", DataType.TIMESTAMP);
+    } else if (JdbcTestUtils.isPostgresql(rdbEngine) || JdbcTestUtils.isSqlServer(rdbEngine)) {
+      return ImmutableMap.of("col1", DataType.TEXT);
+    } else if (JdbcTestUtils.isSqlite(rdbEngine)) {
+      return Collections.emptyMap();
+    } else {
+      throw new AssertionError();
+    }
+  }
+
+  @Override
+  protected TableMetadata getImportableTableMetadata(boolean hasTypeOverride) {
+    TableMetadata.Builder metadata = TableMetadata.newBuilder();
+    metadata.addPartitionKey("pk");
+    metadata.addColumn("pk", DataType.TEXT);
+    metadata.addColumn("col1", DataType.TEXT);
+
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
+      return metadata
+          .addColumn("col2", hasTypeOverride ? DataType.TIMESTAMPTZ : DataType.TIMESTAMP)
+          .build();
+    } else if (JdbcTestUtils.isOracle(rdbEngine)) {
+      return metadata
+          .addColumn("col2", hasTypeOverride ? DataType.TIMESTAMP : DataType.DATE)
+          .build();
+    } else if (JdbcTestUtils.isPostgresql(rdbEngine) || JdbcTestUtils.isSqlServer(rdbEngine)) {
+      return metadata.build();
+    } else {
+      throw new AssertionError();
+    }
   }
 
   @SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
   @Override
   protected void createNonImportableTable(String namespace, String table) throws Exception {
+    String nonImportableDataType;
+    if (JdbcTestUtils.isMysql(rdbEngine)) {
+      nonImportableDataType = "YEAR";
+    } else if (JdbcTestUtils.isPostgresql(rdbEngine)) {
+      nonImportableDataType = "INTERVAL";
+    } else if (JdbcTestUtils.isOracle(rdbEngine)) {
+      nonImportableDataType = "INT";
+    } else if (JdbcTestUtils.isSqlServer(rdbEngine)) {
+      nonImportableDataType = "MONEY";
+    } else if (JdbcTestUtils.isSqlite(rdbEngine)) {
+      nonImportableDataType = "TEXT";
+    } else {
+      throw new AssertionError();
+    }
     testUtils.execute(
         "CREATE TABLE "
             + rdbEngine.encloseFullTableName(namespace, table)
@@ -53,7 +149,9 @@ public class JdbcSchemaLoaderImportIntegrationTest extends SchemaLoaderImportInt
             + rdbEngine.enclose("pk")
             + " CHAR(8),"
             + rdbEngine.enclose("col")
-            + " DATE, PRIMARY KEY("
+            + " "
+            + nonImportableDataType
+            + ", PRIMARY KEY("
             + rdbEngine.enclose("pk")
             + "))");
   }

--- a/core/src/main/java/com/scalar/db/api/Admin.java
+++ b/core/src/main/java/com/scalar/db/api/Admin.java
@@ -451,7 +451,28 @@ public interface Admin {
    *     table does not exist, or if the table does not meet the requirement of ScalarDB table
    * @throws ExecutionException if the operation fails
    */
-  void importTable(String namespace, String table, Map<String, String> options)
+  default void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
+    importTable(namespace, table, options, Collections.emptyMap());
+  }
+
+  /**
+   * Imports an existing table that is not managed by ScalarDB.
+   *
+   * @param namespace an existing namespace
+   * @param table an existing table
+   * @param options options to import
+   * @param overrideColumnsType a map of column data type by column name. Only set the column for
+   *     which you want to override the default data type mapping.
+   * @throws IllegalArgumentException if the table is already managed by ScalarDB, if the target
+   *     table does not exist, or if the table does not meet the requirement of ScalarDB table
+   * @throws ExecutionException if the operation fails
+   */
+  void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException;
 
   /**

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -2,6 +2,8 @@ package com.scalar.db.api;
 
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * An administrative interface for distributed storage implementations. The user can execute
@@ -52,7 +54,26 @@ public interface DistributedStorageAdmin extends Admin, AutoCloseable {
    * @throws ExecutionException if the operation fails
    * @return import table metadata in the ScalarDB format
    */
-  TableMetadata getImportTableMetadata(String namespace, String table) throws ExecutionException;
+  default TableMetadata getImportTableMetadata(String namespace, String table)
+      throws ExecutionException {
+    return getImportTableMetadata(namespace, table, Collections.emptyMap());
+  }
+
+  /**
+   * Get import table metadata in the ScalarDB format.
+   *
+   * @param namespace namespace name of import table
+   * @param table import table name
+   * @param overrideColumnsType a map of column data type by column name. Only set the column for
+   *     which you want to override the default data type mapping.
+   * @throws IllegalArgumentException if the table does not exist
+   * @throws IllegalStateException if the table does not meet the requirement of ScalarDB table
+   * @throws ExecutionException if the operation fails
+   * @return import table metadata in the ScalarDB format
+   */
+  TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType)
+      throws ExecutionException;
 
   /**
    * Add a column in the table without updating the metadata table in ScalarDB.

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -313,10 +313,11 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getImportTableMetadata(String namespace, String table)
+  public TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
     try {
-      return admin.getImportTableMetadata(namespace, table);
+      return admin.getImportTableMetadata(namespace, table, overrideColumnsType);
     } catch (ExecutionException e) {
       throw new ExecutionException(
           CoreError.GETTING_IMPORT_TABLE_METADATA_FAILED.buildMessage(
@@ -326,7 +327,11 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
     TableMetadata tableMetadata = getTableMetadata(namespace, table);
     if (tableMetadata != null) {
@@ -336,7 +341,7 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
     }
 
     try {
-      admin.importTable(namespace, table, options);
+      admin.importTable(namespace, table, options, overrideColumnsType);
     } catch (ExecutionException e) {
       throw new ExecutionException(
           CoreError.IMPORTING_TABLE_FAILED.buildMessage(

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -196,9 +196,13 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    distributedTransactionAdmin.importTable(namespace, table, options);
+    distributedTransactionAdmin.importTable(namespace, table, options, overrideColumnsType);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -729,7 +729,7 @@ public enum CoreError implements ScalarDbError {
   JDBC_IMPORT_DATA_TYPE_OVERRIDE_NOT_SUPPORTED(
       Category.USER_ERROR,
       "0158",
-      "The underlying storage data type %s is not supported as ScalarDB %s data type: %s",
+      "The underlying-storage data type %s is not supported as the ScalarDB %s data type: %s",
       "",
       ""),
 

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -726,6 +726,12 @@ public enum CoreError implements ScalarDbError {
       "This TIMESTAMPTZ column value precision cannot be shorter than one millisecond. Value: %s",
       "",
       ""),
+  JDBC_IMPORT_DATA_TYPE_OVERRIDE_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "0158",
+      "The underlying storage data type %s is not supported as ScalarDB %s data type: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -94,9 +94,10 @@ public class AdminService implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getImportTableMetadata(String namespace, String table)
+  public TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    return admin.getImportTableMetadata(namespace, table);
+    return admin.getImportTableMetadata(namespace, table, overrideColumnsType);
   }
 
   @Override
@@ -107,9 +108,13 @@ public class AdminService implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    admin.importTable(namespace, table, options);
+    admin.importTable(namespace, table, options, overrideColumnsType);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -275,7 +275,8 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getImportTableMetadata(String namespace, String table) {
+  public TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(
         CoreError.CASSANDRA_IMPORT_NOT_SUPPORTED.buildMessage());
   }
@@ -288,7 +289,11 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options) {
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(
         CoreError.CASSANDRA_IMPORT_NOT_SUPPORTED.buildMessage());
   }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -636,7 +636,8 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getImportTableMetadata(String namespace, String table) {
+  public TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(CoreError.COSMOS_IMPORT_NOT_SUPPORTED.buildMessage());
   }
 
@@ -647,7 +648,11 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options) {
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(CoreError.COSMOS_IMPORT_NOT_SUPPORTED.buildMessage());
   }
 

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1363,7 +1363,8 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getImportTableMetadata(String namespace, String table) {
+  public TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in DynamoDB");
   }
@@ -1376,7 +1377,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options) {
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType) {
     throw new UnsupportedOperationException(
         "Import-related functionality is not supported in DynamoDB");
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/AbstractRdbEngine.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/AbstractRdbEngine.java
@@ -1,0 +1,38 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.io.DataType;
+import java.sql.JDBCType;
+import javax.annotation.Nullable;
+
+public abstract class AbstractRdbEngine implements RdbEngineStrategy {
+
+  @Override
+  public final DataType getDataTypeForScalarDb(
+      JDBCType type,
+      String typeName,
+      int columnSize,
+      int digits,
+      String columnDescription,
+      @Nullable DataType overrideDataType) {
+    DataType dataType =
+        getDataTypeForScalarDbInternal(
+            type, typeName, columnSize, digits, columnDescription, overrideDataType);
+
+    if (overrideDataType != null && overrideDataType != dataType) {
+      throw new IllegalArgumentException(
+          CoreError.JDBC_IMPORT_DATA_TYPE_OVERRIDE_NOT_SUPPORTED.buildMessage(
+              typeName, overrideDataType, columnDescription));
+    }
+
+    return dataType;
+  }
+
+  abstract DataType getDataTypeForScalarDbInternal(
+      JDBCType type,
+      String typeName,
+      int columnSize,
+      int digits,
+      String columnDescription,
+      @Nullable DataType overrideDataType);
+}

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
+
   private JdbcUtils() {}
 
   public static BasicDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -7,7 +7,6 @@ import java.util.Map.Entry;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class JdbcUtils {
-
   private JdbcUtils() {}
 
   public static BasicDataSource initDataSource(JdbcConfig config, RdbEngineStrategy rdbEngine) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMariaDB.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMariaDB.java
@@ -3,6 +3,7 @@ package com.scalar.db.storage.jdbc;
 import com.scalar.db.io.DataType;
 import java.sql.Driver;
 import java.sql.JDBCType;
+import javax.annotation.Nullable;
 
 class RdbEngineMariaDB extends RdbEngineMysql {
   @Override
@@ -11,14 +12,20 @@ class RdbEngineMariaDB extends RdbEngineMysql {
   }
 
   @Override
-  public DataType getDataTypeForScalarDb(
-      JDBCType type, String typeName, int columnSize, int digits, String columnDescription) {
+  DataType getDataTypeForScalarDbInternal(
+      JDBCType type,
+      String typeName,
+      int columnSize,
+      int digits,
+      String columnDescription,
+      @Nullable DataType overrideDataType) {
     if (type == JDBCType.BOOLEAN) {
       // MariaDB JDBC driver maps TINYINT(1) type as a BOOLEAN JDBC type which differs from the
       // MySQL driver which maps it to a BIT type.
       return DataType.BOOLEAN;
     } else {
-      return super.getDataTypeForScalarDb(type, typeName, columnSize, digits, columnDescription);
+      return super.getDataTypeForScalarDbInternal(
+          type, typeName, columnSize, digits, columnDescription, overrideDataType);
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -35,7 +35,7 @@ import org.sqlite.SQLiteException;
  * native SQLite library in JAR</a>, we should assure the real error messages in
  * RdbEngineStrategyTest.
  */
-class RdbEngineSqlite implements RdbEngineStrategy {
+class RdbEngineSqlite extends AbstractRdbEngine {
   private static final String NAMESPACE_SEPARATOR = "$";
   private final RdbEngineTimeTypeSqlite timeTypeEngine;
 
@@ -152,8 +152,13 @@ class RdbEngineSqlite implements RdbEngineStrategy {
   }
 
   @Override
-  public DataType getDataTypeForScalarDb(
-      JDBCType type, String typeName, int columnSize, int digits, String columnDescription) {
+  public DataType getDataTypeForScalarDbInternal(
+      JDBCType type,
+      String typeName,
+      int columnSize,
+      int digits,
+      String columnDescription,
+      DataType overrideDataType) {
     throw new AssertionError("SQLite is not supported");
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -42,7 +42,12 @@ public interface RdbEngineStrategy {
   String getDataTypeForKey(DataType dataType);
 
   DataType getDataTypeForScalarDb(
-      JDBCType type, String typeName, int columnSize, int digits, String columnDescription);
+      JDBCType type,
+      String typeName,
+      int columnSize,
+      int digits,
+      String columnDescription,
+      @Nullable DataType overrideDataType);
 
   int getSqlTypes(DataType dataType);
 

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -196,9 +196,10 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public TableMetadata getImportTableMetadata(String namespace, String table)
+  public TableMetadata getImportTableMetadata(
+      String namespace, String table, Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    return getAdmin(namespace, table).getImportTableMetadata(namespace, table);
+    return getAdmin(namespace, table).getImportTableMetadata(namespace, table, overrideColumnsType);
   }
 
   @Override
@@ -209,9 +210,13 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    getAdmin(namespace, table).importTable(namespace, table, options);
+    getAdmin(namespace, table).importTable(namespace, table, options, overrideColumnsType);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdmin.java
@@ -246,7 +246,11 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
     checkNamespace(namespace);
 
@@ -256,7 +260,7 @@ public class ConsensusCommitAdmin implements DistributedTransactionAdmin {
           CoreError.TABLE_ALREADY_EXISTS.buildMessage(
               ScalarDbUtils.getFullTableName(namespace, table)));
     }
-    tableMetadata = admin.getImportTableMetadata(namespace, table);
+    tableMetadata = admin.getImportTableMetadata(namespace, table, overrideColumnsType);
 
     // add transaction metadata columns
     for (Map.Entry<String, DataType> entry :

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdmin.java
@@ -86,9 +86,13 @@ public class JdbcTransactionAdmin implements DistributedTransactionAdmin {
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    jdbcAdmin.importTable(namespace, table, options);
+    jdbcAdmin.importTable(namespace, table, options, overrideColumnsType);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdmin.java
@@ -86,9 +86,13 @@ public class SingleCrudOperationTransactionAdmin implements DistributedTransacti
   }
 
   @Override
-  public void importTable(String namespace, String table, Map<String, String> options)
+  public void importTable(
+      String namespace,
+      String table,
+      Map<String, String> options,
+      Map<String, DataType> overrideColumnsType)
       throws ExecutionException {
-    distributedStorageAdmin.importTable(namespace, table, options);
+    distributedStorageAdmin.importTable(namespace, table, options, overrideColumnsType);
   }
 
   @Override

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -879,12 +879,16 @@ public class CassandraAdminTest {
 
     // Act
     Throwable thrown1 =
-        catchThrowable(() -> cassandraAdmin.getImportTableMetadata(namespace, table));
+        catchThrowable(
+            () -> cassandraAdmin.getImportTableMetadata(namespace, table, Collections.emptyMap()));
     Throwable thrown2 =
         catchThrowable(
             () -> cassandraAdmin.addRawColumnToTable(namespace, table, column, DataType.INT));
     Throwable thrown3 =
-        catchThrowable(() -> cassandraAdmin.importTable(namespace, table, Collections.emptyMap()));
+        catchThrowable(
+            () ->
+                cassandraAdmin.importTable(
+                    namespace, table, Collections.emptyMap(), Collections.emptyMap()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTest.java
@@ -1075,11 +1075,16 @@ public class CosmosAdminTest {
     String column = "col";
 
     // Act
-    Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(namespace, table));
+    Throwable thrown1 =
+        catchThrowable(
+            () -> admin.getImportTableMetadata(namespace, table, Collections.emptyMap()));
     Throwable thrown2 =
         catchThrowable(() -> admin.addRawColumnToTable(namespace, table, column, DataType.INT));
     Throwable thrown3 =
-        catchThrowable(() -> admin.importTable(namespace, table, Collections.emptyMap()));
+        catchThrowable(
+            () ->
+                admin.importTable(
+                    namespace, table, Collections.emptyMap(), Collections.emptyMap()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1595,11 +1595,16 @@ public abstract class DynamoAdminTestBase {
   @Test
   public void unsupportedOperations_ShouldThrowUnsupportedException() {
     // Arrange Act
-    Throwable thrown1 = catchThrowable(() -> admin.getImportTableMetadata(NAMESPACE, TABLE));
+    Throwable thrown1 =
+        catchThrowable(
+            () -> admin.getImportTableMetadata(NAMESPACE, TABLE, Collections.emptyMap()));
     Throwable thrown2 =
         catchThrowable(() -> admin.addRawColumnToTable(NAMESPACE, TABLE, "c1", DataType.INT));
     Throwable thrown3 =
-        catchThrowable(() -> admin.importTable(NAMESPACE, TABLE, Collections.emptyMap()));
+        catchThrowable(
+            () ->
+                admin.importTable(
+                    NAMESPACE, TABLE, Collections.emptyMap(), Collections.emptyMap()));
 
     // Assert
     assertThat(thrown1).isInstanceOf(UnsupportedOperationException.class);

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -617,4 +617,34 @@ public class MultiStorageAdminTest {
     verify(admin1).upgrade(options);
     verify(admin2).upgrade(options);
   }
+
+  @Test
+  public void importTable_ForTable1InNamespace1_ShouldCallAdmin1() throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Map<String, String> options = ImmutableMap.of("a", "b");
+    Map<String, DataType> overrideColumnsType = ImmutableMap.of("c", DataType.TIMESTAMPTZ);
+
+    // Act
+    multiStorageAdmin.importTable(namespace, table, options, overrideColumnsType);
+
+    // Assert
+    verify(admin1).importTable(namespace, table, options, overrideColumnsType);
+  }
+
+  @Test
+  public void getImportTableMetadata_ForTable1InNamespace1_ShouldCallAdmin1()
+      throws ExecutionException {
+    // Arrange
+    String namespace = NAMESPACE1;
+    String table = TABLE1;
+    Map<String, DataType> overrideColumnsType = ImmutableMap.of("c", DataType.TIMESTAMPTZ);
+
+    // Act
+    multiStorageAdmin.getImportTableMetadata(namespace, table, overrideColumnsType);
+
+    // Assert
+    verify(admin1).getImportTableMetadata(namespace, table, overrideColumnsType);
+  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitAdminTestBase.java
@@ -606,6 +606,7 @@ public abstract class ConsensusCommitAdminTestBase {
   public void importTable_ShouldCallStorageAdminProperly() throws ExecutionException {
     // Arrange
     Map<String, String> options = ImmutableMap.of("foo", "bar");
+    Map<String, DataType> overrideColumnsType = ImmutableMap.of("col", DataType.TEXT);
     String primaryKeyColumn = "pk";
     String column = "col";
     TableMetadata metadata =
@@ -615,17 +616,18 @@ public abstract class ConsensusCommitAdminTestBase {
             .addPartitionKey(primaryKeyColumn)
             .build();
     when(distributedStorageAdmin.getTableMetadata(NAMESPACE, TABLE)).thenReturn(null);
-    when(distributedStorageAdmin.getImportTableMetadata(NAMESPACE, TABLE)).thenReturn(metadata);
+    when(distributedStorageAdmin.getImportTableMetadata(NAMESPACE, TABLE, overrideColumnsType))
+        .thenReturn(metadata);
     doNothing()
         .when(distributedStorageAdmin)
         .addRawColumnToTable(anyString(), anyString(), anyString(), any(DataType.class));
 
     // Act
-    admin.importTable(NAMESPACE, TABLE, options);
+    admin.importTable(NAMESPACE, TABLE, options, overrideColumnsType);
 
     // Assert
     verify(distributedStorageAdmin).getTableMetadata(NAMESPACE, TABLE);
-    verify(distributedStorageAdmin).getImportTableMetadata(NAMESPACE, TABLE);
+    verify(distributedStorageAdmin).getImportTableMetadata(NAMESPACE, TABLE, overrideColumnsType);
     for (Entry<String, DataType> entry :
         ConsensusCommitUtils.getTransactionMetaColumns().entrySet()) {
       verify(distributedStorageAdmin)

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionAdminTest.java
@@ -235,10 +235,10 @@ public class JdbcTransactionAdminTest {
     String table = "tbl";
 
     // Act
-    admin.importTable(namespace, table, Collections.emptyMap());
+    admin.importTable(namespace, table, Collections.emptyMap(), Collections.emptyMap());
 
     // Assert
-    verify(jdbcAdmin).importTable(namespace, table, Collections.emptyMap());
+    verify(jdbcAdmin).importTable(namespace, table, Collections.emptyMap(), Collections.emptyMap());
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdminTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionAdminTest.java
@@ -238,12 +238,14 @@ public class SingleCrudOperationTransactionAdminTest {
     // Arrange
     String namespace = "ns";
     String table = "tbl";
+    Map<String, String> options = ImmutableMap.of("a", "b");
+    Map<String, DataType> overrideColumnsType = ImmutableMap.of("c", DataType.TIMESTAMPTZ);
 
     // Act
-    admin.importTable(namespace, table, Collections.emptyMap());
+    admin.importTable(namespace, table, options, overrideColumnsType);
 
     // Assert
-    verify(distributedStorageAdmin).importTable(namespace, table, Collections.emptyMap());
+    verify(distributedStorageAdmin).importTable(namespace, table, options, overrideColumnsType);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminImportTableIntegrationTestBase.java
@@ -4,12 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
 import com.scalar.db.service.StorageFactory;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,9 +33,9 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
 
   private static final String TEST_NAME = "storage_admin_import_table";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private final Map<String, TableMetadata> tables = new HashMap<>();
-
+  private final List<TestData> testDataList = new ArrayList<>();
   protected DistributedStorageAdmin admin;
+  protected DistributedStorage storage;
 
   @BeforeAll
   public void beforeAll() throws Exception {
@@ -48,13 +55,11 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
   }
 
   private void dropTable() throws Exception {
-    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
-      String table = entry.getKey();
-      TableMetadata metadata = entry.getValue();
-      if (metadata == null) {
-        dropNonImportableTable(table);
+    for (TestData testData : testDataList) {
+      if (!testData.isImportableTable()) {
+        dropNonImportableTable(testData.getTableName());
       } else {
-        admin.dropTable(getNamespace(), table);
+        admin.dropTable(getNamespace(), testData.getTableName());
       }
     }
     if (!admin.namespaceExists(getNamespace())) {
@@ -68,6 +73,7 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
   protected void setUp() throws Exception {
     StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
     admin = factory.getStorageAdmin();
+    storage = factory.getStorage();
   }
 
   @AfterEach
@@ -90,27 +96,29 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
   @AfterAll
   protected void afterAll() throws Exception {}
 
-  protected abstract Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
-      throws Exception;
+  protected abstract List<TestData> createExistingDatabaseWithAllDataTypes() throws SQLException;
 
   protected abstract void dropNonImportableTable(String table) throws Exception;
 
   @Test
   public void importTable_ShouldWorkProperly() throws Exception {
     // Arrange
-    tables.putAll(createExistingDatabaseWithAllDataTypes());
+    testDataList.addAll(createExistingDatabaseWithAllDataTypes());
 
     // Act Assert
-    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
-      String table = entry.getKey();
-      TableMetadata metadata = entry.getValue();
-      if (metadata == null) {
-        importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(table);
+    for (TestData testData : testDataList) {
+      if (!testData.isImportableTable()) {
+        importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(
+            testData.getTableName());
       } else {
-        importTable_ForImportableTable_ShouldImportProperly(table, metadata);
+        importTable_ForImportableTable_ShouldImportProperly(
+            testData.getTableName(),
+            testData.getOverrideColumnsType(),
+            testData.getTableMetadata());
       }
     }
     importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException();
+    importTable_ForImportedTable_ShouldPutThenGetCorrectly();
   }
 
   @Test
@@ -123,9 +131,10 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
   }
 
   private void importTable_ForImportableTable_ShouldImportProperly(
-      String table, TableMetadata metadata) throws ExecutionException {
+      String table, Map<String, DataType> overrideColumnsType, TableMetadata metadata)
+      throws ExecutionException {
     // Act
-    admin.importTable(getNamespace(), table, Collections.emptyMap());
+    admin.importTable(getNamespace(), table, Collections.emptyMap(), overrideColumnsType);
 
     // Assert
     assertThat(admin.namespaceExists(getNamespace())).isTrue();
@@ -146,5 +155,85 @@ public abstract class DistributedStorageAdminImportTableIntegrationTestBase {
     assertThatThrownBy(
             () -> admin.importTable(getNamespace(), "non-existing-table", Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  public void importTable_ForImportedTable_ShouldPutThenGetCorrectly() throws ExecutionException {
+    // Arrange
+    List<Put> puts =
+        testDataList.stream()
+            .filter(TestData::isImportableTable)
+            .map(td -> td.getPut(getNamespace(), td.getTableName()))
+            .collect(Collectors.toList());
+    List<Get> gets =
+        testDataList.stream()
+            .filter(TestData::isImportableTable)
+            .map(td -> td.getGet(getNamespace(), td.getTableName()))
+            .collect(Collectors.toList());
+
+    // Act
+    for (Put put : puts) {
+      storage.put(put);
+    }
+    List<Optional<Result>> results = new ArrayList<>();
+    for (Get get : gets) {
+      results.add(storage.get(get));
+    }
+
+    // Assert
+    for (int i = 0; i < results.size(); i++) {
+      Put put = puts.get(i);
+      Optional<Result> optResult = results.get(i);
+
+      assertThat(optResult).isPresent();
+      Result result = optResult.get();
+      Set<String> actualColumnNamesWithoutKeys = new HashSet<>(result.getContainedColumnNames());
+      actualColumnNamesWithoutKeys.removeAll(
+          put.getPartitionKey().getColumns().stream()
+              .map(Column::getName)
+              .collect(Collectors.toSet()));
+
+      assertThat(actualColumnNamesWithoutKeys)
+          .containsExactlyInAnyOrderElementsOf(put.getContainedColumnNames());
+      result.getColumns().entrySet().stream()
+          .filter(
+              e -> {
+                // Filter partition key columns
+                return !put.getPartitionKey().getColumns().contains(e.getValue());
+              })
+          .forEach(
+              entry ->
+                  // Assert each result column is equal to the column inserted with the put
+                  assertThat(entry.getValue()).isEqualTo(put.getColumns().get(entry.getKey())));
+    }
+  }
+
+  /** This interface defines test data for running import table related integration tests. */
+  public interface TestData {
+
+    /** @return true if the table is supported for import, false otherwise */
+    boolean isImportableTable();
+
+    /** @return the table name */
+    String getTableName();
+
+    /** @return the columns for which the data type should be overridden when importing the table */
+    Map<String, DataType> getOverrideColumnsType();
+
+    /*
+     * @return the expected table metadata of the imported table
+     */
+    TableMetadata getTableMetadata();
+
+    /** @return a sample Insert operation for the table */
+    Insert getInsert(String namespace, String table);
+
+    /** @return a sample Put operation for the table */
+    Put getPut(String namespace, String table);
+
+    /**
+     * @return a Get operation to retrieve the record inserted with {@link #getPut(String, String)}
+     *     or {@link #getInsert(String, String)}
+     */
+    Get getGet(String namespace, String table);
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionAdminImportTableIntegrationTestBase.java
@@ -3,13 +3,21 @@ package com.scalar.db.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.scalar.db.api.DistributedStorageAdminImportTableIntegrationTestBase.TestData;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
 import com.scalar.db.service.TransactionFactory;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,9 +34,10 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
 
   private static final String TEST_NAME = "tx_admin_import_table";
   private static final String NAMESPACE = "int_test_" + TEST_NAME;
-  private final Map<String, TableMetadata> tables = new HashMap<>();
+  private final List<TestData> testDataList = new ArrayList<>();
 
   protected DistributedTransactionAdmin admin;
+  protected DistributedTransactionManager manager;
 
   @BeforeAll
   public void beforeAll() throws Exception {
@@ -48,13 +57,11 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
   }
 
   private void dropTable() throws Exception {
-    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
-      String table = entry.getKey();
-      TableMetadata metadata = entry.getValue();
-      if (metadata == null) {
-        dropNonImportableTable(table);
+    for (TestData testData : testDataList) {
+      if (!testData.isImportableTable()) {
+        dropNonImportableTable(testData.getTableName());
       } else {
-        admin.dropTable(getNamespace(), table);
+        admin.dropTable(getNamespace(), testData.getTableName());
       }
     }
     if (!admin.namespaceExists(getNamespace())) {
@@ -62,12 +69,15 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
       admin.repairNamespace(getNamespace(), getCreationOptions());
     }
     admin.dropNamespace(getNamespace());
+    admin.dropCoordinatorTables();
   }
 
   @BeforeEach
   protected void setUp() throws Exception {
     TransactionFactory factory = TransactionFactory.create(getProperties(TEST_NAME));
     admin = factory.getTransactionAdmin();
+    manager = factory.getTransactionManager();
+    admin.createCoordinatorTables(true);
   }
 
   @AfterEach
@@ -90,27 +100,29 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
   @AfterAll
   protected void afterAll() throws Exception {}
 
-  protected abstract Map<String, TableMetadata> createExistingDatabaseWithAllDataTypes()
-      throws Exception;
+  protected abstract List<TestData> createExistingDatabaseWithAllDataTypes() throws Exception;
 
   protected abstract void dropNonImportableTable(String table) throws Exception;
 
   @Test
   public void importTable_ShouldWorkProperly() throws Exception {
     // Arrange
-    tables.putAll(createExistingDatabaseWithAllDataTypes());
+    testDataList.addAll(createExistingDatabaseWithAllDataTypes());
 
     // Act Assert
-    for (Entry<String, TableMetadata> entry : tables.entrySet()) {
-      String table = entry.getKey();
-      TableMetadata metadata = entry.getValue();
-      if (metadata == null) {
-        importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(table);
+    for (TestData testData : testDataList) {
+      if (!testData.isImportableTable()) {
+        importTable_ForNonImportableTable_ShouldThrowIllegalArgumentException(
+            testData.getTableName());
       } else {
-        importTable_ForImportableTable_ShouldImportProperly(table, metadata);
+        importTable_ForImportableTable_ShouldImportProperly(
+            testData.getTableName(),
+            testData.getOverrideColumnsType(),
+            testData.getTableMetadata());
       }
     }
     importTable_ForNonExistingTable_ShouldThrowIllegalArgumentException();
+    importTable_ForImportedTable_ShouldInsertThenGetCorrectly();
   }
 
   @Test
@@ -123,9 +135,10 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
   }
 
   private void importTable_ForImportableTable_ShouldImportProperly(
-      String table, TableMetadata metadata) throws ExecutionException {
+      String table, Map<String, DataType> overrideColumnsType, TableMetadata metadata)
+      throws ExecutionException {
     // Act
-    admin.importTable(getNamespace(), table, Collections.emptyMap());
+    admin.importTable(getNamespace(), table, Collections.emptyMap(), overrideColumnsType);
 
     // Assert
     assertThat(admin.namespaceExists(getNamespace())).isTrue();
@@ -144,5 +157,61 @@ public abstract class DistributedTransactionAdminImportTableIntegrationTestBase 
     assertThatThrownBy(
             () -> admin.importTable(getNamespace(), "non-existing-table", Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  public void importTable_ForImportedTable_ShouldInsertThenGetCorrectly()
+      throws TransactionException {
+    // Arrange
+    List<Insert> inserts =
+        testDataList.stream()
+            .filter(TestData::isImportableTable)
+            .map(td -> td.getInsert(getNamespace(), td.getTableName()))
+            .collect(Collectors.toList());
+    List<Get> gets =
+        testDataList.stream()
+            .filter(TestData::isImportableTable)
+            .map(td -> td.getGet(getNamespace(), td.getTableName()))
+            .collect(Collectors.toList());
+
+    // Act
+    DistributedTransaction tx = manager.start();
+    for (Insert insert : inserts) {
+      tx.insert(insert);
+    }
+    tx.commit();
+
+    List<Optional<Result>> results = new ArrayList<>();
+    tx = manager.start();
+    for (Get get : gets) {
+      results.add(tx.get(get));
+    }
+    tx.commit();
+
+    // Assert
+    for (int i = 0; i < results.size(); i++) {
+      Insert insert = inserts.get(i);
+      Optional<Result> optResult = results.get(i);
+
+      assertThat(optResult).isPresent();
+      Result result = optResult.get();
+      Set<String> actualColumnNamesWithoutKeys = new HashSet<>(result.getContainedColumnNames());
+      actualColumnNamesWithoutKeys.removeAll(
+          insert.getPartitionKey().getColumns().stream()
+              .map(Column::getName)
+              .collect(Collectors.toSet()));
+
+      assertThat(actualColumnNamesWithoutKeys)
+          .containsExactlyInAnyOrderElementsOf(insert.getColumns().keySet());
+      result.getColumns().entrySet().stream()
+          .filter(
+              e -> {
+                // Filter partition key columns
+                return !insert.getPartitionKey().getColumns().contains(e.getValue());
+              })
+          .forEach(
+              entry ->
+                  // Assert each result column is equal to the column inserted with the put
+                  assertThat(entry.getValue()).isEqualTo(insert.getColumns().get(entry.getKey())));
+    }
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/schemaloader/SchemaLoaderImportIntegrationTestBase.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.io.DataType;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
 import java.io.IOException;
@@ -85,7 +87,10 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
   protected Map<String, Object> getImportSchemaJsonMap() {
     return ImmutableMap.of(
         namespace1 + "." + TABLE_1,
-        ImmutableMap.<String, Object>builder().put("transaction", true).build(),
+        ImmutableMap.<String, Object>builder()
+            .put("transaction", true)
+            .put("override-columns-type", getImportableTableOverrideColumnsType())
+            .build(),
         namespace2 + "." + TABLE_2,
         ImmutableMap.<String, Object>builder().put("transaction", false).build());
   }
@@ -149,6 +154,10 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
 
   protected abstract void dropNonImportableTable(String namespace, String table) throws Exception;
 
+  protected abstract Map<String, DataType> getImportableTableOverrideColumnsType();
+
+  protected abstract TableMetadata getImportableTableMetadata(boolean hasTypeOverride);
+
   protected void waitForDifferentSessionDdl() {
     // No wait by default.
   }
@@ -163,9 +172,11 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
     storageAdmin.createNamespace(namespace2);
 
     waitForDifferentSessionDdl();
+    // TABLE_1 set options to override column types.
     createImportableTable(namespace1, TABLE_1);
 
     waitForDifferentSessionDdl();
+    // TABLE_2 does not set options to override column types.
     createImportableTable(namespace2, TABLE_2);
 
     // Act
@@ -177,6 +188,10 @@ public abstract class SchemaLoaderImportIntegrationTestBase {
     assertThat(exitCode).isEqualTo(0);
     assertThat(transactionAdmin.tableExists(namespace1, TABLE_1)).isTrue();
     assertThat(storageAdmin.tableExists(namespace2, TABLE_2)).isTrue();
+    assertThat(transactionAdmin.getTableMetadata(namespace1, TABLE_1))
+        .isEqualTo(getImportableTableMetadata(true));
+    assertThat(storageAdmin.getTableMetadata(namespace2, TABLE_2))
+        .isEqualTo(getImportableTableMetadata(false));
     assertThat(transactionAdmin.coordinatorTablesExist()).isFalse();
   }
 

--- a/schema-loader/sample/import_schema_sample.json
+++ b/schema-loader/sample/import_schema_sample.json
@@ -1,6 +1,10 @@
 {
   "sample_namespace1.sample_table1": {
-    "transaction": true
+    "transaction": true,
+    "override-columns-type": {
+      "c3": "TIME",
+      "c5": "TIMESTAMP"
+    }
   },
   "sample_namespace1.sample_table2": {
     "transaction": true

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/ImportTableSchema.java
@@ -2,18 +2,23 @@ package com.scalar.db.schemaloader;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.scalar.db.common.error.CoreError;
+import com.scalar.db.io.DataType;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
 public class ImportTableSchema {
+  private static final String OVERRIDE_COLUMNS_TYPE = "override-columns-type";
   private final String namespace;
   private final String tableName;
   private final boolean isTransactionTable;
   private final ImmutableMap<String, String> options;
+  private final ImmutableMap<String, DataType> overrideColumnsType;
 
   public ImportTableSchema(
       String tableFullName, JsonObject tableDefinition, Map<String, String> options) {
@@ -30,7 +35,29 @@ public class ImportTableSchema {
     } else {
       isTransactionTable = true;
     }
+    this.overrideColumnsType = parseOverrideColumnsType(tableFullName, tableDefinition);
     this.options = buildOptions(tableDefinition, options);
+  }
+
+  private ImmutableMap<String, DataType> parseOverrideColumnsType(
+      String tableFullName, JsonObject tableDefinition) {
+    if (!tableDefinition.has(OVERRIDE_COLUMNS_TYPE)) {
+      return ImmutableMap.of();
+    }
+    JsonObject columns = tableDefinition.getAsJsonObject(OVERRIDE_COLUMNS_TYPE);
+    ImmutableMap.Builder<String, DataType> columnsBuilder = ImmutableMap.builder();
+    for (Entry<String, JsonElement> column : columns.entrySet()) {
+      String columnName = column.getKey();
+      String columnDataType = column.getValue().getAsString().trim();
+      DataType dataType = TableSchema.DATA_MAP_TYPE.get(columnDataType.toUpperCase());
+      if (dataType == null) {
+        throw new IllegalArgumentException(
+            CoreError.SCHEMA_LOADER_PARSE_ERROR_INVALID_COLUMN_TYPE.buildMessage(
+                tableFullName, columnName, column.getValue().getAsString()));
+      }
+      columnsBuilder.put(columnName, dataType);
+    }
+    return columnsBuilder.buildKeepingLast();
   }
 
   // For the SpotBugs warning CT_CONSTRUCTOR_THROW
@@ -47,7 +74,8 @@ public class ImportTableSchema {
             TableSchema.CLUSTERING_KEY,
             TableSchema.TRANSACTION,
             TableSchema.COLUMNS,
-            TableSchema.SECONDARY_INDEX);
+            TableSchema.SECONDARY_INDEX,
+            OVERRIDE_COLUMNS_TYPE);
     tableDefinition.entrySet().stream()
         .filter(entry -> !keysToIgnore.contains(entry.getKey()))
         .forEach(entry -> optionsBuilder.put(entry.getKey(), entry.getValue().getAsString()));
@@ -69,5 +97,9 @@ public class ImportTableSchema {
 
   public Map<String, String> getOptions() {
     return options;
+  }
+
+  public Map<String, DataType> getOverrideColumnsType() {
+    return overrideColumnsType;
   }
 }

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/SchemaOperator.java
@@ -408,9 +408,13 @@ public class SchemaOperator implements AutoCloseable {
       String table = tableSchema.getTable();
       try {
         if (tableSchema.isTransactionTable()) {
-          transactionAdmin.get().importTable(namespace, table, options);
+          transactionAdmin
+              .get()
+              .importTable(namespace, table, options, tableSchema.getOverrideColumnsType());
         } else {
-          storageAdmin.get().importTable(namespace, table, options);
+          storageAdmin
+              .get()
+              .importTable(namespace, table, options, tableSchema.getOverrideColumnsType());
         }
         logger.info("Importing the table {} in the namespace {} succeeded", table, namespace);
       } catch (ExecutionException e) {

--- a/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
+++ b/schema-loader/src/main/java/com/scalar/db/schemaloader/TableSchema.java
@@ -26,7 +26,7 @@ public class TableSchema {
   static final String PARTITION_KEY = "partition-key";
   static final String CLUSTERING_KEY = "clustering-key";
   static final String SECONDARY_INDEX = "secondary-index";
-  private static final ImmutableMap<String, DataType> DATA_MAP_TYPE =
+  static final ImmutableMap<String, DataType> DATA_MAP_TYPE =
       ImmutableMap.<String, DataType>builder()
           .put("BOOLEAN", DataType.BOOLEAN)
           .put("INT", DataType.INT)

--- a/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
+++ b/schema-loader/src/test/java/com/scalar/db/schemaloader/SchemaOperatorTest.java
@@ -512,12 +512,14 @@ public class SchemaOperatorTest {
     when(importTableSchema.getNamespace()).thenReturn("ns");
     when(importTableSchema.isTransactionTable()).thenReturn(true);
     when(importTableSchema.getTable()).thenReturn("tb");
+    Map<String, DataType> overrideColumnsType = ImmutableMap.of("c1", DataType.INT);
+    when(importTableSchema.getOverrideColumnsType()).thenReturn(overrideColumnsType);
 
     // Act
     operator.importTables(tableSchemaList, options);
 
     // Assert
-    verify(transactionAdmin, times(3)).importTable("ns", "tb", options);
+    verify(transactionAdmin, times(3)).importTable("ns", "tb", options, overrideColumnsType);
     verifyNoInteractions(storageAdmin);
   }
 
@@ -529,12 +531,14 @@ public class SchemaOperatorTest {
     when(importTableSchema.getNamespace()).thenReturn("ns");
     when(importTableSchema.isTransactionTable()).thenReturn(false);
     when(importTableSchema.getTable()).thenReturn("tb");
+    Map<String, DataType> overrideColumnsType = ImmutableMap.of("c1", DataType.INT);
+    when(importTableSchema.getOverrideColumnsType()).thenReturn(overrideColumnsType);
 
     // Act
     operator.importTables(tableSchemaList, options);
 
     // Assert
-    verify(storageAdmin, times(3)).importTable("ns", "tb", options);
+    verify(storageAdmin, times(3)).importTable("ns", "tb", options, overrideColumnsType);
     verifyNoInteractions(transactionAdmin);
   }
 


### PR DESCRIPTION
## Description

This PR brings three main changes to the import table feature:
1. Make the time-related types that could not be imported to be importable.
![image](https://github.com/user-attachments/assets/aeec863c-95bd-4c0d-a115-c16a36610eaf)

2. When importing a table, the default ScalarDB type mapping for a given column can now be overridden. This is only useful for some time-related types as of now:
    - Oracle DATE type which can be used a ScalarDB DATE (default mapping), TIME or TIMESTAMP
    - Oracle TIMESTAMP type which can be used as ScalarDB DATE or TIMESTAMP (default mapping)
    - Mysql DATETIME type which can be used as ScalarDB TIMESTAMP (default mapping) or TIMESTAMPTZ
    
    To do so, the user needs to define the columns requiring type override [through the Schema Loader import table schema file](https://github.com/scalar-labs/scalardb/pull/2461#discussion_r1915789689) or the [Admin API. ](https://github.com/scalar-labs/scalardb/pull/2461#discussion_r1915792640)
    
3. To verify that there is no encoding-decoding issue with the JDBC driver with all data types that ScalarDB supports through the import table feature, I added an integration test that performs a put then get on a generic value for each column.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2301
- https://github.com/scalar-labs/scalardb/pull/2437

## Changes made

See the description above and the comments left below.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This PR will be merged into the feature branch https://github.com/scalar-labs/scalardb/compare/master...add_time_related_types

## Release notes

N/A