### PR TITLE
Finalize integration tests for time related types 

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseConsensusCommitIntegrationTestWithCassandra.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/TwoPhaseConsensusCommitIntegrationTestWithCassandra.java
@@ -16,4 +16,9 @@ public class TwoPhaseConsensusCommitIntegrationTestWithCassandra
   protected Map<String, String> getCreationOptions() {
     return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
   }
+
+  @Override
+  protected boolean isTimestampTypeSupported() {
+    return false;
+  }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageColumnValueIntegrationTestBase.java
@@ -699,7 +699,6 @@ public abstract class DistributedStorageColumnValueIntegrationTestBase {
       TimestampTZColumn col10Value,
       @Nullable TimestampColumn col11Value)
       throws ExecutionException {
-    System.out.println("default timezone: " + TimeZone.getDefault());
     assert (isTimestampTypeSupported() == (col11Value != null));
 
     Optional<Result> actualOpt =

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -16,15 +16,32 @@ import com.scalar.db.exception.transaction.PreparationConflictException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.TransactionNotFoundException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.DateColumn;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
 import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.IntValue;
 import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import com.scalar.db.io.TimeColumn;
+import com.scalar.db.io.TimestampColumn;
+import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.io.Value;
 import com.scalar.db.service.TransactionFactory;
 import com.scalar.db.util.TestUtils;
 import com.scalar.db.util.TestUtils.ExpectedResult;
 import com.scalar.db.util.TestUtils.ExpectedResult.ExpectedResultBuilder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +51,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,19 +72,19 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";
   protected static final String SOME_COLUMN = "some_column";
+  protected static final String BOOLEAN_COL = "boolean_col";
+  protected static final String BIGINT_COL = "bigint_col";
+  protected static final String FLOAT_COL = "float_col";
+  protected static final String DOUBLE_COL = "double_col";
+  protected static final String TEXT_COL = "text_col";
+  protected static final String BLOB_COL = "blob_col";
+  protected static final String DATE_COL = "date_col";
+  protected static final String TIME_COL = "time_col";
+  protected static final String TIMESTAMP_COL = "timestamp_col";
+  protected static final String TIMESTAMPTZ_COL = "timestamptz_col";
   protected static final int INITIAL_BALANCE = 1000;
   protected static final int NUM_ACCOUNTS = 4;
   protected static final int NUM_TYPES = 4;
-  protected static final TableMetadata TABLE_METADATA =
-      TableMetadata.newBuilder()
-          .addColumn(ACCOUNT_ID, DataType.INT)
-          .addColumn(ACCOUNT_TYPE, DataType.INT)
-          .addColumn(BALANCE, DataType.INT)
-          .addColumn(SOME_COLUMN, DataType.INT)
-          .addPartitionKey(ACCOUNT_ID)
-          .addClusteringKey(ACCOUNT_TYPE)
-          .addSecondaryIndex(SOME_COLUMN)
-          .build();
   protected DistributedTransactionAdmin admin1;
   protected DistributedTransactionAdmin admin2;
   protected TwoPhaseCommitTransactionManager manager1;
@@ -105,12 +123,34 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   private void createTables() throws ExecutionException {
+    TableMetadata.Builder tableMetadata =
+        TableMetadata.newBuilder()
+            .addColumn(ACCOUNT_ID, DataType.INT)
+            .addColumn(ACCOUNT_TYPE, DataType.INT)
+            .addColumn(BALANCE, DataType.INT)
+            .addColumn(SOME_COLUMN, DataType.INT)
+            .addColumn(BOOLEAN_COL, DataType.BOOLEAN)
+            .addColumn(BIGINT_COL, DataType.BIGINT)
+            .addColumn(FLOAT_COL, DataType.FLOAT)
+            .addColumn(DOUBLE_COL, DataType.DOUBLE)
+            .addColumn(TEXT_COL, DataType.TEXT)
+            .addColumn(BLOB_COL, DataType.BLOB)
+            .addColumn(DATE_COL, DataType.DATE)
+            .addColumn(TIME_COL, DataType.TIME)
+            .addColumn(TIMESTAMPTZ_COL, DataType.TIMESTAMPTZ)
+            .addPartitionKey(ACCOUNT_ID)
+            .addClusteringKey(ACCOUNT_TYPE)
+            .addSecondaryIndex(SOME_COLUMN);
+    if (isTimestampTypeSupported()) {
+      tableMetadata.addColumn(TIMESTAMP_COL, DataType.TIMESTAMP);
+    }
+
     Map<String, String> options = getCreationOptions();
     admin1.createCoordinatorTables(true, options);
     admin1.createNamespace(namespace1, true, options);
-    admin1.createTable(namespace1, TABLE_1, TABLE_METADATA, true, options);
+    admin1.createTable(namespace1, TABLE_1, tableMetadata.build(), true, options);
     admin2.createNamespace(namespace2, true, options);
-    admin2.createTable(namespace2, TABLE_2, TABLE_METADATA, true, options);
+    admin2.createTable(namespace2, TABLE_2, tableMetadata.build(), true, options);
   }
 
   protected Map<String, String> getCreationOptions() {
@@ -178,7 +218,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    Get get = prepareGet(2, 3, namespace1, TABLE_1);
 
     // Act
     Optional<Result> result = transaction.get(get);
@@ -187,11 +227,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     transaction.commit();
 
     // Assert
-    assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getInt(ACCOUNT_ID)).isEqualTo(0);
-    assertThat(result.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
-    assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE);
-    assertThat(result.get().getInt(SOME_COLUMN)).isEqualTo(0);
+    assertResult(2, 3, result);
   }
 
   @Test
