### PR TITLE
Backport to branch(3.14) : Set up CODEOWNERS to automatically assign reviewers for new PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Members of the ScalarDB team will be automatically requested for review on any pull request
+* @scalar-labs/scalardb


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2681
- **Commit to backport:** 0a10941aa359e59105fe7a46c9f586575d51ba8b

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.14-pull-2681 &&
git cherry-pick --no-rerere-autoupdate -m1 0a10941aa359e59105fe7a46c9f586575d51ba8b
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!