### PR TITLE
Backport to branch(3.14) : Disallow scan operations after delete in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -449,15 +449,17 @@ public enum CoreError implements ScalarDbError {
       "",
       ""),
   CONSENSUS_COMMIT_WRITING_ALREADY_DELETED_DATA_NOT_ALLOWED(
-      Category.USER_ERROR, "0104", "Writing already-deleted data is not allowed", "", ""),
-  CONSENSUS_COMMIT_GETTING_DATA_NEITHER_IN_READ_SET_NOR_DELETE_SET_NOT_ALLOWED(
       Category.USER_ERROR,
-      "0105",
-      "Getting data neither in the read set nor the delete set is not allowed",
+      "0104",
+      "Writing data already-deleted by the same transaction is not allowed",
       "",
       ""),
-  CONSENSUS_COMMIT_READING_ALREADY_WRITTEN_DATA_NOT_ALLOWED(
-      Category.USER_ERROR, "0106", "Reading already-written data is not allowed", "", ""),
+  CONSENSUS_COMMIT_SCANNING_ALREADY_WRITTEN_OR_DELETED_DATA_NOT_ALLOWED(
+      Category.USER_ERROR,
+      "0106",
+      "Scanning data already-written or already-deleted by the same transaction is not allowed",
+      "",
+      ""),
   CONSENSUS_COMMIT_TRANSACTION_NOT_VALIDATED_IN_EXTRA_READ(
       Category.USER_ERROR,
       "0107",
@@ -667,9 +669,17 @@ public enum CoreError implements ScalarDbError {
       "",
       ""),
   CONSENSUS_COMMIT_INSERTING_ALREADY_WRITTEN_DATA_NOT_ALLOWED(
-      Category.USER_ERROR, "0146", "Inserting already-written data is not allowed", "", ""),
+      Category.USER_ERROR,
+      "0146",
+      "Inserting data already-written by the same transaction is not allowed",
+      "",
+      ""),
   CONSENSUS_COMMIT_DELETING_ALREADY_INSERTED_DATA_NOT_ALLOWED(
-      Category.USER_ERROR, "0147", "Deleting already-inserted data is not allowed", "", ""),
+      Category.USER_ERROR,
+      "0147",
+      "Deleting data already-inserted by the same transaction is not allowed",
+      "",
+      ""),
   DATA_LOADER_INVALID_COLUMN_NON_EXISTENT(
       Category.USER_ERROR,
       "0148",

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -78,7 +78,11 @@ public class CrudHandler {
     Get get = (Get) prepareStorageSelection(originalGet);
     Snapshot.Key key = new Snapshot.Key(get);
     readUnread(key, get);
-    return createGetResult(key, get, originalProjections);
+
+    TableMetadata metadata = getTableMetadata(get);
+    return snapshot
+        .getResult(key, get)
+        .map(r -> new FilteredResult(r, originalProjections, metadata, isIncludeMetadataEnabled));
   }
 
   @VisibleForTesting
@@ -112,35 +116,22 @@ public class CrudHandler {
         snapshot.getId());
   }
 