@@ -226,24 +262,32 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
-    Get get =
-        Get.newBuilder(prepareGet(1, 1, namespace1, TABLE_1))
+    GetBuilder.BuildableGetFromExistingWithOngoingWhereAnd get =
+        Get.newBuilder(prepareGet(1, 2, namespace1, TABLE_1))
             .where(ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-            .and(ConditionBuilder.column(SOME_COLUMN).isEqualToInt(1))
-            .build();
+            .and(ConditionBuilder.column(SOME_COLUMN).isEqualToInt(2))
+            .and(ConditionBuilder.column(BOOLEAN_COL).isNotEqualToBoolean(true))
+            .and(ConditionBuilder.column(BIGINT_COL).isLessThanBigInt(BigIntColumn.MAX_VALUE))
+            .and(ConditionBuilder.column(FLOAT_COL).isEqualToFloat(0.12F))
+            .and(ConditionBuilder.column(DOUBLE_COL).isGreaterThanDouble(-10))
+            .and(ConditionBuilder.column(TEXT_COL).isNotEqualToText("foo"))
+            .and(ConditionBuilder.column(DATE_COL).isLessThanDate(LocalDate.of(3000, 1, 1)))
+            .and(ConditionBuilder.column(TIME_COL).isNotNullTime())
+            .and(ConditionBuilder.column(TIMESTAMPTZ_COL).isNotEqualToTimestampTZ(Instant.EPOCH));
+    if (isTimestampTypeSupported()) {
+      get.and(
+          ConditionBuilder.column(TIMESTAMP_COL)
+              .isGreaterThanOrEqualToTimestamp(LocalDateTime.of(1970, 1, 1, 1, 2)));
+    }
 
     // Act
-    Optional<Result> result = transaction.get(get);
+    Optional<Result> result = transaction.get(get.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
 
     // Assert
-    assertThat(result.isPresent()).isTrue();
-    assertThat(result.get().getInt(ACCOUNT_ID)).isEqualTo(1);
-    assertThat(result.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
-    assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE);
-    assertThat(result.get().getInt(SOME_COLUMN)).isEqualTo(1);
+    assertResult(1, 2, result);
   }
 
   @Test
@@ -283,20 +327,9 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
 
     // Assert
     assertThat(results.size()).isEqualTo(3);
-    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(1);
-    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
-    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
-    assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(0);
-
-    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(1);
-    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
-    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
-    assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(1);
-
-    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(1);
-    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
-    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
-    assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(2);
+    assertResult(1, 0, results.get(0));
+    assertResult(1, 1, results.get(1));
+    assertResult(1, 2, results.get(2));
   }
 
   @Test
@@ -531,15 +564,13 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         new ExpectedResultBuilder()
             .column(IntColumn.of(ACCOUNT_ID, 1))
             .column(IntColumn.of(ACCOUNT_TYPE, 2))
-            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
-            .column(IntColumn.of(SOME_COLUMN, 2))
+            .columns(prepareNonKeyColumns(1, 2))
             .build());
     expectedResults.add(
         new ExpectedResultBuilder()
             .column(IntColumn.of(ACCOUNT_ID, 2))
             .column(IntColumn.of(ACCOUNT_TYPE, 1))
-            .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
-            .column(IntColumn.of(SOME_COLUMN, 2))
+            .columns(prepareNonKeyColumns(2, 1))
             .build());
 
     // Act
