### PR TITLE
Backport to branch(3) : Add scanner API to transaction abstraction

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitCassandraEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/ConsensusCommitCassandraEnv.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.cassandra;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Properties;
 
 public final class ConsensusCommitCassandraEnv {

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/ConsensusCommitCosmosEnv.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.cosmos;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Map;
 import java.util.Properties;
 

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitDynamoEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/ConsensusCommitDynamoEnv.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.dynamo;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Map;
 import java.util.Properties;
 

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitJdbcEnv.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/ConsensusCommitJdbcEnv.java
@@ -1,6 +1,6 @@
 package com.scalar.db.storage.jdbc;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import java.util.Properties;
 
 public final class ConsensusCommitJdbcEnv {

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitNullMetadataIntegrationTestWithMultiStorage.java
@@ -1,8 +1,8 @@
 package com.scalar.db.storage.multistorage;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitNullMetadataIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Properties;
 

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/ConsensusCommitSpecificIntegrationTestWithMultiStorage.java
@@ -1,8 +1,8 @@
 package com.scalar.db.storage.multistorage;
 
-import com.scalar.db.common.ConsensusCommitTestUtils;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitSpecificIntegrationTestBase;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitTestUtils;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import java.util.Properties;
 

--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -6,6 +6,7 @@ import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegrationTestBase {
 
@@ -24,17 +25,21 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
 
   @Disabled("JDBC transactions don't support getState()")
   @Override
+  @Test
   public void getState_forSuccessfulTransaction_ShouldReturnCommittedState() {}
 
   @Disabled("JDBC transactions don't support getState()")
   @Override
+  @Test
   public void getState_forFailedTransaction_ShouldReturnAbortedState() {}
 
   @Disabled("JDBC transactions don't support abort()")
   @Override
+  @Test
   public void abort_forOngoingTransaction_ShouldAbortCorrectly() {}
 
   @Disabled("JDBC transactions don't support rollback()")
   @Override
+  @Test
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
 }

--- a/core/src/main/java/com/scalar/db/api/CrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/CrudOperable.java
@@ -12,6 +12,9 @@ import java.util.Optional;
  * An interface for transactional CRUD operations. Note that the LINEARIZABLE consistency level is
  * always used in transactional CRUD operations, so {@link Consistency} specified for CRUD
  * operations is ignored.
+ *
+ * @param <E> the type of {@link TransactionException} that the implementation throws if the
+ *     operation fails
  */
 public interface CrudOperable<E extends TransactionException> {
 
@@ -26,15 +29,36 @@ public interface CrudOperable<E extends TransactionException> {
   Optional<Result> get(Get get) throws E;
 
   /**
-   * Retrieves results from the storage through a transaction with the specified {@link Scan}
-   * command with a partition key and returns a list of {@link Result}. Results can be filtered by
-   * specifying a range of clustering keys.
+   * Retrieves results from the storage through a transaction with the specified {@link Scan} or
+   * {@link ScanAll} or {@link ScanWithIndex} command with a partition key and returns a list of
+   * {@link Result}. Results can be filtered by specifying a range of clustering keys.
+   *
+   * <ul>
+   *   <li>{@link Scan} : by specifying a partition key, it will return results within the
+   *       partition. Results can be filtered by specifying a range of clustering keys.
+   *   <li>{@link ScanAll} : for a given table, it will return all its records even if they span
+   *       several partitions.
+   *   <li>{@link ScanWithIndex} : by specifying an index key, it will return results within the
+   *       index.
+   * </ul>
    *
    * @param scan a {@code Scan} command
    * @return a list of {@link Result}
    * @throws E if the transaction CRUD operation fails
    */
   List<Result> scan(Scan scan) throws E;
+
+  /**
+   * Retrieves results from the storage through a transaction with the specified {@link Scan} or
+   * {@link ScanAll} or {@link ScanWithIndex} command with a partition key and returns a {@link
+   * Scanner} to iterate over the results. Results can be filtered by specifying a range of
+   * clustering keys.
+   *
+   * @param scan a {@code Scan} command
+   * @return a {@code Scanner} to iterate over the results
+   * @throws E if the transaction CRUD operation fails
+   */
+  Scanner<E> getScanner(Scan scan) throws E;
 
   /**
    * Inserts an entry into or updates an entry in the underlying storage through a transaction with
@@ -131,4 +155,32 @@ public interface CrudOperable<E extends TransactionException> {
    * @throws E if the transaction CRUD operation fails
    */
   void mutate(List<? extends Mutation> mutations) throws E;
+
+  /** A scanner abstraction for iterating results. */
+  interface Scanner<E extends TransactionException> extends AutoCloseable, Iterable<Result> {
+    /**
+     * Returns the next result.
+     *
+     * @return an {@code Optional} containing the next result if available, or empty if no more
+     *     results
+     * @throws E if the operation fails
+     */
+    Optional<Result> one() throws E;
+
+    /**
+     * Returns all remaining results.
+     *
+     * @return a {@code List} containing all remaining results
+     * @throws E if the operation fails
+     */
+    List<Result> all() throws E;
+
+    /**
+     * Closes the scanner.
+     *
+     * @throws E if closing the scanner fails
+     */
+    @Override
+    void close() throws E;
+  }
 }

--- a/core/src/main/java/com/scalar/db/api/Scanner.java
+++ b/core/src/main/java/com/scalar/db/api/Scanner.java
@@ -13,17 +13,18 @@ import java.util.Optional;
 public interface Scanner extends Closeable, Iterable<Result> {
 
   /**
-   * Returns the first result in the results.
+   * Returns the next result.
    *
-   * @return the first result in the results
+   * @return an {@code Optional} containing the next result if available, or empty if no more
+   *     results
    * @throws ExecutionException if the operation fails
    */
   Optional<Result> one() throws ExecutionException;
 
   /**
-   * Returns all the results.
+   * Returns all remaining results.
    *
-   * @return the list of {@code Result}s
+   * @return a {@code List} containing all remaining results
    * @throws ExecutionException if the operation fails
    */
   List<Result> all() throws ExecutionException;

--- a/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionCrudOperable.java
@@ -41,6 +41,18 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
+   */
+  @Override
+  Scanner getScanner(Scan scan) throws CrudConflictException, CrudException;
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @deprecated As of release 3.13.0. Will be removed in release 5.0.0.
@@ -154,4 +166,38 @@ public interface TransactionCrudOperable extends CrudOperable<CrudException> {
   @Override
   void mutate(List<? extends Mutation> mutations)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException;
+
+  interface Scanner extends CrudOperable.Scanner<CrudException> {
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    Optional<Result> one() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    List<Result> all() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudException if closing the scanner fails
+     */
+    @Override
+    void close() throws CrudException;
+  }
 }

--- a/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
+++ b/core/src/main/java/com/scalar/db/api/TransactionManagerCrudOperable.java
@@ -47,6 +47,18 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
    * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
    *     faults. You can try retrying the transaction from the beginning, but the transaction may
    *     still fail if the cause is nontranient
+   */
+  @Override
+  Scanner getScanner(Scan scan) throws CrudConflictException, CrudException;
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+   *     (e.g., a conflict error). You can retry the transaction from the beginning
+   * @throws CrudException if the transaction CRUD operation fails due to transient or nontransient
+   *     faults. You can try retrying the transaction from the beginning, but the transaction may
+   *     still fail if the cause is nontranient
    * @throws UnsatisfiedConditionException if a condition is specified, and if the condition is not
    *     satisfied or the entry does not exist
    * @throws UnknownTransactionStatusException if the status of the commit is unknown
@@ -177,4 +189,39 @@ public interface TransactionManagerCrudOperable extends CrudOperable<Transaction
   void mutate(List<? extends Mutation> mutations)
       throws CrudConflictException, CrudException, UnsatisfiedConditionException,
           UnknownTransactionStatusException;
+
+  interface Scanner extends CrudOperable.Scanner<TransactionException> {
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    Optional<Result> one() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudConflictException if the transaction CRUD operation fails due to transient faults
+     *     (e.g., a conflict error). You can retry the transaction from the beginning
+     * @throws CrudException if the transaction CRUD operation fails due to transient or
+     *     nontransient faults. You can try retrying the transaction from the beginning, but the
+     *     transaction may still fail if the cause is nontranient
+     */
+    @Override
+    List<Result> all() throws CrudConflictException, CrudException;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws CrudException if closing the scanner fails
+     * @throws UnknownTransactionStatusException if the status of the commit is unknown
+     */
+    @Override
+    void close() throws CrudException, UnknownTransactionStatusException;
+  }
 }

--- a/core/src/main/java/com/scalar/db/common/AbstractCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractCrudOperableScanner.java
@@ -1,0 +1,61 @@
+package com.scalar.db.common;
+
+import com.google.errorprone.annotations.concurrent.LazyInit;
+import com.scalar.db.api.CrudOperable;
+import com.scalar.db.api.Result;
+import com.scalar.db.exception.transaction.TransactionException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+public abstract class AbstractCrudOperableScanner<E extends TransactionException>
+    implements CrudOperable.Scanner<E> {
+
+  @LazyInit private ScannerIterator scannerIterator;
+
+  @Override
+  @Nonnull
+  public Iterator<Result> iterator() {
+    if (scannerIterator == null) {
+      scannerIterator = new ScannerIterator(this);
+    }
+    return scannerIterator;
+  }
+
+  @NotThreadSafe
+  public class ScannerIterator implements Iterator<Result> {
+
+    private final CrudOperable.Scanner<E> scanner;
+    private Result next;
+
+    public ScannerIterator(CrudOperable.Scanner<E> scanner) {
+      this.scanner = Objects.requireNonNull(scanner);
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (next != null) {
+        return true;
+      }
+
+      try {
+        return (next = scanner.one().orElse(null)) != null;
+      } catch (TransactionException e) {
+        throw new RuntimeException(e.getMessage(), e);
+      }
+    }
+
+    @Override
+    public Result next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      Result ret = next;
+      next = null;
+      return ret;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/AbstractTransactionCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTransactionCrudOperableScanner.java
@@ -1,0 +1,7 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.exception.transaction.CrudException;
+
+public abstract class AbstractTransactionCrudOperableScanner
+    extends AbstractCrudOperableScanner<CrudException> implements TransactionCrudOperable.Scanner {}

--- a/core/src/main/java/com/scalar/db/common/AbstractTransactionManagerCrudOperableScanner.java
+++ b/core/src/main/java/com/scalar/db/common/AbstractTransactionManagerCrudOperableScanner.java
@@ -1,0 +1,8 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.TransactionManagerCrudOperable;
+import com.scalar.db.exception.transaction.TransactionException;
+
+public abstract class AbstractTransactionManagerCrudOperableScanner
+    extends AbstractCrudOperableScanner<TransactionException>
+    implements TransactionManagerCrudOperable.Scanner {}

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -121,6 +121,11 @@ public class ActiveTransactionManagedDistributedTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public synchronized Scanner getScanner(Scan scan) throws CrudException {
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -127,6 +127,11 @@ public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public synchronized Scanner getScanner(Scan scan) throws CrudException {
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransaction.java
@@ -78,6 +78,11 @@ public abstract class DecoratedDistributedTransaction implements DistributedTran
     return transaction.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transaction.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -157,6 +157,11 @@ public abstract class DecoratedDistributedTransactionManager
     return transactionManager.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transactionManager.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransaction.java
@@ -80,6 +80,11 @@ public abstract class DecoratedTwoPhaseCommitTransaction implements TwoPhaseComm
     return transaction.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transaction.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedTwoPhaseCommitTransactionManager.java
@@ -111,6 +111,11 @@ public abstract class DecoratedTwoPhaseCommitTransactionManager
     return transactionManager.scan(scan);
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return transactionManager.getScanner(scan);
+  }
+
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -70,6 +70,12 @@ public class StateManagedDistributedTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public Scanner getScanner(Scan scan) throws CrudException {
+      checkIfActive();
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -76,6 +76,12 @@ public class StateManagedTwoPhaseCommitTransactionManager
       return super.scan(scan);
     }
 
+    @Override
+    public Scanner getScanner(Scan scan) throws CrudException {
+      checkIfActive();
+      return super.getScanner(scan);
+    }
+
     /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
     @Deprecated
     @Override

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -911,6 +911,18 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0203", "Delimiter must not be null", "", ""),
   DATA_LOADER_CONFIG_FILE_PATH_BLANK(
       Category.USER_ERROR, "0204", "Config file path must not be blank", "", ""),
+  CONSENSUS_COMMIT_SCANNER_NOT_CLOSED(
+      Category.USER_ERROR,
+      "0205",
+      "Some scanners were not closed. All scanners must be closed before committing the transaction.",
+      "",
+      ""),
+  TWO_PHASE_CONSENSUS_COMMIT_SCANNER_NOT_CLOSED(
+      Category.USER_ERROR,
+      "0206",
+      "Some scanners were not closed. All scanners must be closed before preparing the transaction.",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -1182,6 +1194,8 @@ public enum CoreError implements ScalarDbError {
       Category.INTERNAL_ERROR, "0052", "Failed to read JSON file. Details: %s.", "", ""),
   DATA_LOADER_JSONLINES_FILE_READ_FAILED(
       Category.INTERNAL_ERROR, "0053", "Failed to read JSON Lines file. Details: %s.", "", ""),
+  JDBC_TRANSACTION_GETTING_SCANNER_FAILED(
+      Category.INTERNAL_ERROR, "0054", "Getting the scanner failed. Details: %s", "", ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -168,10 +168,19 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return manager.getScanner(scan);
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     manager.put(puts);
@@ -197,6 +206,8 @@ public class TransactionService implements DistributedTransactionManager {
     manager.delete(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     manager.delete(deletes);

--- a/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TwoPhaseCommitTransactionService.java
@@ -125,10 +125,19 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
   }
 
   @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    return manager.getScanner(scan);
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
     manager.put(put);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
     manager.put(puts);
@@ -154,6 +163,8 @@ public class TwoPhaseCommitTransactionService implements TwoPhaseCommitTransacti
     manager.delete(delete);
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {
     manager.delete(deletes);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -96,8 +96,13 @@ public class JdbcService {
     }
   }
 
-  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
   public Scanner getScanner(Scan scan, Connection connection)
+      throws SQLException, ExecutionException {
+    return getScanner(scan, connection, true);
+  }
+
+  @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
+  public Scanner getScanner(Scan scan, Connection connection, boolean closeConnectionOnScannerClose)
       throws SQLException, ExecutionException {
     operationChecker.check(scan);
 
@@ -111,7 +116,8 @@ public class JdbcService {
         new ResultInterpreter(scan.getProjections(), tableMetadata, rdbEngine),
         connection,
         preparedStatement,
-        resultSet);
+        resultSet,
+        closeConnectionOnScannerClose);
   }
 
   public List<Result> scan(Scan scan, Connection connection)

--- a/core/src/main/java/com/scalar/db/storage/jdbc/ScannerImpl.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/ScannerImpl.java
@@ -25,17 +25,20 @@ public class ScannerImpl extends AbstractScanner {
   private final Connection connection;
   private final PreparedStatement preparedStatement;
   private final ResultSet resultSet;
+  private final boolean closeConnectionOnClose;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ScannerImpl(
       ResultInterpreter resultInterpreter,
       Connection connection,
       PreparedStatement preparedStatement,
-      ResultSet resultSet) {
+      ResultSet resultSet,
+      boolean closeConnectionOnClose) {
     this.resultInterpreter = Objects.requireNonNull(resultInterpreter);
     this.connection = Objects.requireNonNull(connection);
     this.preparedStatement = Objects.requireNonNull(preparedStatement);
     this.resultSet = Objects.requireNonNull(resultSet);
+    this.closeConnectionOnClose = closeConnectionOnClose;
   }
 
   @Override
@@ -75,10 +78,13 @@ public class ScannerImpl extends AbstractScanner {
     } catch (SQLException e) {
       logger.warn("Failed to close the preparedStatement", e);
     }
-    try {
-      connection.close();
-    } catch (SQLException e) {
-      logger.warn("Failed to close the connection", e);
+
+    if (closeConnectionOnClose) {
+      try {
+        connection.close();
+      } catch (SQLException e) {
+        logger.warn("Failed to close the connection", e);
+      }
     }
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -16,10 +16,12 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransactionManager;
+import com.scalar.db.common.AbstractTransactionManagerCrudOperableScanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CrudConflictException;
@@ -34,6 +36,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
@@ -229,6 +232,88 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    DistributedTransaction transaction = begin();
+
+    TransactionCrudOperable.Scanner scanner;
+    try {
+      scanner = transaction.getScanner(copyAndSetTargetToIfNot(scan));
+    } catch (CrudException e) {
+      rollbackTransaction(transaction);
+      throw e;
+    }
+
+    return new AbstractTransactionManagerCrudOperableScanner() {
+
+      private final AtomicBoolean closed = new AtomicBoolean();
+
+      @Override
+      public Optional<Result> one() throws CrudException {
+        try {
+          return scanner.one();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public List<Result> all() throws CrudException {
+        try {
+          return scanner.all();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public void close() throws CrudException, UnknownTransactionStatusException {
+        if (closed.get()) {
+          return;
+        }
+        closed.set(true);
+
+        try {
+          scanner.close();
+        } catch (CrudException e) {
+          rollbackTransaction(transaction);
+          throw e;
+        }
+
+        try {
+          transaction.commit();
+        } catch (CommitConflictException e) {
+          rollbackTransaction(transaction);
+          throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        } catch (UnknownTransactionStatusException e) {
+          throw e;
+        } catch (TransactionException e) {
+          rollbackTransaction(transaction);
+          throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        }
+      }
+    };
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -239,6 +324,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -285,6 +371,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -16,6 +16,8 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.common.AbstractTransactionCrudOperableScanner;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.CrudException;
@@ -23,10 +25,13 @@ import com.scalar.db.util.ScalarDbUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -42,6 +47,7 @@ public class CrudHandler {
   private final boolean isIncludeMetadataEnabled;
   private final MutationConditionsValidator mutationConditionsValidator;
   private final ParallelExecutor parallelExecutor;
+  private final List<ConsensusCommitScanner> scanners = new ArrayList<>();
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CrudHandler(
@@ -211,6 +217,37 @@ public class CrudHandler {
     snapshot.putIntoReadSet(key, Optional.of(result));
   }
 
+  public TransactionCrudOperable.Scanner getScanner(Scan originalScan) throws CrudException {
+    List<String> originalProjections = new ArrayList<>(originalScan.getProjections());
+    Scan scan = (Scan) prepareStorageSelection(originalScan);
+
+    ConsensusCommitScanner scanner;
+
+    Optional<LinkedHashMap<Snapshot.Key, TransactionResult>> resultsInSnapshot =
+        snapshot.getResults(scan);
+    if (resultsInSnapshot.isPresent()) {
+      scanner =
+          new ConsensusCommitSnapshotScanner(scan, originalProjections, resultsInSnapshot.get());
+    } else {
+      scanner = new ConsensusCommitStorageScanner(scan, originalProjections);
+    }
+
+    scanners.add(scanner);
+    return scanner;
+  }
+
+  public boolean areAllScannersClosed() {
+    return scanners.stream().allMatch(ConsensusCommitScanner::isClosed);
+  }
+
+  public void closeScanners() throws CrudException {
+    for (ConsensusCommitScanner scanner : scanners) {
+      if (!scanner.isClosed()) {
+        scanner.close();
+      }
+    }
+  }
+
   public void put(Put put) throws CrudException {
     Snapshot.Key key = new Snapshot.Key(put);
 
@@ -359,5 +396,170 @@ public class CrudHandler {
   @SuppressFBWarnings("EI_EXPOSE_REP")
   public Snapshot getSnapshot() {
     return snapshot;
+  }
+
+  private interface ConsensusCommitScanner extends TransactionCrudOperable.Scanner {
+    boolean isClosed();
+  }
+
+  @NotThreadSafe
+  private class ConsensusCommitStorageScanner extends AbstractTransactionCrudOperableScanner
+      implements ConsensusCommitScanner {
+
+    private final Scan scan;
+    private final List<String> originalProjections;
+    private final Scanner scanner;
+
+    private final LinkedHashMap<Snapshot.Key, TransactionResult> results = new LinkedHashMap<>();
+    private final AtomicBoolean fullyScanned = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public ConsensusCommitStorageScanner(Scan scan, List<String> originalProjections)
+        throws CrudException {
+      this.scan = scan;
+      this.originalProjections = originalProjections;
+      scanner = scanFromStorage(scan);
+    }
+
+    @Override
+    public Optional<Result> one() throws CrudException {
+      try {
+        Optional<Result> r = scanner.one();
+
+        if (!r.isPresent()) {
+          fullyScanned.set(true);
+          return Optional.empty();
+        }
+
+        Snapshot.Key key = new Snapshot.Key(scan, r.get());
+        TransactionResult result = new TransactionResult(r.get());
+        processScanResult(key, scan, result);
+        results.put(key, result);
+
+        TableMetadata metadata = getTableMetadata(scan);
+        return Optional.of(
+            new FilteredResult(result, originalProjections, metadata, isIncludeMetadataEnabled));
+      } catch (ExecutionException e) {
+        closeScanner();
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_SCANNING_RECORDS_FROM_STORAGE_FAILED.buildMessage(),
+            e,
+            snapshot.getId());
+      } catch (CrudException e) {
+        closeScanner();
+        throw e;
+      }
+    }
+
+    @Override
+    public List<Result> all() throws CrudException {
+      List<Result> results = new ArrayList<>();
+
+      while (true) {
+        Optional<Result> result = one();
+        if (!result.isPresent()) {
+          break;
+        }
+        results.add(result.get());
+      }
+
+      return results;
+    }
+
+    @Override
+    public void close() {
+      if (closed.get()) {
+        return;
+      }
+
+      closeScanner();
+
+      if (fullyScanned.get()) {
+        // If the scanner is fully scanned, we can treat it as a normal scan, and put the results
+        // into the scan set
+        snapshot.putIntoScanSet(scan, results);
+      } else {
+        // If the scanner is not fully scanned, put the results into the scanner set
+        snapshot.putIntoScannerSet(scan, results);
+      }
+
+      snapshot.verifyNoOverlap(scan, results);
+    }
+
+    @Override
+    public boolean isClosed() {
+      return closed.get();
+    }
+
+    private void closeScanner() {
+      closed.set(true);
+      try {
+        scanner.close();
+      } catch (IOException e) {
+        logger.warn("Failed to close the scanner", e);
+      }
+    }
+  }
+
+  @NotThreadSafe
+  private class ConsensusCommitSnapshotScanner extends AbstractTransactionCrudOperableScanner
+      implements ConsensusCommitScanner {
+
+    private final Scan scan;
+    private final List<String> originalProjections;
+    private final Iterator<Map.Entry<Snapshot.Key, TransactionResult>> resultsIterator;
+
+    private final LinkedHashMap<Snapshot.Key, TransactionResult> results = new LinkedHashMap<>();
+    private boolean closed;
+
+    public ConsensusCommitSnapshotScanner(
+        Scan scan,
+        List<String> originalProjections,
+        LinkedHashMap<Snapshot.Key, TransactionResult> resultsInSnapshot) {
+      this.scan = scan;
+      this.originalProjections = originalProjections;
+      resultsIterator = resultsInSnapshot.entrySet().iterator();
+    }
+
+    @Override
+    public Optional<Result> one() throws CrudException {
+      if (!resultsIterator.hasNext()) {
+        return Optional.empty();
+      }
+
+      Map.Entry<Snapshot.Key, TransactionResult> entry = resultsIterator.next();
+      results.put(entry.getKey(), entry.getValue());
+
+      TableMetadata metadata = getTableMetadata(scan);
+      return Optional.of(
+          new FilteredResult(
+              entry.getValue(), originalProjections, metadata, isIncludeMetadataEnabled));
+    }
+
+    @Override
+    public List<Result> all() throws CrudException {
+      List<Result> results = new ArrayList<>();
+
+      while (true) {
+        Optional<Result> result = one();
+        if (!result.isPresent()) {
+          break;
+        }
+        results.add(result.get());
+      }
+
+      return results;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+      snapshot.verifyNoOverlap(scan, results);
+    }
+
+    @Override
+    public boolean isClosed() {
+      return closed;
+    }
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -13,10 +13,12 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
+import com.scalar.db.common.AbstractTransactionManagerCrudOperableScanner;
 import com.scalar.db.common.AbstractTwoPhaseCommitTransactionManager;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
@@ -35,6 +37,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import org.slf4j.Logger;
@@ -186,6 +189,92 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    TwoPhaseCommitTransaction transaction = begin();
+
+    TransactionCrudOperable.Scanner scanner;
+    try {
+      scanner = transaction.getScanner(copyAndSetTargetToIfNot(scan));
+    } catch (CrudException e) {
+      rollbackTransaction(transaction);
+      throw e;
+    }
+
+    return new AbstractTransactionManagerCrudOperableScanner() {
+
+      private final AtomicBoolean closed = new AtomicBoolean();
+
+      @Override
+      public Optional<Result> one() throws CrudException {
+        try {
+          return scanner.one();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public List<Result> all() throws CrudException {
+        try {
+          return scanner.all();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public void close() throws CrudException, UnknownTransactionStatusException {
+        if (closed.get()) {
+          return;
+        }
+        closed.set(true);
+
+        try {
+          scanner.close();
+        } catch (CrudException e) {
+          rollbackTransaction(transaction);
+          throw e;
+        }
+
+        try {
+          transaction.prepare();
+          transaction.validate();
+          transaction.commit();
+        } catch (PreparationConflictException
+            | ValidationConflictException
+            | CommitConflictException e) {
+          rollbackTransaction(transaction);
+          throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        } catch (UnknownTransactionStatusException e) {
+          throw e;
+        } catch (TransactionException e) {
+          rollbackTransaction(transaction);
+          throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        }
+      }
+    };
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -196,6 +285,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -242,6 +332,7 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -12,10 +12,12 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.SerializableStrategy;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransactionManager;
+import com.scalar.db.common.AbstractTransactionManagerCrudOperableScanner;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
@@ -38,6 +40,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
@@ -168,6 +171,95 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
     return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
   }
 
+  @Override
+  public Scanner getScanner(Scan scan) throws CrudException {
+    DistributedTransaction transaction;
+    try {
+      transaction = begin();
+    } catch (TransactionNotFoundException e) {
+      throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    } catch (TransactionException e) {
+      throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+    }
+
+    TransactionCrudOperable.Scanner scanner;
+    try {
+      scanner = transaction.getScanner(copyAndSetTargetToIfNot(scan));
+    } catch (CrudException e) {
+      rollbackTransaction(transaction);
+      throw e;
+    }
+
+    return new AbstractTransactionManagerCrudOperableScanner() {
+
+      private final AtomicBoolean closed = new AtomicBoolean();
+
+      @Override
+      public Optional<Result> one() throws CrudException {
+        try {
+          return scanner.one();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public List<Result> all() throws CrudException {
+        try {
+          return scanner.all();
+        } catch (CrudException e) {
+          closed.set(true);
+
+          try {
+            scanner.close();
+          } catch (CrudException ex) {
+            e.addSuppressed(ex);
+          }
+
+          rollbackTransaction(transaction);
+          throw e;
+        }
+      }
+
+      @Override
+      public void close() throws CrudException, UnknownTransactionStatusException {
+        if (closed.get()) {
+          return;
+        }
+        closed.set(true);
+
+        try {
+          scanner.close();
+        } catch (CrudException e) {
+          rollbackTransaction(transaction);
+          throw e;
+        }
+
+        try {
+          transaction.commit();
+        } catch (CommitConflictException e) {
+          rollbackTransaction(transaction);
+          throw new CrudConflictException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        } catch (UnknownTransactionStatusException e) {
+          throw e;
+        } catch (TransactionException e) {
+          rollbackTransaction(transaction);
+          throw new CrudException(e.getMessage(), e, e.getTransactionId().orElse(null));
+        }
+      }
+    };
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(Put put) throws CrudException, UnknownTransactionStatusException {
@@ -178,6 +270,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void put(List<Put> puts) throws CrudException, UnknownTransactionStatusException {
@@ -224,6 +317,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
         });
   }
 
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
   @Deprecated
   @Override
   public void delete(List<Delete> deletes) throws CrudException, UnknownTransactionStatusException {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -98,7 +98,8 @@ public class JdbcDatabaseTest {
   public void whenScanOperationExecutedAndScannerClosed_shouldCallJdbcService() throws Exception {
     // Arrange
     when(jdbcService.getScanner(any(), any()))
-        .thenReturn(new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet));
+        .thenReturn(
+            new ScannerImpl(resultInterpreter, connection, preparedStatement, resultSet, true));
 
     // Act
     Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -22,6 +22,8 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TransactionManagerCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
@@ -38,6 +40,8 @@ import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.Coordinator.State;
 import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.CoordinatorGroupCommitKeyManipulator;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -664,6 +668,338 @@ public class ConsensusCommitManagerTest {
     verify(transaction).scan(scan);
     verify(transaction).commit();
     assertThat(actual).isEqualTo(results);
+  }
+
+  @Test
+  public void getScannerAndScannerOne_ShouldReturnScannerAndReturnProperResult() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.of(result3))
+        .thenReturn(Optional.empty());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThat(actual.one()).hasValue(result1);
+    assertThat(actual.one()).hasValue(result2);
+    assertThat(actual.one()).hasValue(result3);
+    assertThat(actual.one()).isEmpty();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScannerAndScannerAll_ShouldReturnScannerAndReturnProperResults() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.all())
+        .thenReturn(Arrays.asList(result1, result2, result3))
+        .thenReturn(Collections.emptyList());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    List<Result> results = actual.all();
+    assertThat(results).containsExactly(result1, result2, result3);
+    assertThat(actual.all()).isEmpty();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScannerAndScannerIterator_ShouldReturnScannerAndReturnProperResults()
+      throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.of(result3))
+        .thenReturn(Optional.empty());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+
+    Iterator<Result> iterator = actual.iterator();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result1);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result2);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result3);
+    assertThat(iterator.hasNext()).isFalse();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScanner_CrudExceptionThrownByTransactionGetScanner_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    when(transaction.getScanner(scan)).thenThrow(CrudException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerOne_CrudExceptionThrownByScannerOne_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    when(scanner.one()).thenThrow(CrudException.class);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::one).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerAll_CrudExceptionThrownByScannerAll_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    when(scanner.all()).thenThrow(CrudException.class);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::all).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CrudExceptionThrownByScannerClose_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    doThrow(CrudException.class).when(scanner).close();
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CommitConflictExceptionThrownByTransactionCommit_ShouldRollbackTransactionAndThrowCrudConflictException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(CommitConflictException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudConflictException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_UnknownTransactionStatusExceptionByTransactionCommit_ShouldThrowUnknownTransactionStatusException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(UnknownTransactionStatusException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(UnknownTransactionStatusException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CommitExceptionThrownByTransactionCommit_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    ConsensusCommitManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(CommitException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace("ns")
+            .table("tbl")
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CrudHandlerTest.java
@@ -24,6 +24,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.common.ResultImpl;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -33,6 +34,8 @@ import com.scalar.db.io.DataType;
 import com.scalar.db.io.Key;
 import com.scalar.db.io.TextColumn;
 import com.scalar.db.util.ScalarDbUtils;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,8 +47,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -231,8 +235,8 @@ public class CrudHandlerTest {
               assertThat(exception.getResults().get(0)).isEqualTo(result);
             });
 
-    verify(snapshot, never()).putIntoReadSet(any(), ArgumentMatchers.any());
-    verify(snapshot, never()).putIntoGetSet(any(), ArgumentMatchers.any());
+    verify(snapshot, never()).putIntoReadSet(any(), any());
+    verify(snapshot, never()).putIntoGetSet(any(), any());
   }
 
   @Test
@@ -345,23 +349,29 @@ public class CrudHandlerTest {
     assertThatThrownBy(() -> handler.get(get)).isInstanceOf(IllegalArgumentException.class);
   }
 
-  @Test
-  public void scan_ResultGivenFromStorage_ShouldUpdateSnapshotAndReturn()
-      throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void scanOrGetScanner_ResultGivenFromStorage_ShouldUpdateSnapshotAndReturn(ScanType scanType)
+      throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
     Snapshot.Key key = new Snapshot.Key(scan, result);
     TransactionResult expected = new TransactionResult(result);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
     when(snapshot.getResult(any())).thenReturn(Optional.of(expected));
 
     // Act
-    List<Result> results = handler.scan(scan);
+    List<Result> results = scanOrGetScanner(scan, scanType);
 
     // Assert
+    verify(scanner).close();
     verify(snapshot).putIntoReadSet(key, Optional.of(expected));
     verify(snapshot).putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, expected)));
     verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key, expected));
@@ -370,19 +380,24 @@ public class CrudHandlerTest {
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
   }
 
-  @Test
-  public void
-      scan_PreparedResultGivenFromStorage_ShouldNeverUpdateSnapshotThrowUncommittedRecordException()
-          throws ExecutionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void
+      scanOrGetScanner_PreparedResultGivenFromStorage_ShouldNeverUpdateSnapshotThrowUncommittedRecordException(
+          ScanType scanType) throws ExecutionException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.PREPARED);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.scan(scan))
+    assertThatThrownBy(() -> scanOrGetScanner(scan, scanType))
         .isInstanceOf(UncommittedRecordException.class)
         .satisfies(
             e -> {
@@ -392,13 +407,15 @@ public class CrudHandlerTest {
               assertThat(exception.getResults().get(0)).isEqualTo(result);
             });
 
-    verify(snapshot, never()).putIntoReadSet(any(), ArgumentMatchers.any());
-    verify(snapshot, never()).putIntoScanSet(any(), ArgumentMatchers.any());
+    verify(scanner).close();
+    verify(snapshot, never()).putIntoReadSet(any(), any());
+    verify(snapshot, never()).putIntoScanSet(any(), any());
   }
 
-  @Test
-  public void scan_CalledTwice_SecondTimeShouldReturnTheSameFromSnapshot()
-      throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void scanOrGetScanner_CalledTwice_SecondTimeShouldReturnTheSameFromSnapshot(ScanType scanType)
+      throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan originalScan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(originalScan);
@@ -406,7 +423,11 @@ public class CrudHandlerTest {
     Scan scan2 = prepareScan();
     result = prepareResult(TransactionState.COMMITTED);
     TransactionResult expected = new TransactionResult(result);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
     Snapshot.Key key = new Snapshot.Key(scanForStorage, result);
     when(snapshot.getResults(scanForStorage))
@@ -415,10 +436,11 @@ public class CrudHandlerTest {
     when(snapshot.getResult(key)).thenReturn(Optional.of(expected));
 
     // Act
-    List<Result> results1 = handler.scan(scan1);
-    List<Result> results2 = handler.scan(scan2);
+    List<Result> results1 = scanOrGetScanner(scan1, scanType);
+    List<Result> results2 = scanOrGetScanner(scan2, scanType);
 
     // Assert
+    verify(scanner).close();
     verify(snapshot).putIntoReadSet(key, Optional.of(expected));
     verify(snapshot)
         .putIntoScanSet(scanForStorage, Maps.newLinkedHashMap(ImmutableMap.of(key, expected)));
@@ -430,9 +452,10 @@ public class CrudHandlerTest {
     verify(storage).scan(scanForStorage);
   }
 
-  @Test
-  public void scan_CalledTwiceUnderRealSnapshot_SecondTimeShouldReturnTheSameFromSnapshot()
-      throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void scan_CalledTwiceUnderRealSnapshot_SecondTimeShouldReturnTheSameFromSnapshot(
+      ScanType scanType) throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan originalScan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(originalScan);
@@ -442,30 +465,41 @@ public class CrudHandlerTest {
     TransactionResult expected = new TransactionResult(result);
     snapshot = new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     // Act
-    List<Result> results1 = handler.scan(scan1);
-    List<Result> results2 = handler.scan(scan2);
+    List<Result> results1 = scanOrGetScanner(scan1, scanType);
+    List<Result> results2 = scanOrGetScanner(scan2, scanType);
 
     // Assert
     assertThat(results1.size()).isEqualTo(1);
     assertThat(results1.get(0))
         .isEqualTo(new FilteredResult(expected, Collections.emptyList(), TABLE_METADATA, false));
     assertThat(results1).isEqualTo(results2);
+
+    verify(scanner).close();
     verify(storage, never()).scan(originalScan);
     verify(storage).scan(scanForStorage);
   }
 
-  @Test
-  public void scan_GetCalledAfterScan_ShouldReturnFromStorage()
-      throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void scanOrGetScanner_GetCalledAfterScan_ShouldReturnFromStorage(ScanType scanType)
+      throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
     result = prepareResult(TransactionState.COMMITTED);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
     Get get = prepareGet();
     Snapshot.Key key = new Snapshot.Key(get);
@@ -476,46 +510,55 @@ public class CrudHandlerTest {
     when(snapshot.getResult(key)).thenReturn(transactionResult);
 
     // Act
-    List<Result> results = handler.scan(scan);
+    List<Result> results = scanOrGetScanner(scan, scanType);
     Optional<Result> result = handler.get(get);
 
     // Assert
     verify(storage).scan(scanForStorage);
-
     verify(storage).get(getForStorage);
+    verify(scanner).close();
+
     assertThat(results.size()).isEqualTo(1);
     assertThat(result).isPresent();
     assertThat(results.get(0)).isEqualTo(result.get());
   }
 
-  @Test
-  public void scan_GetCalledAfterScanUnderRealSnapshot_ShouldReturnFromStorage()
-      throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void scanOrGetScanner_GetCalledAfterScanUnderRealSnapshot_ShouldReturnFromStorage(
+      ScanType scanType) throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan scan = toScanForStorageFrom(prepareScan());
     result = prepareResult(TransactionState.COMMITTED);
     snapshot = new Snapshot(ANY_TX_ID, Isolation.SNAPSHOT, tableMetadataManager, parallelExecutor);
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(scan)).thenReturn(scanner);
     Get get = prepareGet();
     when(storage.get(get)).thenReturn(Optional.of(result));
 
     // Act
-    List<Result> results = handler.scan(scan);
+    List<Result> results = scanOrGetScanner(scan, scanType);
     Optional<Result> result = handler.get(get);
 
     // Assert
     verify(storage).scan(scan);
     verify(storage).get(get);
+    verify(scanner).close();
+
     assertThat(results.size()).isEqualTo(1);
     assertThat(result).isPresent();
     assertThat(results.get(0)).isEqualTo(result.get());
   }
 
-  @Test
-  public void scan_CalledAfterDeleteUnderRealSnapshot_ShouldThrowIllegalArgumentException()
-      throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void scanOrGetScanner_CalledAfterDeleteUnderRealSnapshot_ShouldThrowIllegalArgumentException(
+      ScanType scanType) throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
@@ -551,9 +594,17 @@ public class CrudHandlerTest {
             new ConcurrentHashMap<>(),
             new HashMap<>(),
             new HashMap<>(),
-            deleteSet);
+            deleteSet,
+            new ArrayList<>());
     handler = new CrudHandler(storage, snapshot, tableMetadataManager, false, parallelExecutor);
-    when(scanner.iterator()).thenReturn(Arrays.asList(result, result2).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Arrays.asList(result, result2).iterator());
+    } else {
+      when(scanner.one())
+          .thenReturn(Optional.of(result))
+          .thenReturn(Optional.of(result2))
+          .thenReturn(Optional.empty());
+    }
     when(storage.scan(scanForStorage)).thenReturn(scanner);
 
     Delete delete =
@@ -568,26 +619,35 @@ public class CrudHandlerTest {
     assertThat(deleteSet.size()).isEqualTo(1);
     assertThat(deleteSet).containsKey(new Snapshot.Key(delete));
 
-    assertThatThrownBy(() -> handler.scan(scan)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> scanOrGetScanner(scan, scanType))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    verify(scanner).close();
   }
 
-  @Test
-  public void
-      scan_CrossPartitionScanAndResultFromStorageGiven_ShouldUpdateSnapshotAndVerifyNoOverlapThenReturn()
-          throws ExecutionException, CrudException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void
+      scanOrGetScanner_CrossPartitionScanAndResultFromStorageGiven_ShouldUpdateSnapshotAndVerifyNoOverlapThenReturn(
+          ScanType scanType) throws ExecutionException, CrudException, IOException {
     // Arrange
     Scan scan = prepareCrossPartitionScan();
     result = prepareResult(TransactionState.COMMITTED);
     Snapshot.Key key = new Snapshot.Key(scan, result);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(any(ScanAll.class))).thenReturn(scanner);
     TransactionResult transactionResult = new TransactionResult(result);
     when(snapshot.getResult(key)).thenReturn(Optional.of(transactionResult));
 
     // Act
-    List<Result> results = handler.scan(scan);
+    List<Result> results = scanOrGetScanner(scan, scanType);
 
     // Assert
+    verify(scanner).close();
     verify(snapshot).putIntoReadSet(key, Optional.of(transactionResult));
     verify(snapshot)
         .putIntoScanSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key, transactionResult)));
@@ -598,18 +658,23 @@ public class CrudHandlerTest {
             new FilteredResult(transactionResult, Collections.emptyList(), TABLE_METADATA, false));
   }
 
-  @Test
-  public void
-      scan_CrossPartitionScanAndPreparedResultFromStorageGiven_ShouldNeverUpdateSnapshotNorVerifyNoOverlapButThrowUncommittedRecordException()
-          throws ExecutionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  void
+      scanOrGetScanner_CrossPartitionScanAndPreparedResultFromStorageGiven_ShouldNeverUpdateSnapshotNorVerifyNoOverlapButThrowUncommittedRecordException(
+          ScanType scanType) throws ExecutionException, IOException {
     // Arrange
     Scan scan = prepareCrossPartitionScan();
     result = prepareResult(TransactionState.PREPARED);
-    when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    if (scanType == ScanType.SCAN) {
+      when(scanner.iterator()).thenReturn(Collections.singletonList(result).iterator());
+    } else {
+      when(scanner.one()).thenReturn(Optional.of(result)).thenReturn(Optional.empty());
+    }
     when(storage.scan(any(ScanAll.class))).thenReturn(scanner);
 
     // Act Assert
-    assertThatThrownBy(() -> handler.scan(scan))
+    assertThatThrownBy(() -> scanOrGetScanner(scan, scanType))
         .isInstanceOf(UncommittedRecordException.class)
         .satisfies(
             e -> {
@@ -619,14 +684,16 @@ public class CrudHandlerTest {
               assertThat(exception.getResults().get(0)).isEqualTo(result);
             });
 
-    verify(snapshot, never()).putIntoReadSet(any(Snapshot.Key.class), ArgumentMatchers.any());
+    verify(scanner).close();
+    verify(snapshot, never()).putIntoReadSet(any(Snapshot.Key.class), any());
+    verify(snapshot, never()).putIntoScannerSet(any(Scan.class), any());
     verify(snapshot, never()).verifyNoOverlap(any(), any());
   }
 
   @Test
   public void
       scan_RuntimeExceptionCausedByExecutionExceptionThrownByIteratorHasNext_ShouldThrowCrudException()
-          throws ExecutionException {
+          throws ExecutionException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
@@ -643,11 +710,13 @@ public class CrudHandlerTest {
     assertThatThrownBy(() -> handler.scan(scan))
         .isInstanceOf(CrudException.class)
         .hasCause(executionException);
+
+    verify(scanner).close();
   }
 
   @Test
   public void scan_RuntimeExceptionThrownByIteratorHasNext_ShouldThrowCrudException()
-      throws ExecutionException {
+      throws ExecutionException, IOException {
     // Arrange
     Scan scan = prepareScan();
     Scan scanForStorage = toScanForStorageFrom(scan);
@@ -662,6 +731,60 @@ public class CrudHandlerTest {
     assertThatThrownBy(() -> handler.scan(scan))
         .isInstanceOf(CrudException.class)
         .hasCause(runtimeException);
+
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScanner_ExecutionExceptionThrownByScannerOne_ShouldThrowCrudException()
+      throws ExecutionException, IOException, CrudException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    ExecutionException executionException = mock(ExecutionException.class);
+    when(scanner.one()).thenThrow(executionException);
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan);
+    assertThatThrownBy(actualScanner::one)
+        .isInstanceOf(CrudException.class)
+        .hasCause(executionException);
+
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScanner_ScannerNotFullyScanned_ShouldPutReadSetAndScannerSetInSnapshotAndVerifyScan()
+          throws ExecutionException, CrudException, IOException {
+    // Arrange
+    Scan scan = prepareScan();
+    Scan scanForStorage = toScanForStorageFrom(scan);
+    Result result1 = prepareResult(TransactionState.COMMITTED);
+    Result result2 = prepareResult(TransactionState.COMMITTED);
+    Snapshot.Key key1 = new Snapshot.Key(scan, result1);
+    TransactionResult txResult1 = new TransactionResult(result1);
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.empty());
+    when(storage.scan(scanForStorage)).thenReturn(scanner);
+
+    // Act
+    TransactionCrudOperable.Scanner actualScanner = handler.getScanner(scan);
+    Optional<Result> actualResult = actualScanner.one();
+    actualScanner.close();
+
+    // Assert
+    verify(scanner).close();
+    verify(snapshot).putIntoReadSet(key1, Optional.of(txResult1));
+    verify(snapshot)
+        .putIntoScannerSet(scan, Maps.newLinkedHashMap(ImmutableMap.of(key1, txResult1)));
+    verify(snapshot).verifyNoOverlap(scan, ImmutableMap.of(key1, txResult1));
+
+    assertThat(actualResult)
+        .hasValue(new FilteredResult(txResult1, Collections.emptyList(), TABLE_METADATA, false));
   }
 
   @Test
@@ -1190,5 +1313,35 @@ public class CrudHandlerTest {
     assertThat(tasks.size()).isEqualTo(4);
 
     assertThat(transactionIdCaptor.getValue()).isEqualTo(ANY_TX_ID);
+  }
+
+  private List<Result> scanOrGetScanner(Scan scan, ScanType scanType) throws CrudException {
+    if (scanType == ScanType.SCAN) {
+      return handler.scan(scan);
+    }
+
+    try (TransactionCrudOperable.Scanner scanner = handler.getScanner(scan)) {
+      switch (scanType) {
+        case SCANNER_ONE:
+          List<Result> results = new ArrayList<>();
+          while (true) {
+            Optional<Result> result = scanner.one();
+            if (!result.isPresent()) {
+              return results;
+            }
+            results.add(result.get());
+          }
+        case SCANNER_ALL:
+          return scanner.all();
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  enum ScanType {
+    SCAN,
+    SCANNER_ONE,
+    SCANNER_ALL
   }
 }

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -20,6 +20,8 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.TransactionManagerCrudOperable;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
@@ -41,6 +43,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -176,6 +179,369 @@ public class JdbcTransactionManagerTest {
               transaction.scan(scan);
             })
         .isInstanceOf(CrudConflictException.class);
+  }
+
+  @Test
+  public void getScannerAndScannerOne_ShouldReturnScannerAndReturnProperResult() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.of(result3))
+        .thenReturn(Optional.empty());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThat(actual.one()).hasValue(result1);
+    assertThat(actual.one()).hasValue(result2);
+    assertThat(actual.one()).hasValue(result3);
+    assertThat(actual.one()).isEmpty();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScannerAndScannerAll_ShouldReturnScannerAndReturnProperResults() throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.all())
+        .thenReturn(Arrays.asList(result1, result2, result3))
+        .thenReturn(Collections.emptyList());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    List<Result> results = actual.all();
+    assertThat(results).containsExactly(result1, result2, result3);
+    assertThat(actual.all()).isEmpty();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void getScannerAndScannerIterator_ShouldReturnScannerAndReturnProperResults()
+      throws Exception {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    Result result1 = mock(Result.class);
+    Result result2 = mock(Result.class);
+    Result result3 = mock(Result.class);
+
+    when(scanner.one())
+        .thenReturn(Optional.of(result1))
+        .thenReturn(Optional.of(result2))
+        .thenReturn(Optional.of(result3))
+        .thenReturn(Optional.empty());
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+
+    Iterator<Result> iterator = actual.iterator();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result1);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result2);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(result3);
+    assertThat(iterator.hasNext()).isFalse();
+    actual.close();
+
+    verify(spied).begin();
+    verify(transaction).commit();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScanner_TransactionNotFoundExceptionThrownByTransactionBegin_ShouldThrowCrudConflictException()
+          throws TransactionException {
+    // Arrange
+    JdbcTransactionManager spied = spy(manager);
+    doThrow(TransactionNotFoundException.class).when(spied).begin();
+
+    Scan scan = mock(Scan.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudConflictException.class);
+
+    verify(spied).begin();
+  }
+
+  @Test
+  public void getScanner_TransactionExceptionThrownByTransactionBegin_ShouldThrowCrudException()
+      throws TransactionException {
+    // Arrange
+    JdbcTransactionManager spied = spy(manager);
+    doThrow(TransactionException.class).when(spied).begin();
+
+    Scan scan = mock(Scan.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+  }
+
+  @Test
+  public void
+      getScanner_CrudExceptionThrownByTransactionGetScanner_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    when(transaction.getScanner(scan)).thenThrow(CrudException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerOne_CrudExceptionThrownByScannerOne_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    when(scanner.one()).thenThrow(CrudException.class);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::one).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerAll_CrudExceptionThrownByScannerAll_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    when(scanner.all()).thenThrow(CrudException.class);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::all).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CrudExceptionThrownByScannerClose_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    doThrow(CrudException.class).when(scanner).close();
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CommitConflictExceptionThrownByTransactionCommit_ShouldRollbackTransactionAndThrowCrudConflictException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(CommitConflictException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudConflictException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_UnknownTransactionStatusExceptionByTransactionCommit_ShouldThrowUnknownTransactionStatusException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(UnknownTransactionStatusException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(UnknownTransactionStatusException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+  }
+
+  @Test
+  public void
+      getScannerAndScannerClose_CommitExceptionThrownByTransactionCommit_ShouldRollbackTransactionAndThrowCrudException()
+          throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+
+    JdbcTransactionManager spied = spy(manager);
+    doReturn(transaction).when(spied).begin();
+    doThrow(CommitException.class).when(transaction).commit();
+
+    Scan scan =
+        Scan.newBuilder()
+            .namespace(NAMESPACE)
+            .table(TABLE)
+            .partitionKey(Key.ofText("p1", "val"))
+            .build();
+
+    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
+    when(transaction.getScanner(scan)).thenReturn(scanner);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
+    assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
+
+    verify(spied).begin();
+    verify(scanner).close();
+    verify(transaction).rollback();
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -57,6 +57,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,15 +275,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(1, 0, 2);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -291,9 +295,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertResult(1, 2, results.get(2));
   }
 
-  @Test
-  public void scan_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -303,7 +308,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -320,9 +325,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(2);
   }
 
-  @Test
-  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -333,7 +339,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -354,16 +360,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
   }
 
-  @Test
-  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(1, 0, 2).withOrdering(Ordering.desc(ACCOUNT_TYPE));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -384,16 +391,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(0);
   }
 
-  @Test
-  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(1, 0, 2).withLimit(2);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -424,15 +432,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     Scan scan = prepareScan(0, 4, 6);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -484,8 +494,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result2).isEqualTo(result1);
   }
 
-  @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -517,8 +529,8 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build());
 
     // Act
-    List<Result> results1 = transaction.scan(scanBuiltByConstructor);
-    List<Result> results2 = transaction.scan(scanBuiltByBuilder);
+    List<Result> results1 = scanOrGetScanner(transaction, scanBuiltByConstructor, scanType);
+    List<Result> results2 = scanOrGetScanner(transaction, scanBuiltByBuilder, scanType);
     transaction.commit();
 
     // Assert
@@ -526,9 +538,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results2, expectedResults);
   }
 
