### PR TITLE
Add importTable without overrideColumnsType to DecoratedDistributedTransactionAdmin

### DIFF
--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -196,6 +196,12 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
+  public void importTable(String namespace, String table, Map<String, String> options)
+      throws ExecutionException {
+    distributedTransactionAdmin.importTable(namespace, table, options);
+  }
+
+  @Override
   public void importTable(
       String namespace,
       String table,


### PR DESCRIPTION
## Description

This PR adds the `importTable` method without the `overrideColumnsType` argument to `DecoratedDistributedTransactionAdmin`.

## Related issues and/or PRs

N/A

## Changes made

Add the `importTable` method without the `overrideColumnsType` argument to `DecoratedDistributedTransactionAdmin`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