@@ -557,19 +588,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   @Test
   public void putAndCommit_PutGivenForNonExisting_ShouldCreateRecord() throws TransactionException {
     // Arrange
-    int expected = INITIAL_BALANCE;
-    Put put =
+    PutBuilder.Buildable put =
         Put.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .build();
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(0, 0).forEach(put::value);
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    transaction.put(put);
+    transaction.put(put.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -581,28 +610,33 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.prepare();
     another.validate();
     another.commit();
-    assertThat(result.isPresent()).isTrue();
-    assertThat(getBalance(result.get())).isEqualTo(expected);
+
+    assertResult(0, 0, result);
   }
 
   @Test
   public void putAndCommit_PutGivenForExisting_ShouldUpdateRecord() throws TransactionException {
     // Arrange
-    populateRecords(manager1, namespace1, TABLE_1);
+    InsertBuilder.Buildable insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(2, 2).forEach(insert::value);
+    insert(insert.build());
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    int expected = INITIAL_BALANCE + 100;
-    Put put =
+    PutBuilder.Buildable put =
         Put.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
             .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .enableImplicitPreRead()
-            .build();
-    transaction.put(put);
+            .enableImplicitPreRead();
+    prepareNonKeyColumns(0, 0).forEach(put::value);
+    transaction.put(put.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -614,8 +648,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.validate();
     another.commit();
 
-    assertThat(actual.isPresent()).isTrue();
-    assertThat(getBalance(actual.get())).isEqualTo(expected);
+    assertResult(0, 0, actual);
   }
 
   @Test
@@ -849,18 +882,26 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   @Test
   public void mutateAndCommit_ShouldMutateRecordsProperly() throws TransactionException {
     // Arrange
-    populateRecords(manager1, namespace1, TABLE_1);
-    Put put =
-        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
-            .intValue(BALANCE, INITIAL_BALANCE - 100)
-            .enableImplicitPreRead()
-            .build();
-    Delete delete = prepareDelete(1, 0, namespace1, TABLE_1);
+    InsertBuilder.Buildable insertRecord1 =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(1, 1).forEach(insertRecord1::value);
+    Insert insertRecord2 = prepareInsert(1, 0, namespace1, TABLE_1);
+
+    insert(insertRecord1.build(), insertRecord2);
+
+    PutBuilder.Buildable putRecord1 =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).enableImplicitPreRead();
+    prepareNonKeyColumns(0, 0).forEach(putRecord1::value);
+    Delete deleteRecord2 = prepareDelete(1, 0, namespace1, TABLE_1);
 
     TwoPhaseCommitTransaction transaction = manager1.begin();
 
     // Act
-    transaction.mutate(Arrays.asList(put, delete));
+    transaction.mutate(Arrays.asList(putRecord1.build(), deleteRecord2));
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -873,8 +914,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.validate();
     another.commit();
 
-    assertThat(result1.isPresent()).isTrue();
-    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE - 100);
+    assertResult(0, 0, result1);
     assertThat(result2.isPresent()).isFalse();
   }
 
@@ -882,22 +922,28 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void mutateAndCommit_WithMultipleSubTransactions_ShouldMutateRecordsProperly()
       throws TransactionException {
     // Arrange
-    populateRecords(manager1, namespace1, TABLE_1);
-    populateRecords(manager2, namespace2, TABLE_2);
+    InsertBuilder.Buildable insertForTable1 =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(1, 1).forEach(insertForTable1::value);
+    Insert insertForTable2 = prepareInsert(1, 0, namespace2, TABLE_2);
 
-    Put put =
-        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
-            .intValue(BALANCE, INITIAL_BALANCE - 100)
-            .enableImplicitPreRead()
-            .build();
-    Delete delete = prepareDelete(1, 0, namespace2, TABLE_2);
+    insert(insertForTable1.build(), insertForTable2);
+
+    PutBuilder.Buildable putForTable1 =
+        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1)).enableImplicitPreRead();
+    prepareNonKeyColumns(0, 0).forEach(putForTable1::value);
+    Delete deleteForTable2 = prepareDelete(1, 0, namespace2, TABLE_2);
 
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     TwoPhaseCommitTransaction transaction2 = manager2.join(transaction1.getId());
 
     // Act
-    transaction1.put(put);
-    transaction2.delete(delete);
+    transaction1.put(putForTable1.build());
+    transaction2.delete(deleteForTable2);
 
     // Prepare
     transaction1.prepare();
@@ -929,8 +975,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another1.commit();
     another2.commit();
 
-    assertThat(result1.isPresent()).isTrue();
-    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE - 100);
+    assertResult(0, 0, result1);
     assertThat(result2.isPresent()).isFalse();
   }
 
@@ -1099,8 +1144,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
                                 new ExpectedResultBuilder()
                                     .column(IntColumn.of(ACCOUNT_ID, i))
                                     .column(IntColumn.of(ACCOUNT_TYPE, j))
-                                    .column(IntColumn.of(BALANCE, INITIAL_BALANCE))
-                                    .column(IntColumn.of(SOME_COLUMN, i * j))
+                                    .columns(prepareNonKeyColumns(i, j))
                                     .build())));
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
@@ -1110,20 +1154,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction putTransaction = manager1.begin();
-    putTransaction.put(
-        Arrays.asList(
-            new Put(Key.ofInt(ACCOUNT_ID, 1), Key.ofInt(ACCOUNT_TYPE, 1))
-                .forNamespace(namespace1)
-                .forTable(TABLE_1),
-            new Put(Key.ofInt(ACCOUNT_ID, 1), Key.ofInt(ACCOUNT_TYPE, 2))
-                .forNamespace(namespace1)
-                .forTable(TABLE_1),
-            new Put(Key.ofInt(ACCOUNT_ID, 2), Key.ofInt(ACCOUNT_TYPE, 1))
-                .forNamespace(namespace1)
-                .forTable(TABLE_1),
-            new Put(Key.ofInt(ACCOUNT_ID, 3), Key.ofInt(ACCOUNT_TYPE, 0))
-                .forNamespace(namespace1)
-                .forTable(TABLE_1)));
+    insert(
+        prepareInsert(1, 1, namespace1, TABLE_1),
+        prepareInsert(1, 2, namespace1, TABLE_1),
+        prepareInsert(2, 1, namespace1, TABLE_1),
+        prepareInsert(3, 0, namespace1, TABLE_1));
     putTransaction.prepare();
     putTransaction.validate();
     putTransaction.commit();