-  private Optional<Result> createGetResult(Snapshot.Key key, Get get, List<String> projections)
-      throws CrudException {
-    TableMetadata metadata = getTableMetadata(key.getNamespace(), key.getTable());
-    return snapshot
-        .getResult(key, get)
-        .map(r -> new FilteredResult(r, projections, metadata, isIncludeMetadataEnabled));
-  }
-
-  public List<Result> scan(Scan scan) throws CrudException {
-    List<Result> results = scanInternal(scan);
-
-    // We verify if this scan does not overlap previous writes using the actual scan result. Because
-    // we support arbitrary conditions in the where clause of a scan (not only ScanAll, but also
-    // Scan and ScanWithIndex), we cannot determine whether the scan results will include a record
-    // whose key is the same as the key specified in the previous writes, without knowing the
-    // obtained keys in the actual scan. With this check, users can avoid seeing unexpected scan
-    // results that have not included previous writes yet.
-    snapshot.verify(scan);
-
-    return results;
-  }
-
-  private List<Result> scanInternal(Scan originalScan) throws CrudException {
+  public List<Result> scan(Scan originalScan) throws CrudException {
     List<String> originalProjections = new ArrayList<>(originalScan.getProjections());
     Scan scan = (Scan) prepareStorageSelection(originalScan);
+    Map<Snapshot.Key, TransactionResult> results = scanInternal(scan);
+    snapshot.verifyNoOverlap(scan, results);
 
+    TableMetadata metadata = getTableMetadata(scan);
+    return results.values().stream()
+        .map(r -> new FilteredResult(r, originalProjections, metadata, isIncludeMetadataEnabled))
+        .collect(Collectors.toList());
+  }
+
+  private Map<Snapshot.Key, TransactionResult> scanInternal(Scan scan) throws CrudException {
     Optional<Map<Snapshot.Key, TransactionResult>> resultsInSnapshot = snapshot.getResults(scan);
     if (resultsInSnapshot.isPresent()) {
-      return createScanResults(scan, originalProjections, resultsInSnapshot.get());
+      return resultsInSnapshot.get();
     }
 
     Map<Snapshot.Key, TransactionResult> results = new LinkedHashMap<>();
@@ -150,23 +141,21 @@ public class CrudHandler {
       scanner = scanFromStorage(scan);
       for (Result r : scanner) {
         TransactionResult result = new TransactionResult(r);
-        if (!result.isCommitted()) {
-          throw new UncommittedRecordException(
-              scan,
-              result,
-              CoreError.CONSENSUS_COMMIT_READ_UNCOMMITTED_RECORD.buildMessage(),
-              snapshot.getId());
-        }
-
         Snapshot.Key key = new Snapshot.Key(scan, r);
-
-        // We always update the read set to create before image by using the latest record (result)
-        // because another conflicting transaction might have updated the record after this
-        // transaction read it first.
-        snapshot.putIntoReadSet(key, Optional.of(result));
-
-        snapshot.getResult(key).ifPresent(value -> results.put(key, value));
+        processScanResult(key, scan, result);
+        results.put(key, result);
       }
+    } catch (RuntimeException e) {
+      Exception exception;
+      if (e.getCause() instanceof ExecutionException) {
+        exception = (ExecutionException) e.getCause();
+      } else {
+        exception = e;
+      }
+      throw new CrudException(
+          CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
+          exception,
+          snapshot.getId());
     } finally {
       if (scanner != null) {
         try {
@@ -176,19 +165,26 @@ public class CrudHandler {
         }
       }
     }
+
     snapshot.putIntoScanSet(scan, results);
 
-    return createScanResults(scan, originalProjections, results);
+    return results;
   }
 
-  private List<Result> createScanResults(
-      Scan scan, List<String> projections, Map<Snapshot.Key, TransactionResult> results)
+  private void processScanResult(Snapshot.Key key, Scan scan, TransactionResult result)
       throws CrudException {
-    assert scan.forNamespace().isPresent() && scan.forTable().isPresent();
-    TableMetadata metadata = getTableMetadata(scan.forNamespace().get(), scan.forTable().get());
-    return results.values().stream()
-        .map(r -> new FilteredResult(r, projections, metadata, isIncludeMetadataEnabled))
-        .collect(Collectors.toList());
+    if (!result.isCommitted()) {
+      throw new UncommittedRecordException(
+          scan,
+          result,
+          CoreError.CONSENSUS_COMMIT_READ_UNCOMMITTED_RECORD.buildMessage(),
+          snapshot.getId());
+    }
+
+    // We always update the read set to create before image by using the latest record (result)
+    // because another conflicting transaction might have updated the record after this
+    // transaction read it first.
+    snapshot.putIntoReadSet(key, Optional.of(result));
   }
 
   public void put(Put put) throws CrudException {
@@ -321,14 +317,14 @@ public class CrudHandler {
     }
   }
 
-  private TableMetadata getTableMetadata(String namespace, String table) throws CrudException {
+  private TableMetadata getTableMetadata(Operation operation) throws CrudException {
     try {
       TransactionTableMetadata metadata =
-          tableMetadataManager.getTransactionTableMetadata(namespace, table);
+          tableMetadataManager.getTransactionTableMetadata(operation);
       if (metadata == null) {
+        assert operation.forFullTableName().isPresent();
         throw new IllegalArgumentException(
-            CoreError.TABLE_NOT_FOUND.buildMessage(
-                ScalarDbUtils.getFullTableName(namespace, table)));
+            CoreError.TABLE_NOT_FOUND.buildMessage(operation.forFullTableName().get()));
       }
       return metadata.getTableMetadata();
     } catch (ExecutionException e) {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -35,6 +35,7 @@ import com.scalar.db.util.ScalarDbUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -360,7 +361,7 @@ public class CrudHandlerTest {
     // Assert
     verify(snapshot).putIntoReadSet(key, Optional.of(expected));
     verify(snapshot).putIntoScanSet(scan, ImmutableMap.of(key, expected));
-    verify(snapshot).verify(scan);
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, expected));
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
@@ -511,7 +512,7 @@ public class CrudHandlerTest {
   }
 
   @Test
-  public void scan_CalledAfterDeleteUnderRealSnapshot_ShouldReturnResultsWithoutDeletedRecord()
+  public void scan_CalledAfterDeleteUnderRealSnapshot_ShouldThrowIllegalArgumentException()
       throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareScan();
@@ -559,32 +560,19 @@ public class CrudHandlerTest {
             .forNamespace(ANY_NAMESPACE_NAME)
             .forTable(ANY_TABLE_NAME);
 
-    // Act
+    // Act Assert
     handler.delete(delete);
-    List<Result> results = handler.scan(scan);
-
-    // Assert
-    assertThat(results.size()).isEqualTo(1);
-    assertThat(results.get(0))
-        .isEqualTo(new FilteredResult(result, Collections.emptyList(), TABLE_METADATA, false));
 
     // check the delete set
     assertThat(deleteSet.size()).isEqualTo(1);
     assertThat(deleteSet).containsKey(new Snapshot.Key(delete));
 
-    // check if the scanned data is inserted correctly in the read set
-    assertThat(readSet.size()).isEqualTo(2);
-    Snapshot.Key key1 = new Snapshot.Key(scan, result);
-    assertThat(readSet.get(key1).isPresent()).isTrue();
-    assertThat(readSet.get(key1).get()).isEqualTo(new TransactionResult(result));
-    Snapshot.Key key2 = new Snapshot.Key(scan, result2);
-    assertThat(readSet.get(key2).isPresent()).isTrue();
-    assertThat(readSet.get(key2).get()).isEqualTo(new TransactionResult(result2));
+    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   public void
-      scan_CrossPartitionScanAndResultFromStorageGiven_ShouldUpdateSnapshotAndValidateThenReturn()
+      scan_CrossPartitionScanAndResultFromStorageGiven_ShouldUpdateSnapshotAndVerifyNoOverlapThenReturn()
           throws ExecutionException, CrudException {
     // Arrange
     Scan scan = prepareCrossPartitionScan();
@@ -601,7 +589,7 @@ public class CrudHandlerTest {
     // Assert
     verify(snapshot).putIntoReadSet(key, Optional.of(transactionResult));
     verify(snapshot).putIntoScanSet(scan, ImmutableMap.of(key, transactionResult));
-    verify(snapshot).verify(scan);
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, transactionResult));
     assertThat(results.size()).isEqualTo(1);
     assertThat(results.get(0))
         .isEqualTo(
@@ -610,7 +598,7 @@ public class CrudHandlerTest {
 
   @Test
   public void
-      scan_CrossPartitionScanAndPreparedResultFromStorageGiven_ShouldNeverUpdateSnapshotNorValidateButThrowUncommittedRecordException()
+      scan_CrossPartitionScanAndPreparedResultFromStorageGiven_ShouldNeverUpdateSnapshotNorVerifyNoOverlapButThrowUncommittedRecordException()
           throws ExecutionException {
     // Arrange
     Scan scan = prepareCrossPartitionScan();
@@ -630,7 +618,48 @@ public class CrudHandlerTest {
             });
 
     verify(snapshot, never()).putIntoReadSet(any(Snapshot.Key.class), ArgumentMatchers.any());
-    verify(snapshot, never()).verify(any());
+    verify(snapshot, never()).verifyNoOverlap(any(), any());
+  }
+
+  @Test
+  public void
+      scan_RuntimeExceptionCausedByExecutionExceptionThrownByIteratorHasNext_ShouldThrowCrudException()
+          throws ExecutionException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    ExecutionException executionException = mock(ExecutionException.class);
+    RuntimeException runtimeException = mock(RuntimeException.class);
+    when(runtimeException.getCause()).thenReturn(executionException);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    when(scanner.iterator()).thenReturn(iterator);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scan))
+        .isInstanceOf(CrudException.class)
+        .hasCause(executionException);
+  }
+
+  @Test
+  public void scan_RuntimeExceptionThrownByIteratorHasNext_ShouldThrowCrudException()
+      throws ExecutionException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    @SuppressWarnings("unchecked")
+    Iterator<Result> iterator = mock(Iterator.class);
+    RuntimeException runtimeException = mock(RuntimeException.class);
+    when(iterator.hasNext()).thenThrow(runtimeException);
+    when(scanner.iterator()).thenReturn(iterator);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Act Assert
+    assertThatThrownBy(() -> handler.scan(scan))
+        .isInstanceOf(CrudException.class)
+        .hasCause(runtimeException);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -2803,26 +2803,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scan_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
-    // Arrange
-    DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction.commit();
-
-    // Act
-    DistributedTransaction transaction1 = manager.begin();
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    List<Result> resultBefore = transaction1.scan(scan);
-    transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    List<Result> resultAfter = transaction1.scan(scan);
-    assertThatCode(transaction1::commit).doesNotThrowAnyException();
-
-    // Assert
-    assertThat(resultBefore.size()).isEqualTo(1);
-    assertThat(resultAfter.size()).isEqualTo(0);
-  }
-
-  @Test
   public void delete_PutCalledBefore_ShouldDelete() throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
@@ -3074,24 +3054,20 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scan_DeleteGivenBefore_ShouldScan() throws TransactionException {
+  public void scan_DeleteGivenBefore_ShouldThrowIllegalArgumentException()
+      throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
     transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
     transaction.put(preparePut(0, 1, namespace1, TABLE_1).withValue(BALANCE, 1));
     transaction.commit();
 
-    // Act
+    // Act Assert
     DistributedTransaction transaction1 = manager.begin();
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     Scan scan = prepareScan(0, 0, 1, namespace1, TABLE_1);
-    List<Result> results = transaction1.scan(scan);
-    assertThatCode(transaction1::commit).doesNotThrowAnyException();
-
-    // Assert
-    assertThat(results.size()).isEqualTo(1);
-    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
-    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThatThrownBy(() -> transaction1.scan(scan)).isInstanceOf(IllegalArgumentException.class);
+    transaction1.rollback();
   }
 
   @Test
@@ -3119,42 +3095,21 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scanAll_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
-    // Arrange
-    DistributedTransaction transaction = manager.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
-    transaction.commit();
-
-    // Act
-    DistributedTransaction transaction1 = manager.begin();
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    List<Result> resultBefore = transaction1.scan(scanAll);
-    transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    List<Result> resultAfter = transaction1.scan(scanAll);
-    assertThatCode(transaction1::commit).doesNotThrowAnyException();
-
-    // Assert
-    assertThat(resultBefore.size()).isEqualTo(1);
-    assertThat(resultAfter.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void scanAll_DeleteGivenBefore_ShouldScanAll() throws TransactionException {
+  public void scanAll_DeleteGivenBefore_ShouldThrowIllegalArgumentException()
+      throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.begin();
     transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
     transaction.put(preparePut(0, 1, namespace1, TABLE_1).withIntValue(BALANCE, 1));
     transaction.commit();
 
-    // Act
+    // Act Assert
     DistributedTransaction transaction1 = manager.begin();
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    List<Result> results = transaction1.scan(scanAll);
-    assertThatCode(transaction1::commit).doesNotThrowAnyException();
-
-    // Assert
-    assertThat(results.size()).isEqualTo(1);
+    assertThatThrownBy(() -> transaction1.scan(scanAll))
+        .isInstanceOf(IllegalArgumentException.class);
+    transaction1.rollback();
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitSpecificIntegrationTestBase.java
@@ -2591,32 +2591,6 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scan_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
-    // Arrange
-    TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
-    transaction.prepare();
-    transaction.commit();
-
-    // Act Assert
-    TwoPhaseCommitTransaction transaction1 = manager1.begin();
-    List<Result> resultBefore = transaction1.scan(prepareScan(0, 0, 0, namespace1, TABLE_1));
-    transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    List<Result> resultAfter = transaction1.scan(prepareScan(0, 0, 0, namespace1, TABLE_1));
-
-    assertThatCode(
-            () -> {
-              transaction1.prepare();
-              transaction1.commit();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    assertThat(resultBefore.size()).isEqualTo(1);
-    assertThat(resultAfter.size()).isEqualTo(0);
-  }
-
-  @Test
   public void delete_PutCalledBefore_ShouldDelete() throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -2700,7 +2674,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scan_DeleteGivenBefore_ShouldScan() throws TransactionException {
+  public void scan_DeleteGivenBefore_ShouldThrowIllegalArgumentException()
+      throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.put(preparePut(0, 0, namespace1, TABLE_1).withValue(BALANCE, 1));
@@ -2708,20 +2683,12 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction.prepare();
     transaction.commit();
 
-    // Act
+    // Act Assert
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     Scan scan = prepareScan(0, 0, 1, namespace1, TABLE_1);
-    List<Result> results = transaction1.scan(scan);
-    assertThatCode(
-            () -> {
-              transaction1.prepare();
-              transaction1.commit();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    assertThat(results.size()).isEqualTo(1);
+    assertThatThrownBy(() -> transaction1.scan(scan)).isInstanceOf(IllegalArgumentException.class);
+    transaction1.rollback();
   }
 
   @Test
@@ -2809,33 +2776,8 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
   }
 
   @Test
-  public void scanAll_DeleteCalledBefore_ShouldReturnEmpty() throws TransactionException {
-    // Arrange
-    TwoPhaseCommitTransaction transaction = manager1.begin();
-    transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
-    transaction.prepare();
-    transaction.commit();
-
-    // Act
-    TwoPhaseCommitTransaction transaction1 = manager1.begin();
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    List<Result> resultBefore = transaction1.scan(scanAll);
-    transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
-    List<Result> resultAfter = transaction1.scan(scanAll);
-    assertThatCode(
-            () -> {
-              transaction1.prepare();
-              transaction1.commit();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    assertThat(resultBefore.size()).isEqualTo(1);
-    assertThat(resultAfter.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void scanAll_DeleteGivenBefore_ShouldScanAll() throws TransactionException {
+  public void scanAll_DeleteGivenBefore_ShouldThrowIllegalArgumentException()
+      throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     transaction.put(preparePut(0, 0, namespace1, TABLE_1).withIntValue(BALANCE, 1));
@@ -2843,20 +2785,13 @@ public abstract class TwoPhaseConsensusCommitSpecificIntegrationTestBase {
     transaction.prepare();
     transaction.commit();
 
-    // Act
+    // Act Assert
     TwoPhaseCommitTransaction transaction1 = manager1.begin();
     transaction1.delete(prepareDelete(0, 0, namespace1, TABLE_1));
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    List<Result> results = transaction1.scan(scanAll);
-    assertThatCode(
-            () -> {
-              transaction1.prepare();
-              transaction1.commit();
-            })
-        .doesNotThrowAnyException();
-
-    // Assert
-    assertThat(results.size()).isEqualTo(1);
+    assertThatThrownBy(() -> transaction1.scan(scanAll))
+        .isInstanceOf(IllegalArgumentException.class);
+    transaction1.rollback();
   }
 
   @Test


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2610
- **Commit to backport:** 29bbb7324cbc4f6880d6a99030acd0067516dedd

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.14-pull-2610 &&
git cherry-pick --no-rerere-autoupdate -m1 29bbb7324cbc4f6880d6a99030acd0067516dedd
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!