### PR TITLE
Add beginReadOnly() method to transaction abstraction

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -7,6 +7,8 @@ import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegrationTestBase {
 
@@ -42,4 +44,16 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
   @Override
   @Test
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord() {}
+
+  @Disabled("Implement later")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
+      ScanType scanType) {}
 }

--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -82,6 +82,34 @@ public interface DistributedTransactionManager
       throws TransactionNotFoundException, TransactionException;
 
   /**
+   * Begins a new transaction in read-only mode.
+   *
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to begin due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to begin due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to begin the
+   *     transaction due to nontransient faults
+   */
+  DistributedTransaction beginReadOnly() throws TransactionNotFoundException, TransactionException;
+
+  /**
+   * Begins a new transaction with the specified transaction ID in read-only mode. It is users'
+   * responsibility to guarantee uniqueness of the ID, so it is not recommended to use this method
+   * unless you know exactly what you are doing.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to begin due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to begin due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to begin the
+   *     transaction due to nontransient faults
+   */
+  DistributedTransaction beginReadOnly(String txId)
+      throws TransactionNotFoundException, TransactionException;
+
+  /**
    * Starts a new transaction. This method is an alias of {@link #begin()}.
    *
    * @return {@link DistributedTransaction}
@@ -110,6 +138,39 @@ public interface DistributedTransactionManager
   default DistributedTransaction start(String txId)
       throws TransactionNotFoundException, TransactionException {
     return begin(txId);
+  }
+
+  /**
+   * Starts a new transaction in read-only mode. This method is an alias of {@link
+   * #beginReadOnly()}.
+   *
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to start due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to start due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to start the
+   *     transaction due to nontransient faults
+   */
+  default DistributedTransaction startReadOnly()
+      throws TransactionNotFoundException, TransactionException {
+    return beginReadOnly();
+  }
+
+  /**
+   * Starts a new transaction with the specified transaction ID in read-only mode. This method is an
+   * alias of {@link #beginReadOnly(String)}.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to start due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to start due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to start the
+   *     transaction due to nontransient faults
+   */
+  default DistributedTransaction startReadOnly(String txId)
+      throws TransactionNotFoundException, TransactionException {
+    return beginReadOnly(txId);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -26,9 +26,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ThreadSafe
 public class ActiveTransactionManagedDistributedTransactionManager
     extends DecoratedDistributedTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ThreadSafe
 public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -77,6 +77,16 @@ public abstract class DecoratedDistributedTransactionManager
   }
 
   @Override
+  public DistributedTransaction beginReadOnly() throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.beginReadOnly());
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.beginReadOnly(txId));
+  }
+
+  @Override
   public DistributedTransaction start() throws TransactionException {
     return decorateTransactionOnBeginOrStart(transactionManager.start());
   }
@@ -84,6 +94,16 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public DistributedTransaction start(String txId) throws TransactionException {
     return decorateTransactionOnBeginOrStart(transactionManager.start(txId));
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly(String txId) throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.startReadOnly(txId));
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly() throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.startReadOnly());
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */

