### PR TITLE
Handle Get with index correctly in CrudHandler

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -720,6 +720,13 @@ public class Snapshot {
       this((Operation) get);
     }
 
+    public Key(Get get, Result result) {
+      this.namespace = get.forNamespace().get();
+      this.table = get.forTable().get();
+      this.partitionKey = result.getPartitionKey().get();
+      this.clusteringKey = result.getClusteringKey();
+    }
+
     public Key(Put put) {
       this((Operation) put);
     }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -4351,6 +4351,149 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
   }
 
+  @Test
+  public void getAndUpdate_GetWithIndexGiven_ShouldUpdate() throws TransactionException {
+    // Arrange
+    manager.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+
+    // Act Assert
+    DistributedTransaction transaction = manager.begin();
+    Optional<Result> actual =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .indexKey(Key.ofInt(BALANCE, INITIAL_BALANCE))
+                .build());
+
+    assertThat(actual).isPresent();
+    assertThat(actual.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(actual.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+
+    transaction.commit();
+
+    transaction = manager.begin();
+    actual =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .build());
+    transaction.commit();
+
+    assertThat(actual).isPresent();
+    assertThat(actual.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(actual.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(1);
+  }
+
+  @Test
+  public void scanAndUpdate_ScanWithIndexGiven_ShouldUpdate() throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    // Act Assert
+    DistributedTransaction transaction = manager.begin();
+    List<Result> actualResults =
+        transaction.scan(
+            Scan.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .indexKey(Key.ofInt(BALANCE, INITIAL_BALANCE))
+                .build());
+
+    assertThat(actualResults).hasSize(2);
+    Set<Integer> expectedTypes = Sets.newHashSet(0, 1);
+    for (Result result : actualResults) {
+      assertThat(result.getInt(ACCOUNT_ID)).isEqualTo(0);
+      expectedTypes.remove(result.getInt(ACCOUNT_TYPE));
+      assertThat(result.getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+    }
+    assertThat(expectedTypes).isEmpty();
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+            .intValue(BALANCE, 2)
+            .build());
+
+    transaction.commit();
+
+    transaction = manager.begin();
+    Optional<Result> actual1 =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .build());
+    Optional<Result> actual2 =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .build());
+    transaction.commit();
+
+    assertThat(actual1).isPresent();
+    assertThat(actual1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(actual1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(actual1.get().getInt(BALANCE)).isEqualTo(1);
+
+    assertThat(actual2).isPresent();
+    assertThat(actual2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(actual2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(actual2.get().getInt(BALANCE)).isEqualTo(2);
+  }
+
   private DistributedTransaction prepareTransfer(
       int fromId,
       String fromNamespace,


### PR DESCRIPTION
## Description

Currently, we create a `Snapshot.Key` instance from the `Get` object in `CrudHandler`, as shown here:
https://github.com/scalar-labs/scalardb/blob/63520ebb7c7b830032d5aaf0a88431bab2510847/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java#L79

This approach works for regular Get operations. However, it is incorrect for Get operations using a secondary index, as they do not contain primary key information. In such cases, we should create the `Snapshot.Key` instance from the result of the secondary index Get operation. This bug can lead to unnecessary implicit pre-reads when updating records retrieved by a secondary index Get operation within a transaction.

To fix this issue, this PR updates `CrudHandler` to correctly handle Get operations that use secondary indexes.

## Related issues and/or PRs

N/A

## Changes made

I’ve added some inline comments. Please take a look for the details.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed a bug that caused unnecessary implicit pre-reads when updating records retrieved by a secondary index Get operation within a transaction.
