### PR TITLE
Add getScanner() method to transaction interfaces

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -6,6 +6,7 @@ import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegrationTestBase {
 
@@ -24,17 +25,31 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
 
   @Disabled("JDBC transactions don't support getState()")
   @Override
+  @Test
   public void getState_forSuccessfulTransaction_ShouldReturnCommittedState() {}
 
   @Disabled("JDBC transactions don't support getState()")
   @Override
+  @Test
   public void getState_forFailedTransaction_ShouldReturnAbortedState() {}
 
   @Disabled("JDBC transactions don't support abort()")
   @Override
+  @Test
   public void abort_forOngoingTransaction_ShouldAbortCorrectly() {}
 
   @Disabled("JDBC transactions don't support rollback()")
   @Override
+  @Test
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 }

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -41,6 +41,18 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
+   */
+  @Override
+  Scanner getScanner(Scan scan) throws CrudConflictException, CrudException;
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
@@ -154,4 +166,38 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
   @Override
   void mutate(List<? extends Mutation> mutations)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException;
+
+  interface Scanner extends CrudOperable.Scanner<CrudException> {
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    Optional<Result> one() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    List<Result> all() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudException if closing the scanner fails
+     */
+    @Override
+    void close() throws CrudException;
+  }
 }

--- a/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
@@ -47,6 +47,18 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
+   */
+  @Override
+  Scanner getScanner(Scan scan) throws CrudConflictException, CrudException;
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
@@ -177,4 +189,39 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
   void mutate(List<? extends Mutation> mutations)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException,
           UnknownTransactionStatusException;
+
+  interface Scanner extends CrudOperable.Scanner<TransactionException> {
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    Optional<Result> one() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    List<Result> all() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudException if closing the scanner fails
+     * @throws UnknownTransactionStatusException if the status of the commit is unknown
+     */
+    @Override
+    void close() throws CrudException, UnknownTransactionStatusException;
+  }
 }

