### PR TITLE
Add the replication related APIs to DistributedAdmin for SSR

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionAdmin.java
@@ -8,7 +8,8 @@ import java.util.Map;
  * An administrative interface for distributed transaction implementations. The user can execute
  * administrative operations with it like createNamespace/createTable/getTableMetadata.
  */
-public interface DistributedTransactionAdmin extends Admin, AuthAdmin, AbacAdmin, AutoCloseable {
+public interface DistributedTransactionAdmin
+    extends Admin, AuthAdmin, AbacAdmin, ReplicationAdmin, AutoCloseable {
 
   /**
    * Creates coordinator namespace and tables.

--- a/core/src/main/java/com/scalar/db/api/ReplicationAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/ReplicationAdmin.java
@@ -5,10 +5,7 @@ import com.scalar.db.exception.storage.ExecutionException;
 import java.util.Collections;
 import java.util.Map;
 
-/**
- * An administrative interface for the replication feature. The user can execute administrative
- * operations with it like createNamespace/createTable/getTableMetadata.
- */
+/** An administrative interface for the replication feature. */
 public interface ReplicationAdmin {
 
   /**

--- a/core/src/main/java/com/scalar/db/api/ReplicationAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/ReplicationAdmin.java
@@ -1,0 +1,126 @@
+package com.scalar.db.api;
+
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An administrative interface for the replication feature. The user can execute administrative
+ * operations with it like createNamespace/createTable/getTableMetadata.
+ */
+public interface ReplicationAdmin {
+
+  /**
+   * Creates the replication-related namespace and tables in the replication database.
+   *
+   * @param options options to create namespace and tables
+   * @throws ExecutionException if the operation fails
+   */
+  default void createReplicationTables(Map<String, String> options) throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.REPLICATION_NOT_ENABLED.buildMessage());
+  }
+
+  /**
+   * Creates the replication-related namespace and tables in the replication database.
+   *
+   * @param ifNotExist if set to true, the replication-related namespace and tables will be created
+   *     only if they do not exist. If set to false, it will throw an exception if they already
+   *     exist
+   * @param options options to create namespace and tables
+   * @throws IllegalArgumentException if the replication-related namespace or tables already exist
+   *     and ifNotExist is set to false
+   * @throws ExecutionException if the operation fails
+   */
+  default void createReplicationTables(boolean ifNotExist, Map<String, String> options)
+      throws ExecutionException {
+    if (ifNotExist && replicationTablesExist()) {
+      return;
+    }
+    createReplicationTables(options);
+  }
+
+  /**
+   * Creates the replication-related namespace and tables in the replication database.
+   *
+   * @param ifNotExist if set to true, the replication-related namespace and tables will be created
+   *     only if they do not exist. If set to false, it will throw an exception if they already
+   *     exist
+   * @throws IllegalArgumentException if the replication-related namespace or tables already exist
+   *     and ifNotExist is set to false
+   * @throws ExecutionException if the operation fails
+   */
+  default void createReplicationTables(boolean ifNotExist) throws ExecutionException {
+    if (ifNotExist && replicationTablesExist()) {
+      return;
+    }
+    createReplicationTables(Collections.emptyMap());
+  }
+
+  /**
+   * Creates the replication-related namespace and tables in the replication database.
+   *
+   * @throws ExecutionException if the operation fails
+   */
+  default void createReplicationTables() throws ExecutionException {
+    createReplicationTables(Collections.emptyMap());
+  }
+
+  /**
+   * Drops the replication-related namespace and tables in the replication database.
+   *
+   * @throws IllegalArgumentException if the replication-related tables do not exist
+   * @throws ExecutionException if the operation fails
+   */
+  default void dropReplicationTables() throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.REPLICATION_NOT_ENABLED.buildMessage());
+  }
+
+  /**
+   * Drops the replication-related namespace and tables in the replication database.
+   *
+   * @param ifExist if set to true, the replication-related namespace and tables will be dropped
+   *     only if they exist. If set to false, it will throw an exception if they do not exist
+   * @throws IllegalArgumentException if the replication-related tables do not exist if ifExist is
+   *     set to false
+   * @throws ExecutionException if the operation fails
+   */
+  default void dropReplicationTables(boolean ifExist) throws ExecutionException {
+    if (ifExist && !replicationTablesExist()) {
+      return;
+    }
+    dropReplicationTables();
+  }
+
+  /**
+   * Truncates the replication-related tables in the replication database.
+   *
+   * @throws IllegalArgumentException if the replication-related tables do not exist
+   * @throws ExecutionException if the operation fails
+   */
+  default void truncateReplicationTables() throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.REPLICATION_NOT_ENABLED.buildMessage());
+  }
+
+  /**
+   * Repairs the replication-related tables in the replication database which may be in an unknown
+   * state.
+   *
+   * @param options options to repair
+   * @throws IllegalArgumentException if the replication-related tables do not exist
+   * @throws ExecutionException if the operation fails
+   */
+  default void repairReplicationTables(Map<String, String> options) throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.REPLICATION_NOT_ENABLED.buildMessage());
+  }
+
+  /**
+   * Checks whether all the replication-related tables exist in the replication database.
+   *
+   * @return true if all the replication-related tables exist, false otherwise
+   * @throws ExecutionException if the operation fails
+   */
+  default boolean replicationTablesExist() throws ExecutionException {
+    throw new UnsupportedOperationException(CoreError.REPLICATION_NOT_ENABLED.buildMessage());
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionAdmin.java
@@ -559,6 +559,52 @@ public abstract class DecoratedDistributedTransactionAdmin implements Distribute
   }
 
   @Override
