### PR TITLE
Remove unused table added by mistake from integration test

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -67,7 +67,6 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   protected static final String NAMESPACE_BASE_NAME = "int_test_";
   protected static final String TABLE = "test_table";
-  protected static final String TABLE_2 = "test_table_2";
   protected static final String ACCOUNT_ID = "account_id";
   protected static final String ACCOUNT_TYPE = "account_type";
   protected static final String BALANCE = "balance";
@@ -138,7 +137,6 @@ public abstract class DistributedTransactionIntegrationTestBase {
     admin.createCoordinatorTables(true, options);
     admin.createNamespace(namespace, true, options);
     admin.createTable(namespace, TABLE, tableMetadata.build(), true, options);
-    admin.createTable(namespace, TABLE_2, tableMetadata.build(), true, options);
   }
 
   protected Map<String, String> getCreationOptions() {
@@ -148,7 +146,6 @@ public abstract class DistributedTransactionIntegrationTestBase {
   @BeforeEach
   public void setUp() throws Exception {
     admin.truncateTable(namespace, TABLE);
-    admin.truncateTable(namespace, TABLE_2);
     admin.truncateCoordinatorTables();
   }
 
@@ -179,7 +176,6 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
   private void dropTables() throws ExecutionException {
     admin.dropTable(namespace, TABLE);
-    admin.dropTable(namespace, TABLE_2);
     admin.dropNamespace(namespace);
     admin.dropCoordinatorTables();
   }


### PR DESCRIPTION
## Description

This removes a table added by mistake in https://github.com/scalar-labs/scalardb/pull/2474 for debugging purposes.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2474

## Changes made

Remove an unused table from `DistributedTransactionAdminIntegrationTestBase`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
