### PR TITLE
Optimize JDBC storage by using Connection.setReadOnly()

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -82,6 +82,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
+      rdbEngine.setReadOnly(connection, true);
       return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw new ExecutionException(
@@ -97,6 +98,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
+      rdbEngine.setReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
     } catch (SQLException e) {
       close(connection);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -91,6 +91,9 @@ public final class JdbcUtils {
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
+
+    dataSource.setDefaultReadOnly(false);
+
     dataSource.setMinIdle(config.getTableMetadataConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getTableMetadataConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getTableMetadataConnectionPoolMaxTotal());
@@ -115,6 +118,9 @@ public final class JdbcUtils {
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
+
+    dataSource.setDefaultReadOnly(false);
+
     dataSource.setMinIdle(config.getAdminConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getAdminConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getAdminConnectionPoolMaxTotal());

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -63,6 +63,8 @@ public final class JdbcUtils {
               }
             });
 
+    dataSource.setDefaultReadOnly(false);
+
     dataSource.setMinIdle(config.getConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getConnectionPoolMaxTotal());

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -13,6 +13,7 @@ import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
@@ -336,5 +337,10 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   @Override
   public RdbEngineTimeTypeStrategy<Integer, Long, Long, Long> getTimeTypeStrategy() {
     return timeTypeEngine;
+  }
+
+  @Override
+  public void setReadOnly(Connection connection, boolean readOnly) {
+    // Do nothing. SQLite does not support read-only mode.
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -10,6 +10,7 @@ import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
@@ -227,5 +228,9 @@ public interface RdbEngineStrategy {
    */
   default void throwIfDuplicatedIndexWarning(SQLWarning warning) throws SQLException {
     // Do nothing
+  }
+
+  default void setReadOnly(Connection connection, boolean readOnly) throws SQLException {
+    connection.setReadOnly(readOnly);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -71,6 +71,7 @@ public class JdbcDatabaseTest {
     jdbcDatabase.get(get);
 
     // Assert
+    verify(connection).setReadOnly(true);
     verify(jdbcService).get(any(), any());
     verify(connection).close();
   }
@@ -89,6 +90,7 @@ public class JdbcDatabaseTest {
               jdbcDatabase.get(get);
             })
         .isInstanceOf(ExecutionException.class);
+    verify(connection).setReadOnly(true);
     verify(connection).close();
   }
 
@@ -104,6 +106,7 @@ public class JdbcDatabaseTest {
     scanner.close();
 
     // Assert
+    verify(connection).setReadOnly(true);
     verify(jdbcService).getScanner(any(), any());
     verify(connection).close();
   }
@@ -122,6 +125,7 @@ public class JdbcDatabaseTest {
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(ExecutionException.class);
+    verify(connection).setReadOnly(true);
     verify(connection).close();
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -182,6 +182,8 @@ public class JdbcUtilsTest {
     assertThat(tableMetadataDataSource.getUsername()).isEqualTo("user");
     assertThat(tableMetadataDataSource.getPassword()).isEqualTo("oracle");
 
+    assertThat(tableMetadataDataSource.getDefaultReadOnly()).isFalse();
+
     assertThat(tableMetadataDataSource.getMinIdle()).isEqualTo(100);
     assertThat(tableMetadataDataSource.getMaxIdle()).isEqualTo(200);
     assertThat(tableMetadataDataSource.getMaxTotal()).isEqualTo(300);
@@ -213,6 +215,8 @@ public class JdbcUtilsTest {
     assertThat(adminDataSource.getUrl()).isEqualTo("jdbc:sqlserver://localhost:1433");
     assertThat(adminDataSource.getUsername()).isEqualTo("user");
     assertThat(adminDataSource.getPassword()).isEqualTo("sqlserver");
+
+    assertThat(adminDataSource.getDefaultReadOnly()).isFalse();
 
     assertThat(adminDataSource.getMinIdle()).isEqualTo(100);
     assertThat(adminDataSource.getMaxIdle()).isEqualTo(200);

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -66,6 +66,7 @@ public class JdbcUtilsTest {
     assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(true);
     assertThat(dataSource.getDefaultTransactionIsolation())
         .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
+    assertThat(dataSource.getDefaultReadOnly()).isFalse();
 
     assertThat(dataSource.getMinIdle()).isEqualTo(10);
     assertThat(dataSource.getMaxIdle()).isEqualTo(20);
@@ -109,6 +110,7 @@ public class JdbcUtilsTest {
     assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(false);
     assertThat(dataSource.getDefaultTransactionIsolation())
         .isEqualTo(Connection.TRANSACTION_READ_COMMITTED);
+    assertThat(dataSource.getDefaultReadOnly()).isFalse();
 
     assertThat(dataSource.getMinIdle()).isEqualTo(30);
     assertThat(dataSource.getMaxIdle()).isEqualTo(40);


### PR DESCRIPTION
## Description

This PR updates the JDBC storage to use `Connection.setReadOnly()` to optimize read operations.

For details about the `Connection.setReadOnly()` method, see:  
https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setReadOnly-boolean-

## Related issues and/or PRs

N/A

## Changes made

- Updated the JDBC storage to use `Connection.setReadOnly()` for the Get and Scan operations.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