@@ -1144,26 +1179,22 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             new ExpectedResultBuilder()
                 .column(IntColumn.of(ACCOUNT_ID, 1))
                 .column(IntColumn.of(ACCOUNT_TYPE, 1))
-                .column(IntColumn.ofNull(BALANCE))
-                .column(IntColumn.ofNull(SOME_COLUMN))
+                .columns(prepareNonKeyColumns(1, 1))
                 .build(),
             new ExpectedResultBuilder()
                 .column(IntColumn.of(ACCOUNT_ID, 1))
                 .column(IntColumn.of(ACCOUNT_TYPE, 2))
-                .column(IntColumn.ofNull(BALANCE))
-                .column(IntColumn.ofNull(SOME_COLUMN))
+                .columns(prepareNonKeyColumns(1, 2))
                 .build(),
             new ExpectedResultBuilder()
                 .column(IntColumn.of(ACCOUNT_ID, 2))
                 .column(IntColumn.of(ACCOUNT_TYPE, 1))
-                .column(IntColumn.ofNull(BALANCE))
-                .column(IntColumn.ofNull(SOME_COLUMN))
+                .columns(prepareNonKeyColumns(2, 1))
                 .build(),
             new ExpectedResultBuilder()
                 .column(IntColumn.of(ACCOUNT_ID, 3))
                 .column(IntColumn.of(ACCOUNT_TYPE, 0))
-                .column(IntColumn.ofNull(BALANCE))
-                .column(IntColumn.ofNull(SOME_COLUMN))
+                .columns(prepareNonKeyColumns(3, 0))
                 .build()));
     assertThat(results).hasSize(2);
   }
@@ -1565,37 +1596,37 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   @Test
   public void put_withPutIfWithVerifiedCondition_shouldPutProperly() throws TransactionException {
     // Arrange
-    int someColumnValue = 10;
-    Put initialData =
-        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
-            .intValue(BALANCE, INITIAL_BALANCE)
-            .intValue(SOME_COLUMN, someColumnValue)
-            .build();
-    put(initialData);
+    PutBuilder.Buildable initialData = Put.newBuilder(preparePut(2, 3, namespace1, TABLE_1));
+    prepareNonKeyColumns(1, 2).forEach(initialData::value);
+    put(initialData.build());
 
-    int updatedBalance = 2;
-    Put putIf =
-        Put.newBuilder(initialData)
-            .intValue(BALANCE, updatedBalance)
-            .condition(
-                ConditionBuilder.putIf(
-                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
-                    .build())
-            .enableImplicitPreRead()
-            .build();
+    List<ConditionalExpression> conditions =
+        Lists.newArrayList(
+            ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE),
+            ConditionBuilder.column(SOME_COLUMN).isNotNullInt(),
+            ConditionBuilder.column(BOOLEAN_COL).isNotEqualToBoolean(true),
+            ConditionBuilder.column(BIGINT_COL).isLessThanBigInt(BigIntColumn.MAX_VALUE),
+            ConditionBuilder.column(FLOAT_COL).isEqualToFloat(0.12F),
+            ConditionBuilder.column(DOUBLE_COL).isGreaterThanDouble(-10),
+            ConditionBuilder.column(TEXT_COL).isNotEqualToText("foo"),
+            ConditionBuilder.column(DATE_COL).isLessThanDate(LocalDate.of(3000, 1, 1)),
+            ConditionBuilder.column(TIME_COL).isNotNullTime(),
+            ConditionBuilder.column(TIMESTAMPTZ_COL).isNotEqualToTimestampTZ(Instant.EPOCH));
+    if (isTimestampTypeSupported()) {
+      conditions.add(
+          ConditionBuilder.column(TIMESTAMP_COL)
+              .isGreaterThanOrEqualToTimestamp(LocalDateTime.of(1970, 1, 1, 1, 2)));
+    }
+    PutBuilder.Buildable putIf = Put.newBuilder(initialData.build()).clearValues();
+    prepareNonKeyColumns(2, 3).forEach(putIf::value);
+    putIf.condition(ConditionBuilder.putIf(conditions)).enableImplicitPreRead().build();
 
     // Act
-    put(putIf);
+    put(putIf.build());
 
     // Assert
-    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
-    assertThat(optResult.isPresent()).isTrue();
-    Result result = optResult.get();
-    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
-    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
-    assertThat(result.getInt(BALANCE)).isEqualTo(updatedBalance);
-    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(someColumnValue);
+    Optional<Result> optResult = get(prepareGet(2, 3, namespace1, TABLE_1));
+    assertResult(2, 3, optResult);
   }
 
   @Test
