### PR TITLE
Implement scanner API for JDBC transactions

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -42,14 +42,4 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
   @Override
   @Test
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
-
-  @Disabled("Implement later")
-  @Override
-  @Test
-  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
-
-  @Disabled("Implement later")
-  @Override
-  @Test
-  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 }

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -1182,6 +1182,8 @@ public enum CoreError implements ScalarDbError {
       Category.INTERNAL_ERROR, "0052", "Failed to read JSON file. Details: %s.", "", ""),
   DATA_LOADER_JSONLINES_FILE_READ_FAILED(
       Category.INTERNAL_ERROR, "0053", "Failed to read JSON Lines file. Details: %s.", "", ""),
+  JDBC_TRANSACTION_GETTING_SCANNER_FAILED(
+      Category.INTERNAL_ERROR, "0054", "Getting the scanner failed. Details: %s", "", ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -96,8 +96,13 @@ public class JdbcService {
     }
   }
 
-  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
   public Scanner getScanner(Scan scan, Connection connection)
+      throws SQLException, ExecutionException {
+    return getScanner(scan, connection, true);
+  }
+
+  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
+  public Scanner getScanner(Scan scan, Connection connection, boolean closeConnectionOnScannerClose)
       throws SQLException, ExecutionException {
     operationChecker.check(scan);
 
@@ -111,7 +116,8 @@ public class JdbcService {
         new ResultInterpreter(scan.getProjections(), tableMetadata, rdbEngine),
         connection,
         preparedStatement,
-        resultSet);
+        resultSet,
+        closeConnectionOnScannerClose);
   }
 
   public List<Result> scan(Scan scan, Connection connection)