+  public void createReplicationTables(Map<String, String> options) throws ExecutionException {
+    distributedTransactionAdmin.createReplicationTables(options);
+  }
+
+  @Override
+  public void createReplicationTables(boolean ifNotExist, Map<String, String> options)
+      throws ExecutionException {
+    distributedTransactionAdmin.createReplicationTables(ifNotExist, options);
+  }
+
+  @Override
+  public void createReplicationTables(boolean ifNotExist) throws ExecutionException {
+    distributedTransactionAdmin.createReplicationTables(ifNotExist);
+  }
+
+  @Override
+  public void createReplicationTables() throws ExecutionException {
+    distributedTransactionAdmin.createReplicationTables();
+  }
+
+  @Override
+  public void dropReplicationTables() throws ExecutionException {
+    distributedTransactionAdmin.dropReplicationTables();
+  }
+
+  @Override
+  public void dropReplicationTables(boolean ifExist) throws ExecutionException {
+    distributedTransactionAdmin.dropReplicationTables(ifExist);
+  }
+
+  @Override
+  public void truncateReplicationTables() throws ExecutionException {
+    distributedTransactionAdmin.truncateReplicationTables();
+  }
+
+  @Override
+  public void repairReplicationTables(Map<String, String> options) throws ExecutionException {
+    distributedTransactionAdmin.repairReplicationTables(options);
+  }
+
+  @Override
+  public boolean replicationTablesExist() throws ExecutionException {
+    return distributedTransactionAdmin.replicationTablesExist();
+  }
+
+  @Override
   public void close() {
     distributedTransactionAdmin.close();
   }

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -848,6 +848,13 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0186", "The CSV row: %s does not match header: %s.", "", ""),
   DATA_LOADER_JSON_CONTENT_START_ERROR(
       Category.USER_ERROR, "0187", "Expected JSON file content to be an array", "", ""),
+  REPLICATION_NOT_ENABLED(
+      Category.USER_ERROR,
+      "0188",
+      // TODO: Update the message once the licence type is determined.
+      "The replication feature is not enabled. To use this feature, you must enable it",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category


### PR DESCRIPTION
## Description

We've [implemented `ReplicationDistributedTransactionAdmin` in ScalarDB Cluster](https://github.com/scalar-labs/scalardb-cluster/pull/994) that has some new APIs. `DistributedAdmin` doesn't have the API yet, so users can't use the new APIs via `DistributedAdmin`. This PR add those new APIs to `DistributedAdmin`.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb-cluster/pull/994

## Changes made

- Add `ReplicationAdmin` that contains the new replication related APIs
- Update `DistributedAdmin` to inherit `ReplicationAdmin` as well as other Admin interfaces
- Update `DecoratedDistributedTransactionAdmin` to support the new APIs as well as other Admin interfaces

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A