@@ -1745,26 +1776,33 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void delete_withDeleteIfWithVerifiedCondition_shouldDeleteProperly()
       throws TransactionException {
     // Arrange
-    Put initialData =
-        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
-            .intValue(BALANCE, INITIAL_BALANCE)
-            .build();
-    put(initialData);
+    PutBuilder.Buildable initialData = Put.newBuilder(preparePut(1, 2, namespace1, TABLE_1));
+    prepareNonKeyColumns(1, 2).forEach(initialData::value);
+    put(initialData.build());
+
+    List<ConditionalExpression> conditions =
+        Lists.newArrayList(
+            ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE),
+            ConditionBuilder.column(SOME_COLUMN).isNotNullInt(),
+            ConditionBuilder.column(BOOLEAN_COL).isNotEqualToBoolean(true),
+            ConditionBuilder.column(BIGINT_COL).isLessThanBigInt(BigIntColumn.MAX_VALUE),
+            ConditionBuilder.column(FLOAT_COL).isEqualToFloat(0.12F),
+            ConditionBuilder.column(DOUBLE_COL).isGreaterThanDouble(-10),
+            ConditionBuilder.column(TEXT_COL).isNotEqualToText("foo"),
+            ConditionBuilder.column(DATE_COL).isLessThanDate(LocalDate.of(3000, 1, 1)),
+            ConditionBuilder.column(TIME_COL).isNotNullTime(),
+            ConditionBuilder.column(TIMESTAMPTZ_COL).isNotEqualToTimestampTZ(Instant.EPOCH));
 
     Delete deleteIf =
-        Delete.newBuilder(prepareDelete(0, 0, namespace1, TABLE_1))
-            .condition(
-                ConditionBuilder.deleteIf(
-                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-                    .and(ConditionBuilder.column(SOME_COLUMN).isNullInt())
-                    .build())
+        Delete.newBuilder(prepareDelete(1, 2, namespace1, TABLE_1))
+            .condition(ConditionBuilder.deleteIf(conditions))
             .build();
 
     // Act
     delete(deleteIf);
 
     // Assert
-    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
+    Optional<Result> optResult = get(prepareGet(1, 2, namespace1, TABLE_1));
     assertThat(optResult.isPresent()).isFalse();
   }
 
@@ -1834,19 +1872,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void insertAndCommit_InsertGivenForNonExisting_ShouldCreateRecord()
       throws TransactionException {
     // Arrange
-    int expected = INITIAL_BALANCE;
-    Insert insert =
-        Insert.newBuilder()
-            .namespace(namespace1)
-            .table(TABLE_1)
-            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .build();
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    transaction.insert(insert);
+    transaction.insert(prepareInsert(0, 0, namespace1, TABLE_1));
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1858,8 +1887,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.prepare();
     another.validate();
     another.commit();
-    assertThat(result.isPresent()).isTrue();
-    assertThat(getBalance(result.get())).isEqualTo(expected);
+    assertResult(0, 0, result);
   }
 
   @Test