-  @Test
-  public void scan_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
@@ -541,7 +554,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -554,8 +567,9 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results.get(0).getInt(SOME_COLUMN)).isEqualTo(6);
   }
 
-  @Test
-  public void scan_ScanAllGivenForCommittedRecord_ShouldReturnRecords()
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
       throws TransactionException {
     // Arrange
     populateRecords();
@@ -563,7 +577,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll();
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -583,9 +597,10 @@ public abstract class DistributedTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
-  @Test
-  public void scan_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     insert(prepareInsert(1, 1), prepareInsert(1, 2), prepareInsert(2, 1), prepareInsert(3, 0));
 
@@ -593,7 +608,7 @@ public abstract class DistributedTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll().withLimit(2);
 
     // Act
-    List<Result> results = scanAllTransaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(scanAllTransaction, scanAll, scanType);
     scanAllTransaction.commit();
 
     // Assert
@@ -623,16 +638,17 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(results).hasSize(2);
   }
 
-  @Test
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
     ScanAll scanAll = prepareScanAll().withProjection(ACCOUNT_TYPE).withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -651,14 +667,16 @@ public abstract class DistributedTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
-  @Test
-  public void scanAll_ScanAllGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     DistributedTransaction transaction = manager.start();
     ScanAll scanAll = prepareScanAll();
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -1048,17 +1066,18 @@ public abstract class DistributedTransactionIntegrationTestBase {
     assertThat(result.get().isNull(SOME_COLUMN)).isTrue();
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
     Scan scan = prepareScan(0, 0, 0).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.commit();
 
     // Assert
@@ -1070,17 +1089,18 @@ public abstract class DistributedTransactionIntegrationTestBase {
         });
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     populateSingleRecord();
     DistributedTransaction transaction = manager.begin();
     ScanAll scanAll = prepareScanAll().withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.commit();
 
     // Assert