--- a/core/src/main/java/com/scalar/db/common/ReadOnlyDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/ReadOnlyDistributedTransaction.java
@@ -1,0 +1,75 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.transaction.CrudException;
+import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class ReadOnlyDistributedTransaction extends DecoratedDistributedTransaction {
+
+  public ReadOnlyDistributedTransaction(DistributedTransaction transaction) {
+    super(transaction);
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void put(Put put) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -20,7 +20,9 @@ import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class StateManagedDistributedTransactionManager
     extends DecoratedDistributedTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -22,7 +22,9 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class StateManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -923,6 +923,12 @@ public enum CoreError implements ScalarDbError {
       "Some scanners were not closed. All scanners must be closed before preparing the transaction.",
       "",
       ""),
+  MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION(
+      Category.USER_ERROR,
+      "0207",
+      "Mutations are not allowed in read-only transactions. Transaction ID: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -82,6 +82,16 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
+  public DistributedTransaction beginReadOnly() throws TransactionException {
+    return manager.beginReadOnly();
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) throws TransactionException {
+    return manager.beginReadOnly(txId);
+  }
+
+  @Override
   public DistributedTransaction start() throws TransactionException {
     return manager.start();
   }
@@ -89,6 +99,16 @@ public class TransactionService implements DistributedTransactionManager {
   @Override
   public DistributedTransaction start(String txId) throws TransactionException {
     return manager.start(txId);
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly() throws TransactionException {
+    return manager.startReadOnly();
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly(String txId) throws TransactionException {
+    return manager.startReadOnly(txId);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -145,6 +145,16 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     return begin(txId, config.getIsolation());
   }
 
+  @Override
+  public DistributedTransaction beginReadOnly() {
+    throw new UnsupportedOperationException("implement later");
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) {
+    throw new UnsupportedOperationException("implement later");
+  }
+
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -109,6 +109,16 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
     }
   }
 
+  @Override
+  public DistributedTransaction beginReadOnly() {
+    throw new UnsupportedOperationException("implement later");
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) {
+    throw new UnsupportedOperationException("implement later");
+  }
+
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @SuppressWarnings("InlineMeSuggester")
   @Deprecated

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -76,6 +76,20 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
             .buildMessage());
   }
 
+  @Override
+  public DistributedTransaction beginReadOnly() throws TransactionException {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_BEGINNING_TRANSACTION_NOT_ALLOWED
+            .buildMessage());
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) throws TransactionException {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_BEGINNING_TRANSACTION_NOT_ALLOWED
+            .buildMessage());
+  }
+
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -198,6 +198,22 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.beginReadOnly();
+    Get get = prepareGet(2, 3);
+
+    // Act
+    Optional<Result> result = transaction.get(get);
+    transaction.commit();
+
+    // Assert
+    assertResult(2, 3, result);
+  }
+
+  @Test
   public void get_GetWithProjectionGivenForCommittedRecord_ShouldReturnRecord()
       throws TransactionException {
     // Arrange
@@ -282,6 +298,26 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
+    Scan scan = prepareScan(1, 0, 2);
+
+    // Act
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(3);
+    assertResult(1, 0, results.get(0));
+    assertResult(1, 1, results.get(1));
+    assertResult(1, 2, results.get(2));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.beginReadOnly();
     Scan scan = prepareScan(1, 0, 2);
 
     // Act

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitIntegrationTestBase.java
@@ -15,7 +15,10 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Key;
 import java.util.Optional;
 import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public abstract class ConsensusCommitIntegrationTestBase
     extends DistributedTransactionIntegrationTestBase {
@@ -929,4 +932,16 @@ public abstract class ConsensusCommitIntegrationTestBase
     Optional<Result> optResult = get(prepareGet(0, 0));
     assertThat(optResult).isNotPresent();
   }
+
+  @Disabled("Implement later")
+  @Override
+  @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord() {}
+
+  @Disabled("Implement later")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
+      ScanType scanType) {}
 }

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -58,6 +58,11 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
   @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
   public void get_GetWithProjectionGivenForCommittedRecord_ShouldReturnRecord() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
@@ -75,6 +80,13 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @ParameterizedTest
   @EnumSource(ScanType.class)
   public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override


### PR DESCRIPTION
## Description

This PR adds a `beginReadOnly()` method to `DistributedTransactionManager` to begin a transaction in read-only mode.
We do not add this method to `TwoPhaseCommitTransactionManager` because ensuring and managing read-only behavior across multiple transaction managers is challenging.

Please note that this feature is being developed in the `support-begin-in-read-only-mode` feature branch, as the changes may cause compile errors in dependent projects. Once all implementations are complete, we will merge this feature branch into the `master` branch.

## Related issues and/or PRs

N/A

## Changes made

Added some inline comments. Please take a look for the details!

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
