### PR TITLE
[Dependabot] Ignore dependency `com.microsoft.sqlserver:mssql-jdbc:12.9.0.jre8-preview`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "software.amazon.awssdk:*"
         update-types: [ "version-update:semver-patch" ]
+      - dependency-name: "com.microsoft.sqlserver:mssql-jdbc"
+        versions: ["12.9.0.jre8-preview"]
 
   # For GitHub Actions, update all actions on the default, support and release branches
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

Update the dependabot configuration to ignore the `com.microsoft.sqlserver:mssql-jdbc:12.9.0.jre8-preview` dependency.

## Related issues and/or PRs

N/A

## Changes made

See above

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)


## Release notes

N/A
