### PR TITLE
Add more integration tests for scanner API

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitCassandraEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitCassandraEnv.java
@@ -1,7 +1,7 @@
 package com.scalar.db.storage.cassandra;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Properties;
 
 public final class ConsensusCommitCassandraEnv {

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
@@ -1,7 +1,7 @@
 package com.scalar.db.storage.cosmos;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Map;
 import java.util.Properties;
 

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitDynamoEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitDynamoEnv.java
@@ -1,7 +1,7 @@
 package com.scalar.db.storage.dynamo;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Map;
 import java.util.Properties;
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitJdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitJdbcEnv.java
@@ -1,7 +1,7 @@
 package com.scalar.db.storage.jdbc;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitIntegrationTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Properties;
 
 public final class ConsensusCommitJdbcEnv {

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
@@ -1,9 +1,9 @@
 package com.scalar.db.storage.multistorage;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cassandra.CassandraAdmin;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Collections;
 import java.util.Map;

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
@@ -1,9 +1,9 @@
 package com.scalar.db.storage.multistorage;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cassandra.CassandraAdmin;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Collections;
 import java.util.Map;

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -57,6 +57,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,15 +275,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(1, 0, 2);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -291,9 +295,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertResult(1, 2, results.get(2));
   }
 
-  @Test
-  public void scan_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -303,7 +308,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -320,9 +325,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(2);
   }
 
-  @Test
-  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -333,7 +339,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -354,16 +360,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
   }
 
-  @Test
-  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(1, 0, 2).withOrdering(Ordering.desc(ACCOUNT_TYPE));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -384,16 +391,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(0);
   }
 
-  @Test
-  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(1, 0, 2).withLimit(2);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -424,15 +432,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(0, 4, 6);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -484,8 +494,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result2).isEqualTo(result1);
   }
 
-  @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -517,8 +529,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build());
 
     // Act
-    List<Result> results1 = transaction.scan(scanBuiltByConstructor);
-    List<Result> results2 = transaction.scan(scanBuiltByBuilder);
+    List<Result> results1 = scanOrGetScanner(transaction, scanBuiltByConstructor, scanType);
+    List<Result> results2 = scanOrGetScanner(transaction, scanBuiltByBuilder, scanType);
     transaction.commit();
 
     // Assert
@@ -526,9 +538,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results2, expectedResults);
   }
 
-  @Test
-  public void scan_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -541,7 +554,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -554,8 +567,9 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(6);
   }
 
-  @Test
-  public void scan_ScanAllGivenForCommittedRecord_ShouldReturnRecords()
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
       throws TransactionException {
     // Arrange
     populateRecords();
@@ -563,7 +577,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll();
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -583,9 +597,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
-  @Test
-  public void scan_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     insert(prepareInsert(1, 1), prepareInsert(1, 2), prepareInsert(2, 1), prepareInsert(3, 0));
 
@@ -593,7 +608,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll().withLimit(2);
 
     // Act
-    List<Result> results = scanAllTransaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(scanAllTransaction, scanAll, scanType);
     scanAllTransaction.commit();
 
     // Assert
@@ -623,16 +638,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results).hasSize(2);
   }
 
