### PR TITLE
Add GitHub action to assign reviewers on PR created by Dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Members of the ScalarDB team will be automatically requested for review on any pull request
-* @scalar-labs/scalardb

--- a/.github/workflows/assign-dependabot-pr-reviewers.yaml
+++ b/.github/workflows/assign-dependabot-pr-reviewers.yaml
@@ -1,0 +1,23 @@
+name: Assign reviewer to dependabot PRs
+# This action assigns the ScalarDB team as reviewers when Dependabot opens a pull request.
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Assign ScalarDB team as reviewers for Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: gh pr edit $PR_NUMBER --repo $REPOSITORY --add-reviewer scalar-labs/scalardb
+


### PR DESCRIPTION
## Description

https://github.com/scalar-labs/scalardb/pull/2681 sets up a `CODEOWNERS` file to automatically assign the ScalarDB team as reviewers to any pull request created. 
This was introduced primarily to assign reviewers for PR created by Dependabot.
However,  setting up `CODEOWNERS` also assigns reviewers for the backport PR, which is not wanted.
Instead, we create a GitHub action to assign reviewers only for PRs created by Dependabot.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2681

## Changes made

- Add action to assign reviewer to PR that Dependabot creates
- Remove the codeowner file

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