@@ -1091,6 +1111,30 @@ public abstract class DistributedTransactionIntegrationTestBase {
             .build();
     TestUtils.assertResultsContainsExactlyInAnyOrder(
         results, Collections.singletonList(expectedResult));
+  }
+
+  @Test
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.start();
+    Scan scan = prepareScan(0, 0, 2);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isPresent();
+    assertResult(0, 0, result1.get());
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isPresent();
+    assertResult(0, 1, result2.get());
+
+    scanner.close();
+
+    transaction.commit();
   }
 
   @Test
@@ -1183,6 +1227,29 @@ public abstract class DistributedTransactionIntegrationTestBase {
               () -> {
                 DistributedTransaction tx = managerWithDefaultNamespace.start();
                 tx.scan(scan);
+                tx.commit();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
+    Properties properties = getProperties(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);
+    try (DistributedTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTransactionManager()) {
+      // Arrange
+      populateRecords();
+      Scan scan = Scan.newBuilder().table(TABLE).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TransactionCrudOperable.Scanner scanner = tx.getScanner(scan);
+                scanner.all();
+                scanner.close();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -2007,6 +2074,42 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
+  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    Scan scan = prepareScan(1, 0, 2);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner scanner = manager.getScanner(scan);
+
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isPresent();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(result1.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result1.get().getInt(SOME_COLUMN)).isEqualTo(0);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isPresent();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(result2.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result2.get().getInt(SOME_COLUMN)).isEqualTo(1);
+
+    Optional<Result> result3 = scanner.one();
+    assertThat(result3).isPresent();
+    assertThat(result3.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result3.get().getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(result3.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result3.get().getInt(SOME_COLUMN)).isEqualTo(2);
+
+    assertThat(scanner.one()).isNotPresent();
+
+    scanner.close();
+  }
+
+  @Test
   public void manager_put_PutGivenForNonExisting_ShouldCreateRecord() throws TransactionException {
     // Arrange
     int expected = INITIAL_BALANCE;
@@ -2246,6 +2349,30 @@ public abstract class DistributedTransactionIntegrationTestBase {
 
       // Act Assert
       Assertions.assertThatCode(() -> managerWithDefaultNamespace.scan(scan))
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  public void manager_getScanner_DefaultNamespaceGiven_ShouldWorkProperly()
+      throws TransactionException {
+    // Arrange
+    Properties properties = getProperties(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace);
+    try (DistributedTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTransactionManager()) {
+      // Arrange
+      populateRecords();
+      Scan scan = Scan.newBuilder().table(TABLE).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TransactionManagerCrudOperable.Scanner scanner =
+                    managerWithDefaultNamespace.getScanner(scan);
+                scanner.all();
+                scanner.close();
+              })
           .doesNotThrowAnyException();
     }
   }
@@ -2669,5 +2796,36 @@ public abstract class DistributedTransactionIntegrationTestBase {
           TimestampColumn.of(TIMESTAMP_COL, LocalDateTime.of(1970, 1, 1, accountId, accountType)));
     }
     return columns.build();
+  }
+
+  protected List<Result> scanOrGetScanner(
+      DistributedTransaction transaction, Scan scan, ScanType scanType) throws CrudException {
+    if (scanType == ScanType.SCAN) {
+      return transaction.scan(scan);
+    }
+
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      switch (scanType) {
+        case SCANNER_ONE:
+          List<Result> results = new ArrayList<>();
+          while (true) {
+            Optional<Result> result = scanner.one();
+            if (!result.isPresent()) {
+              return results;
+            }
+            results.add(result.get());
+          }
+        case SCANNER_ALL:
+          return scanner.all();
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  public enum ScanType {
+    SCAN,
+    SCANNER_ONE,
+    SCANNER_ALL
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/TwoPhaseCommitTransactionIntegrationTestBase.java
@@ -57,6 +57,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -312,15 +314,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -332,9 +336,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertResult(1, 2, results.get(2));
   }
 
-  @Test
-  public void scan_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
@@ -344,7 +349,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -363,9 +368,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results.get(1).getInt(SOME_COLUMN)).isEqualTo(2);
   }
 
-  @Test
-  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
@@ -376,7 +382,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -399,16 +405,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results.get(2).contains(SOME_COLUMN)).isFalse();
   }
 