@@ -1897,19 +1925,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void upsertAndCommit_UpsertGivenForNonExisting_ShouldCreateRecord()
       throws TransactionException {
     // Arrange
-    int expected = INITIAL_BALANCE;
-    Upsert upsert =
+    UpsertBuilder.Buildable upsert =
         Upsert.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .build();
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(0, 0).forEach(upsert::value);
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    transaction.upsert(upsert);
+    transaction.upsert(upsert.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1921,28 +1947,32 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.prepare();
     another.validate();
     another.commit();
-    assertThat(result.isPresent()).isTrue();
-    assertThat(getBalance(result.get())).isEqualTo(expected);
+    assertResult(0, 0, result);
   }
 
   @Test
   public void upsertAndCommit_UpsertGivenForExisting_ShouldUpdateRecord()
       throws TransactionException {
     // Arrange
-    populateRecords(manager1, namespace1, TABLE_1);
+    InsertBuilder.Buildable insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(1, 1).forEach(insert::value);
+    insert(insert.build());
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    int expected = INITIAL_BALANCE + 100;
-    Upsert upsert =
+    UpsertBuilder.Buildable upsert =
         Upsert.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .build();
-    transaction.upsert(upsert);
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(0, 0).forEach(upsert::value);
+    transaction.upsert(upsert.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1955,7 +1985,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.commit();
 
     assertThat(actual.isPresent()).isTrue();
-    assertThat(getBalance(actual.get())).isEqualTo(expected);
+    assertResult(0, 0, actual);
   }
 
   @Test
@@ -2014,20 +2044,25 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void updateAndCommit_UpdateGivenForExisting_ShouldUpdateRecord()
       throws TransactionException {
     // Arrange
-    populateRecords(manager1, namespace1, TABLE_1);
+    InsertBuilder.Buildable insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(1, 1).forEach(insert::value);
+    insert(insert.build());
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    int expected = INITIAL_BALANCE + 100;
-    Update update =
+    UpdateBuilder.Buildable update =
         Update.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .build();
-    transaction.update(update);
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(0, 0).forEach(update::value);
+    transaction.update(update.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -2039,29 +2074,33 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.validate();
     another.commit();
 
-    assertThat(actual.isPresent()).isTrue();
-    assertThat(getBalance(actual.get())).isEqualTo(expected);
+    assertResult(0, 0, actual);
   }
 
   @Test
   public void updateAndCommit_UpdateWithUpdateIfExistsGivenForExisting_ShouldUpdateRecord()
       throws TransactionException {
     // Arrange
-    populateRecords(manager1, namespace1, TABLE_1);
+    InsertBuilder.Buildable insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0));
+    prepareNonKeyColumns(1, 1).forEach(insert::value);
+    insert(insert.build());
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    int expected = INITIAL_BALANCE + 100;
-    Update update =
+    UpdateBuilder.Buildable update =
         Update.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
             .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
             .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, expected)
-            .condition(ConditionBuilder.updateIfExists())
-            .build();
-    transaction.update(update);
+            .condition(ConditionBuilder.updateIfExists());
+    prepareNonKeyColumns(0, 0).forEach(update::value);
+    transaction.update(update.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -2073,53 +2112,59 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     another.validate();
     another.commit();
 
-    assertThat(actual.isPresent()).isTrue();
-    assertThat(getBalance(actual.get())).isEqualTo(expected);
+    assertResult(0, 0, actual);
   }
 
   @Test
   public void update_withUpdateIfWithVerifiedCondition_shouldUpdateProperly()
       throws TransactionException {
     // Arrange
-    int someColumnValue = 10;
-    Put initialData =
-        Put.newBuilder(preparePut(0, 0, namespace1, TABLE_1))
-            .intValue(BALANCE, INITIAL_BALANCE)
-            .intValue(SOME_COLUMN, someColumnValue)
-            .build();
-    put(initialData);
+    InsertBuilder.Buildable insert =
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 2))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 3));
+    prepareNonKeyColumns(1, 2).forEach(insert::value);
+    insert(insert.build());
 
-    int updatedBalance = 2;
-    Update updateIf =
+    List<ConditionalExpression> conditions =
+        Lists.newArrayList(
+            ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE),
+            ConditionBuilder.column(SOME_COLUMN).isNotNullInt(),
+            ConditionBuilder.column(BOOLEAN_COL).isNotEqualToBoolean(true),
+            ConditionBuilder.column(BIGINT_COL).isLessThanBigInt(BigIntColumn.MAX_VALUE),
+            ConditionBuilder.column(FLOAT_COL).isEqualToFloat(0.12F),
+            ConditionBuilder.column(DOUBLE_COL).isGreaterThanDouble(-10),
+            ConditionBuilder.column(TEXT_COL).isNotEqualToText("foo"),
+            ConditionBuilder.column(DATE_COL).isLessThanDate(LocalDate.of(3000, 1, 1)),
+            ConditionBuilder.column(TIME_COL).isNotNullTime(),
+            ConditionBuilder.column(TIMESTAMPTZ_COL).isNotEqualToTimestampTZ(Instant.EPOCH));
+    if (isTimestampTypeSupported()) {
+      conditions.add(
+          ConditionBuilder.column(TIMESTAMP_COL)
+              .isGreaterThanOrEqualToTimestamp(LocalDateTime.of(1970, 1, 1, 1, 2)));
+    }
+    UpdateBuilder.Buildable updateIf =
         Update.newBuilder()
             .namespace(namespace1)
             .table(TABLE_1)
-            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-            .intValue(BALANCE, updatedBalance)
-            .condition(
-                ConditionBuilder.updateIf(
-                        ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-                    .and(ConditionBuilder.column(SOME_COLUMN).isNotNullInt())
-                    .build())
-            .build();
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 2))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 3))
+            .condition(ConditionBuilder.updateIf(conditions));
+    prepareNonKeyColumns(2, 3).forEach(updateIf::value);
 
     TwoPhaseCommitTransaction transaction = manager1.start();
 
     // Act
-    transaction.update(updateIf);
+    transaction.update(updateIf.build());
     transaction.prepare();
     transaction.validate();
     transaction.commit();
 
     // Assert
-    Optional<Result> optResult = get(prepareGet(0, 0, namespace1, TABLE_1));
-    assertThat(optResult.isPresent()).isTrue();
-    Result result = optResult.get();
-    assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
-    assertThat(result.getInt(ACCOUNT_TYPE)).isEqualTo(0);
-    assertThat(result.getInt(BALANCE)).isEqualTo(updatedBalance);
-    assertThat(result.getInt(SOME_COLUMN)).isEqualTo(someColumnValue);
+    Optional<Result> actual = get(prepareGet(2, 3, namespace1, TABLE_1));
+    assertResult(2, 3, actual);
   }
 
   @Test
@@ -2652,6 +2697,21 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     }
   }
 
