### PR TITLE
Fix missing unit tests for MariaDB RdbEngine

### DIFF
--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTest.java
@@ -83,7 +83,9 @@ public class JdbcAdminTest {
           RdbEngine.SQLITE,
           new RdbEngineSqlite(),
           RdbEngine.YUGABYTE,
-          new RdbEngineYugabyte());
+          new RdbEngineYugabyte(),
+          RdbEngine.MARIADB,
+          new RdbEngineMariaDB());
 
   @Mock private BasicDataSource dataSource;
   @Mock private Connection connection;
@@ -119,6 +121,7 @@ public class JdbcAdminTest {
   private void mockUndefinedTableError(RdbEngine rdbEngine, SQLException sqlException) {
     switch (rdbEngine) {
       case MYSQL:
+      case MARIADB:
         when(sqlException.getErrorCode()).thenReturn(1049);
         break;
       case POSTGRESQL:
@@ -3450,6 +3453,7 @@ public class JdbcAdminTest {
       case SQL_SERVER:
       case MYSQL:
       case ORACLE:
+      case MARIADB:
         duplicateKeyException = mock(SQLException.class);
         when(duplicateKeyException.getSQLState()).thenReturn("23000");
         break;

--- a/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngine.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/RdbEngine.java
@@ -11,7 +11,8 @@ public enum RdbEngine {
   ORACLE,
   SQL_SERVER,
   SQLITE,
-  YUGABYTE;
+  YUGABYTE,
+  MARIADB;
 
   public static RdbEngineStrategy createRdbEngineStrategy(RdbEngine rdbEngine) {
     switch (rdbEngine) {
@@ -27,6 +28,8 @@ public enum RdbEngine {
         return new RdbEngineSqlite();
       case YUGABYTE:
         return new RdbEngineYugabyte();
+      case MARIADB:
+        return new RdbEngineMariaDB();
       default:
         throw new AssertionError();
     }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/query/QueryBuilderTest.java
@@ -334,6 +334,7 @@ public class QueryBuilderTest {
       case MYSQL:
       case POSTGRESQL:
       case YUGABYTE:
+      case MARIADB:
         expectedQuery =
             "SELECT c1,c2 FROM n1.t1 WHERE p1=? AND c1>=? AND c1<=? "
                 + "ORDER BY c1 ASC,c2 DESC LIMIT 10";
@@ -1300,6 +1301,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery =
             "INSERT INTO n1.t1 (p1,v1,v2,v3) VALUES (?,?,?,?)"
                 + " ON DUPLICATE KEY UPDATE v1=?,v2=?,v3=?";
@@ -1340,6 +1342,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "v1Value");
         verify(preparedStatement).setString(3, "v2Value");
@@ -1364,6 +1367,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery =
             "INSERT INTO n1.t1 (p1,c1,v1,v2,v3) VALUES (?,?,?,?,?)"
                 + " ON DUPLICATE KEY UPDATE v1=?,v2=?,v3=?";
@@ -1406,6 +1410,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "c1Value");
         verify(preparedStatement).setString(3, "v1Value");
@@ -1434,6 +1439,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery =
             "INSERT INTO n1.t1 (p1,p2,c1,c2,v1,v2,v3,v4) VALUES (?,?,?,?,?,?,?,?)"
                 + " ON DUPLICATE KEY UPDATE v1=?,v2=?,v3=?,v4=?";
@@ -1480,6 +1486,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");
         verify(preparedStatement).setString(3, "c1Value");
@@ -1518,6 +1525,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery =
             "INSERT INTO n1.t1 (p1,p2,c1,c2,v1,v2,v3,v4,v5) VALUES (?,?,?,?,?,?,?,?,?)"
                 + " ON DUPLICATE KEY UPDATE v1=?,v2=?,v3=?,v4=?,v5=?";
@@ -1565,6 +1573,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");
         verify(preparedStatement).setString(3, "c1Value");
@@ -1617,6 +1626,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery = "INSERT IGNORE INTO n1.t1 (p1) VALUES (?)";
         break;
       case POSTGRESQL:
@@ -1649,6 +1659,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         break;
       case ORACLE:
@@ -1661,6 +1672,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery = "INSERT IGNORE INTO n1.t1 (p1,c1) VALUES (?,?)";
         break;
       case POSTGRESQL:
@@ -1698,6 +1710,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "c1Value");
         break;
@@ -1713,6 +1726,7 @@ public class QueryBuilderTest {
     preparedStatement = mock(PreparedStatement.class);
     switch (rdbEngineType) {
       case MYSQL:
+      case MARIADB:
         expectedQuery = "INSERT IGNORE INTO n1.t1 (p1,p2,c1,c2) VALUES (?,?,?,?)";
         break;
       case POSTGRESQL:
@@ -1754,6 +1768,7 @@ public class QueryBuilderTest {
       case POSTGRESQL:
       case SQLITE:
       case YUGABYTE:
+      case MARIADB:
         verify(preparedStatement).setString(1, "p1Value");
         verify(preparedStatement).setString(2, "p2Value");
         verify(preparedStatement).setString(3, "c1Value");


### PR DESCRIPTION
## Description

When adding the MariaDB driver in https://github.com/scalar-labs/scalardb/pull/2391, I forgot to modify some unit test related to the `RdbEngineMariaDB` class. 

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2391

## Changes made

Add missing unit test change to test the `RdbEngineMariaDB` class fully.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A