### PR TITLE
Fix for `admin.getNamespaceNames()` when used with DynamoDB with the namespace prefix setting

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1278,8 +1278,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
       for (Map<String, AttributeValue> tableMetadata : scanResponse.items()) {
         String fullTableName = tableMetadata.get(METADATA_ATTR_TABLE).s();
-        String namespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
-        nonPrefixedNamespaceNames.add(namespaceName);
+        String prefixedNamespaceName = fullTableName.substring(0, fullTableName.indexOf('.'));
+        String nonPrefixedNamespaceName = prefixedNamespaceName.substring(namespacePrefix.length());
+        nonPrefixedNamespaceNames.add(nonPrefixedNamespaceName);
       }
     } while (!lastEvaluatedKey.isEmpty());
 

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1243,20 +1243,23 @@ public abstract class DynamoAdminTestBase {
     when(scanResponse.lastEvaluatedKey())
         .thenReturn(lastEvaluatedKeyFirstIteration)
         .thenReturn(lastEvaluatedKeySecondIteration);
+    String ns1 = getNamespacePrefixConfig().orElse("") + "ns1";
+    String ns2 = getNamespacePrefixConfig().orElse("") + "ns2";
+    when(scanResponse.count()).thenReturn(2);
     when(scanResponse.items())
         .thenReturn(
             ImmutableList.of(
                 ImmutableMap.of(
                     DynamoAdmin.METADATA_ATTR_TABLE,
-                    AttributeValue.builder().s("ns1.tbl1").build())))
+                    AttributeValue.builder().s(ns1 + ".tbl1").build())))
         .thenReturn(
             ImmutableList.of(
                 ImmutableMap.of(
                     DynamoAdmin.METADATA_ATTR_TABLE,
-                    AttributeValue.builder().s("ns1.tbl2").build()),
+                    AttributeValue.builder().s(ns1 + ".tbl2").build()),
                 ImmutableMap.of(
                     DynamoAdmin.METADATA_ATTR_TABLE,
-                    AttributeValue.builder().s("ns2.tbl3").build())));
+                    AttributeValue.builder().s(ns2 + ".tbl3").build())));
 
     // Act
     Set<String> actual = admin.getNamespaceNames();


### PR DESCRIPTION
## Description

This PR addresses the following bug.
With DynamoDB and using the namespace prefix setting `scalar.db.dynamo.namespace.prefix`. The namespace returned by `DistributedStorageAdmin.getNamespaceNames()` contains the prefix, while it should not.

## Related issues and/or PRs

N/A

## Changes made

- `DynamoAdmin.getNamespaceNames()` properly removes the prefix from the namespace names
-  Fixed the associated faulty unit test 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed an issue with `DistributedStorageAdmin.getNamespaceNames()` API when using the DynamoDB storage with the namespace prefix setting `scalar.db.dynamo.namespace.prefix`. The namespace names returned by this method wrongly contained the prefix.
