### PR TITLE
Backport to branch(3) : Optimize JDBC storage by using Connection.setReadOnly()

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -82,6 +82,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
+      rdbEngine.setReadOnly(connection, true);
       return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw new ExecutionException(
@@ -97,6 +98,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
+      rdbEngine.setReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
     } catch (SQLException e) {
       close(connection);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcUtils.java
@@ -63,6 +63,8 @@ public final class JdbcUtils {
               }
             });
 
+    dataSource.setDefaultReadOnly(false);
+
     dataSource.setMinIdle(config.getConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getConnectionPoolMaxTotal());
@@ -89,6 +91,9 @@ public final class JdbcUtils {
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
+
+    dataSource.setDefaultReadOnly(false);
+
     dataSource.setMinIdle(config.getTableMetadataConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getTableMetadataConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getTableMetadataConnectionPoolMaxTotal());
@@ -113,6 +118,9 @@ public final class JdbcUtils {
     dataSource.setUrl(config.getJdbcUrl());
     config.getUsername().ifPresent(dataSource::setUsername);
     config.getPassword().ifPresent(dataSource::setPassword);
+
+    dataSource.setDefaultReadOnly(false);
+
     dataSource.setMinIdle(config.getAdminConnectionPoolMinIdle());
     dataSource.setMaxIdle(config.getAdminConnectionPoolMaxIdle());
     dataSource.setMaxTotal(config.getAdminConnectionPoolMaxTotal());

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -13,6 +13,7 @@ import com.scalar.db.storage.jdbc.query.SelectWithLimitQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
 import com.scalar.db.util.TimeRelatedColumnEncodingUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
@@ -335,5 +336,10 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
   @Override
   public RdbEngineTimeTypeStrategy<Integer, Long, Long, Long> getTimeTypeStrategy() {
     return timeTypeEngine;
+  }
+
+  @Override
+  public void setReadOnly(Connection connection, boolean readOnly) {
+    // Do nothing. SQLite does not support read-only mode.
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -10,6 +10,7 @@ import com.scalar.db.io.TimestampColumn;
 import com.scalar.db.io.TimestampTZColumn;
 import com.scalar.db.storage.jdbc.query.SelectQuery;
 import com.scalar.db.storage.jdbc.query.UpsertQuery;
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
@@ -225,5 +226,9 @@ public interface RdbEngineStrategy {
    */
   default void throwIfDuplicatedIndexWarning(SQLWarning warning) throws SQLException {
     // Do nothing
+  }
+
+  default void setReadOnly(Connection connection, boolean readOnly) throws SQLException {
+    connection.setReadOnly(readOnly);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -71,6 +71,7 @@ public class JdbcDatabaseTest {
     jdbcDatabase.get(get);
 
     // Assert
+    verify(connection).setReadOnly(true);
     verify(jdbcService).get(any(), any());
     verify(connection).close();
   }
@@ -89,6 +90,7 @@ public class JdbcDatabaseTest {
               jdbcDatabase.get(get);
             })
         .isInstanceOf(ExecutionException.class);
+    verify(connection).setReadOnly(true);
     verify(connection).close();
   }
 
@@ -104,6 +106,7 @@ public class JdbcDatabaseTest {
     scanner.close();
 
     // Assert
+    verify(connection).setReadOnly(true);
     verify(jdbcService).getScanner(any(), any());
     verify(connection).close();
   }
@@ -122,6 +125,7 @@ public class JdbcDatabaseTest {
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(ExecutionException.class);
+    verify(connection).setReadOnly(true);
     verify(connection).close();
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcUtilsTest.java
@@ -66,6 +66,7 @@ public class JdbcUtilsTest {
     assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(true);
     assertThat(dataSource.getDefaultTransactionIsolation())
         .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
+    assertThat(dataSource.getDefaultReadOnly()).isFalse();
 
     assertThat(dataSource.getMinIdle()).isEqualTo(10);
     assertThat(dataSource.getMaxIdle()).isEqualTo(20);
@@ -109,6 +110,7 @@ public class JdbcUtilsTest {
     assertThat(dataSource.getAutoCommitOnReturn()).isEqualTo(false);
     assertThat(dataSource.getDefaultTransactionIsolation())
         .isEqualTo(Connection.TRANSACTION_READ_COMMITTED);
+    assertThat(dataSource.getDefaultReadOnly()).isFalse();
 
     assertThat(dataSource.getMinIdle()).isEqualTo(30);
     assertThat(dataSource.getMaxIdle()).isEqualTo(40);
@@ -180,6 +182,8 @@ public class JdbcUtilsTest {
     assertThat(tableMetadataDataSource.getUsername()).isEqualTo("user");
     assertThat(tableMetadataDataSource.getPassword()).isEqualTo("oracle");
 
+    assertThat(tableMetadataDataSource.getDefaultReadOnly()).isFalse();
+
     assertThat(tableMetadataDataSource.getMinIdle()).isEqualTo(100);
     assertThat(tableMetadataDataSource.getMaxIdle()).isEqualTo(200);
     assertThat(tableMetadataDataSource.getMaxTotal()).isEqualTo(300);
@@ -211,6 +215,8 @@ public class JdbcUtilsTest {
     assertThat(adminDataSource.getUrl()).isEqualTo("jdbc:sqlserver://localhost:1433");
     assertThat(adminDataSource.getUsername()).isEqualTo("user");
     assertThat(adminDataSource.getPassword()).isEqualTo("sqlserver");
+
+    assertThat(adminDataSource.getDefaultReadOnly()).isFalse();
 
     assertThat(adminDataSource.getMinIdle()).isEqualTo(100);
     assertThat(adminDataSource.getMaxIdle()).isEqualTo(200);


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2651
- **Commit to backport:** a763467df31151c38810e16c3b0d474b31c509f7

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2651 &&
git cherry-pick --no-rerere-autoupdate -m1 a763467df31151c38810e16c3b0d474b31c509f7
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!