### PR TITLE
Remove EXTRA_WRITE strategy in Consensus Commit

### DIFF
--- a/conf/database.properties
+++ b/conf/database.properties
@@ -17,11 +17,6 @@ scalar.db.password=cassandra
 # Isolation level used for Consensus Commit. Either `SNAPSHOT` or `SERIALIZABLE` can be specified. The default is `SNAPSHOT`.
 #scalar.db.consensus_commit.isolation_level=
 
-# Serializable strategy used for Consensus Commit.
-# Either `EXTRA_READ` or `EXTRA_WRITE` can be specified. The default is `EXTRA_READ`.
-# If `SNAPSHOT` is specified in the property `scalar.db.consensus_commit.isolation_level`, this is ignored.
-#scalar.db.consensus_commit.serializable_strategy=
-
 # The given namespace name will be used by operations that do not already specify a namespace.
 # By default, no default namespace name is set on operations.
 #scalar.db.default_namespace_name=<a_namespace_name>

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -458,11 +458,11 @@ public enum CoreError implements ScalarDbError {
       ""),
   CONSENSUS_COMMIT_READING_ALREADY_WRITTEN_DATA_NOT_ALLOWED(
       Category.USER_ERROR, "0106", "Reading already-written data is not allowed", "", ""),
-  CONSENSUS_COMMIT_TRANSACTION_NOT_VALIDATED_IN_EXTRA_READ(
+  CONSENSUS_COMMIT_TRANSACTION_NOT_VALIDATED_IN_SERIALIZABLE(
       Category.USER_ERROR,
       "0107",
       "The transaction is not validated."
-          + " When using the EXTRA_READ serializable strategy, you need to call validate()"
+          + " When using the SERIALIZABLE isolation level, you need to call validate()"
           + " before calling commit()",
       "",
       ""),
@@ -929,13 +929,7 @@ public enum CoreError implements ScalarDbError {
       "The condition on the column '%s' is not satisfied",
       "",
       ""),
-  CONSENSUS_COMMIT_READING_EMPTY_RECORDS_IN_EXTRA_WRITE(
-      Category.CONCURRENCY_ERROR,
-      "0021",
-      "Reading empty records might cause a write skew anomaly, so the transaction has been aborted for safety purposes",
-      "",
-      ""),
-  CONSENSUS_COMMIT_ANTI_DEPENDENCY_FOUND_IN_EXTRA_READ(
+  CONSENSUS_COMMIT_ANTI_DEPENDENCY_FOUND(
       Category.CONCURRENCY_ERROR,
       "0022",
       "An anti-dependency was found. The transaction has been aborted",

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandler.java
@@ -205,8 +205,8 @@ public class CommitHandler {
 
   public void validate(Snapshot snapshot) throws ValidationException {
     try {
-      // validation is executed when SERIALIZABLE with EXTRA_READ strategy is chosen.
-      snapshot.toSerializableWithExtraRead(storage);
+      // validation is executed when SERIALIZABLE is chosen.
+      snapshot.toSerializable(storage);
     } catch (ExecutionException e) {
       throw new ValidationException(
           CoreError.CONSENSUS_COMMIT_VALIDATION_FAILED.buildMessage(), e, snapshot.getId());

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -11,7 +11,6 @@ import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DeleteIf;
-import com.scalar.db.api.Get;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
@@ -65,9 +64,8 @@ public class CommitMutationComposer extends AbstractMutationComposer {
 
   private void add(Selection base, @Nullable TransactionResult result) throws ExecutionException {
     if (result == null) {
-      // for deleting non-existing record that was prepared with DELETED for Serializable with
-      // Extra-write
-      mutations.add(composeDelete(base, null));
+      throw new AssertionError(
+          "This path should not be reached since the EXTRA_WRITE strategy is deleted");
     } else if (result.getState().equals(TransactionState.PREPARED)) {
       // for rollforward in lazy recovery
       mutations.add(composePut(base, result));
@@ -122,10 +120,8 @@ public class CommitMutationComposer extends AbstractMutationComposer {
         TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
         return ScalarDbUtils.getPartitionKey(result, metadata.getTableMetadata());
       } else {
-        // for deleting non-existing record that was prepared with DELETED for Serializable with
-        // Extra-write
-        assert base instanceof Get;
-        return base.getPartitionKey();
+        throw new AssertionError(
+            "This path should not be reached since the EXTRA_WRITE strategy is deleted");
       }
     }
   }
@@ -142,10 +138,8 @@ public class CommitMutationComposer extends AbstractMutationComposer {
         TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
         return ScalarDbUtils.getClusteringKey(result, metadata.getTableMetadata());
       } else {
-        // for deleting non-existing record that was prepared with DELETED for Serializable with
-        // Extra-write
-        assert base instanceof Get;
-        return base.getClusteringKey();
+        throw new AssertionError(
+            "This path should not be reached since the EXTRA_WRITE strategy is deleted");
       }
     }
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -134,26 +134,26 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
 
   @Override
   public DistributedTransaction begin() {
-    return begin(config.getIsolation(), config.getSerializableStrategy());
+    return begin(config.getIsolation());
   }
 
   @Override
   public DistributedTransaction begin(String txId) {
-    return begin(txId, config.getIsolation(), config.getSerializableStrategy());
+    return begin(txId, config.getIsolation());
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public DistributedTransaction start(com.scalar.db.api.Isolation isolation) {
-    return begin(Isolation.valueOf(isolation.name()), config.getSerializableStrategy());
+    return begin(Isolation.valueOf(isolation.name()));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public DistributedTransaction start(String txId, com.scalar.db.api.Isolation isolation) {
-    return begin(txId, Isolation.valueOf(isolation.name()), config.getSerializableStrategy());
+    return begin(txId, Isolation.valueOf(isolation.name()));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -161,14 +161,14 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   @Override
   public DistributedTransaction start(
       com.scalar.db.api.Isolation isolation, com.scalar.db.api.SerializableStrategy strategy) {
-    return begin(Isolation.valueOf(isolation.name()), (SerializableStrategy) strategy);
+    return begin(Isolation.valueOf(isolation.name()));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public DistributedTransaction start(com.scalar.db.api.SerializableStrategy strategy) {
-    return begin(Isolation.SERIALIZABLE, (SerializableStrategy) strategy);
+    return begin(Isolation.SERIALIZABLE);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -176,7 +176,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   @Override
   public DistributedTransaction start(
       String txId, com.scalar.db.api.SerializableStrategy strategy) {
-    return begin(txId, Isolation.SERIALIZABLE, (SerializableStrategy) strategy);
+    return begin(txId, Isolation.SERIALIZABLE);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -186,31 +186,29 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       String txId,
       com.scalar.db.api.Isolation isolation,
       com.scalar.db.api.SerializableStrategy strategy) {
-    return begin(txId, Isolation.valueOf(isolation.name()), (SerializableStrategy) strategy);
+    return begin(txId, Isolation.valueOf(isolation.name()));
   }
 
   @VisibleForTesting
-  DistributedTransaction begin(Isolation isolation, SerializableStrategy strategy) {
+  DistributedTransaction begin(Isolation isolation) {
     String txId = UUID.randomUUID().toString();
-    return begin(txId, isolation, strategy);
+    return begin(txId, isolation);
   }
 
   @VisibleForTesting
-  DistributedTransaction begin(String txId, Isolation isolation, SerializableStrategy strategy) {
+  DistributedTransaction begin(String txId, Isolation isolation) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     checkNotNull(isolation);
     if (isGroupCommitEnabled()) {
       assert groupCommitter != null;
       txId = groupCommitter.reserve(txId);
     }
-    if (!config.getIsolation().equals(isolation)
-        || !config.getSerializableStrategy().equals(strategy)) {
+    if (!config.getIsolation().equals(isolation)) {
       logger.warn(
-          "Setting different isolation level or serializable strategy from the ones "
-              + "in DatabaseConfig might cause unexpected anomalies");
+          "Setting different isolation level from the one in DatabaseConfig might cause unexpected "
+              + "anomalies");
     }
-    Snapshot snapshot =
-        new Snapshot(txId, isolation, strategy, tableMetadataManager, parallelExecutor);
+    Snapshot snapshot = new Snapshot(txId, isolation, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(
             storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled, parallelExecutor);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
@@ -156,11 +156,8 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
         clusteringKey =
             ScalarDbUtils.getClusteringKey(result, metadata.getTableMetadata()).orElse(null);
       } else {
-        // for deleting non-existing record that was prepared with DELETED for Serializable with
-        // Extra-write
-        assert operation instanceof Get;
-        partitionKey = operation.getPartitionKey();
-        clusteringKey = operation.getClusteringKey().orElse(null);
+        throw new AssertionError(
+            "This path should not be reached since the EXTRA_WRITE strategy is deleted");
       }
     }
 

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/SerializableStrategy.java
@@ -6,8 +6,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * A Serializable strategy used in Consensus Commit algorithm. Both strategies basically make
  * transactions avoid an anti-dependency that is the root cause of the anomalies in Snapshot
  * Isolation.
+ *
+ * @deprecated As of release 3.16.0. Will be removed in release 5.0.0
  */
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_INTERFACE")
+@Deprecated
 public enum SerializableStrategy implements com.scalar.db.api.SerializableStrategy {
   /**
    * Extra-write strategy converts all read set into write set when preparing records to remove

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -239,7 +239,7 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
   public void commit() throws CommitConflictException, UnknownTransactionStatusException {
     if (crud.getSnapshot().isValidationRequired() && !validated) {
       throw new IllegalStateException(
-          CoreError.CONSENSUS_COMMIT_TRANSACTION_NOT_VALIDATED_IN_EXTRA_READ.buildMessage());
+          CoreError.CONSENSUS_COMMIT_TRANSACTION_NOT_VALIDATED_IN_SERIALIZABLE.buildMessage());
     }
 
     try {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -130,43 +130,41 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
   @Override
   public TwoPhaseCommitTransaction begin() {
     String txId = UUID.randomUUID().toString();
-    return begin(txId, config.getIsolation(), config.getSerializableStrategy());
+    return begin(txId, config.getIsolation());
   }
 
   @Override
   public TwoPhaseCommitTransaction begin(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
-    return begin(txId, config.getIsolation(), config.getSerializableStrategy());
+    return begin(txId, config.getIsolation());
   }
 
   @VisibleForTesting
-  TwoPhaseCommitTransaction begin(Isolation isolation, SerializableStrategy strategy) {
+  TwoPhaseCommitTransaction begin(Isolation isolation) {
     String txId = UUID.randomUUID().toString();
-    return begin(txId, isolation, strategy);
+    return begin(txId, isolation);
   }
 
   @VisibleForTesting
-  TwoPhaseCommitTransaction begin(String txId, Isolation isolation, SerializableStrategy strategy) {
+  TwoPhaseCommitTransaction begin(String txId, Isolation isolation) {
     throwIfGroupCommitIsEnabled();
-    return createNewTransaction(txId, isolation, strategy);
+    return createNewTransaction(txId, isolation);
   }
 
   @Override
   public TwoPhaseCommitTransaction join(String txId) {
     checkArgument(!Strings.isNullOrEmpty(txId));
-    return join(txId, config.getIsolation(), config.getSerializableStrategy());
+    return join(txId, config.getIsolation());
   }
 
   @VisibleForTesting
-  TwoPhaseCommitTransaction join(String txId, Isolation isolation, SerializableStrategy strategy) {
+  TwoPhaseCommitTransaction join(String txId, Isolation isolation) {
     throwIfGroupCommitIsEnabled();
-    return createNewTransaction(txId, isolation, strategy);
+    return createNewTransaction(txId, isolation);
   }
 
-  private TwoPhaseCommitTransaction createNewTransaction(
-      String txId, Isolation isolation, SerializableStrategy strategy) {
-    Snapshot snapshot =
-        new Snapshot(txId, isolation, strategy, tableMetadataManager, parallelExecutor);
+  private TwoPhaseCommitTransaction createNewTransaction(String txId, Isolation isolation) {
+    Snapshot snapshot = new Snapshot(txId, isolation, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(
             storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled, parallelExecutor);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -121,11 +121,7 @@ public class CommitHandlerTest {
   private Snapshot prepareSnapshotWithDifferentPartitionPut() {
     Snapshot snapshot =
         new Snapshot(
-            anyId(),
-            Isolation.SNAPSHOT,
-            SerializableStrategy.EXTRA_WRITE,
-            tableMetadataManager,
-            new ParallelExecutor(config));
+            anyId(), Isolation.SNAPSHOT, tableMetadataManager, new ParallelExecutor(config));
 
     // different partition
     Put put1 = preparePut1();
@@ -139,11 +135,7 @@ public class CommitHandlerTest {
   private Snapshot prepareSnapshotWithSamePartitionPut() {
     Snapshot snapshot =
         new Snapshot(
-            anyId(),
-            Isolation.SNAPSHOT,
-            SerializableStrategy.EXTRA_WRITE,
-            tableMetadataManager,
-            new ParallelExecutor(config));
+            anyId(), Isolation.SNAPSHOT, tableMetadataManager, new ParallelExecutor(config));
 
     // same partition
     Put put1 = preparePut1();
@@ -395,7 +387,7 @@ public class CommitHandlerTest {
     // Arrange
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     doNothing().when(storage).mutate(anyList());
-    doThrow(ValidationConflictException.class).when(snapshot).toSerializableWithExtraRead(storage);
+    doThrow(ValidationConflictException.class).when(snapshot).toSerializable(storage);
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(Snapshot.class));
 
@@ -419,7 +411,7 @@ public class CommitHandlerTest {
     // Arrange
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializableWithExtraRead(storage);
+    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doNothing().when(coordinator).putState(any(Coordinator.State.class));
     doNothing().when(handler).rollbackRecords(any(Snapshot.class));
 
@@ -444,7 +436,7 @@ public class CommitHandlerTest {
     // Arrange
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializableWithExtraRead(storage);
+    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
@@ -475,7 +467,7 @@ public class CommitHandlerTest {
     // Arrange
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializableWithExtraRead(storage);
+    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
@@ -504,7 +496,7 @@ public class CommitHandlerTest {
     // Arrange
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializableWithExtraRead(storage);
+    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorConflictException.class)
         .when(coordinator)
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));
@@ -533,7 +525,7 @@ public class CommitHandlerTest {
     // Arrange
     Snapshot snapshot = spy(prepareSnapshotWithDifferentPartitionPut());
     doNothing().when(storage).mutate(anyList());
-    doThrow(ExecutionException.class).when(snapshot).toSerializableWithExtraRead(storage);
+    doThrow(ExecutionException.class).when(snapshot).toSerializable(storage);
     doThrow(CoordinatorException.class)
         .when(coordinator)
         .putState(new Coordinator.State(anyId(), TransactionState.ABORTED));

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposerTest.java
@@ -254,28 +254,4 @@ public class CommitMutationComposerTest {
             new ConditionalExpression(STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
     assertThat(actual).isEqualTo(expected);
   }
-
-  @Test
-  public void
-      add_GetAndNullResultGiven_ShouldComposeDeleteForDeletingNonExistingRecordForSerializableWithExtraWrite()
-          throws ExecutionException {
-    // Arrange
-    Get get = prepareGet();
-
-    // Act
-    composer.add(get, null);
-
-    // Assert
-    Delete actual = (Delete) composer.get().get(0);
-    Delete expected =
-        new Delete(get.getPartitionKey(), get.getClusteringKey().orElse(null))
-            .forNamespace(get.forNamespace().get())
-            .forTable(get.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(
-        new DeleteIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID), Operator.EQ),
-            new ConditionalExpression(STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
-    assertThat(actual).isEqualTo(expected);
-  }
 }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -19,7 +19,6 @@ public class ConsensusCommitConfigTest {
 
     // Assert
     assertThat(config.getIsolation()).isEqualTo(Isolation.SNAPSHOT);
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_READ);
     assertThat(config.getCoordinatorNamespace()).isNotPresent();
     assertThat(config.getParallelExecutorCount()).isEqualTo(128);
     assertThat(config.isParallelPreparationEnabled()).isTrue();
@@ -63,32 +62,6 @@ public class ConsensusCommitConfigTest {
     // Arrange
     Properties props = new Properties();
     props.setProperty(ConsensusCommitConfig.ISOLATION_LEVEL, "READ_COMMITTED");
-
-    // Act Assert
-    assertThatThrownBy(() -> new ConsensusCommitConfig(new DatabaseConfig(props)))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void constructor_PropertiesWithSerializableStrategyGiven_ShouldLoadProperly() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(
-        ConsensusCommitConfig.SERIALIZABLE_STRATEGY, SerializableStrategy.EXTRA_WRITE.toString());
-
-    // Act
-    ConsensusCommitConfig config = new ConsensusCommitConfig(new DatabaseConfig(props));
-
-    // Assert
-    assertThat(config.getSerializableStrategy()).isEqualTo(SerializableStrategy.EXTRA_WRITE);
-  }
-
-  @Test
-  public void
-      constructor_UnsupportedSerializableStrategyGiven_ShouldThrowIllegalArgumentException() {
-    // Arrange
-    Properties props = new Properties();
-    props.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, "NO_STRATEGY");
 
     // Act Assert
     assertThatThrownBy(() -> new ConsensusCommitConfig(new DatabaseConfig(props)))

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -76,8 +76,6 @@ public class ConsensusCommitManagerTest {
             null);
 
     when(consensusCommitConfig.getIsolation()).thenReturn(Isolation.SNAPSHOT);
-    when(consensusCommitConfig.getSerializableStrategy())
-        .thenReturn(SerializableStrategy.EXTRA_READ);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -301,8 +301,7 @@ public class CrudHandlerTest {
     Get get2 = prepareGet();
     Result result = prepareResult(TransactionState.COMMITTED);
     Optional<TransactionResult> expected = Optional.of(new TransactionResult(result));
-    snapshot =
-        new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, null, tableMetadataManager, parallelExecutor);
+    snapshot = new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
     when(storage.get(getForStorage)).thenReturn(Optional.of(result));
 
@@ -435,8 +434,7 @@ public class CrudHandlerTest {
     Scan scan2 = prepareScan();
     result = prepareResult(TransactionState.COMMITTED);
     TransactionResult expected = new TransactionResult(result);
-    snapshot =
-        new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, null, tableMetadataManager, parallelExecutor);
+    snapshot = new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(scanForStorage)).thenReturn(scanner);
@@ -490,8 +488,7 @@ public class CrudHandlerTest {
     // Arrange
     Scan scan = toScanForStorageFrom(prepareScan());
     result = prepareResult(TransactionState.COMMITTED);
-    snapshot =
-        new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, null, tableMetadataManager, parallelExecutor);
+    snapshot = new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
     when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
     when(storage.scan(scan)).thenReturn(scanner);
@@ -542,7 +539,6 @@ public class CrudHandlerTest {
         new Snapshot(
             ANY_TX_ID,
             Isolation.SNAPSHOT,
-            null,
             tableMetadataManager,
             parallelExecutor,
             readSet,

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionalExpression;
 import com.scalar.db.api.Consistency;
 import com.scalar.db.api.Delete;
-import com.scalar.db.api.Get;
 import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIf;
@@ -98,14 +97,6 @@ public class PrepareMutationComposerTest {
     Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
     Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
     return new Delete(partitionKey, clusteringKey)
-        .forNamespace(ANY_NAMESPACE_NAME)
-        .forTable(ANY_TABLE_NAME);
-  }
-
-  private Get prepareGet() {
-    Key partitionKey = new Key(ANY_NAME_1, ANY_TEXT_1);
-    Key clusteringKey = new Key(ANY_NAME_2, ANY_TEXT_2);
-    return new Get(partitionKey, clusteringKey)
         .forNamespace(ANY_NAMESPACE_NAME)
         .forTable(ANY_TABLE_NAME);
   }
@@ -400,31 +391,6 @@ public class PrepareMutationComposerTest {
         new Put(delete.getPartitionKey(), delete.getClusteringKey().orElse(null))
             .forNamespace(delete.forNamespace().get())
             .forTable(delete.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(new PutIfNotExists());
-    expected.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
-    expected.withValue(Attribute.toIdValue(ANY_ID_3));
-    expected.withValue(Attribute.toStateValue(TransactionState.DELETED));
-    expected.withValue(Attribute.toVersionValue(1));
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  public void
-      add_GetAndNullResultGiven_ShouldComposePutForPuttingNonExistingRecordForSerializableWithExtraWrite()
-          throws ExecutionException {
-    // Arrange
-    Get get = prepareGet();
-
-    // Act
-    composer.add(get, null);
-
-    // Assert
-    Put actual = (Put) composer.get().get(0);
-    Put expected =
-        new Put(get.getPartitionKey(), get.getClusteringKey().orElse(null))
-            .forNamespace(get.forNamespace().get())
-            .forTable(get.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(new PutIfNotExists());
     expected.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposerTest.java
@@ -289,32 +289,6 @@ public class RollbackMutationComposerTest {
   }
 
   @Test
-  public void
-      add_GetAndNullResultGiven_ShouldComposeDeleteForDeletingNonExistingRecordForSerializableWithExtraWrite()
-          throws ExecutionException {
-    // Arrange
-    TransactionResult result = prepareInitialResult(ANY_ID_2, TransactionState.DELETED);
-    when(storage.get(any(Get.class))).thenReturn(Optional.of(result));
-    Get get = prepareGet();
-
-    // Act
-    composer.add(get, null);
-
-    // Assert
-    Delete actual = (Delete) composer.get().get(0);
-    Delete expected =
-        new Delete(get.getPartitionKey(), get.getClusteringKey().orElse(null))
-            .forNamespace(get.forNamespace().get())
-            .forTable(get.forTable().get());
-    expected.withConsistency(Consistency.LINEARIZABLE);
-    expected.withCondition(
-        new DeleteIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ),
-            new ConditionalExpression(STATE, toStateValue(TransactionState.DELETED), Operator.EQ)));
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
   public void add_PutAndNullResultGivenAndOldResultGivenFromStorage_ShouldDoNothing()
       throws ExecutionException {
     // Arrange

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -67,7 +67,6 @@ public class TwoPhaseConsensusCommitManagerTest {
 
     // Arrange
     when(config.getIsolation()).thenReturn(Isolation.SNAPSHOT);
-    when(config.getSerializableStrategy()).thenReturn(SerializableStrategy.EXTRA_READ);
 
     manager =
         new TwoPhaseConsensusCommitManager(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -703,7 +703,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void commit_ExtraReadUsedAndValidatedState_ShouldCommitProperly()
+  public void commit_SerializableUsedAndValidatedState_ShouldCommitProperly()
       throws CommitException, UnknownTransactionStatusException, PreparationException,
           ValidationException {
     // Arrange
@@ -722,7 +722,7 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void commit_ExtraReadUsedAndPreparedState_ShouldThrowIllegalStateException()
+  public void commit_SerializableUsedAndPreparedState_ShouldThrowIllegalStateException()
       throws PreparationException {
     // Arrange
     transaction.prepare();

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -2020,7 +2019,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   private void
-      commit_WriteSkewOnExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException(
+      commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException(
           String namespace1, String table1, String namespace2, String table2)
           throws TransactionException {
     // Arrange
@@ -2028,83 +2027,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         Arrays.asList(
             preparePut(0, 0, namespace1, table1).withValue(BALANCE, 1),
             preparePut(0, 1, namespace2, table2).withValue(BALANCE, 1));
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     transaction.put(puts);
     transaction.commit();
 
     // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Get get1_1 = prepareGet(0, 1, namespace2, table2);
-    Optional<Result> result1 = transaction1.get(get1_1);
-    assertThat(result1).isPresent();
-    int current1 = getBalance(result1.get());
-    Get get1_2 = prepareGet(0, 0, namespace1, table1);
-    transaction1.get(get1_2);
-    Get get2_1 = prepareGet(0, 0, namespace1, table1);
-    Optional<Result> result2 = transaction2.get(get2_1);
-    assertThat(result2).isPresent();
-    int current2 = getBalance(result2.get());
-    Get get2_2 = prepareGet(0, 1, namespace2, table2);
-    transaction2.get(get2_2);
-    Put put1 = preparePut(0, 0, namespace1, table1).withValue(BALANCE, current1 + 1);
-    transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace2, table2).withValue(BALANCE, current2 + 1);
-    transaction2.put(put2);
-    transaction1.commit();
-    Throwable thrown = catchThrowable(transaction2::commit);
-
-    // Assert
-    transaction = manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    result1 = transaction.get(get1_1);
-    assertThat(result1).isPresent();
-    assertThat(getBalance(result1.get())).isEqualTo(1);
-    result2 = transaction.get(get2_1);
-    assertThat(result2).isPresent();
-    assertThat(getBalance(result2.get())).isEqualTo(2);
-    transaction.commit();
-
-    assertThat(thrown).isInstanceOf(CommitConflictException.class);
-  }
-
-  @Test
-  public void
-      commit_WriteSkewOnExistingRecordsInSameTableWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException()
-          throws TransactionException {
-    commit_WriteSkewOnExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException(
-        namespace1, TABLE_1, namespace1, TABLE_1);
-  }
-
-  @Test
-  public void
-      commit_WriteSkewOnExistingRecordsInDifferentTablesWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException()
-          throws TransactionException {
-    commit_WriteSkewOnExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException(
-        namespace1, TABLE_1, namespace2, TABLE_2);
-  }
-
-  private void
-      commit_WriteSkewOnExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException(
-          String namespace1, String table1, String namespace2, String table2)
-          throws TransactionException {
-    // Arrange
-    List<Put> puts =
-        Arrays.asList(
-            preparePut(0, 0, namespace1, table1).withValue(BALANCE, 1),
-            preparePut(0, 1, namespace2, table2).withValue(BALANCE, 1));
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    transaction.put(puts);
-    transaction.commit();
-
-    // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction1 = manager.begin(Isolation.SERIALIZABLE);
+    DistributedTransaction transaction2 = manager.begin(Isolation.SERIALIZABLE);
 
     Get get1_1 = prepareGet(0, 1, namespace2, table2);
     Optional<Result> result1 = transaction1.get(get1_1);
@@ -2126,7 +2055,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     Throwable thrown = catchThrowable(transaction2::commit);
 
     // Assert
-    transaction = manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    transaction = manager.begin(Isolation.SERIALIZABLE);
     result1 = transaction.get(get1_1);
     assertThat(result1).isPresent();
     assertThat(getBalance(result1.get())).isEqualTo(1);
@@ -2140,149 +2069,34 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @Test
   public void
-      commit_WriteSkewOnExistingRecordsInSameTableWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException()
+      commit_WriteSkewOnExistingRecordsInSameTableWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException()
           throws TransactionException {
-    commit_WriteSkewOnExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException(
+    commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException(
         namespace1, TABLE_1, namespace1, TABLE_1);
   }
 
   @Test
   public void
-      commit_WriteSkewOnExistingRecordsInDifferentTablesWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException()
+      commit_WriteSkewOnExistingRecordsInDifferentTablesWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException()
           throws TransactionException {
-    commit_WriteSkewOnExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException(
+    commit_WriteSkewOnExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException(
         namespace1, TABLE_1, namespace2, TABLE_2);
-  }
-
-  private void
-      commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException(
-          String namespace1, String table1, String namespace2, String table2)
-          throws TransactionException {
-    // Arrange
-    // no records
-
-    // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Get get1_1 = prepareGet(0, 1, namespace2, table2);
-    Optional<Result> result1 = transaction1.get(get1_1);
-    Get get1_2 = prepareGet(0, 0, namespace1, table1);
-    transaction1.get(get1_2);
-    int current1 = 0;
-    Get get2_1 = prepareGet(0, 0, namespace1, table1);
-    Optional<Result> result2 = transaction2.get(get2_1);
-    Get get2_2 = prepareGet(0, 1, namespace2, table2);
-    transaction2.get(get2_2);
-    int current2 = 0;
-    Put put1 = preparePut(0, 0, namespace1, table1).withValue(BALANCE, current1 + 1);
-    transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace2, table2).withValue(BALANCE, current2 + 1);
-    transaction2.put(put2);
-    Throwable thrown1 = catchThrowable(transaction1::commit);
-    Throwable thrown2 = catchThrowable(transaction2::commit);
-
-    // Assert
-    assertThat(result1.isPresent()).isFalse();
-    assertThat(result2.isPresent()).isFalse();
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    result1 = transaction.get(get1_1);
-    assertThat(result1.isPresent()).isFalse();
-    result2 = transaction.get(get2_1);
-    assertThat(result2).isPresent();
-    assertThat(getBalance(result2.get())).isEqualTo(1);
-    transaction.commit();
-
-    assertThat(thrown1).doesNotThrowAnyException();
-    assertThat(thrown2).isInstanceOf(CommitConflictException.class);
-  }
-
-  @Test
-  public void
-      commit_WriteSkewOnNonExistingRecordsInSameTableWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitException()
-          throws TransactionException {
-    commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException(
-        namespace1, TABLE_1, namespace1, TABLE_1);
-  }
-
-  @Test
-  public void
-      commit_WriteSkewOnNonExistingRecordsInDifferentTablesWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitException()
-          throws TransactionException {
-    commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWrite_OneShouldCommitTheOtherShouldThrowCommitConflictException(
-        namespace1, TABLE_1, namespace2, TABLE_2);
-  }
-
-  private void
-      commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly(
-          String namespace1, String table1, String namespace2, String table2)
-          throws TransactionException, CoordinatorException {
-    // Arrange
-    Coordinator.State state = new Coordinator.State(ANY_ID_1, TransactionState.ABORTED);
-    coordinator.putState(state);
-
-    // Act
-    DistributedTransaction transaction1 =
-        manager.begin(ANY_ID_1, Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Get get1_1 = prepareGet(0, 1, namespace2, table2);
-    Optional<Result> result1 = transaction1.get(get1_1);
-    Get get1_2 = prepareGet(0, 0, namespace1, table1);
-    Optional<Result> result2 = transaction1.get(get1_2);
-    int current1 = 0;
-    Put put1 = preparePut(0, 0, namespace1, table1).withValue(BALANCE, current1 + 1);
-    transaction1.put(put1);
-    Throwable thrown1 = catchThrowable(transaction1::commit);
-
-    // Assert
-    assertThat(result1.isPresent()).isFalse();
-    assertThat(result2.isPresent()).isFalse();
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    result1 = transaction.get(get1_1);
-    result2 = transaction.get(get1_2);
-    assertThat(result1.isPresent()).isFalse();
-    assertThat(result2.isPresent()).isFalse();
-    transaction.commit();
-
-    assertThat(thrown1).isInstanceOf(CommitException.class);
   }
 
   private boolean isGroupCommitEnabled() {
     return consensusCommitConfig.isCoordinatorGroupCommitEnabled();
   }
 
-  @Test
-  @DisabledIf("isGroupCommitEnabled")
-  public void
-      commit_WriteSkewOnNonExistingRecordsInSameTableWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly()
-          throws TransactionException, CoordinatorException {
-    commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly(
-        namespace1, TABLE_1, namespace1, TABLE_1);
-  }
-
-  @Test
-  @DisabledIf("isGroupCommitEnabled")
-  public void
-      commit_WriteSkewOnNonExistingRecordsInDifferentTableWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly()
-          throws TransactionException, CoordinatorException {
-    commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraWriteAndCommitStatusFailed_ShouldRollbackProperly(
-        namespace1, TABLE_1, namespace2, TABLE_2);
-  }
-
   private void
-      commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException(
+      commit_WriteSkewOnNonExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException(
           String namespace1, String table1, String namespace2, String table2)
           throws TransactionException {
     // Arrange
     // no records
 
     // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction1 = manager.begin(Isolation.SERIALIZABLE);
+    DistributedTransaction transaction2 = manager.begin(Isolation.SERIALIZABLE);
     Get get1_1 = prepareGet(0, 1, namespace2, table2);
     Optional<Result> result1 = transaction1.get(get1_1);
     Get get1_2 = prepareGet(0, 0, namespace1, table1);
@@ -2303,8 +2117,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Assert
     assertThat(result1.isPresent()).isFalse();
     assertThat(result2.isPresent()).isFalse();
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     result1 = transaction.get(get1_1);
     assertThat(result1.isPresent()).isFalse();
     result2 = transaction.get(get2_1);
@@ -2318,32 +2131,30 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @Test
   public void
-      commit_WriteSkewOnNonExistingRecordsInSameTableWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitException()
+      commit_WriteSkewOnNonExistingRecordsInSameTableWithSerializable_OneShouldCommitTheOtherShouldThrowCommitException()
           throws TransactionException {
-    commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException(
+    commit_WriteSkewOnNonExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException(
         namespace1, TABLE_1, namespace1, TABLE_1);
   }
 
   @Test
   public void
-      commit_WriteSkewOnNonExistingRecordsInDifferentTablesWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitException()
+      commit_WriteSkewOnNonExistingRecordsInDifferentTablesWithSerializable_OneShouldCommitTheOtherShouldThrowCommitException()
           throws TransactionException {
-    commit_WriteSkewOnNonExistingRecordsWithSerializableWithExtraRead_OneShouldCommitTheOtherShouldThrowCommitConflictException(
+    commit_WriteSkewOnNonExistingRecordsWithSerializable_OneShouldCommitTheOtherShouldThrowCommitConflictException(
         namespace1, TABLE_1, namespace2, TABLE_2);
   }
 
   @Test
   public void
-      commit_WriteSkewWithScanOnNonExistingRecordsWithSerializableWithExtraWrite_ShouldThrowCommitConflictException()
+      commit_WriteSkewWithScanOnNonExistingRecordsWithSerializable_ShouldThrowCommitConflictException()
           throws TransactionException {
     // Arrange
     // no records
 
     // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
+    DistributedTransaction transaction1 = manager.begin(Isolation.SERIALIZABLE);
+    DistributedTransaction transaction2 = manager.begin(Isolation.SERIALIZABLE);
     List<Result> results1 = transaction1.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     int count1 = results1.size();
     List<Result> results2 = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
@@ -2358,46 +2169,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Assert
     assertThat(results1).isEmpty();
     assertThat(results2).isEmpty();
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_WRITE);
-    Optional<Result> result1 = transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
-    Optional<Result> result2 = transaction.get(prepareGet(0, 1, namespace1, TABLE_1));
-    assertThat(result1.isPresent()).isFalse();
-    assertThat(result2.isPresent()).isFalse();
-    transaction.commit();
-
-    assertThat(thrown1).isInstanceOf(CommitConflictException.class);
-    assertThat(thrown2).isInstanceOf(CommitConflictException.class);
-  }
-
-  @Test
-  public void
-      commit_WriteSkewWithScanOnNonExistingRecordsWithSerializableWithExtraRead_ShouldThrowCommitConflictException()
-          throws TransactionException {
-    // Arrange
-    // no records
-
-    // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    List<Result> results1 = transaction1.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
-    int count1 = results1.size();
-    List<Result> results2 = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
-    int count2 = results2.size();
-    Put put1 = preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, count1 + 1);
-    transaction1.put(put1);
-    Put put2 = preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, count2 + 1);
-    transaction2.put(put2);
-    Throwable thrown1 = catchThrowable(transaction1::commit);
-    Throwable thrown2 = catchThrowable(transaction2::commit);
-
-    // Assert
-    assertThat(results1).isEmpty();
-    assertThat(results2).isEmpty();
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     Optional<Result> result1 = transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
     assertThat(result1.isPresent()).isTrue();
     assertThat(getBalance(result1.get())).isEqualTo(1);
@@ -2411,23 +2183,20 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @Test
   public void
-      commit_WriteSkewWithScanOnExistingRecordsWithSerializableWithExtraRead_ShouldThrowCommitConflictException()
+      commit_WriteSkewWithScanOnExistingRecordsWithSerializable_ShouldThrowCommitConflictException()
           throws TransactionException {
     // Arrange
     List<Put> puts =
         Arrays.asList(
             preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1),
             preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     transaction.put(puts);
     transaction.commit();
 
     // Act
-    DistributedTransaction transaction1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    DistributedTransaction transaction2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction1 = manager.begin(Isolation.SERIALIZABLE);
+    DistributedTransaction transaction2 = manager.begin(Isolation.SERIALIZABLE);
     List<Result> results1 = transaction1.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
     int count1 = results1.size();
     List<Result> results2 = transaction2.scan(prepareScan(0, 0, 1, namespace1, TABLE_1));
@@ -2440,7 +2209,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     Throwable thrown2 = catchThrowable(transaction2::commit);
 
     // Assert
-    transaction = manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    transaction = manager.begin(Isolation.SERIALIZABLE);
     Optional<Result> result1 = transaction.get(prepareGet(0, 0, namespace1, TABLE_1));
     assertThat(result1).isPresent();
     assertThat(getBalance(result1.get())).isEqualTo(3);
@@ -2454,14 +2223,13 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scanAndCommit_MultipleScansGivenInTransactionWithExtraRead_ShouldCommitProperly()
+  public void scanAndCommit_MultipleScansGivenInTransactionWithSerializable_ShouldCommitProperly()
       throws TransactionException {
     // Arrange
     populateRecords(namespace1, TABLE_1);
 
     // Act Assert
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     transaction.scan(prepareScan(0, namespace1, TABLE_1));
     transaction.scan(prepareScan(1, namespace1, TABLE_1));
     assertThatCode(transaction::commit).doesNotThrowAnyException();
@@ -3225,8 +2993,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     populateRecords(namespace1, TABLE_1);
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     Get get =
         Get.newBuilder(prepareGet(1, 1, namespace1, TABLE_1))
             .where(ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
@@ -3250,8 +3017,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
       throws TransactionException {
     // Arrange
     populateRecords(namespace1, TABLE_1);
-    DistributedTransaction transaction =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
     Get get =
         Get.newBuilder(prepareGet(1, 1, namespace1, TABLE_1))
             .where(ConditionBuilder.column(BALANCE).isEqualToInt(INITIAL_BALANCE))
@@ -3435,10 +3201,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     // Arrange
 
     // Act
-    DistributedTransaction failingTxn =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    DistributedTransaction successTxn =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction failingTxn = manager.begin(Isolation.SERIALIZABLE);
+    DistributedTransaction successTxn = manager.begin(Isolation.SERIALIZABLE);
     failingTxn.get(prepareGet(1, 0, namespace1, TABLE_1));
     failingTxn.put(preparePut(0, 0, namespace1, TABLE_1));
     successTxn.put(preparePut(1, 0, namespace1, TABLE_1));
@@ -3473,10 +3237,8 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   @EnabledIf("isGroupCommitEnabled")
   void put_WhenAllTransactionsAbort_ShouldBeAbortedProperly() throws Exception {
     // Act
-    DistributedTransaction failingTxn1 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
-    DistributedTransaction failingTxn2 =
-        manager.begin(Isolation.SERIALIZABLE, SerializableStrategy.EXTRA_READ);
+    DistributedTransaction failingTxn1 = manager.begin(Isolation.SERIALIZABLE);
+    DistributedTransaction failingTxn2 = manager.begin(Isolation.SERIALIZABLE);
 
     doThrow(PreparationConflictException.class).when(commit).prepare(any());
 


### PR DESCRIPTION
## Description

This PR removes the `EXTRA_WRITE` strategy in Consensus Commit. After this change, if the `EXTRA_WRITE` strategy is specified when using Consensus Commit, the `EXTRA_READ` strategy will be used instead.

## Related issues and/or PRs

N/A

## Changes made

- Removed the `EXTRA_WRITE` strategy in Consensus Commit.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Removed the `EXTRA_WRITE` strategy from Consensus Commit. After this change, if the `EXTRA_WRITE` strategy is specified when using Consensus Commit, the `EXTRA_READ` strategy will be used instead.
