### PR TITLE
Add link to ScalarDB design doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ To learn more, see [ScalarDB Overview](https://scalardb.scalar-labs.com/docs/lat
 2. To set up and run various samples instances, see the [list of ScalarDB sample applications](https://scalardb.scalar-labs.com/docs/latest/scalardb-samples).
 3. Learn about the [configurations for ScalarDB Core](https://scalardb.scalar-labs.com/docs/latest/configurations) and the [configurations for ScalarDB Cluster](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-cluster-configurations).
 4. Learn about features, such as:
+5. Learn about ScalarDB and its features:
+   - [ScalarDB design](https://scalardb.scalar-labs.com/docs/latest/design)
    - [User authentication/authorization](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-auth-with-sql) (for enterprise customers)
    - [Attribute-based access control](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/authorize-with-abac) (for enterprise customers)
    - [Vector search](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/getting-started-with-vector-search) (for enterprise customers)
 
-For additional documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/latest/).
+For additional documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/latest).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ To learn more, see [ScalarDB Overview](https://scalardb.scalar-labs.com/docs/lat
    - **Get started with ScalarDB Cluster (for enterprise customers):** To set up a basic application that uses ScalarDB Cluster through the Java API, see [Getting Started with ScalarDB Cluster](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/getting-started-with-scalardb-cluster).
 2. To set up and run various samples instances, see the [list of ScalarDB sample applications](https://scalardb.scalar-labs.com/docs/latest/scalardb-samples).
 3. Learn about the [configurations for ScalarDB Core](https://scalardb.scalar-labs.com/docs/latest/configurations) and the [configurations for ScalarDB Cluster](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-cluster-configurations).
-4. Learn about features, such as:
 5. Learn about ScalarDB and its features:
    - [ScalarDB design](https://scalardb.scalar-labs.com/docs/latest/design)
    - [User authentication/authorization](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-auth-with-sql) (for enterprise customers)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To learn more, see [ScalarDB Overview](https://scalardb.scalar-labs.com/docs/lat
    - **Get started with ScalarDB Cluster (for enterprise customers):** To set up a basic application that uses ScalarDB Cluster through the Java API, see [Getting Started with ScalarDB Cluster](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/getting-started-with-scalardb-cluster).
 2. To set up and run various samples instances, see the [list of ScalarDB sample applications](https://scalardb.scalar-labs.com/docs/latest/scalardb-samples).
 3. Learn about the [configurations for ScalarDB Core](https://scalardb.scalar-labs.com/docs/latest/configurations) and the [configurations for ScalarDB Cluster](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-cluster-configurations).
-5. Learn about ScalarDB and its features:
+4. Learn about ScalarDB and its features:
    - [ScalarDB design](https://scalardb.scalar-labs.com/docs/latest/design)
    - [User authentication/authorization](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-auth-with-sql) (for enterprise customers)
    - [Attribute-based access control](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/authorize-with-abac) (for enterprise customers)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To learn more, see [ScalarDB Overview](https://scalardb.scalar-labs.com/docs/lat
    - [User authentication/authorization](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-auth-with-sql) (for enterprise customers)
    - [Attribute-based access control](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/authorize-with-abac) (for enterprise customers)
    - [Vector search](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/getting-started-with-vector-search) (for enterprise customers)
-   - For a comprehensive list of features, see [Features](https://scalardb.scalar-labs.com/docs/latest/features).
+   - For a comprehensive list of features, see [ScalarDB Features](https://scalardb.scalar-labs.com/docs/latest/features).
 
 For additional documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/latest).
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To learn more, see [ScalarDB Overview](https://scalardb.scalar-labs.com/docs/lat
    - [User authentication/authorization](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/scalardb-auth-with-sql) (for enterprise customers)
    - [Attribute-based access control](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/authorize-with-abac) (for enterprise customers)
    - [Vector search](https://scalardb.scalar-labs.com/docs/latest/scalardb-cluster/getting-started-with-vector-search) (for enterprise customers)
+   - For a comprehensive list of features, see [Features](https://scalardb.scalar-labs.com/docs/latest/features).
 
 For additional documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/latest).
 


### PR DESCRIPTION
## Description

This PR adds a link to the ScalarDB design doc in the root-level README. Since we added the same in the README in the [scalar-labs/scalardl repository](https://github.com/scalar-labs/scalardl) recently, we should do the same here for consistency.

## Related issues and/or PRs

- Previous PR for the README in this repository:
  - https://github.com/scalar-labs/scalardb/pull/2611
- Similar PR for the README in the **scalar-labs/scalardl repository:**
  - https://github.com/scalar-labs/scalardl/pull/128

## Changes made

- Added a link to the ScalarDB design doc on the docs site.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A