### PR TITLE
Add close for storage, transaction in data loader core

### DIFF
--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/ImportManager.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/ImportManager.java
@@ -152,8 +152,45 @@ public class ImportManager implements ImportEventListener {
   /** {@inheritDoc} Forwards the event to all registered listeners. */
   @Override
   public void onAllDataChunksCompleted() {
+    Throwable firstException = null;
+
     for (ImportEventListener listener : listeners) {
-      listener.onAllDataChunksCompleted();
+      try {
+        listener.onAllDataChunksCompleted();
+      } catch (Throwable e) {
+        if (firstException == null) {
+          firstException = e;
+        } else {
+          firstException.addSuppressed(e);
+        }
+      }
+    }
+
+    try {
+      closeResources();
+    } catch (Throwable e) {
+      if (firstException != null) {
+        firstException.addSuppressed(e);
+      } else {
+        firstException = e;
+      }
+    }
+
+    if (firstException != null) {
+      throw new RuntimeException("Error during completion", firstException);
+    }
+  }
+
+  /** Close resources properly once the process is completed */
+  public void closeResources() {
+    try {
+      if (distributedStorage != null) {
+        distributedStorage.close();
+      } else if (distributedTransactionManager != null) {
+        distributedTransactionManager.close();
+      }
+    } catch (Throwable e) {
+      throw new RuntimeException("Failed to close the resource", e);
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds code changes to close distributed storage/distributed transaction manager object once the import process is completed.
This change was added from following feedbacks (https://github.com/scalar-labs/scalardb/pull/2618#discussion_r2106398180, https://github.com/scalar-labs/scalardb/pull/2618#discussion_r2106402060) from the PR https://github.com/scalar-labs/scalardb/pull/2618.

## Related issues and/or PRs

NA

## Changes made

I have added changes in core to close istributed storage/distributed transaction manager object one the import process is completed.
I have added the method call to close resource on the import manager method which executed at the end of the import (`onAllDataChunksCompleted`). I have also made some changes recommended from AI suggestions (exception handling part added additionally).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA

## Release notes

NA
