### PR TITLE
Support begin in read-only mode for JDBC transactions

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/transaction/jdbc/JdbcTransactionIntegrationTest.java
@@ -7,8 +7,6 @@ import com.scalar.db.storage.jdbc.JdbcEnv;
 import java.util.Properties;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegrationTestBase {
 
@@ -44,16 +42,4 @@ public class JdbcTransactionIntegrationTest extends DistributedTransactionIntegr
   @Override
   @Test
   public void rollback_forOngoingTransaction_ShouldRollbackCorrectly() {}
-
-  @Disabled("Implement later")
-  @Override
-  @Test
-  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord() {}
-
-  @Disabled("Implement later")
-  @Override
-  @ParameterizedTest
-  @EnumSource(ScanType.class)
-  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
-      ScanType scanType) {}
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -438,7 +438,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     boolean tableExists = false;
 
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       try (PreparedStatement preparedStatement =
           connection.prepareStatement(getSelectColumnsStatement())) {
@@ -510,7 +510,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       String catalogName = rdbEngine.getCatalogName(namespace);
       String schemaName = rdbEngine.getSchemaName(namespace);
@@ -608,7 +608,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             + enclose(METADATA_COL_FULL_TABLE_NAME)
             + " LIKE ?";
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       try (PreparedStatement preparedStatement =
           connection.prepareStatement(selectTablesOfNamespaceStatement)) {
@@ -644,7 +644,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             + enclose(NAMESPACE_COL_NAMESPACE_NAME)
             + " = ?";
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       try (PreparedStatement statement = connection.prepareStatement(selectQuery)) {
         statement.setString(1, namespace);
@@ -992,7 +992,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   @Override
   public Set<String> getNamespaceNames() throws ExecutionException {
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       String selectQuery =
           "SELECT * FROM " + encloseFullTableName(metadataSchema, NAMESPACES_TABLE);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -82,7 +82,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
       return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw new ExecutionException(
@@ -98,7 +98,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
     } catch (SQLException e) {
       close(connection);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -340,7 +340,7 @@ class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
-  public void setReadOnly(Connection connection, boolean readOnly) {
+  public void setConnectionToReadOnly(Connection connection, boolean readOnly) {
     // Do nothing. SQLite does not support read-only mode.
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -230,7 +230,8 @@ public interface RdbEngineStrategy {
     // Do nothing
   }
 
-  default void setReadOnly(Connection connection, boolean readOnly) throws SQLException {
+  default void setConnectionToReadOnly(Connection connection, boolean readOnly)
+      throws SQLException {
     connection.setReadOnly(readOnly);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -117,7 +117,7 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
 
       DistributedTransaction transaction;
       if (readOnly) {
-        rdbEngine.setReadOnly(connection, true);
+        rdbEngine.setConnectionToReadOnly(connection, true);
         transaction =
             new ReadOnlyDistributedTransaction(
                 new JdbcTransaction(txId, jdbcService, connection, rdbEngine));

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -195,14 +195,12 @@ public class JdbcTransactionManagerTest {
   }
 
   @Test
-  public void begin_ConnectionFailure_ShouldThrowTransactionException() throws Exception {
+  public void begin_SQLExceptionThrown_ShouldThrowTransactionException() throws Exception {
     // Arrange
-    when(dataSource.getConnection()).thenThrow(new SQLException("Connection failed"));
+    when(dataSource.getConnection()).thenThrow(SQLException.class);
 
-    // Act & Assert
-    assertThatThrownBy(() -> manager.begin())
-        .isInstanceOf(TransactionException.class)
-        .hasMessageContaining("Connection failed");
+    // Act Assert
+    assertThatThrownBy(() -> manager.begin()).isInstanceOf(TransactionException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds support for beginning a transaction in read-only mode for JDBC transactions.

Note that this feature is being developed in the `support-begin-in-read-only-mode` feature branch.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2734

## Changes made

Added some inline comments. Please take a look for the details!

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
