### PR TITLE
Improve DecoratedDistributedTransactionManager and DecoratedTwoPhaseCommitTransactionManager

### DIFF
--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -6,12 +6,10 @@ import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Insert;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
@@ -84,69 +82,9 @@ public class ActiveTransactionManagedDistributedTransactionManager
   }
 
   @Override
-  public DistributedTransaction begin() throws TransactionException {
-    return new ActiveTransaction(super.begin());
-  }
-
-  @Override
-  public DistributedTransaction begin(String txId) throws TransactionException {
-    return new ActiveTransaction(super.begin(txId));
-  }
-
-  @Override
-  public DistributedTransaction start() throws TransactionException {
-    return new ActiveTransaction(super.start());
-  }
-
-  @Override
-  public DistributedTransaction start(String txId) throws TransactionException {
-    return new ActiveTransaction(super.start(txId));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(Isolation isolation) throws TransactionException {
-    return new ActiveTransaction(super.start(isolation));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(String txId, Isolation isolation)
-      throws TransactionException {
-    return new ActiveTransaction(super.start(txId, isolation));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
-      throws TransactionException {
-    return new ActiveTransaction(super.start(isolation, strategy));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
-    return new ActiveTransaction(super.start(strategy));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(String txId, SerializableStrategy strategy)
-      throws TransactionException {
-    return new ActiveTransaction(super.start(txId, strategy));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(
-      String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
-    return new ActiveTransaction(super.start(txId, isolation, strategy));
+  protected DistributedTransaction decorateTransactionOnBeginOrStart(
+      DistributedTransaction transaction) throws TransactionException {
+    return new ActiveTransaction(transaction);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -85,23 +85,9 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
   }
 
   @Override
-  public TwoPhaseCommitTransaction begin() throws TransactionException {
-    return new ActiveTransaction(super.begin());
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction begin(String txId) throws TransactionException {
-    return new ActiveTransaction(super.begin(txId));
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction start() throws TransactionException {
-    return new ActiveTransaction(super.start());
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction start(String txId) throws TransactionException {
-    return new ActiveTransaction(super.start(txId));
+  protected TwoPhaseCommitTransaction decorateTransactionOnBeginOrStart(
+      TwoPhaseCommitTransaction transaction) throws TransactionException {
+    return new ActiveTransaction(transaction);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -68,29 +68,29 @@ public abstract class DecoratedDistributedTransactionManager
 
   @Override
   public DistributedTransaction begin() throws TransactionException {
-    return transactionManager.begin();
+    return decorateTransactionOnBeginOrStart(transactionManager.begin());
   }
 
   @Override
   public DistributedTransaction begin(String txId) throws TransactionException {
-    return transactionManager.begin(txId);
+    return decorateTransactionOnBeginOrStart(transactionManager.begin(txId));
   }
 
   @Override
   public DistributedTransaction start() throws TransactionException {
-    return transactionManager.start();
+    return decorateTransactionOnBeginOrStart(transactionManager.start());
   }
 
   @Override
   public DistributedTransaction start(String txId) throws TransactionException {
-    return transactionManager.start(txId);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(txId));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public DistributedTransaction start(Isolation isolation) throws TransactionException {
-    return transactionManager.start(isolation);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(isolation));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -98,7 +98,7 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public DistributedTransaction start(String txId, Isolation isolation)
       throws TransactionException {
-    return transactionManager.start(txId, isolation);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(txId, isolation));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -106,14 +106,14 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
       throws TransactionException {
-    return transactionManager.start(isolation, strategy);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(isolation, strategy));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override
   public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
-    return transactionManager.start(strategy);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(strategy));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -121,7 +121,7 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public DistributedTransaction start(String txId, SerializableStrategy strategy)
       throws TransactionException {
-    return transactionManager.start(txId, strategy);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(txId, strategy));
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -129,7 +129,12 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public DistributedTransaction start(
       String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
-    return transactionManager.start(txId, isolation, strategy);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(txId, isolation, strategy));
+  }
+
+  protected DistributedTransaction decorateTransactionOnBeginOrStart(
+      DistributedTransaction transaction) throws TransactionException {
+    return transaction;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
@@ -68,22 +68,27 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
 
   @Override
   public TwoPhaseCommitTransaction begin() throws TransactionException {
-    return transactionManager.begin();
+    return decorateTransactionOnBeginOrStart(transactionManager.begin());
   }
 
   @Override
   public TwoPhaseCommitTransaction begin(String txId) throws TransactionException {
-    return transactionManager.begin(txId);
+    return decorateTransactionOnBeginOrStart(transactionManager.begin(txId));
   }
 
   @Override
   public TwoPhaseCommitTransaction start() throws TransactionException {
-    return transactionManager.start();
+    return decorateTransactionOnBeginOrStart(transactionManager.start());
   }
 
   @Override
   public TwoPhaseCommitTransaction start(String txId) throws TransactionException {
-    return transactionManager.start(txId);
+    return decorateTransactionOnBeginOrStart(transactionManager.start(txId));
+  }
+
+  protected TwoPhaseCommitTransaction decorateTransactionOnBeginOrStart(
+      TwoPhaseCommitTransaction transaction) throws TransactionException {
+    return transaction;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -6,12 +6,10 @@ import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Insert;
-import com.scalar.db.api.Isolation;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
@@ -19,7 +17,6 @@ import com.scalar.db.exception.transaction.AbortException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.RollbackException;
-import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.List;
 import java.util.Optional;
@@ -33,69 +30,9 @@ public class StateManagedDistributedTransactionManager
   }
 
   @Override
-  public DistributedTransaction begin() throws TransactionException {
-    return new StateManagedTransaction(super.begin());
-  }
-
-  @Override
-  public DistributedTransaction begin(String txId) throws TransactionException {
-    return new StateManagedTransaction(super.begin(txId));
-  }
-
-  @Override
-  public DistributedTransaction start() throws TransactionException {
-    return new StateManagedTransaction(super.start());
-  }
-
-  @Override
-  public DistributedTransaction start(String txId) throws TransactionException {
-    return new StateManagedTransaction(super.start(txId));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(Isolation isolation) throws TransactionException {
-    return new StateManagedTransaction(super.start(isolation));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(String txId, Isolation isolation)
-      throws TransactionException {
-    return new StateManagedTransaction(super.start(txId, isolation));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(Isolation isolation, SerializableStrategy strategy)
-      throws TransactionException {
-    return new StateManagedTransaction(super.start(isolation, strategy));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(SerializableStrategy strategy) throws TransactionException {
-    return new StateManagedTransaction(super.start(strategy));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(String txId, SerializableStrategy strategy)
-      throws TransactionException {
-    return new StateManagedTransaction(super.start(txId, strategy));
-  }
-
-  /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
-  @Deprecated
-  @Override
-  public DistributedTransaction start(
-      String txId, Isolation isolation, SerializableStrategy strategy) throws TransactionException {
-    return new StateManagedTransaction(super.start(txId, isolation, strategy));
+  protected DistributedTransaction decorateTransactionOnBeginOrStart(
+      DistributedTransaction transaction) {
+    return new StateManagedTransaction(transaction);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -18,7 +18,6 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationException;
 import com.scalar.db.exception.transaction.RollbackException;
-import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
 import java.util.List;
@@ -33,23 +32,9 @@ public class StateManagedTwoPhaseCommitTransactionManager
   }
 
   @Override
-  public TwoPhaseCommitTransaction begin() throws TransactionException {
-    return new StateManagedTransaction(super.begin());
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction begin(String txId) throws TransactionException {
-    return new StateManagedTransaction(super.begin(txId));
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction start() throws TransactionException {
-    return new StateManagedTransaction(super.start());
-  }
-
-  @Override
-  public TwoPhaseCommitTransaction start(String txId) throws TransactionException {
-    return new StateManagedTransaction(super.start(txId));
+  protected TwoPhaseCommitTransaction decorateTransactionOnBeginOrStart(
+      TwoPhaseCommitTransaction transaction) {
+    return new StateManagedTransaction(transaction);
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds the `decorateTransactionOnBeginOrStart()` method to both `DecoratedDistributedTransactionManager` and `DecoratedTwoPhaseCommitTransactionManager` to reduce code duplication.

## Related issues and/or PRs

N/A

## Changes made

- Added the `decorateTransactionOnBeginOrStart()` method to `DecoratedDistributedTransactionManager` and `DecoratedTwoPhaseCommitTransactionManager`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