--- a/core/src/main/java/com/scalar/db/storage/jdbc/ScannerImpl.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/ScannerImpl.java
@@ -25,17 +25,20 @@ public class ScannerImpl extends AbstractScanner {
   private final Connection connection;
   private final PreparedStatement preparedStatement;
   private final ResultSet resultSet;
+  private final boolean closeConnectionOnClose;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ScannerImpl(
       ResultInterpreter resultInterpreter,
       Connection connection,
       PreparedStatement preparedStatement,
-      ResultSet resultSet) {
+      ResultSet resultSet,
+      boolean closeConnectionOnClose) {
     this.resultInterpreter = Objects.requireNonNull(resultInterpreter);
     this.connection = Objects.requireNonNull(connection);
     this.preparedStatement = Objects.requireNonNull(preparedStatement);
     this.resultSet = Objects.requireNonNull(resultSet);
+    this.closeConnectionOnClose = closeConnectionOnClose;
   }
 
   @Override
@@ -75,10 +78,13 @@ public class ScannerImpl extends AbstractScanner {
     } catch (SQLException e) {
       logger.warn("Failed to close the preparedStatement", e);
     }
-    try {
-      connection.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the connection", e);
+
+    if (closeConnectionOnClose) {
+      try {
+        connection.close();
+      } catch (SQLException e) {
+        logger.warn("Failed to close the connection", e);
+      }
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransaction.java
@@ -20,6 +20,7 @@ import com.scalar.db.api.UpdateIf;
 import com.scalar.db.api.UpdateIfExists;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransaction;
+import com.scalar.db.common.AbstractTransactionCrudOperableScanner;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CommitConflictException;
@@ -32,6 +33,7 @@ import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.storage.jdbc.JdbcService;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import com.scalar.db.util.ScalarDbUtils;
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -96,7 +98,46 @@ public class JdbcTransaction extends AbstractDistributedTransaction {
 
   @Override
   public Scanner getScanner(Scan scan) throws CrudException {
-    throw new UnsupportedOperationException("Implement later");
+    scan = copyAndSetTargetToIfNot(scan);
+
+    com.scalar.db.api.Scanner scanner;
+    try {
+      scanner = jdbcService.getScanner(scan, connection, false);
+    } catch (SQLException e) {
+      throw createCrudException(
+          e, CoreError.JDBC_TRANSACTION_GETTING_SCANNER_FAILED.buildMessage(e.getMessage()));
+    } catch (ExecutionException e) {
+      throw new CrudException(e.getMessage(), e, txId);
+    }
+
+    return new AbstractTransactionCrudOperableScanner() {
+      @Override
+      public Optional<Result> one() throws CrudException {
+        try {
+          return scanner.one();
+        } catch (ExecutionException e) {
+          throw new CrudException(e.getMessage(), e, txId);
+        }
+      }
+
+      @Override
+      public List<Result> all() throws CrudException {
+        try {
+          return scanner.all();
+        } catch (ExecutionException e) {
+          throw new CrudException(e.getMessage(), e, txId);
+        }
+      }
+
+      @Override
+      public void close() throws CrudException {
+        try {
+          scanner.close();
+        } catch (IOException e) {
+          throw new CrudException(e.getMessage(), e, txId);
+        }
+      }
+    };
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -12,10 +12,12 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.SerializableStrategy;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransactionManager;
+import com.scalar.db.common.AbstractTransactionManagerCrudOperableScanner;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
@@ -38,6 +40,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
@@ -170,9 +173,93 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
 
   @Override
   public Scanner getScanner(Scan scan) throws CrudException {
-    throw new UnsupportedOperationException("Implement later");
+    DistributedTransaction transaction;
+    try {
+      transaction = begin();
+    } catch (TransactionNotFoundException e) {
+      throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    } catch (TransactionException e) {
+      throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    }
+
+    TransactionCrudOperable.Scanner scanner;
+    try {
+      scanner = transaction.getScanner(copyAndSetTargetToIfNot(scan));
+    } catch (CrudException e) {
+      rollbackTransaction(transaction);
+      throw e;
+    }
+
+    return new AbstractTransactionManagerCrudOperableScanner() {
+
+      private final AtomicBoolean closed = new AtomicBoolean();
+
+      @Override
+      public Optional<Result> one() throws CrudException {
+        try {
+          return scanner.one();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public List<Result> all() throws CrudException {
+        try {
+          return scanner.all();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public void close() throws CrudException, UnknownTransactionStatusException {
+        if (closed.get()) {
+          return;
+        }
+        closed.set(true);
+
+        try {
+          scanner.close();
+        } catch (CrudException e) {
+          rollbackTransaction(transaction);
+          throw e;
+        }
+
+        try {
+          transaction.commit();
+        } catch (CommitConflictException e) {
+          rollbackTransaction(transaction);
+          throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        } catch (UnknownTransactionStatusException e) {
+          throw e;
+        } catch (TransactionException e) {
+          rollbackTransaction(transaction);
+          throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        }
+      }
+    };
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -183,6 +270,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -229,6 +317,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -98,7 +98,8 @@ public class JdbcDatabaseTest {
   public void whenScanOperationExecutedAndScannerClosed_shouldCallJdbcService() throws Exception {
     // Arrange
     when(jdbcService.getScanner(any(), any()))
-        .thenReturn(new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet));
+        .thenReturn(
+            new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet, true));
 
     // Act
     Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -20,6 +20,8 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TransactionManagerCrudOperable;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
@@ -41,6 +43,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -176,6 +179,369 @@ public class JdbcTransactionManagerTest {
               transaction.scan(scan);
             })
         .isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void getScannerAndScannerOne_ShouldReturnScannerAndReturnProperResult() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.of(result3))
+        .thenReturn(Optional.empty());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThat(actual.one()).hasValue(result1);
+    assertThat(actual.one()).hasValue(result2);
+    assertThat(actual.one()).hasValue(result3);
+    assertThat(actual.one()).isEmpty();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScannerAndScannerAll_ShouldReturnScannerAndReturnProperResults() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.all())
+        .thenReturn(Arrays.asList(result1, result2, result3))
+        .thenReturn(Collections.emptyList());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    List<Result> results = actual.all();
+    assertThat(results).containsExactly(result1, result2, result3);
+    assertThat(actual.all()).isEmpty();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScannerAndScannerIterator_ShouldReturnScannerAndReturnProperResults()
+      throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.of(result3))
+        .thenReturn(Optional.empty());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+
+    Iterator<Result> iterator = actual.iterator();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result1);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result2);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result3);
+    assertThat(iterator.hasNext()).isFalse();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScanner_TransactionNotFoundExceptionThrownByTransactionBegin_ShouldThrowCrudConflictException()
+          throws TransactionException {
+    // Arrange
+    JdbcTransactionManager spied = spy(manager);
+    doThrow(TransactionNotFoundException.class).when(spied).begin();
+
+    Scan scan = mock(Scan.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudConflictException.class);
+
+    verify(spied).begin();
+  }
+
+  @Test
+  public void getScanner_TransactionExceptionThrownByTransactionBegin_ShouldThrowCrudException()
+      throws TransactionException {
+    // Arrange
+    JdbcTransactionManager spied = spy(manager);
+    doThrow(TransactionException.class).when(spied).begin();
+
+    Scan scan = mock(Scan.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+  }
+
+  @Test
+  public void
+      getScanner_CrudExceptionThrownByTransactionGetScanner_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    when(transaction.getScanner(scan)).thenThrow(CrudException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerOne_CrudExceptionThrownByScannerOne_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    when(scanner.one()).thenThrow(CrudException.class);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::one).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerAll_CrudExceptionThrownByScannerAll_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    when(scanner.all()).thenThrow(CrudException.class);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::all).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CrudExceptionThrownByScannerClose_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    doThrow(CrudException.class).when(scanner).close();
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CommitConflictExceptionThrownByTransactionCommit_ShouldRollbackTransactionAndThrowCrudConflictException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(CommitConflictException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudConflictException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_UnknownTransactionStatusExceptionByTransactionCommit_ShouldThrowUnknownTransactionStatusException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(UnknownTransactionStatusException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(UnknownTransactionStatusException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CommitExceptionThrownByTransactionCommit_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(CommitException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds a scanner API implementation for JDBC transactions.

Note that we are working on this feature in the `add-scanner-api-to-transaction-abstraction` feature branch.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2698

## Changes made

- Added a scanner API implementation for JDBC transactions.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
