### PR TITLE
Refactor import logic and remove redundant status mapping

### DIFF
--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/ImportEventListener.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/ImportEventListener.java
@@ -19,13 +19,6 @@ public interface ImportEventListener {
   void onDataChunkStarted(ImportDataChunkStatus status);
 
   /**
-   * Updates or adds new status information for a data chunk.
-   *
-   * @param status the updated status information for the data chunk
-   */
-  void addOrUpdateDataChunkStatus(ImportDataChunkStatus status);
-
-  /**
    * Called when processing of a data chunk is completed.
    *
    * @param status the final status of the completed data chunk

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/log/SingleFileImportLogger.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/log/SingleFileImportLogger.java
@@ -71,15 +71,6 @@ public class SingleFileImportLogger extends AbstractImportLogger {
   }
 
   /**
-   * Called to add or update the status of a data chunk. This implementation does nothing as the
-   * status is only logged when the data chunk is completed.
-   *
-   * @param status the status of the data chunk
-   */
-  @Override
-  public void addOrUpdateDataChunkStatus(ImportDataChunkStatus status) {}
-
-  /**
    * Called when a data chunk is completed. Logs the summary of the data chunk to the summary log
    * file.
    *

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/log/SplitByDataChunkImportLogger.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/log/SplitByDataChunkImportLogger.java
@@ -113,15 +113,6 @@ public class SplitByDataChunkImportLogger extends AbstractImportLogger {
   }
 
   /**
-   * Called to add or update the status of a data chunk. This implementation does nothing as the
-   * status is only logged when the data chunk is completed.
-   *
-   * @param status the status of the data chunk
-   */
-  @Override
-  public void addOrUpdateDataChunkStatus(ImportDataChunkStatus status) {}
-
-  /**
    * Called when a data chunk is completed. Logs the summary of the data chunk and closes the log
    * writers for that data chunk.
    *

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/processor/CsvImportProcessor.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/processor/CsvImportProcessor.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.dataloader.core.DataLoaderObjectMapper;
 import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunk;
-import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunkStatus;
 import com.scalar.db.dataloader.core.dataimport.datachunk.ImportRow;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -14,12 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -51,60 +44,6 @@ public class CsvImportProcessor extends ImportProcessor {
   }
 
   /**
-   * Processes the source data from the given import file.
-   *
-   * <p>This method reads data from the provided {@link BufferedReader}, processes it in chunks, and
-   * batches transactions according to the specified sizes. The method returns a list of {@link
-   * ImportDataChunkStatus} objects, each representing the status of a processed data chunk.
-   *
-   * @param dataChunkSize the number of records to include in each data chunk
-   * @param transactionBatchSize the number of records to include in each transaction batch
-   * @param reader the {@link BufferedReader} used to read the source file
-   * @return a map of {@link ImportDataChunkStatus} objects indicating the processing status of each
-   *     data chunk
-   */
-  @Override
-  public ConcurrentHashMap<Integer, ImportDataChunkStatus> process(
-      int dataChunkSize, int transactionBatchSize, BufferedReader reader) {
-    ExecutorService dataChunkExecutor = Executors.newSingleThreadExecutor();
-    BlockingQueue<ImportDataChunk> dataChunkQueue =
-        new LinkedBlockingQueue<>(params.getImportOptions().getDataChunkQueueSize());
-
-    try {
-      CompletableFuture<Void> readerFuture =
-          CompletableFuture.runAsync(
-              () -> readDataChunks(reader, dataChunkSize, dataChunkQueue), dataChunkExecutor);
-
-      ConcurrentHashMap<Integer, ImportDataChunkStatus> result = new ConcurrentHashMap<>();
-
-      while (!(dataChunkQueue.isEmpty() && readerFuture.isDone())) {
-        ImportDataChunk dataChunk = dataChunkQueue.poll(100, TimeUnit.MILLISECONDS);
-        if (dataChunk != null) {
-          ImportDataChunkStatus status = processDataChunk(dataChunk, transactionBatchSize);
-          result.put(status.getDataChunkId(), status);
-        }
-      }
-      readerFuture.join();
-      return result;
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(
-          CoreError.DATA_LOADER_DATA_CHUNK_PROCESS_FAILED.buildMessage(e.getMessage()), e);
-    } finally {
-      dataChunkExecutor.shutdown();
-      try {
-        if (!dataChunkExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
-          dataChunkExecutor.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        dataChunkExecutor.shutdownNow();
-        Thread.currentThread().interrupt();
-      }
-      notifyAllDataChunksCompleted();
-    }
-  }
-
-  /**
    * Reads and processes CSV data in chunks from the provided reader.
    *
    * <p>This method:
@@ -122,7 +61,8 @@ public class CsvImportProcessor extends ImportProcessor {
    * @param dataChunkQueue the queue where data chunks are placed for processing
    * @throws RuntimeException if there are errors reading the file or if interrupted
    */
-  private void readDataChunks(
+  @Override
+  protected void readDataChunks(
       BufferedReader reader, int dataChunkSize, BlockingQueue<ImportDataChunk> dataChunkQueue) {
     try {
       String delimiter =

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/processor/ImportProcessor.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/processor/ImportProcessor.java
@@ -1,6 +1,7 @@
 package com.scalar.db.dataloader.core.dataimport.processor;
 
 import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.common.error.CoreError;
 import com.scalar.db.dataloader.core.ScalarDbMode;
 import com.scalar.db.dataloader.core.dataimport.ImportEventListener;
 import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunk;
@@ -22,11 +23,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -56,11 +60,57 @@ public abstract class ImportProcessor {
    * @param transactionBatchSize the number of records to group together in a single transaction
    *     (only used in transaction mode)
    * @param reader the {@link BufferedReader} used to read the source file
-   * @return a map of {@link ImportDataChunkStatus} objects indicating the processing status and
-   *     results of each data chunk
    */
-  public abstract ConcurrentHashMap<Integer, ImportDataChunkStatus> process(
-      int dataChunkSize, int transactionBatchSize, BufferedReader reader);
+  public void process(int dataChunkSize, int transactionBatchSize, BufferedReader reader) {
+    ExecutorService dataChunkExecutor = Executors.newSingleThreadExecutor();
+    BlockingQueue<ImportDataChunk> dataChunkQueue =
+        new LinkedBlockingQueue<>(params.getImportOptions().getDataChunkQueueSize());
+
+    try {
+      CompletableFuture<Void> readerFuture =
+          CompletableFuture.runAsync(
+              () -> readDataChunks(reader, dataChunkSize, dataChunkQueue), dataChunkExecutor);
+
+      while (!(dataChunkQueue.isEmpty() && readerFuture.isDone())) {
+        ImportDataChunk dataChunk = dataChunkQueue.poll(100, TimeUnit.MILLISECONDS);
+        if (dataChunk != null) {
+          processDataChunk(dataChunk, transactionBatchSize);
+        }
+      }
+
+      readerFuture.join();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(
+          CoreError.DATA_LOADER_DATA_CHUNK_PROCESS_FAILED.buildMessage(e.getMessage()), e);
+    } finally {
+      dataChunkExecutor.shutdown();
+      try {
+        if (!dataChunkExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+          dataChunkExecutor.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        dataChunkExecutor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+      notifyAllDataChunksCompleted();
+    }
+  }
+
+  /**
+   * Reads and processes data in chunks from the provided reader.
+   *
+   * <p>This method should be implemented by each processor to handle the specific format of the
+   * input data. It reads data from the reader, converts it to the appropriate format, and enqueues
+   * it for processing.
+   *
+   * @param reader the BufferedReader containing the data
+   * @param dataChunkSize the number of rows to include in each chunk
+   * @param dataChunkQueue the queue where data chunks are placed for processing
+   * @throws RuntimeException if there are errors reading the file or if interrupted
+   */
+  protected abstract void readDataChunks(
+      BufferedReader reader, int dataChunkSize, BlockingQueue<ImportDataChunk> dataChunkQueue);
 
   /**
    * Add import event listener to listener list
@@ -100,7 +150,6 @@ public abstract class ImportProcessor {
   protected void notifyDataChunkStarted(ImportDataChunkStatus status) {
     for (ImportEventListener listener : listeners) {
       listener.onDataChunkStarted(status);
-      listener.addOrUpdateDataChunkStatus(status);
     }
   }
 
@@ -112,7 +161,6 @@ public abstract class ImportProcessor {
   protected void notifyDataChunkCompleted(ImportDataChunkStatus status) {
     for (ImportEventListener listener : listeners) {
       listener.onDataChunkCompleted(status);
-      listener.addOrUpdateDataChunkStatus(status);
     }
   }
 
@@ -294,10 +342,8 @@ public abstract class ImportProcessor {
    *
    * @param dataChunk the data chunk to process
    * @param transactionBatchSize the size of transaction batches (used only in transaction mode)
-   * @return an {@link ImportDataChunkStatus} containing the complete processing results and metrics
    */
-  protected ImportDataChunkStatus processDataChunk(
-      ImportDataChunk dataChunk, int transactionBatchSize) {
+  private void processDataChunk(ImportDataChunk dataChunk, int transactionBatchSize) {
     ImportDataChunkStatus status =
         ImportDataChunkStatus.builder()
             .dataChunkId(dataChunk.getDataChunkId())
@@ -312,7 +358,6 @@ public abstract class ImportProcessor {
       importDataChunkStatus = processDataChunkWithoutTransactions(dataChunk);
     }
     notifyDataChunkCompleted(importDataChunkStatus);
-    return importDataChunkStatus;
   }
 
   /**

--- a/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/processor/JsonImportProcessor.java
+++ b/data-loader/core/src/main/java/com/scalar/db/dataloader/core/dataimport/processor/JsonImportProcessor.java
@@ -7,19 +7,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.dataloader.core.DataLoaderObjectMapper;
 import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunk;
-import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunkStatus;
 import com.scalar.db.dataloader.core.dataimport.datachunk.ImportRow;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -50,61 +43,6 @@ public class JsonImportProcessor extends ImportProcessor {
   }
 
   /**
-   * Processes the source data from the given import file.
-   *
-   * <p>This method reads data from the provided {@link BufferedReader}, processes it in chunks, and
-   * batches transactions according to the specified sizes. The method returns a list of {@link
-   * ImportDataChunkStatus} objects, each representing the status of a processed data chunk.
-   *
-   * @param dataChunkSize the number of records to include in each data chunk
-   * @param transactionBatchSize the number of records to include in each transaction batch
-   * @param reader the {@link BufferedReader} used to read the source file
-   * @return a map of {@link ImportDataChunkStatus} objects indicating the processing status of each
-   *     data chunk
-   */
-  @Override
-  public ConcurrentHashMap<Integer, ImportDataChunkStatus> process(
-      int dataChunkSize, int transactionBatchSize, BufferedReader reader) {
-    ExecutorService dataChunkExecutor = Executors.newSingleThreadExecutor();
-    BlockingQueue<ImportDataChunk> dataChunkQueue =
-        new LinkedBlockingQueue<>(params.getImportOptions().getDataChunkQueueSize());
-
-    try {
-      CompletableFuture<Void> readerFuture =
-          CompletableFuture.runAsync(
-              () -> readDataChunks(reader, dataChunkSize, dataChunkQueue), dataChunkExecutor);
-
-      ConcurrentHashMap<Integer, ImportDataChunkStatus> result = new ConcurrentHashMap<>();
-
-      while (!(dataChunkQueue.isEmpty() && readerFuture.isDone())) {
-        ImportDataChunk dataChunk = dataChunkQueue.poll(100, TimeUnit.MILLISECONDS);
-        if (dataChunk != null) {
-          ImportDataChunkStatus status = processDataChunk(dataChunk, transactionBatchSize);
-          result.put(status.getDataChunkId(), status);
-        }
-      }
-
-      readerFuture.join();
-      return result;
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(
-          CoreError.DATA_LOADER_DATA_CHUNK_PROCESS_FAILED.buildMessage(e.getMessage()), e);
-    } finally {
-      dataChunkExecutor.shutdown();
-      try {
-        if (!dataChunkExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
-          dataChunkExecutor.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        dataChunkExecutor.shutdownNow();
-        Thread.currentThread().interrupt();
-      }
-      notifyAllDataChunksCompleted();
-    }
-  }
-
-  /**
    * Reads data chunks from the JSON file and adds them to the processing queue.
    *
    * <p>This method reads the JSON file as an array of objects, creating data chunks of the
@@ -119,7 +57,8 @@ public class JsonImportProcessor extends ImportProcessor {
    * @throws RuntimeException if there is an error reading the JSON file or if the thread is
    *     interrupted
    */
-  private void readDataChunks(
+  @Override
+  protected void readDataChunks(
       BufferedReader reader, int dataChunkSize, BlockingQueue<ImportDataChunk> dataChunkQueue) {
     try (JsonParser jsonParser = new JsonFactory().createParser(reader)) {
       if (jsonParser.nextToken() != JsonToken.START_ARRAY) {

--- a/data-loader/core/src/test/java/com/scalar/db/dataloader/core/dataimport/processor/CsvImportProcessorTest.java
+++ b/data-loader/core/src/test/java/com/scalar/db/dataloader/core/dataimport/processor/CsvImportProcessorTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.dataloader.core.dataimport.ImportOptions;
 import com.scalar.db.dataloader.core.dataimport.controlfile.ControlFileValidationLevel;
 import com.scalar.db.dataloader.core.dataimport.dao.ScalarDbDao;
 import com.scalar.db.dataloader.core.dataimport.dao.ScalarDbDaoException;
-import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunkStatus;
 import com.scalar.db.dataloader.core.dataimport.log.LogMode;
 import com.scalar.db.exception.transaction.TransactionException;
 import java.util.HashMap;
@@ -91,10 +90,10 @@ class CsvImportProcessorTest {
             .tableMetadataByTableName(tableMetadataByTableName)
             .build();
     csvImportProcessor = new CsvImportProcessor(params);
-    Map<Integer, ImportDataChunkStatus> statusList =
-        csvImportProcessor.process(5, 1, UnitTestUtils.getCsvReader());
-    assert statusList != null;
-    Assertions.assertEquals(1, statusList.size());
+    Assertions.assertDoesNotThrow(
+        () -> {
+          csvImportProcessor.process(5, 1, UnitTestUtils.getCsvReader());
+        });
   }
 
   @Test
@@ -110,9 +109,9 @@ class CsvImportProcessorTest {
             .tableMetadataByTableName(tableMetadataByTableName)
             .build();
     csvImportProcessor = new CsvImportProcessor(params);
-    Map<Integer, ImportDataChunkStatus> statusList =
-        csvImportProcessor.process(5, 1, UnitTestUtils.getCsvReader());
-    assert statusList != null;
-    Assertions.assertEquals(1, statusList.size());
+    Assertions.assertDoesNotThrow(
+        () -> {
+          csvImportProcessor.process(5, 1, UnitTestUtils.getCsvReader());
+        });
   }
 }

--- a/data-loader/core/src/test/java/com/scalar/db/dataloader/core/dataimport/processor/JsonImportProcessorTest.java
+++ b/data-loader/core/src/test/java/com/scalar/db/dataloader/core/dataimport/processor/JsonImportProcessorTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.dataloader.core.dataimport.ImportOptions;
 import com.scalar.db.dataloader.core.dataimport.controlfile.ControlFileValidationLevel;
 import com.scalar.db.dataloader.core.dataimport.dao.ScalarDbDao;
 import com.scalar.db.dataloader.core.dataimport.dao.ScalarDbDaoException;
-import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunkStatus;
 import com.scalar.db.dataloader.core.dataimport.log.LogMode;
 import com.scalar.db.exception.transaction.TransactionException;
 import java.util.HashMap;
@@ -91,10 +90,10 @@ class JsonImportProcessorTest {
             .tableMetadataByTableName(tableMetadataByTableName)
             .build();
     jsonImportProcessor = new JsonImportProcessor(params);
-    Map<Integer, ImportDataChunkStatus> statusList =
-        jsonImportProcessor.process(5, 1, UnitTestUtils.getJsonReader());
-    assert statusList != null;
-    Assertions.assertEquals(1, statusList.size());
+    Assertions.assertDoesNotThrow(
+        () -> {
+          jsonImportProcessor.process(5, 1, UnitTestUtils.getJsonReader());
+        });
   }
 
   @Test
@@ -110,9 +109,9 @@ class JsonImportProcessorTest {
             .tableMetadataByTableName(tableMetadataByTableName)
             .build();
     jsonImportProcessor = new JsonImportProcessor(params);
-    Map<Integer, ImportDataChunkStatus> statusList =
-        jsonImportProcessor.process(5, 1, UnitTestUtils.getJsonReader());
-    assert statusList != null;
-    Assertions.assertEquals(1, statusList.size());
+    Assertions.assertDoesNotThrow(
+        () -> {
+          jsonImportProcessor.process(5, 1, UnitTestUtils.getJsonReader());
+        });
   }
 }

--- a/data-loader/core/src/test/java/com/scalar/db/dataloader/core/dataimport/processor/JsonLinesImportProcessorTest.java
+++ b/data-loader/core/src/test/java/com/scalar/db/dataloader/core/dataimport/processor/JsonLinesImportProcessorTest.java
@@ -15,7 +15,6 @@ import com.scalar.db.dataloader.core.dataimport.ImportOptions;
 import com.scalar.db.dataloader.core.dataimport.controlfile.ControlFileValidationLevel;
 import com.scalar.db.dataloader.core.dataimport.dao.ScalarDbDao;
 import com.scalar.db.dataloader.core.dataimport.dao.ScalarDbDaoException;
-import com.scalar.db.dataloader.core.dataimport.datachunk.ImportDataChunkStatus;
 import com.scalar.db.dataloader.core.dataimport.log.LogMode;
 import com.scalar.db.exception.transaction.TransactionException;
 import java.util.HashMap;
@@ -91,10 +90,10 @@ class JsonLinesImportProcessorTest {
             .tableMetadataByTableName(tableMetadataByTableName)
             .build();
     jsonLinesImportProcessor = new JsonLinesImportProcessor(params);
-    Map<Integer, ImportDataChunkStatus> statusList =
-        jsonLinesImportProcessor.process(5, 1, UnitTestUtils.getJsonLinesReader());
-    assert statusList != null;
-    Assertions.assertEquals(1, statusList.size());
+    Assertions.assertDoesNotThrow(
+        () -> {
+          jsonLinesImportProcessor.process(5, 1, UnitTestUtils.getJsonLinesReader());
+        });
   }
 
   @Test
@@ -110,9 +109,9 @@ class JsonLinesImportProcessorTest {
             .tableMetadataByTableName(tableMetadataByTableName)
             .build();
     jsonLinesImportProcessor = new JsonLinesImportProcessor(params);
-    Map<Integer, ImportDataChunkStatus> statusList =
-        jsonLinesImportProcessor.process(5, 1, UnitTestUtils.getJsonLinesReader());
-    assert statusList != null;
-    Assertions.assertEquals(1, statusList.size());
+    Assertions.assertDoesNotThrow(
+        () -> {
+          jsonLinesImportProcessor.process(5, 1, UnitTestUtils.getJsonLinesReader());
+        });
   }
 }


### PR DESCRIPTION
## Description

This PR refactors the import processors in the data loader and removes the unnecessary usage of the import result status map, which is no longer needed.

Previously, the status map was created and persisted for the entire lifetime of the application. This led to continuous memory growth during large imports, potentially causing excessive memory usage or even out-of-memory (OOM) issues. By removing this map, we reduce memory consumption and improve the overall efficiency and stability of the import process.

Please take a look when you get a chance. Thank you!

## Related issues and/or PRs

NA

## Changes made

- Move `process` method to parent class, as they are the same for import processors
- Remove the usage of the status map for storing import results

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA

## Release notes

NA