-  @Test
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     ScanAll scanAll = prepareScanAll().withProjection(ACCOUNT_TYPE).withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -651,14 +667,16 @@ public abstract class DistributedTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
-  @Test
-  public void scan_ScanAllGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.start();
     ScanAll scanAll = prepareScanAll();
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -1048,17 +1066,18 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.get().isNull(SOME_COLUMN)).isTrue();
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
     Scan scan = prepareScan(0, 0, 0).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -1070,17 +1089,18 @@ public abstract class DistributedTransactionIntegrationTestBase {
         });
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
     ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -1207,6 +1227,29 @@ public abstract class DistributedTransactionIntegrationTestBase {
               () -> {
                 DistributedTransaction tx = managerWithDefaultNamespace.start();
                 tx.scan(scan);
+                tx.commit();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
+    Properties properties = getProperties(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);
+    try (DistributedTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTransactionManager()) {
+      // Arrange
+      populateRecords();
+      Scan scan = Scan.newBuilder().table(TABLE).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TransactionCrudOperable.Scanner scanner = tx.getScanner(scan);
+                scanner.all();
+                scanner.close();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -2311,6 +2354,30 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
+  public void manager_getScanner_DefaultNamespaceGiven_ShouldWorkProperly()
+      throws TransactionException {
+    // Arrange
+    Properties properties = getProperties(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);
+    try (DistributedTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTransactionManager()) {
+      // Arrange
+      populateRecords();
+      Scan scan = Scan.newBuilder().table(TABLE).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TransactionManagerCrudOperable.Scanner scanner =
+                    managerWithDefaultNamespace.getScanner(scan);
+                scanner.all();
+                scanner.close();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
   public void manager_put_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);
@@ -2729,5 +2796,36 @@ public abstract class DistributedTransactionIntegrationTestBase {
           TimestampColumn.of(TIMESTAMP_COL, LocalDateTime.of(1970, 1, 1, accountId, accountType)));
     }
     return columns.build();
+  }
+
+  protected List<Result> scanOrGetScanner(
+      DistributedTransaction transaction, Scan scan, ScanType scanType) throws CrudException {
+    if (scanType == ScanType.SCAN) {
+      return transaction.scan(scan);
+    }
+
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      switch (scanType) {
+        case SCANNER_ONE:
+          List<Result> results = new ArrayList<>();
+          while (true) {
+            Optional<Result> result = scanner.one();
+            if (!result.isPresent()) {
+              return results;
+            }
+            results.add(result.get());
+          }
+        case SCANNER_ALL:
+          return scanner.all();
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  public enum ScanType {
+    SCAN,
+    SCANNER_ONE,
+    SCANNER_ALL
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -57,6 +57,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -312,15 +314,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -332,9 +336,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertResult(1, 2, results.get(2));
   }
 
-  @Test
-  public void scan_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
@@ -344,7 +349,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -363,9 +368,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(2);
   }
 
-  @Test
-  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
@@ -376,7 +382,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -399,16 +405,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results.get(2).contains(SOME_COLUMN)).isFalse();
   }
 
-  @Test
-  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1).withOrdering(Ordering.desc(ACCOUNT_TYPE));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -431,16 +438,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(0);
   }
 
-  @Test
-  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1).withLimit(2);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -475,15 +483,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(0, 4, 4, namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -541,8 +551,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result2).isEqualTo(result1);
   }
 
-  @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
@@ -574,8 +586,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .build());
 
     // Act
-    List<Result> results1 = transaction.scan(scanBuiltByConstructor);
-    List<Result> results2 = transaction.scan(scanBuiltByBuilder);
+    List<Result> results1 = scanOrGetScanner(transaction, scanBuiltByConstructor, scanType);
+    List<Result> results2 = scanOrGetScanner(transaction, scanBuiltByBuilder, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1118,8 +1130,9 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(state).isEqualTo(TransactionState.ABORTED);
   }
 
-  @Test
-  public void scan_ScanAllGivenForCommittedRecord_ShouldReturnRecords()
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
       throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
@@ -1127,7 +1140,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1149,9 +1162,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
-  @Test
-  public void scan_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction putTransaction = manager1.begin();
     insert(
@@ -1167,7 +1181,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1).withLimit(2);
 
     // Act
-    List<Result> results = scanAllTransaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(scanAllTransaction, scanAll, scanType);
     scanAllTransaction.prepare();
     scanAllTransaction.validate();
     scanAllTransaction.commit();
@@ -1199,9 +1213,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results).hasSize(2);
   }
 
-  @Test
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1209,7 +1224,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         prepareScanAll(namespace1, TABLE_1).withProjection(ACCOUNT_TYPE).withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1235,14 +1250,16 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         });
   }
 
