### PR TITLE
Add name to NamespacePolicy and TablePolicy

### DIFF
--- a/core/src/main/java/com/scalar/db/api/AbacAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/AbacAdmin.java
@@ -339,51 +339,48 @@ public interface AbacAdmin {
   }
 
   /**
-   * Applies the given policy to the given namespace.
+   * Creates a namespace policy with the given policy and the given namespace.
    *
+   * @param namespacePolicyName the namespace policy name
    * @param policyName the policy name
    * @param namespaceName the namespace name
    * @throws ExecutionException if the operation fails
    */
-  default void applyPolicyToNamespace(String policyName, String namespaceName)
+  default void createNamespacePolicy(
+      String namespacePolicyName, String policyName, String namespaceName)
       throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
   /**
-   * Enables the given policy for the given namespace.
+   * Enables a namespace policy that has the given name.
    *
-   * @param policyName the policy name
-   * @param namespaceName the namespace name
+   * @param namespacePolicyName the namespace policy name
    * @throws ExecutionException if the operation fails
    */
-  default void enableNamespacePolicy(String policyName, String namespaceName)
-      throws ExecutionException {
+  default void enableNamespacePolicy(String namespacePolicyName) throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
   /**
-   * Disables the given policy for the given namespace.
+   * Disables a namespace policy that has the given name.
    *
-   * @param policyName the policy name
-   * @param namespaceName the namespace name
+   * @param namespacePolicyName the namespace policy name
    * @throws ExecutionException if the operation fails
    */
-  default void disableNamespacePolicy(String policyName, String namespaceName)
-      throws ExecutionException {
+  default void disableNamespacePolicy(String namespacePolicyName) throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
   /**
-   * Retrieves the namespace policy for the given namespace.
+   * Retrieves a namespace policy that has the given name.
    *
-   * @param policyName the policy name
-   * @param namespaceName the namespace name
+   * @param namespacePolicyName the namespace policy name
    * @return the namespace policy. If the policy is not applied to the namespace, returns an empty
    *     optional
    * @throws ExecutionException if the operation fails
    */
-  default Optional<NamespacePolicy> getNamespacePolicy(String policyName, String namespaceName)
+  default Optional<NamespacePolicy> getNamespacePolicy(String namespacePolicyName)
       throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
@@ -399,55 +396,48 @@ public interface AbacAdmin {
   }
 
   /**
-   * Applies the given policy to the given table of the given namespace.
+   * Creates a table policy with the given policy and the given table.
    *
+   * @param tablePolicyName the table policy name
    * @param policyName the policy name
    * @param namespaceName the namespace name
    * @param tableName the table name
    * @throws ExecutionException if the operation fails
    */
-  default void applyPolicyToTable(String policyName, String namespaceName, String tableName)
+  default void createTablePolicy(
+      String tablePolicyName, String policyName, String namespaceName, String tableName)
       throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
   /**
-   * Enables the given policy of the given table of the given namespace.
+   * Enables a table policy that has the given name.
    *
-   * @param policyName the policy name
-   * @param namespaceName the namespace name
-   * @param tableName the table name
+   * @param tablePolicyName the table policy name
    * @throws ExecutionException if the operation fails
    */
-  default void enableTablePolicy(String policyName, String namespaceName, String tableName)
-      throws ExecutionException {
+  default void enableTablePolicy(String tablePolicyName) throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
   /**
-   * Disables the given policy of the given table of the given namespace.
+   * Disables a table policy that has the given name.
    *
-   * @param policyName the policy name
-   * @param namespaceName the namespace name
-   * @param tableName the table name
+   * @param tablePolicyName the table policy name
    * @throws ExecutionException if the operation fails
    */
-  default void disableTablePolicy(String policyName, String namespaceName, String tableName)
-      throws ExecutionException {
+  default void disableTablePolicy(String tablePolicyName) throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
   /**
-   * Retrieves the table policy for the given table of the given namespace.
+   * Retrieves a table policy that has the given name.
    *
-   * @param policyName the policy name
-   * @param namespaceName the namespace name
-   * @param tableName the table name
+   * @param tablePolicyName the table policy name
    * @return the table policy. If the policy is not applied to the table, returns an empty optional
    * @throws ExecutionException if the operation fails
    */
-  default Optional<TablePolicy> getTablePolicy(
-      String policyName, String namespaceName, String tableName) throws ExecutionException {
+  default Optional<TablePolicy> getTablePolicy(String tablePolicyName) throws ExecutionException {
     throw new UnsupportedOperationException(CoreError.ABAC_NOT_ENABLED.buildMessage());
   }
 
@@ -732,6 +722,13 @@ public interface AbacAdmin {
   /** The namespace policy. */
   interface NamespacePolicy {
     /**
+     * Returns the namespace policy name.
+     *
+     * @return the namespace policy name
+     */
+    String getName();
+
+    /**
      * Returns the policy name.
      *
      * @return the policy name
@@ -755,6 +752,13 @@ public interface AbacAdmin {
 
   /** The table policy. */
   interface TablePolicy {
+    /**
+     * Returns the table policy name.
+     *
+     * @return the table policy name
+     */
+    String getName();
+
     /**
      * Returns the policy name.
      *

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -492,27 +492,27 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
-  public void applyPolicyToNamespace(String policyName, String namespaceName)
+  public void createNamespacePolicy(
+      String namespacePolicyName, String policyName, String namespaceName)
       throws ExecutionException {
-    distributedTransactionAdmin.applyPolicyToNamespace(policyName, namespaceName);
+    distributedTransactionAdmin.createNamespacePolicy(
+        namespacePolicyName, policyName, namespaceName);
   }
 
   @Override
-  public void enableNamespacePolicy(String policyName, String namespaceName)
-      throws ExecutionException {
-    distributedTransactionAdmin.enableNamespacePolicy(policyName, namespaceName);
+  public void enableNamespacePolicy(String namespacePolicyName) throws ExecutionException {
+    distributedTransactionAdmin.enableNamespacePolicy(namespacePolicyName);
   }
 
   @Override
-  public void disableNamespacePolicy(String policyName, String namespaceName)
-      throws ExecutionException {
-    distributedTransactionAdmin.disableNamespacePolicy(policyName, namespaceName);
+  public void disableNamespacePolicy(String namespacePolicyName) throws ExecutionException {
+    distributedTransactionAdmin.disableNamespacePolicy(namespacePolicyName);
   }
 
   @Override
-  public Optional<NamespacePolicy> getNamespacePolicy(String policyName, String namespaceName)
+  public Optional<NamespacePolicy> getNamespacePolicy(String namespacePolicyName)
       throws ExecutionException {
-    return distributedTransactionAdmin.getNamespacePolicy(policyName, namespaceName);
+    return distributedTransactionAdmin.getNamespacePolicy(namespacePolicyName);
   }
 
   @Override
@@ -521,27 +521,26 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
-  public void applyPolicyToTable(String policyName, String namespaceName, String tableName)
+  public void createTablePolicy(
+      String tablePolicyName, String policyName, String namespaceName, String tableName)
       throws ExecutionException {
-    distributedTransactionAdmin.applyPolicyToTable(policyName, namespaceName, tableName);
+    distributedTransactionAdmin.createTablePolicy(
+        tablePolicyName, policyName, namespaceName, tableName);
   }
 
   @Override
-  public void enableTablePolicy(String policyName, String namespaceName, String tableName)
-      throws ExecutionException {
-    distributedTransactionAdmin.enableTablePolicy(policyName, namespaceName, tableName);
+  public void enableTablePolicy(String tablePolicyName) throws ExecutionException {
+    distributedTransactionAdmin.enableTablePolicy(tablePolicyName);
   }
 
   @Override
-  public void disableTablePolicy(String policyName, String namespaceName, String tableName)
-      throws ExecutionException {
-    distributedTransactionAdmin.disableTablePolicy(policyName, namespaceName, tableName);
+  public void disableTablePolicy(String tablePolicyName) throws ExecutionException {
+    distributedTransactionAdmin.disableTablePolicy(tablePolicyName);
   }
 
   @Override
-  public Optional<TablePolicy> getTablePolicy(
-      String policyName, String namespaceName, String tableName) throws ExecutionException {
-    return distributedTransactionAdmin.getTablePolicy(policyName, namespaceName, tableName);
+  public Optional<TablePolicy> getTablePolicy(String tablePolicyName) throws ExecutionException {
+    return distributedTransactionAdmin.getTablePolicy(tablePolicyName);
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR adds a name to `AbacAdmin.NamespacePolicy` and `AbacAdmin.TablePolicy`. Additionally, it modifies some method names and signatures of `AbacAdmin` accordingly.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2405

## Changes made

- 

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
