### PR TITLE
Add exception handling for DateTimeParseException

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -896,6 +896,12 @@ public enum CoreError implements ScalarDbError {
   DATA_LOADER_FILE_PATH_IS_BLANK(
       Category.USER_ERROR, "0197", "File path must not be blank.", "", ""),
   DATA_LOADER_FILE_NOT_FOUND(Category.USER_ERROR, "0198", "File not found: %s", "", ""),
+  DATA_LOADER_INVALID_DATE_TIME_FOR_COLUMN_VALUE(
+      Category.USER_ERROR,
+      "0199",
+      "Invalid date time value specified for column %s in table %s in namespace %s.",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/util/ColumnUtils.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/util/ColumnUtils.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashSet;
@@ -133,6 +134,11 @@ public final class ColumnUtils {
     } catch (NumberFormatException e) {
       throw new ColumnParsingException(
           CoreError.DATA_LOADER_INVALID_NUMBER_FORMAT_FOR_COLUMN_VALUE.buildMessage(
+              columnName, columnInfo.getTableName(), columnInfo.getNamespace()),
+          e);
+    } catch (DateTimeParseException e) {
+      throw new ColumnParsingException(
+          CoreError.DATA_LOADER_INVALID_DATE_TIME_FOR_COLUMN_VALUE.buildMessage(
               columnName, columnInfo.getTableName(), columnInfo.getNamespace()),
           e);
     } catch (IllegalArgumentException e) {

--- a/data-loader/core/src/test/java/com/scalar/db/dataloader/core/util/ColumnUtilsTest.java
+++ b/data-loader/core/src/test/java/com/scalar/db/dataloader/core/util/ColumnUtilsTest.java
@@ -184,6 +184,25 @@ class ColumnUtilsTest {
             columnName, "table", "ns"),
         exception.getMessage());
   }
+  /**
+   * Tests that attempting to create a date time column with an invalid format throws a
+   * DateTimeParseException with appropriate error message.
+   */
+  @Test
+  void createColumnFromValue_invalidNumberFormat_throwsDateTimeParseException() {
+    String columnName = "timestampColumn";
+    String value = "not_a_timestamp";
+    ColumnInfo columnInfo =
+        ColumnInfo.builder().namespace("ns").tableName("table").columnName(columnName).build();
+    ColumnParsingException exception =
+        assertThrows(
+            ColumnParsingException.class,
+            () -> ColumnUtils.createColumnFromValue(DataType.TIMESTAMP, columnInfo, value));
+    assertEquals(
+        CoreError.DATA_LOADER_INVALID_DATE_TIME_FOR_COLUMN_VALUE.buildMessage(
+            columnName, "table", "ns"),
+        exception.getMessage());
+  }
 
   /**
    * Tests the extraction of columns from a ScalarDB Result object. Verifies that all columns are

--- a/data-loader/core/src/test/java/com/scalar/db/dataloader/core/util/ColumnUtilsTest.java
+++ b/data-loader/core/src/test/java/com/scalar/db/dataloader/core/util/ColumnUtilsTest.java
@@ -189,7 +189,7 @@ class ColumnUtilsTest {
    * DateTimeParseException with appropriate error message.
    */
   @Test
-  void createColumnFromValue_invalidNumberFormat_throwsDateTimeParseException() {
+  void createColumnFromValue_invalidDateTimeFormat_throwsDateTimeParseException() {
     String columnName = "timestampColumn";
     String value = "not_a_timestamp";
     ColumnInfo columnInfo =


### PR DESCRIPTION
## Description

I have added a catch clause to handle `DateTimeParseException` thrown on value conversion for field `TIMESTAMP` when a value of epoch time `1620822456000` which caused a `java.time.format.DateTimeParseException` during testing and for now it was decided to handle the exception and return a proper error message via log files so the user is informed clearly.


 

## Related issues and/or PRs

NA

## Changes made

* Added a catch clause for `java.time.format.DateTimeParseException` in column value conversion and also added  a error message to core error class. 
* Added a unit test case for it

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

For now, adding the proper error handling is ok to make sure the process does not crash and stop while running. However, probably it is better in the future to support and allow the user to map unix epoch time to timestamp format and have the data loader handle this conversion.

## Release notes

Add exception handling for DateTimeParseException on column value conversion