-  @Test
-  public void scan_ScanAllGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1274,10 +1291,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result.get().isNull(SOME_COLUMN)).isTrue();
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     populateSingleRecord(namespace1, TABLE_1);
@@ -1286,7 +1304,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1300,10 +1318,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         });
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     populateSingleRecord(namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1311,7 +1330,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         prepareScanAll(namespace1, TABLE_1).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1407,8 +1426,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void get_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Get get =
@@ -1421,8 +1440,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.get(get);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1433,8 +1454,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void scan_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
@@ -1442,8 +1463,35 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.scan(scan);
+                tx.prepare();
+                tx.validate();
+                tx.commit();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
+    Properties properties = getProperties1(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
+      // Arrange
+      populateRecords(manager1, namespace1, TABLE_1);
+      Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
+                TransactionCrudOperable.Scanner scanner = tx.getScanner(scan);
+                scanner.all();
+                scanner.close();
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1454,8 +1502,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void put_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Put put =
@@ -1470,8 +1518,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.put(put);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1482,8 +1532,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void insert_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Insert insert =
@@ -1497,8 +1547,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.insert(insert);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1509,8 +1561,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void upsert_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Upsert upsert =
@@ -1524,8 +1576,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.upsert(upsert);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1536,8 +1590,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void update_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Update update =
@@ -1551,8 +1605,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.update(update);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1563,8 +1619,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void delete_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Delete delete =
@@ -1577,8 +1633,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.delete(delete);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1589,8 +1647,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void mutate_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Mutation putAsMutation1 =
@@ -1611,8 +1669,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.mutate(ImmutableList.of(putAsMutation1, deleteAsMutation2));
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -2552,8 +2612,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void manager_get_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Get get =
@@ -2573,8 +2633,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void manager_scan_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
@@ -2586,11 +2646,34 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   @Test
+  public void manager_getScanner_DefaultNamespaceGiven_ShouldWorkProperly()
+      throws TransactionException {
+    Properties properties = getProperties1(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
+      // Arrange
+      populateRecords(manager1, namespace1, TABLE_1);
+      Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TransactionManagerCrudOperable.Scanner scanner =
+                    managerWithDefaultNamespace.getScanner(scan);
+                scanner.all();
+                scanner.close();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
   public void manager_put_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Put put =
@@ -2613,8 +2696,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Insert insert =
@@ -2636,8 +2719,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Upsert upsert =
@@ -2659,8 +2742,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Update update =
@@ -2682,8 +2765,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Delete delete =
@@ -2704,8 +2787,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Mutation putAsMutation1 =
@@ -3033,5 +3116,36 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
           TimestampColumn.of(TIMESTAMP_COL, LocalDateTime.of(1970, 1, 1, accountId, accountType)));
     }
     return columns.build();
+  }
+
+  protected List<Result> scanOrGetScanner(
+      TwoPhaseCommitTransaction transaction, Scan scan, ScanType scanType) throws CrudException {
+    if (scanType == ScanType.SCAN) {
+      return transaction.scan(scan);
+    }
+
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      switch (scanType) {
+        case SCANNER_ONE:
+          List<Result> results = new ArrayList<>();
+          while (true) {
+            Optional<Result> result = scanner.one();
+            if (!result.isPresent()) {
+              return results;
+            }
+            results.add(result.get());
+          }
+        case SCANNER_ALL:
+          return scanner.all();
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  public enum ScanType {
+    SCAN,
+    SCANNER_ONE,
+    SCANNER_ALL
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTestUtils.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTestUtils.java
@@ -1,4 +1,4 @@
-package com.scalar.db.common;
+package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_DELAYED_SLOT_MOVE_TIMEOUT_MILLIS;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED;

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -9,6 +9,8 @@ import com.scalar.db.io.Key;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public abstract class SingleCrudOperationTransactionIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -70,23 +72,30 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -95,8 +104,9 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForNonExisting_ShouldReturnEmpty(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -105,28 +115,36 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanAllGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanAllGivenForNonExisting_ShouldReturnEmpty() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForNonExisting_ShouldReturnEmpty(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -201,15 +219,19 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns() {}
+      scanOrGetScanner_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns() {}
+      scanOrGetScanner_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support resuming a transaction")
   @Override
@@ -242,6 +264,11 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Override
   @Test
   public void scan_DefaultNamespaceGiven_ShouldWorkProperly() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
+  public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -418,11 +445,15 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords(
+      ScanType scanType) {}
 }


### PR DESCRIPTION
## Description

This PR adds more integration tests for the Scanner API.

Note that we are working on this feature in the `add-scanner-api-to-transaction-abstraction` feature branch.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2698
- https://github.com/scalar-labs/scalardb/pull/2701
- https://github.com/scalar-labs/scalardb/pull/2702
- https://github.com/scalar-labs/scalardb/pull/2711

## Changes made

- Added more integration tests for the Scanner API.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