--- a/core/src/main/java/com/scalar/db/common/AbstractCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractCrudOperableScanner.java
@@ -1,0 +1,61 @@
+package com.scalar.db.common;
+
+import com.google.errorprone.annotations.concurrent.LazyInit;
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Result;
+import com.scalar.db.exception.transaction.TransactionException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+public abstract class AbstractCrudOperableScanner<E extends TransactionException>
+    implements CrudOperable.Scanner<E> {
+
+  @LazyInit private ScannerIterator scannerIterator;
+
+  @Override
+  @Nonnull
+  public Iterator<Result> iterator() {
+    if (scannerIterator == null) {
+      scannerIterator = new ScannerIterator(this);
+    }
+    return scannerIterator;
+  }
+
+  @NotThreadSafe
+  public class ScannerIterator implements Iterator<Result> {
+
+    private final CrudOperable.Scanner<E> scanner;
+    private Result next;
+
+    public ScannerIterator(CrudOperable.Scanner<E> scanner) {
+      this.scanner = Objects.requireNonNull(scanner);
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (next != null) {
+        return true;
+      }
+
+      try {
+        return (next = scanner.one().orElse(null)) != null;
+      } catch (TransactionException e) {
+        throw new RuntimeException(e.getMessage(), e);
+      }
+    }
+
+    @Override
+    public Result next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      Result ret = next;
+      next = null;
+      return ret;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/AbstractTransactionCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTransactionCrudOperableScanner.java
@@ -1,0 +1,7 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.exception.transaction.CrudException;
+
+public abstract class AbstractTransactionCrudOperableScanner
+    extends AbstractCrudOperableScanner<CrudException> implements TransactionCrudOperable.Scanner {}

--- a/core/src/main/java/com/scalar/db/common/AbstractTransactionManagerCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTransactionManagerCrudOperableScanner.java
@@ -1,0 +1,8 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.TransactionManagerCrudOperable;
+import com.scalar.db.exception.transaction.TransactionException;
+
+public abstract class AbstractTransactionManagerCrudOperableScanner
+    extends AbstractCrudOperableScanner<TransactionException>
+    implements TransactionManagerCrudOperable.Scanner {}

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -121,6 +121,11 @@ public class ActiveTransactionManagedDistributedTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public synchronized Scanner getScanner(Scan scan) throws CrudException {
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -127,6 +127,11 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public synchronized Scanner getScanner(Scan scan) throws CrudException {
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
@@ -78,6 +78,11 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     return transaction.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transaction.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -157,6 +157,11 @@ public abstract class DecoratedDistributedTransactionManager
     return transactionManager.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transactionManager.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -80,6 +80,11 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     return transaction.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transaction.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
@@ -111,6 +111,11 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     return transactionManager.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transactionManager.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -70,6 +70,12 @@ public class StateManagedDistributedTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public Scanner getScanner(Scan scan) throws CrudException {
+      checkIfActive();
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -76,6 +76,12 @@ public class StateManagedTwoPhaseCommitTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public Scanner getScanner(Scan scan) throws CrudException {
+      checkIfActive();
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -168,10 +168,19 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return manager.getScanner(scan);
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     manager.put(puts);
@@ -197,6 +206,8 @@ public class TransactionService implements DistributedTransactionManager {
     manager.delete(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     manager.delete(deletes);

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -125,10 +125,19 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   }
 
   @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return manager.getScanner(scan);
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     manager.put(puts);
@@ -154,6 +163,8 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     manager.delete(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     manager.delete(deletes);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -96,6 +96,11 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     }
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -229,6 +229,11 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
+  }
+
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommit.java
@@ -86,6 +86,11 @@ public class TwoPhaseConsensusCommit extends AbstractTwoPhaseCommitTransaction {
     }
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -186,6 +186,11 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
+  }
+
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -94,6 +94,11 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
     }
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -168,6 +168,11 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
     return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
+  }
+
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -20,7 +20,6 @@ import com.scalar.db.api.PutBuilder;
 import com.scalar.db.api.PutIf;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
-import com.scalar.db.api.Scanner;
 import com.scalar.db.api.SerializableStrategy;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
@@ -156,11 +155,17 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
   public List<Result> scan(Scan scan) throws CrudException {
     scan = copyAndSetTargetToIfNot(scan);
 
-    try (Scanner scanner = storage.scan(scan.withConsistency(Consistency.LINEARIZABLE))) {
+    try (com.scalar.db.api.Scanner scanner =
+        storage.scan(scan.withConsistency(Consistency.LINEARIZABLE))) {
       return scanner.all();
     } catch (ExecutionException | IOException e) {
       throw new CrudException(e.getMessage(), e, null);
     }
+  }
+
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    throw new UnsupportedOperationException("Implement later");
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -15,6 +15,7 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Key;
 import java.util.Optional;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public abstract class ConsensusCommitIntegrationTestBase
@@ -929,4 +930,14 @@ public abstract class ConsensusCommitIntegrationTestBase
     Optional<Result> optResult = get(prepareGet(0, 0));
     assertThat(optResult).isNotPresent();
   }
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitIntegrationTestBase.java
@@ -2,6 +2,8 @@ package com.scalar.db.transaction.consensuscommit;
 
 import com.scalar.db.api.TwoPhaseCommitTransactionIntegrationTestBase;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public abstract class TwoPhaseConsensusCommitIntegrationTestBase
     extends TwoPhaseCommitTransactionIntegrationTestBase {
@@ -38,4 +40,14 @@ public abstract class TwoPhaseConsensusCommitIntegrationTestBase
   protected Properties getProps2(String testName) {
     return getProps1(testName);
   }
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -126,7 +126,12 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
   @Test
-  public void scanAll_ScanAllGivenForNonExisting_ShouldReturnEmpty() {}
+  public void scan_ScanAllGivenForNonExisting_ShouldReturnEmpty() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -404,6 +409,11 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Override
   @Test
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 
   @Disabled(
       "Single CRUD operation transactions don't support executing multiple mutations in a transaction")


### PR DESCRIPTION
## Description

This PR adds the getScanner() method to the transaction interfaces.

We are working on this feature in the `add-scanner-api-to-transaction-abstraction` feature branch, as this change may cause compile errors in dependent projects.

## Related issues and/or PRs

N/A

## Changes made

- 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.

## Release notes

N/A
