### PR TITLE
Backport to branch(3.11) : Bump the dependencies group across 1 directory with 2 updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
         guavaVersion = '32.1.3-jre'
         slf4jVersion = '1.7.36'
         cassandraDriverVersion = '3.11.5'
-        azureCosmosVersion = '4.53.1'
+        azureCosmosVersion = '4.67.0'
         jooqVersion = '3.14.16'
         awssdkVersion = '2.22.3'
         commonsDbcp2Version = '2.11.0'

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosAdminTestBase.java
@@ -506,14 +506,12 @@ public abstract class CosmosAdminTestBase {
     verify(container)
         .queryItems(
             eq("SELECT t.id, t.concatenatedPartitionKey FROM " + "t"),
-            refEq(new CosmosQueryRequestOptions()),
+            any(CosmosQueryRequestOptions.class),
             eq(Record.class));
     verify(container)
-        .deleteItem(
-            eq("id1"), refEq(new PartitionKey("p1")), refEq(new CosmosItemRequestOptions()));
+        .deleteItem(eq("id1"), refEq(new PartitionKey("p1")), any(CosmosItemRequestOptions.class));
     verify(container)
-        .deleteItem(
-            eq("id2"), refEq(new PartitionKey("p2")), refEq(new CosmosItemRequestOptions()));
+        .deleteItem(eq("id2"), refEq(new PartitionKey("p2")), any(CosmosItemRequestOptions.class));
   }
 
   @Test
@@ -544,7 +542,7 @@ public abstract class CosmosAdminTestBase {
     verify(container)
         .queryItems(
             eq("SELECT * FROM metadata WHERE metadata.id LIKE 'ns.%'"),
-            refEq(new CosmosQueryRequestOptions()),
+            any(CosmosQueryRequestOptions.class),
             eq(CosmosTableMetadata.class));
   }
 


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2552
- **Commit to backport:** 559de5c00cf26a729390fbeef0c179f88a55d1a2

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.11-pull-2552 &&
git cherry-pick --no-rerere-autoupdate -m1 559de5c00cf26a729390fbeef0c179f88a55d1a2
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!