### PR TITLE
Add support for scanner fetch size in storage adapters

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -1117,7 +1117,7 @@ public enum CoreError implements ScalarDbError {
   JDBC_ERROR_OCCURRED_IN_SELECTION(
       Category.INTERNAL_ERROR, "0027", "An error occurred in the selection. Details: %s", "", ""),
   JDBC_FETCHING_NEXT_RESULT_FAILED(
-      Category.INTERNAL_ERROR, "0028", "Fetching the next result failed", "", ""),
+      Category.INTERNAL_ERROR, "0028", "Fetching the next result failed. Details: %s", "", ""),
   JDBC_TRANSACTION_ROLLING_BACK_TRANSACTION_FAILED(
       Category.INTERNAL_ERROR, "0029", "Rolling back the transaction failed. Details: %s", "", ""),
   JDBC_TRANSACTION_COMMITTING_TRANSACTION_FAILED(
@@ -1196,6 +1196,8 @@ public enum CoreError implements ScalarDbError {
       Category.INTERNAL_ERROR, "0053", "Failed to read JSON Lines file. Details: %s.", "", ""),
   JDBC_TRANSACTION_GETTING_SCANNER_FAILED(
       Category.INTERNAL_ERROR, "0054", "Getting the scanner failed. Details: %s", "", ""),
+  JDBC_CLOSING_SCANNER_FAILED(
+      Category.INTERNAL_ERROR, "0055", "Closing the scanner failed. Details: %s", "", ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -38,6 +38,7 @@ public class DatabaseConfig {
   private boolean crossPartitionScanFilteringEnabled;
   private boolean crossPartitionScanOrderingEnabled;
   private String systemNamespaceName;
+  private int scannerFetchSize;
 
   public static final String PREFIX = "scalar.db.";
   public static final String CONTACT_POINTS = PREFIX + "contact_points";
@@ -56,9 +57,11 @@ public class DatabaseConfig {
   public static final String CROSS_PARTITION_SCAN_FILTERING = SCAN_PREFIX + "filtering.enabled";
   public static final String CROSS_PARTITION_SCAN_ORDERING = SCAN_PREFIX + "ordering.enabled";
   public static final String SYSTEM_NAMESPACE_NAME = PREFIX + "system_namespace_name";
+  public static final String SCANNER_FETCH_SIZE = PREFIX + "scanner_fetch_size";
 
   public static final int DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS = 60;
   public static final String DEFAULT_SYSTEM_NAMESPACE_NAME = "scalardb";
+  public static final int DEFAULT_SCANNER_FETCH_SIZE = 10;
 
   public DatabaseConfig(File propertiesFile) throws IOException {
     try (FileInputStream stream = new FileInputStream(propertiesFile)) {
@@ -118,6 +121,8 @@ public class DatabaseConfig {
     }
 
     systemNamespaceName = getSystemNamespaceName(getProperties());
+
+    scannerFetchSize = getInt(getProperties(), SCANNER_FETCH_SIZE, DEFAULT_SCANNER_FETCH_SIZE);
   }
 
   public List<String> getContactPoints() {
@@ -170,6 +175,10 @@ public class DatabaseConfig {
 
   public String getSystemNamespaceName() {
     return systemNamespaceName;
+  }
+
+  public int getScannerFetchSize() {
+    return scannerFetchSize;
   }
 
   public static String getTransactionManager(Properties properties) {

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -56,7 +56,7 @@ public class Cassandra extends AbstractDistributedStorage {
 
     handlers =
         StatementHandlerManager.builder()
-            .select(new SelectStatementHandler(session))
+            .select(new SelectStatementHandler(session, config.getScannerFetchSize()))
             .insert(new InsertStatementHandler(session))
             .update(new UpdateStatementHandler(session))
             .delete(new DeleteStatementHandler(session))

--- a/core/src/main/java/com/scalar/db/storage/cassandra/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/SelectStatementHandler.java
@@ -41,13 +41,18 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class SelectStatementHandler extends StatementHandler {
+
+  private final int fetchSize;
+
   /**
    * Constructs {@code SelectStatementHandler} with the specified {@code Session}
    *
    * @param session session to be used with this statement
+   * @param fetchSize the number of rows to be fetched at once
    */
-  public SelectStatementHandler(Session session) {
+  public SelectStatementHandler(Session session, int fetchSize) {
     super(session);
+    this.fetchSize = fetchSize;
   }
 
   @Override
@@ -94,6 +99,7 @@ public class SelectStatementHandler extends StatementHandler {
   @Override
   @Nonnull
   protected ResultSet execute(BoundStatement bound, Operation operation) {
+    bound.setFetchSize(fetchSize);
     return session.execute(bound);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -62,7 +62,8 @@ public class Cosmos extends AbstractDistributedStorage {
             new CosmosAdmin(client, config), databaseConfig.getMetadataCacheExpirationTimeSecs());
     operationChecker = new CosmosOperationChecker(databaseConfig, metadataManager);
 
-    selectStatementHandler = new SelectStatementHandler(client, metadataManager);
+    selectStatementHandler =
+        new SelectStatementHandler(client, metadataManager, databaseConfig.getScannerFetchSize());
     putStatementHandler = new PutStatementHandler(client, metadataManager);
     deleteStatementHandler = new DeleteStatementHandler(client, metadataManager);
     batchHandler = new BatchHandler(client, metadataManager);

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -77,7 +77,11 @@ public class Dynamo extends AbstractDistributedStorage {
     operationChecker = new DynamoOperationChecker(databaseConfig, metadataManager);
 
     selectStatementHandler =
-        new SelectStatementHandler(client, metadataManager, config.getNamespacePrefix());
+        new SelectStatementHandler(
+            client,
+            metadataManager,
+            config.getNamespacePrefix(),
+            databaseConfig.getScannerFetchSize());
     putStatementHandler =
         new PutStatementHandler(client, metadataManager, config.getNamespacePrefix());
     deleteStatementHandler =

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -49,6 +49,7 @@ public class SelectStatementHandler {
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
   private final String namespacePrefix;
+  private final int fetchSize;
 
   /**
    * Constructs a {@code SelectStatementHandler} with the specified {@link DynamoDbClient} and a new
@@ -62,10 +63,12 @@ public class SelectStatementHandler {
   public SelectStatementHandler(
       DynamoDbClient client,
       TableMetadataManager metadataManager,
-      Optional<String> namespacePrefix) {
+      Optional<String> namespacePrefix,
+      int fetchSize) {
     this.client = checkNotNull(client);
     this.metadataManager = checkNotNull(metadataManager);
     this.namespacePrefix = namespacePrefix.orElse("");
+    this.fetchSize = fetchSize;
   }
 
   @Nonnull
@@ -151,7 +154,10 @@ public class SelectStatementHandler {
     com.scalar.db.storage.dynamo.request.QueryRequest request =
         new com.scalar.db.storage.dynamo.request.QueryRequest(client, builder.build());
     return new QueryScanner(
-        request, limit, new ResultInterpreter(selection.getProjections(), tableMetadata));
+        request,
+        fetchSize,
+        limit,
+        new ResultInterpreter(selection.getProjections(), tableMetadata));
   }
 
   private Scanner executeScan(Scan scan, TableMetadata tableMetadata) {
@@ -184,7 +190,10 @@ public class SelectStatementHandler {
     com.scalar.db.storage.dynamo.request.QueryRequest queryRequest =
         new com.scalar.db.storage.dynamo.request.QueryRequest(client, builder.build());
     return new QueryScanner(
-        queryRequest, scan.getLimit(), new ResultInterpreter(scan.getProjections(), tableMetadata));
+        queryRequest,
+        fetchSize,
+        scan.getLimit(),
+        new ResultInterpreter(scan.getProjections(), tableMetadata));
   }
 
   private Scanner executeFullScan(ScanAll scan, TableMetadata tableMetadata) {
@@ -205,6 +214,7 @@ public class SelectStatementHandler {
         new com.scalar.db.storage.dynamo.request.ScanRequest(client, builder.build());
     return new QueryScanner(
         requestWrapper,
+        fetchSize,
         scan.getLimit(),
         new ResultInterpreter(scan.getProjections(), tableMetadata));
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -44,13 +44,20 @@ public class JdbcService {
   private final OperationChecker operationChecker;
   private final RdbEngineStrategy rdbEngine;
   private final QueryBuilder queryBuilder;
+  private final int scannerFetchSize;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public JdbcService(
       TableMetadataManager tableMetadataManager,
       OperationChecker operationChecker,
-      RdbEngineStrategy rdbEngine) {
-    this(tableMetadataManager, operationChecker, rdbEngine, new QueryBuilder(rdbEngine));
+      RdbEngineStrategy rdbEngine,
+      int scannerFetchSize) {
+    this(
+        tableMetadataManager,
+        operationChecker,
+        rdbEngine,
+        new QueryBuilder(rdbEngine),
+        scannerFetchSize);
   }
 
   @VisibleForTesting
@@ -58,11 +65,13 @@ public class JdbcService {
       TableMetadataManager tableMetadataManager,
       OperationChecker operationChecker,
       RdbEngineStrategy rdbEngine,
-      QueryBuilder queryBuilder) {
+      QueryBuilder queryBuilder,
+      int scannerFetchSize) {
     this.tableMetadataManager = Objects.requireNonNull(tableMetadataManager);
     this.operationChecker = Objects.requireNonNull(operationChecker);
     this.rdbEngine = Objects.requireNonNull(rdbEngine);
     this.queryBuilder = Objects.requireNonNull(queryBuilder);
+    this.scannerFetchSize = scannerFetchSize;
   }
 
   public Optional<Result> get(Get get, Connection connection)
@@ -102,7 +111,8 @@ public class JdbcService {
   }
 
   @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
-  public Scanner getScanner(Scan scan, Connection connection, boolean closeConnectionOnScannerClose)
+  public Scanner getScanner(
+      Scan scan, Connection connection, boolean commitAndCloseConnectionOnScannerClose)
       throws SQLException, ExecutionException {
     operationChecker.check(scan);
 
@@ -111,13 +121,14 @@ public class JdbcService {
     SelectQuery selectQuery = buildSelectQuery(scan, tableMetadata);
     PreparedStatement preparedStatement = connection.prepareStatement(selectQuery.sql());
     selectQuery.bind(preparedStatement);
+    preparedStatement.setFetchSize(scannerFetchSize);
     ResultSet resultSet = preparedStatement.executeQuery();
     return new ScannerImpl(
         new ResultInterpreter(scan.getProjections(), tableMetadata, rdbEngine),
         connection,
         preparedStatement,
         resultSet,
-        closeConnectionOnScannerClose);
+        commitAndCloseConnectionOnScannerClose);
   }
 
   public List<Result> scan(Scan scan, Connection connection)

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -20,6 +20,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -443,5 +445,10 @@ class RdbEngineMysql extends AbstractRdbEngine {
   public RdbEngineTimeTypeStrategy<LocalDate, LocalTime, LocalDateTime, LocalDateTime>
       getTimeTypeStrategy() {
     return timeTypeEngine;
+  }
+
+  @Override
+  public Map<String, String> getConnectionProperties() {
+    return Collections.singletonMap("useCursorFetch", "true");
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -70,7 +70,12 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
             databaseConfig.getMetadataCacheExpirationTimeSecs());
 
     OperationChecker operationChecker = new OperationChecker(databaseConfig, tableMetadataManager);
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine);
+    jdbcService =
+        new JdbcService(
+            tableMetadataManager,
+            operationChecker,
+            rdbEngine,
+            databaseConfig.getScannerFetchSize());
   }
 
   @VisibleForTesting

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -41,6 +41,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScannerFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -69,6 +70,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScannerFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -97,6 +99,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScannerFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -127,6 +130,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScannerFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -401,5 +405,18 @@ public class DatabaseConfigTest {
     // Act Assert
     assertThatThrownBy(() -> new DatabaseConfig(props))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_PropertiesWithScannerFetchSizeGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.SCANNER_FETCH_SIZE, "1000");
+
+    // Act
+    DatabaseConfig config = new DatabaseConfig(props);
+
+    // Assert
+    assertThat(config.getScannerFetchSize()).isEqualTo(1000);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 public class SelectStatementHandlerTest {
+  private static final int FETCH_SIZE = 10;
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table_name";
   private static final String ANY_NAME_1 = "name1";
@@ -55,7 +56,7 @@ public class SelectStatementHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new SelectStatementHandler(session);
+    handler = new SelectStatementHandler(session, FETCH_SIZE);
   }
 
   private Get prepareGet() {
@@ -497,7 +498,7 @@ public class SelectStatementHandlerTest {
   public void handle_DriverExceptionThrown_ShouldThrowProperExecutionException() {
     // Arrange
     get = prepareGetWithClusteringKey();
-    SelectStatementHandler spy = Mockito.spy(new SelectStatementHandler(session));
+    SelectStatementHandler spy = Mockito.spy(new SelectStatementHandler(session, FETCH_SIZE));
     doReturn(prepared).when(spy).prepare(get);
     doReturn(bound).when(spy).bind(prepared, get);
 
@@ -525,7 +526,7 @@ public class SelectStatementHandlerTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new SelectStatementHandler(null))
+    assertThatThrownBy(() -> new SelectStatementHandler(null, FETCH_SIZE))
         .isInstanceOf(NullPointerException.class);
   }
 
@@ -594,5 +595,18 @@ public class SelectStatementHandlerTest {
 
     // Assert
     verify(session).prepare(expected);
+  }
+
+  @Test
+  public void execute_ShouldSetFetchSizeAndExecute() {
+    // Arrange
+    Get get = prepareGet();
+
+    // Act
+    handler.execute(bound, get);
+
+    // Assert
+    verify(bound).setFetchSize(FETCH_SIZE);
+    verify(session).execute(bound);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
@@ -9,6 +9,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class StatementHandlerTest {
+
+  private static final int FETCH_SIZE = 10;
+
   @Mock private TableMetadataManager metadataManager;
 
   @BeforeEach
@@ -19,7 +22,7 @@ public class StatementHandlerTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new SelectStatementHandler(null, metadataManager))
+    assertThatThrownBy(() -> new SelectStatementHandler(null, metadataManager, FETCH_SIZE))
         .isInstanceOf(NullPointerException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 public abstract class SelectStatementHandlerTestBase {
+  private static final int FETCH_SIZE = 10;
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -74,7 +75,7 @@ public abstract class SelectStatementHandlerTestBase {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new SelectStatementHandler(client, metadataManager, getNamespacePrefix());
+    handler = new SelectStatementHandler(client, metadataManager, getNamespacePrefix(), FETCH_SIZE);
 
     when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
     when(metadata.getPartitionKeyNames())
@@ -1877,7 +1878,7 @@ public abstract class SelectStatementHandlerTestBase {
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.scanIndexForward()).isNull();
-    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
@@ -1927,7 +1928,7 @@ public abstract class SelectStatementHandlerTestBase {
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.scanIndexForward()).isNull();
-    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
@@ -1946,7 +1947,7 @@ public abstract class SelectStatementHandlerTestBase {
     ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
     verify(client).scan(captor.capture());
     ScanRequest actualRequest = captor.getValue();
-    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
@@ -1965,7 +1966,7 @@ public abstract class SelectStatementHandlerTestBase {
     ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
     verify(client).scan(captor.capture());
     ScanRequest actualRequest = captor.getValue();
-    assertThat(actualRequest.limit()).isEqualTo(null);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1977,7 +1977,8 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @Test
-  public void scan_ScanLargeDataWithLimit_ShouldRetrieveExpectedValues() throws ExecutionException {
+  public void scan_ScanLargeDataWithLimit_ShouldRetrieveExpectedValues()
+      throws ExecutionException, IOException {
     // Arrange
     int recordCount = 345;
     int limit = 234;
@@ -2003,7 +2004,7 @@ public abstract class DistributedStorageIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = storage.scan(scan).all();
+    List<Result> results = scanAll(scan);
 
     // Assert
     assertThat(results.size()).isEqualTo(limit);
@@ -2328,7 +2329,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
   @Test
   public void scan_ScanAllLargeDataWithLimit_ShouldRetrieveExpectedValues()
-      throws ExecutionException {
+      throws ExecutionException, IOException {
     // Arrange
     int recordCount = 345;
     int limit = 234;
@@ -2349,7 +2350,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     Scan scan = Scan.newBuilder().namespace(namespace).table(TABLE).all().limit(limit).build();
 
     // Act
-    List<Result> results = storage.scan(scan).all();
+    List<Result> results = scanAll(scan);
 
     // Assert
     assertThat(results.size()).isEqualTo(limit);


### PR DESCRIPTION
## Description

This PR adds support for scanner fetch size in the storage adapters. It introduces a property, `scalar.db.scanner_fetch_size`, to control the number of records fetched by the scan API in the storage layer. It includes support for all storage adapters.

## Related issues and/or PRs

N/A

## Changes made

-

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added support for scanner fetch size in the storage adapters. You can control the number of records fetched by the scan API in the storage layer by configuring the `scalar.db.scanner_fetch_size` property.