### PR TITLE
Remove version from prepare-records condition in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
@@ -1,7 +1,6 @@
 package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
-import static com.scalar.db.transaction.consensuscommit.Attribute.VERSION;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitOperationAttributes.isInsertModeEnabled;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getNextTxVersion;
 
@@ -73,13 +72,10 @@ public class PrepareMutationComposer extends AbstractMutationComposer {
       if (result.isDeemedAsCommitted()) {
         // record is deemed-commit state
         putBuilder.condition(
-            ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText())
-                .and(ConditionBuilder.column(VERSION).isNullInt())
-                .build());
+            ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText()).build());
       } else {
         putBuilder.condition(
             ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(result.getId()))
-                .and(ConditionBuilder.column(VERSION).isEqualToInt(version))
                 .build());
       }
     } else { // initial record or insert mode enabled
@@ -113,13 +109,10 @@ public class PrepareMutationComposer extends AbstractMutationComposer {
       // check if the record is not interrupted by other conflicting transactions
       if (result.isDeemedAsCommitted()) {
         putBuilder.condition(
-            ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText())
-                .and(ConditionBuilder.column(VERSION).isNullInt())
-                .build());
+            ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText()).build());
       } else {
         putBuilder.condition(
             ConditionBuilder.putIf(ConditionBuilder.column(ID).isEqualToText(result.getId()))
-                .and(ConditionBuilder.column(VERSION).isEqualToInt(version))
                 .build());
       }
     } else {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -497,9 +497,9 @@ public class Snapshot {
       tasks.add(
           () -> {
             Optional<TransactionResult> originalResult = getSet.get(get);
-            // Only get tx_id and tx_version columns because we use only them to compare
+            // Only get the tx_id column because we use only them to compare
             get.clearProjections();
-            get.withProjection(Attribute.ID).withProjection(Attribute.VERSION);
+            get.withProjection(Attribute.ID);
 
             // Check if a read record is not changed
             Optional<TransactionResult> latestResult = storage.get(get).map(TransactionResult::new);
@@ -537,9 +537,9 @@ public class Snapshot {
       throws ExecutionException, ValidationConflictException {
     Scanner scanner = null;
     try {
-      // Only get tx_id, tx_version and primary key columns because we use only them to compare
+      // Only get tx_id and primary key columns because we use only them to compare
       scan.clearProjections();
-      scan.withProjection(Attribute.ID).withProjection(Attribute.VERSION);
+      scan.withProjection(Attribute.ID);
       ScalarDbUtils.addProjectionsForKeys(scan, getTableMetadata(scan));
 
       if (scan.getLimit() == 0) {
@@ -653,8 +653,7 @@ public class Snapshot {
   }
 
   private boolean isChanged(TransactionResult latestResult, TransactionResult result) {
-    return !Objects.equals(latestResult.getId(), result.getId())
-        || latestResult.getVersion() != result.getVersion();
+    return !Objects.equals(latestResult.getId(), result.getId());
   }
 
   private void throwExceptionDueToAntiDependency() throws ValidationConflictException {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposerTest.java
@@ -2,9 +2,7 @@ package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.api.ConditionalExpression.Operator;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
-import static com.scalar.db.transaction.consensuscommit.Attribute.VERSION;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
-import static com.scalar.db.transaction.consensuscommit.Attribute.toVersionValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -182,10 +180,7 @@ public class PrepareMutationComposerTest {
     // Assert
     Put actual = (Put) composer.get().get(0);
     put.withConsistency(Consistency.LINEARIZABLE);
-    put.withCondition(
-        new PutIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ),
-            new ConditionalExpression(VERSION, toVersionValue(2), Operator.EQ)));
+    put.withCondition(new PutIf(new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ)));
     put.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
     put.withValue(Attribute.toIdValue(ANY_ID_3));
     put.withValue(Attribute.toStateValue(TransactionState.PREPARED));
@@ -226,10 +221,7 @@ public class PrepareMutationComposerTest {
             .intValue(Attribute.BEFORE_STATE, null)
             .intValue(Attribute.BEFORE_VERSION, 0)
             .intValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2)
-            .condition(
-                ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText())
-                    .and(ConditionBuilder.column(VERSION).isNullInt())
-                    .build())
+            .condition(ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText()).build())
             .build();
     assertThat(actual).isEqualTo(expected);
   }
@@ -321,9 +313,7 @@ public class PrepareMutationComposerTest {
             .forTable(delete.forTable().get());
     expected.withConsistency(Consistency.LINEARIZABLE);
     expected.withCondition(
-        new PutIf(
-            new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ),
-            new ConditionalExpression(VERSION, toVersionValue(2), Operator.EQ)));
+        new PutIf(new ConditionalExpression(ID, toIdValue(ANY_ID_2), Operator.EQ)));
     expected.withValue(Attribute.toPreparedAtValue(ANY_TIME_5));
     expected.withValue(Attribute.toIdValue(ANY_ID_3));
     expected.withValue(Attribute.toStateValue(TransactionState.DELETED));
@@ -368,10 +358,7 @@ public class PrepareMutationComposerTest {
             .intValue(Attribute.BEFORE_STATE, null)
             .intValue(Attribute.BEFORE_VERSION, 0)
             .intValue(Attribute.BEFORE_PREFIX + ANY_NAME_3, ANY_INT_2)
-            .condition(
-                ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText())
-                    .and(ConditionBuilder.column(VERSION).isNullInt())
-                    .build())
+            .condition(ConditionBuilder.putIf(ConditionBuilder.column(ID).isNullText()).build())
             .build();
     assertThat(actual).isEqualTo(expected);
   }


### PR DESCRIPTION
## Description

Currently, in the prepare-records phase of Consensus Commit, both the transaction ID and version are set as conditions for Put and Delete operations. However, setting only the transaction ID should be sufficient since the transaction ID alone is enough to ensure correctness.

This PR removes the version column from the prepare-records conditions in Consensus Commit.

## Related issues and/or PRs

N/A

## Changes made

- Removed the version column from the prepare-records condition in Consensus Commit
- Updated the code to use only the transaction ID for comparison in the serializable validation phase.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
