### PR TITLE
Backport to branch(3.15) : Bump the dependencies group across 1 directory with 2 updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
         guavaVersion = '32.1.3-jre'
         slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.11.5'
-        azureCosmosVersion = '4.66.0'
+        azureCosmosVersion = '4.67.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.30.2'
         commonsDbcp2Version = '2.13.0'


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2552
- **Commit to backport:** 559de5c00cf26a729390fbeef0c179f88a55d1a2

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.15-pull-2552 &&
git cherry-pick --no-rerere-autoupdate -m1 559de5c00cf26a729390fbeef0c179f88a55d1a2
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!