-  @Test
-  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1).withOrdering(Ordering.desc(ACCOUNT_TYPE));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -431,16 +438,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results.get(2).getInt(SOME_COLUMN)).isEqualTo(0);
   }
 
-  @Test
-  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1).withLimit(2);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -475,15 +483,17 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result.isPresent()).isFalse();
   }
 
-  @Test
-  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
     Scan scan = prepareScan(0, 4, 4, namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -541,8 +551,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result2).isEqualTo(result1);
   }
 
-  @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType)
+      throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.start();
@@ -574,8 +586,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .build());
 
     // Act
-    List<Result> results1 = transaction.scan(scanBuiltByConstructor);
-    List<Result> results2 = transaction.scan(scanBuiltByBuilder);
+    List<Result> results1 = scanOrGetScanner(transaction, scanBuiltByConstructor, scanType);
+    List<Result> results2 = scanOrGetScanner(transaction, scanBuiltByBuilder, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1118,8 +1130,9 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(state).isEqualTo(TransactionState.ABORTED);
   }
 
-  @Test
-  public void scan_ScanAllGivenForCommittedRecord_ShouldReturnRecords()
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType)
       throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
@@ -1127,7 +1140,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1149,9 +1162,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     TestUtils.assertResultsContainsExactlyInAnyOrder(results, expectedResults);
   }
 
