### PR TITLE
Backport to branch(3.15) : Change DATE type encoding to integer

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/ResultInterpreter.java
@@ -98,8 +98,7 @@ public class ResultInterpreter {
         return recordValue == null
             ? DateColumn.ofNull(name)
             : DateColumn.of(
-                name,
-                TimeRelatedColumnEncodingUtils.decodeDate(((Number) recordValue).longValue()));
+                name, TimeRelatedColumnEncodingUtils.decodeDate(((Number) recordValue).intValue()));
       case TIME:
         return recordValue == null
             ? TimeColumn.ofNull(name)

--- a/core/src/main/java/com/scalar/db/storage/dynamo/ResultInterpreter.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/ResultInterpreter.java
@@ -81,7 +81,7 @@ public class ResultInterpreter {
         return isNull
             ? DateColumn.ofNull(name)
             : DateColumn.of(
-                name, TimeRelatedColumnEncodingUtils.decodeDate(Long.parseLong(itemValue.n())));
+                name, TimeRelatedColumnEncodingUtils.decodeDate(Integer.parseInt(itemValue.n())));
       case TIME:
         return isNull
             ? TimeColumn.ofNull(name)

--- a/core/src/main/java/com/scalar/db/storage/dynamo/bytes/BytesUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/bytes/BytesUtils.java
@@ -112,12 +112,20 @@ public final class BytesUtils {
   }
 
   static void encodeLong(long value, Order order, ByteBuffer dst) {
-    dst.put(
-        mask((byte) ((value >> 56) ^ 0x80), order)); // Flip a sign bit to make it binary comparable
+    // Flip a sign bit to make it binary comparable
+    dst.put(mask((byte) ((value >> 56) ^ 0x80), order));
     dst.put(mask((byte) (value >> 48), order));
     dst.put(mask((byte) (value >> 40), order));
     dst.put(mask((byte) (value >> 32), order));
     dst.put(mask((byte) (value >> 24), order));
+    dst.put(mask((byte) (value >> 16), order));
+    dst.put(mask((byte) (value >> 8), order));
+    dst.put(mask((byte) value, order));
+  }
+
+  static void encodeInt(int value, Order order, ByteBuffer dst) {
+    // Flip a sign bit to make it binary comparable
+    dst.put(mask((byte) ((value >> 24) ^ 0x80), order));
     dst.put(mask((byte) (value >> 16), order));
     dst.put(mask((byte) (value >> 8), order));
     dst.put(mask((byte) value, order));

--- a/core/src/main/java/com/scalar/db/storage/dynamo/bytes/DateBytesEncoder.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/bytes/DateBytesEncoder.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.dynamo.bytes;
 
-import static com.scalar.db.storage.dynamo.bytes.BytesUtils.encodeLong;
+import static com.scalar.db.storage.dynamo.bytes.BytesUtils.encodeInt;
 
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.io.DateColumn;
@@ -17,14 +17,14 @@ public class DateBytesEncoder implements BytesEncoder<DateColumn> {
   public int encodedLength(DateColumn column, Order order) {
     assert column.getValue().isPresent();
 
-    return 8;
+    return 4;
   }
 
   @Override
   public void encode(DateColumn column, Order order, ByteBuffer dst) {
     assert column.getValue().isPresent();
 
-    long value = TimeRelatedColumnEncodingUtils.encode(column);
-    encodeLong(value, order, dst);
+    int value = TimeRelatedColumnEncodingUtils.encode(column);
+    encodeInt(value, order, dst);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/dynamo/bytes/IntBytesEncoder.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/bytes/IntBytesEncoder.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.dynamo.bytes;
 
-import static com.scalar.db.storage.dynamo.bytes.BytesUtils.mask;
+import static com.scalar.db.storage.dynamo.bytes.BytesUtils.encodeInt;
 
 import com.scalar.db.api.Scan.Ordering.Order;
 import com.scalar.db.io.IntColumn;
@@ -22,9 +22,6 @@ public class IntBytesEncoder implements BytesEncoder<IntColumn> {
     assert !column.hasNullValue();
 
     int v = column.getIntValue();
-    dst.put(mask((byte) ((v >> 24) ^ 0x80), order)); // Flip a sign bit to make it binary comparable
-    dst.put(mask((byte) (v >> 16), order));
-    dst.put(mask((byte) (v >> 8), order));
-    dst.put(mask((byte) v, order));
+    encodeInt(v, order, dst);
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -89,9 +89,9 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
       case BOOLEAN:
         return "BOOLEAN";
       case INT:
+      case DATE:
         return "INT";
       case BIGINT:
-      case DATE:
       case TIME:
       case TIMESTAMP:
       case TIMESTAMPTZ:
@@ -120,8 +120,8 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
       case BOOLEAN:
         return Types.BOOLEAN;
       case INT:
-        return Types.INTEGER;
       case DATE:
+        return Types.INTEGER;
       case TIME:
       case TIMESTAMP:
       case TIMESTAMPTZ:
@@ -306,7 +306,7 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
   @Override
   public DateColumn parseDateColumn(ResultSet resultSet, String columnName) throws SQLException {
     return DateColumn.of(
-        columnName, TimeRelatedColumnEncodingUtils.decodeDate(resultSet.getLong(columnName)));
+        columnName, TimeRelatedColumnEncodingUtils.decodeDate(resultSet.getInt(columnName)));
   }
 
   @Override
@@ -331,7 +331,7 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
-  public RdbEngineTimeTypeStrategy<Long, Long, Long, Long> getTimeTypeStrategy() {
+  public RdbEngineTimeTypeStrategy<Integer, Long, Long, Long> getTimeTypeStrategy() {
     return timeTypeEngine;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineTimeTypeSqlite.java
@@ -6,10 +6,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
-public class RdbEngineTimeTypeSqlite implements RdbEngineTimeTypeStrategy<Long, Long, Long, Long> {
+public class RdbEngineTimeTypeSqlite
+    implements RdbEngineTimeTypeStrategy<Integer, Long, Long, Long> {
 
   @Override
-  public Long convert(LocalDate date) {
+  public Integer convert(LocalDate date) {
     return TimeRelatedColumnEncodingUtils.encode(date);
   }
 

--- a/core/src/main/java/com/scalar/db/util/TimeRelatedColumnEncodingUtils.java
+++ b/core/src/main/java/com/scalar/db/util/TimeRelatedColumnEncodingUtils.java
@@ -17,16 +17,16 @@ import java.time.ZoneOffset;
 public final class TimeRelatedColumnEncodingUtils {
   private TimeRelatedColumnEncodingUtils() {}
 
-  public static long encode(DateColumn column) {
+  public static int encode(DateColumn column) {
     assert column.getDateValue() != null;
     return encode(column.getDateValue());
   }
 
-  public static long encode(LocalDate date) {
-    return date.toEpochDay();
+  public static int encode(LocalDate date) {
+    return Math.toIntExact(date.toEpochDay());
   }
 
-  public static LocalDate decodeDate(long epochDay) {
+  public static LocalDate decodeDate(int epochDay) {
     return LocalDate.ofEpochDay(epochDay);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/TimeRelatedColumnEncodingUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/TimeRelatedColumnEncodingUtilsTest.java
@@ -26,10 +26,25 @@ class TimeRelatedColumnEncodingUtilsTest {
     DateColumn column = DateColumn.of("date", LocalDate.of(2023, 10, 1));
 
     // Act
-    long encoded = TimeRelatedColumnEncodingUtils.encode(column);
+    int encoded = TimeRelatedColumnEncodingUtils.encode(column);
 
     // Assert
     assertThat(encoded).isEqualTo(LocalDate.of(2023, 10, 1).toEpochDay());
+  }
+
+  @Test
+  public void encodeThenDecodeDate_ShouldPreserveDataIntegrity() {
+    // Arrange
+    DateColumn min = DateColumn.of("date", DateColumn.MIN_VALUE);
+    DateColumn max = DateColumn.of("date", DateColumn.MAX_VALUE);
+
+    // Act Assert
+    assertThat(
+            TimeRelatedColumnEncodingUtils.decodeDate(TimeRelatedColumnEncodingUtils.encode(min)))
+        .isEqualTo(min.getDateValue());
+    assertThat(
+            TimeRelatedColumnEncodingUtils.decodeDate(TimeRelatedColumnEncodingUtils.encode(max)))
+        .isEqualTo(max.getDateValue());
   }
 
   @Test
@@ -42,6 +57,21 @@ class TimeRelatedColumnEncodingUtilsTest {
 
     // Assert
     assertThat(encoded).isEqualTo(LocalTime.of(12, 34, 56, 123_456_000).toNanoOfDay());
+  }
+
+  @Test
+  public void encodeThenDecodeTime_ShouldPreserveDataIntegrity() {
+    // Arrange
+    TimeColumn min = TimeColumn.of("time", TimeColumn.MIN_VALUE);
+    TimeColumn max = TimeColumn.of("time", TimeColumn.MAX_VALUE);
+
+    // Act Assert
+    assertThat(
+            TimeRelatedColumnEncodingUtils.decodeTime(TimeRelatedColumnEncodingUtils.encode(min)))
+        .isEqualTo(min.getTimeValue());
+    assertThat(
+            TimeRelatedColumnEncodingUtils.decodeTime(TimeRelatedColumnEncodingUtils.encode(max)))
+        .isEqualTo(max.getTimeValue());
   }
 
   @Test
@@ -124,7 +154,7 @@ class TimeRelatedColumnEncodingUtilsTest {
   public void decodeDate_ShouldWorkProperly() {
     // Arrange Act
     LocalDate date =
-        TimeRelatedColumnEncodingUtils.decodeDate(LocalDate.of(2023, 10, 1).toEpochDay());
+        TimeRelatedColumnEncodingUtils.decodeDate((int) LocalDate.of(2023, 10, 1).toEpochDay());
 
     // Assert
     assertThat(date).isEqualTo(LocalDate.of(2023, 10, 1));

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcAdminTestBase.java
@@ -967,7 +967,7 @@ public abstract class JdbcAdminTestBase {
             + "\"indexed\" BOOLEAN NOT NULL,"
             + "\"ordinal_position\" INTEGER NOT NULL,"
             + "PRIMARY KEY (\"full_table_name\", \"column_name\"))",
-        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT,\"c8\" BIGINT,\"c9\" BIGINT,\"c10\" BIGINT,\"c11\" BIGINT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
+        "CREATE TABLE \"my_ns$foo_table\"(\"c3\" BOOLEAN,\"c1\" TEXT,\"c4\" BLOB,\"c2\" BIGINT,\"c5\" INT,\"c6\" DOUBLE,\"c7\" FLOAT,\"c8\" INT,\"c9\" BIGINT,\"c10\" BIGINT,\"c11\" BIGINT, PRIMARY KEY (\"c3\",\"c1\",\"c4\"))",
         "CREATE INDEX \"index_my_ns_foo_table_c4\" ON \"my_ns$foo_table\" (\"c4\")",
         "CREATE INDEX \"index_my_ns_foo_table_c1\" ON \"my_ns$foo_table\" (\"c1\")",
         "INSERT INTO \""


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2491
- **Commit to backport:** 9cb186774e8dbc9f3af6394383f55f6bca9c8e57

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.15-pull-2491 &&
git cherry-pick --no-rerere-autoupdate -m1 9cb186774e8dbc9f3af6394383f55f6bca9c8e57
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!