+  protected void insert(Insert... insert) throws TransactionException {
+    TwoPhaseCommitTransaction tx = manager1.start();
+    try {
+      for (Insert i : insert) {
+        tx.insert(i);
+      }
+      tx.prepare();
+      tx.validate();
+      tx.commit();
+    } catch (TransactionException e) {
+      tx.rollback();
+      throw e;
+    }
+  }
+
   private void delete(Delete delete) throws TransactionException {
     TwoPhaseCommitTransaction tx = manager1.start();
     try {
@@ -2669,29 +2729,24 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       TwoPhaseCommitTransactionManager manager1, String namespaceName, String tableName)
       throws TransactionException {
     TwoPhaseCommitTransaction transaction = manager1.begin();
-    IntStream.range(0, NUM_ACCOUNTS)
-        .forEach(
-            i ->
-                IntStream.range(0, NUM_TYPES)
-                    .forEach(
-                        j -> {
-                          Key partitionKey = Key.ofInt(ACCOUNT_ID, i);
-                          Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, j);
-                          Put put =
-                              Put.newBuilder()
-                                  .namespace(namespaceName)
-                                  .table(tableName)
-                                  .partitionKey(partitionKey)
-                                  .clusteringKey(clusteringKey)
-                                  .intValue(BALANCE, INITIAL_BALANCE)
-                                  .intValue(SOME_COLUMN, i * j)
-                                  .build();
-                          try {
-                            transaction.put(put);
-                          } catch (CrudException e) {
-                            throw new RuntimeException(e);
-                          }
-                        }));
+    for (int i = 0; i < NUM_ACCOUNTS; i++) {
+      for (int j = 0; j < NUM_TYPES; j++) {
+        Key partitionKey = Key.ofInt(ACCOUNT_ID, i);
+        Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, j);
+        InsertBuilder.Buildable insert =
+            Insert.newBuilder()
+                .namespace(namespaceName)
+                .table(tableName)
+                .partitionKey(partitionKey)
+                .clusteringKey(clusteringKey);
+        prepareNonKeyColumns(i, j).forEach(insert::value);
+        try {
+          transaction.insert(insert.build());
+        } catch (CrudException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -2764,6 +2819,20 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         .withConsistency(Consistency.LINEARIZABLE);
   }
 
+  protected Insert prepareInsert(int id, int type, String namespaceName, String tableName) {
+    Key partitionKey = Key.ofInt(ACCOUNT_ID, id);
+    Key clusteringKey = Key.ofInt(ACCOUNT_TYPE, type);
+    InsertBuilder.Buildable insert =
+        Insert.newBuilder()
+            .namespace(namespaceName)
+            .table(tableName)
+            .partitionKey(partitionKey)
+            .clusteringKey(clusteringKey);
+    prepareNonKeyColumns(id, type).forEach(insert::value);
+
+    return insert.build();
+  }
+
   protected List<Put> preparePuts(String namespaceName, String tableName) {
     List<Put> puts = new ArrayList<>();
     IntStream.range(0, NUM_ACCOUNTS)
@@ -2788,5 +2857,119 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     Optional<Value<?>> balance = result.getValue(BALANCE);
     assertThat(balance).isPresent();
     return balance.get().getAsInt();
+  }
+
+  protected boolean isTimestampTypeSupported() {
+    return true;
+  }
+
+  private void assertResult(int accountId, int accountType, Optional<Result> optResult) {
+    assertResult(accountId, accountType, optResult.orElse(null));
+  }
+
+  private void assertResult(int accountId, int accountType, Result result) {
+    String resultErrorMessage =
+        String.format("Result { accountId=%d, accountType=%d }", accountId, accountType);
+
+    assertThat(result).describedAs(resultErrorMessage + " is null").isNotNull();
+
+    List<String> columns =
+        Lists.newArrayList(
+            ACCOUNT_ID,
+            ACCOUNT_TYPE,
+            BALANCE,
+            SOME_COLUMN,
+            BOOLEAN_COL,
+            BIGINT_COL,
+            FLOAT_COL,
+            DOUBLE_COL,
+            TEXT_COL,
+            BLOB_COL,
+            DATE_COL,
+            TIME_COL,
+            TIMESTAMPTZ_COL);
+    if (isTimestampTypeSupported()) {
+      columns.add(TIMESTAMP_COL);
+    }
+    assertThat(result.getContainedColumnNames())
+        .describedAs("Columns are missing. %s", resultErrorMessage)
+        .containsExactlyInAnyOrderElementsOf(columns);
+    for (String column : columns) {
+      assertThat(result.isNull(column))
+          .describedAs("Column {%s} is null. %s", column, resultErrorMessage)
+          .isFalse();
+    }
+
+    String columnMessage = "Unexpected value for column {%s}. %s";
+    assertThat(result.getInt(ACCOUNT_ID))
+        .describedAs(columnMessage, ACCOUNT_ID, resultErrorMessage)
+        .isEqualTo(accountId);
+    assertThat(result.getInt(ACCOUNT_TYPE))
+        .describedAs(columnMessage, ACCOUNT_TYPE, resultErrorMessage)
+        .isEqualTo(accountType);
+    assertThat(result.getInt(BALANCE))
+        .describedAs(columnMessage, BALANCE, resultErrorMessage)
+        .isEqualTo(INITIAL_BALANCE);
+    assertThat(result.getInt(SOME_COLUMN))
+        .describedAs(columnMessage, SOME_COLUMN, resultErrorMessage)
+        .isEqualTo(accountId * accountType);
+    assertThat(result.getBoolean(BOOLEAN_COL))
+        .describedAs(columnMessage, BOOLEAN_COL, resultErrorMessage)
+        .isEqualTo(accountId % 2 == 0);
+    assertThat(result.getBigInt(BIGINT_COL))
+        .describedAs(columnMessage, BIGINT_COL, resultErrorMessage)
+        .isEqualTo((long) Math.pow(accountId, accountType));
+    assertThat(result.getFloat(FLOAT_COL))
+        .describedAs(columnMessage, FLOAT_COL, resultErrorMessage)
+        .isEqualTo(Float.parseFloat("0." + accountId + accountType));
+    assertThat(result.getDouble(DOUBLE_COL))
+        .describedAs(columnMessage, DOUBLE_COL, resultErrorMessage)
+        .isEqualTo(Float.parseFloat("10." + accountId + accountType));
+    assertThat(result.getText(TEXT_COL))
+        .describedAs(columnMessage, TEXT_COL, resultErrorMessage)
+        .isEqualTo(accountId + "" + accountType);
+    assertThat(result.getBlobAsBytes(BLOB_COL))
+        .describedAs(columnMessage, BLOB_COL, resultErrorMessage)
+        .isEqualTo((accountId + "" + accountType).getBytes(StandardCharsets.UTF_8));
+    assertThat(result.getDate(DATE_COL))
+        .describedAs(columnMessage, DATE_COL, resultErrorMessage)
+        .isEqualTo(LocalDate.ofEpochDay(accountId + accountType));
+    assertThat(result.getTime(TIME_COL))
+        .describedAs(columnMessage, TIME_COL, resultErrorMessage)
+        .isEqualTo(LocalTime.of(accountId, accountType));
+    assertThat(result.getTimestampTZ(TIMESTAMPTZ_COL))
+        .describedAs(columnMessage, TIMESTAMPTZ_COL, resultErrorMessage)
+        .isEqualTo(LocalDateTime.of(1970, 1, 1, accountId, accountType).toInstant(ZoneOffset.UTC));
+    if (isTimestampTypeSupported()) {
+      assertThat(result.getTimestamp(TIMESTAMP_COL))
+          .describedAs(columnMessage, TIMESTAMP_COL, resultErrorMessage)
+          .isEqualTo(LocalDateTime.of(1970, 1, 1, accountId, accountType));
+    }
+  }
+
+  protected List<Column<?>> prepareNonKeyColumns(int accountId, int accountType) {
+    ImmutableList.Builder<Column<?>> columns =
+        new ImmutableList.Builder<Column<?>>()
+            .add(
+                IntColumn.of(BALANCE, INITIAL_BALANCE),
+                IntColumn.of(SOME_COLUMN, accountId * accountType),
+                BooleanColumn.of(BOOLEAN_COL, accountId % 2 == 0),
+                BigIntColumn.of(BIGINT_COL, (long) Math.pow(accountId, accountType)),
+                FloatColumn.of(FLOAT_COL, Float.parseFloat("0." + accountId + accountType)),
+                DoubleColumn.of(DOUBLE_COL, Float.parseFloat("10." + accountId + accountType)),
+                TextColumn.of(TEXT_COL, accountId + "" + accountType),
+                BlobColumn.of(
+                    BLOB_COL, (accountId + "" + accountType).getBytes(StandardCharsets.UTF_8)),
+                DateColumn.of(DATE_COL, LocalDate.ofEpochDay(accountId + accountType)),
+                TimeColumn.of(TIME_COL, LocalTime.of(accountId, accountType)),
+                TimestampTZColumn.of(
+                    TIMESTAMPTZ_COL,
+                    LocalDateTime.of(1970, 1, 1, accountId, accountType)
+                        .toInstant(ZoneOffset.UTC)));
+    if (isTimestampTypeSupported()) {
+      columns.add(
+          TimestampColumn.of(TIMESTAMP_COL, LocalDateTime.of(1970, 1, 1, accountId, accountType)));
+    }
+    return columns.build();
   }
 }


### PR DESCRIPTION
## Description

This PR:
- updates key integration tests of `TwoPhaseCommitTransactionIntegrationTestBase` to performs operations on a table with all the data types. Similar changes were made to `DistributedTransactionIntegrationTestBase` in https://github.com/scalar-labs/scalardb/pull/2437
- does small fixes in `DistributedStorageColumnValueIntegrationTestBase` and `DistributedStorageAdminIntegrationTestBase`

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2437

## Changes made

See the description above.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)


This PR will be merged into the feature branch https://github.com/scalar-labs/scalardb/compare/master...add_time_related_types

## Release notes

N/A