-  @Test
-  public void scan_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords(
+      ScanType scanType) throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction putTransaction = manager1.begin();
     insert(
@@ -1167,7 +1181,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1).withLimit(2);
 
     // Act
-    List<Result> results = scanAllTransaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(scanAllTransaction, scanAll, scanType);
     scanAllTransaction.prepare();
     scanAllTransaction.validate();
     scanAllTransaction.commit();
@@ -1199,9 +1213,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(results).hasSize(2);
   }
 
-  @Test
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues()
-      throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues(
+      ScanType scanType) throws TransactionException {
     // Arrange
     populateRecords(manager1, namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1209,7 +1224,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         prepareScanAll(namespace1, TABLE_1).withProjection(ACCOUNT_TYPE).withProjection(BALANCE);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1235,14 +1250,16 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         });
   }
 
-  @Test
-  public void scan_ScanAllGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForNonExisting_ShouldReturnEmpty(ScanType scanType)
+      throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1274,10 +1291,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
     assertThat(result.get().isNull(SOME_COLUMN)).isTrue();
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     TwoPhaseCommitTransaction transaction = manager1.begin();
     populateSingleRecord(namespace1, TABLE_1);
@@ -1286,7 +1304,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scan);
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1300,10 +1318,11 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         });
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns()
-          throws TransactionException {
+      scanOrGetScanner_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) throws TransactionException {
     // Arrange
     populateSingleRecord(namespace1, TABLE_1);
     TwoPhaseCommitTransaction transaction = manager1.begin();
@@ -1311,7 +1330,7 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
         prepareScanAll(namespace1, TABLE_1).withProjections(Arrays.asList(BALANCE, SOME_COLUMN));
 
     // Act
-    List<Result> results = transaction.scan(scanAll);
+    List<Result> results = scanOrGetScanner(transaction, scanAll, scanType);
     transaction.prepare();
     transaction.validate();
     transaction.commit();
@@ -1324,6 +1343,32 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
             .build();
     TestUtils.assertResultsContainsExactlyInAnyOrder(
         results, Collections.singletonList(expectedResult));
+  }
+
+  @Test
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    TwoPhaseCommitTransaction transaction = manager1.start();
+    Scan scan = prepareScan(0, 0, 2, namespace1, TABLE_1);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isPresent();
+    assertResult(0, 0, result1.get());
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isPresent();
+    assertResult(0, 1, result2.get());
+
+    scanner.close();
+
+    transaction.prepare();
+    transaction.validate();
+    transaction.commit();
   }
 
   @Test
@@ -1381,8 +1426,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void get_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Get get =
@@ -1395,8 +1440,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.get(get);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1407,8 +1454,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void scan_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
@@ -1416,8 +1463,35 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.scan(scan);
+                tx.prepare();
+                tx.validate();
+                tx.commit();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
+    Properties properties = getProperties1(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
+      // Arrange
+      populateRecords(manager1, namespace1, TABLE_1);
+      Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
+                TransactionCrudOperable.Scanner scanner = tx.getScanner(scan);
+                scanner.all();
+                scanner.close();
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1428,8 +1502,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void put_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Put put =
@@ -1444,8 +1518,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.put(put);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1456,8 +1532,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void insert_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Insert insert =
@@ -1471,8 +1547,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.insert(insert);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1483,8 +1561,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void upsert_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Upsert upsert =
@@ -1498,8 +1576,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.upsert(upsert);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1510,8 +1590,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void update_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Update update =
@@ -1525,8 +1605,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.update(update);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1537,8 +1619,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void delete_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Delete delete =
@@ -1551,8 +1633,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.delete(delete);
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -1563,8 +1647,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void mutate_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Mutation putAsMutation1 =
@@ -1585,8 +1669,10 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       // Act Assert
       Assertions.assertThatCode(
               () -> {
-                DistributedTransaction tx = managerWithDefaultNamespace.start();
+                TwoPhaseCommitTransaction tx = managerWithDefaultNamespace.start();
                 tx.mutate(ImmutableList.of(putAsMutation1, deleteAsMutation2));
+                tx.prepare();
+                tx.validate();
                 tx.commit();
               })
           .doesNotThrowAnyException();
@@ -2280,6 +2366,42 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   @Test
+  public void manager_getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords()
+      throws TransactionException {
+    // Arrange
+    populateRecords(manager1, namespace1, TABLE_1);
+    Scan scan = prepareScan(1, 0, 2, namespace1, TABLE_1);
+
+    // Act Assert
+    TransactionManagerCrudOperable.Scanner scanner = manager1.getScanner(scan);
+
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isPresent();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(result1.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result1.get().getInt(SOME_COLUMN)).isEqualTo(0);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isPresent();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(result2.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result2.get().getInt(SOME_COLUMN)).isEqualTo(1);
+
+    Optional<Result> result3 = scanner.one();
+    assertThat(result3).isPresent();
+    assertThat(result3.get().getInt(ACCOUNT_ID)).isEqualTo(1);
+    assertThat(result3.get().getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(result3.get())).isEqualTo(INITIAL_BALANCE);
+    assertThat(result3.get().getInt(SOME_COLUMN)).isEqualTo(2);
+
+    assertThat(scanner.one()).isNotPresent();
+
+    scanner.close();
+  }
+
+  @Test
   public void manager_put_PutGivenForNonExisting_ShouldCreateRecord() throws TransactionException {
     // Arrange
     int expected = INITIAL_BALANCE;
@@ -2490,8 +2612,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void manager_get_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Get get =
@@ -2511,8 +2633,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   public void manager_scan_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
@@ -2524,11 +2646,34 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
   }
 
   @Test
+  public void manager_getScanner_DefaultNamespaceGiven_ShouldWorkProperly()
+      throws TransactionException {
+    Properties properties = getProperties1(getTestName());
+    properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
+      // Arrange
+      populateRecords(manager1, namespace1, TABLE_1);
+      Scan scan = Scan.newBuilder().table(TABLE_1).all().build();
+
+      // Act Assert
+      Assertions.assertThatCode(
+              () -> {
+                TransactionManagerCrudOperable.Scanner scanner =
+                    managerWithDefaultNamespace.getScanner(scan);
+                scanner.all();
+                scanner.close();
+              })
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
   public void manager_put_DefaultNamespaceGiven_ShouldWorkProperly() throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Put put =
@@ -2551,8 +2696,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Insert insert =
@@ -2574,8 +2719,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Upsert upsert =
@@ -2597,8 +2742,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Update update =
@@ -2620,8 +2765,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Delete delete =
@@ -2642,8 +2787,8 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
       throws TransactionException {
     Properties properties = getProperties1(getTestName());
     properties.put(DatabaseConfig.DEFAULT_NAMESPACE_NAME, namespace1);
-    try (DistributedTransactionManager managerWithDefaultNamespace =
-        TransactionFactory.create(properties).getTransactionManager()) {
+    try (TwoPhaseCommitTransactionManager managerWithDefaultNamespace =
+        TransactionFactory.create(properties).getTwoPhaseCommitTransactionManager()) {
       // Arrange
       populateRecords(manager1, namespace1, TABLE_1);
       Mutation putAsMutation1 =
@@ -2971,5 +3116,36 @@ public abstract class TwoPhaseCommitTransactionIntegrationTestBase {
           TimestampColumn.of(TIMESTAMP_COL, LocalDateTime.of(1970, 1, 1, accountId, accountType)));
     }
     return columns.build();
+  }
+
+  protected List<Result> scanOrGetScanner(
+      TwoPhaseCommitTransaction transaction, Scan scan, ScanType scanType) throws CrudException {
+    if (scanType == ScanType.SCAN) {
+      return transaction.scan(scan);
+    }
+
+    try (TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan)) {
+      switch (scanType) {
+        case SCANNER_ONE:
+          List<Result> results = new ArrayList<>();
+          while (true) {
+            Optional<Result> result = scanner.one();
+            if (!result.isPresent()) {
+              return results;
+            }
+            results.add(result.get());
+          }
+        case SCANNER_ALL:
+          return scanner.all();
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  public enum ScanType {
+    SCAN,
+    SCANNER_ONE,
+    SCANNER_ALL
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -32,6 +32,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
 import com.scalar.db.api.Selection;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.api.Update;
 import com.scalar.db.config.DatabaseConfig;
@@ -4362,6 +4363,220 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
 
     assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void getScanner_WithSerializable_ShouldNotThrowAnyException() throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      getScanner_FirstInsertedRecordByAnotherTransaction_WithSerializable_ShouldNotThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      getScanner_RecordInsertedByAnotherTransaction_WithSerializable_ShouldNotThrowAnyException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    another.commit();
+
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      getScanner_RecordUpdatedByAnotherTransaction_WithSerializable_ShouldThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.begin(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 0)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTestUtils.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTestUtils.java
@@ -1,4 +1,4 @@
-package com.scalar.db.common;
+package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_DELAYED_SLOT_MOVE_TIMEOUT_MILLIS;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED;

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -9,6 +9,8 @@ import com.scalar.db.io.Key;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public abstract class SingleCrudOperationTransactionIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -70,23 +72,30 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithProjectionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithOrderingGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithLimitGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -95,8 +104,9 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForNonExisting_ShouldReturnEmpty() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForNonExisting_ShouldReturnEmpty(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -105,28 +115,41 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForIndexColumn_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumn_ShouldReturnRecords(ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords(
+      ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues(
+      ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanAllGivenForNonExisting_ShouldReturnEmpty(ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
   @Test
-  public void scan_ScanAllGivenForCommittedRecord_ShouldReturnRecords() {}
-
-  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
-  @Override
-  @Test
-  public void scan_ScanAllGivenWithLimit_ShouldReturnLimitedAmountOfRecords() {}
-
-  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
-  @Override
-  @Test
-  public void scan_ScanAllWithProjectionsGiven_ShouldRetrieveSpecifiedValues() {}
-
-  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
-  @Override
-  @Test
-  public void scanAll_ScanAllGivenForNonExisting_ShouldReturnEmpty() {}
+  public void getScanner_ScanGivenForCommittedRecord_ShouldReturnRecords() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -196,15 +219,19 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns() {}
+      scanOrGetScanner_ScanWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
   public void
-      scan_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns() {}
+      scanOrGetScanner_ScanAllWithProjectionsGivenOnNonPrimaryKeyColumnsForCommittedRecord_ShouldReturnOnlyProjectedColumns(
+          ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support resuming a transaction")
   @Override
@@ -237,6 +264,11 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Override
   @Test
   public void scan_DefaultNamespaceGiven_ShouldWorkProperly() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
+  public void getScanner_DefaultNamespaceGiven_ShouldWorkProperly() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
@@ -413,11 +445,15 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanWithConjunctionsGivenForCommittedRecord_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
-  @Test
-  public void scan_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords() {}
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForIndexColumnWithConjunctions_ShouldReturnRecords(
+      ScanType scanType) {}
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2729
- **Commit to backport:** a70034d6ef096704c531dd9e46ce8b350aa7440e

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2729 &&
git cherry-pick --no-rerere-autoupdate -m1 a70034d6ef096704c531dd9e46ce8b350aa7440e
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!