### PR TITLE
Backport to branch(3) : Add support for scan fetch size in storage adapters

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -1125,7 +1125,7 @@ public enum CoreError implements ScalarDbError {
   JDBC_ERROR_OCCURRED_IN_SELECTION(
       Category.INTERNAL_ERROR, "0027", "An error occurred in the selection. Details: %s", "", ""),
   JDBC_FETCHING_NEXT_RESULT_FAILED(
-      Category.INTERNAL_ERROR, "0028", "Fetching the next result failed", "", ""),
+      Category.INTERNAL_ERROR, "0028", "Fetching the next result failed. Details: %s", "", ""),
   JDBC_TRANSACTION_ROLLING_BACK_TRANSACTION_FAILED(
       Category.INTERNAL_ERROR, "0029", "Rolling back the transaction failed. Details: %s", "", ""),
   JDBC_TRANSACTION_COMMITTING_TRANSACTION_FAILED(
@@ -1204,6 +1204,8 @@ public enum CoreError implements ScalarDbError {
       Category.INTERNAL_ERROR, "0053", "Failed to read JSON Lines file. Details: %s.", "", ""),
   JDBC_TRANSACTION_GETTING_SCANNER_FAILED(
       Category.INTERNAL_ERROR, "0054", "Getting the scanner failed. Details: %s", "", ""),
+  JDBC_CLOSING_SCANNER_FAILED(
+      Category.INTERNAL_ERROR, "0055", "Closing the scanner failed. Details: %s", "", ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
+++ b/core/src/main/java/com/scalar/db/config/DatabaseConfig.java
@@ -37,6 +37,7 @@ public class DatabaseConfig {
   private boolean crossPartitionScanEnabled;
   private boolean crossPartitionScanFilteringEnabled;
   private boolean crossPartitionScanOrderingEnabled;
+  private int scanFetchSize;
 
   public static final String PREFIX = "scalar.db.";
   public static final String CONTACT_POINTS = PREFIX + "contact_points";
@@ -54,9 +55,11 @@ public class DatabaseConfig {
   public static final String CROSS_PARTITION_SCAN = SCAN_PREFIX + "enabled";
   public static final String CROSS_PARTITION_SCAN_FILTERING = SCAN_PREFIX + "filtering.enabled";
   public static final String CROSS_PARTITION_SCAN_ORDERING = SCAN_PREFIX + "ordering.enabled";
+  public static final String SCAN_FETCH_SIZE = PREFIX + "scan_fetch_size";
 
   public static final int DEFAULT_METADATA_CACHE_EXPIRATION_TIME_SECS = 60;
   public static final String DEFAULT_SYSTEM_NAMESPACE_NAME = "scalardb";
+  public static final int DEFAULT_SCAN_FETCH_SIZE = 10;
 
   public DatabaseConfig(File propertiesFile) throws IOException {
     try (FileInputStream stream = new FileInputStream(propertiesFile)) {
@@ -114,6 +117,8 @@ public class DatabaseConfig {
               .CROSS_PARTITION_SCAN_MUST_BE_ENABLED_TO_USE_CROSS_PARTITION_SCAN_WITH_FILTERING_OR_ORDERING
               .buildMessage());
     }
+
+    scanFetchSize = getInt(getProperties(), SCAN_FETCH_SIZE, DEFAULT_SCAN_FETCH_SIZE);
   }
 
   public List<String> getContactPoints() {
@@ -162,6 +167,10 @@ public class DatabaseConfig {
 
   public boolean isCrossPartitionScanOrderingEnabled() {
     return crossPartitionScanOrderingEnabled;
+  }
+
+  public int getScanFetchSize() {
+    return scanFetchSize;
   }
 
   public static String getTransactionManager(Properties properties) {

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -56,7 +56,7 @@ public class Cassandra extends AbstractDistributedStorage {
 
     handlers =
         StatementHandlerManager.builder()
-            .select(new SelectStatementHandler(session))
+            .select(new SelectStatementHandler(session, config.getScanFetchSize()))
             .insert(new InsertStatementHandler(session))
             .update(new UpdateStatementHandler(session))
             .delete(new DeleteStatementHandler(session))

--- a/core/src/main/java/com/scalar/db/storage/cassandra/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/SelectStatementHandler.java
@@ -41,13 +41,18 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class SelectStatementHandler extends StatementHandler {
+
+  private final int fetchSize;
+
   /**
    * Constructs {@code SelectStatementHandler} with the specified {@code Session}
    *
    * @param session session to be used with this statement
+   * @param fetchSize the number of rows to be fetched at once
    */
-  public SelectStatementHandler(Session session) {
+  public SelectStatementHandler(Session session, int fetchSize) {
     super(session);
+    this.fetchSize = fetchSize;
   }
 
   @Override
@@ -94,6 +99,7 @@ public class SelectStatementHandler extends StatementHandler {
   @Override
   @Nonnull
   protected ResultSet execute(BoundStatement bound, Operation operation) {
+    bound.setFetchSize(fetchSize);
     return session.execute(bound);
   }
 

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -62,7 +62,8 @@ public class Cosmos extends AbstractDistributedStorage {
             new CosmosAdmin(client, config), databaseConfig.getMetadataCacheExpirationTimeSecs());
     operationChecker = new CosmosOperationChecker(databaseConfig, metadataManager);
 
-    selectStatementHandler = new SelectStatementHandler(client, metadataManager);
+    selectStatementHandler =
+        new SelectStatementHandler(client, metadataManager, databaseConfig.getScanFetchSize());
     putStatementHandler = new PutStatementHandler(client, metadataManager);
     deleteStatementHandler = new DeleteStatementHandler(client, metadataManager);
     batchHandler = new BatchHandler(client, metadataManager);

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -77,7 +77,11 @@ public class Dynamo extends AbstractDistributedStorage {
     operationChecker = new DynamoOperationChecker(databaseConfig, metadataManager);
 
     selectStatementHandler =
-        new SelectStatementHandler(client, metadataManager, config.getNamespacePrefix());
+        new SelectStatementHandler(
+            client,
+            metadataManager,
+            config.getNamespacePrefix(),
+            databaseConfig.getScanFetchSize());
     putStatementHandler =
         new PutStatementHandler(client, metadataManager, config.getNamespacePrefix());
     deleteStatementHandler =

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -49,6 +49,7 @@ public class SelectStatementHandler {
   private final DynamoDbClient client;
   private final TableMetadataManager metadataManager;
   private final String namespacePrefix;
+  private final int fetchSize;
 
   /**
    * Constructs a {@code SelectStatementHandler} with the specified {@link DynamoDbClient} and a new
@@ -62,10 +63,12 @@ public class SelectStatementHandler {
   public SelectStatementHandler(
       DynamoDbClient client,
       TableMetadataManager metadataManager,
-      Optional<String> namespacePrefix) {
+      Optional<String> namespacePrefix,
+      int fetchSize) {
     this.client = checkNotNull(client);
     this.metadataManager = checkNotNull(metadataManager);
     this.namespacePrefix = namespacePrefix.orElse("");
+    this.fetchSize = fetchSize;
   }
 
   @Nonnull
@@ -151,7 +154,10 @@ public class SelectStatementHandler {
     com.scalar.db.storage.dynamo.request.QueryRequest request =
         new com.scalar.db.storage.dynamo.request.QueryRequest(client, builder.build());
     return new QueryScanner(
-        request, limit, new ResultInterpreter(selection.getProjections(), tableMetadata));
+        request,
+        fetchSize,
+        limit,
+        new ResultInterpreter(selection.getProjections(), tableMetadata));
   }
 
   private Scanner executeScan(Scan scan, TableMetadata tableMetadata) {
@@ -184,7 +190,10 @@ public class SelectStatementHandler {
     com.scalar.db.storage.dynamo.request.QueryRequest queryRequest =
         new com.scalar.db.storage.dynamo.request.QueryRequest(client, builder.build());
     return new QueryScanner(
-        queryRequest, scan.getLimit(), new ResultInterpreter(scan.getProjections(), tableMetadata));
+        queryRequest,
+        fetchSize,
+        scan.getLimit(),
+        new ResultInterpreter(scan.getProjections(), tableMetadata));
   }
 
   private Scanner executeFullScan(ScanAll scan, TableMetadata tableMetadata) {
@@ -205,6 +214,7 @@ public class SelectStatementHandler {
         new com.scalar.db.storage.dynamo.request.ScanRequest(client, builder.build());
     return new QueryScanner(
         requestWrapper,
+        fetchSize,
         scan.getLimit(),
         new ResultInterpreter(scan.getProjections(), tableMetadata));
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -59,7 +59,9 @@ public class JdbcDatabase extends AbstractDistributedStorage {
             databaseConfig.getMetadataCacheExpirationTimeSecs());
 
     OperationChecker operationChecker = new OperationChecker(databaseConfig, tableMetadataManager);
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine);
+    jdbcService =
+        new JdbcService(
+            tableMetadataManager, operationChecker, rdbEngine, databaseConfig.getScanFetchSize());
   }
 
   @VisibleForTesting
@@ -98,9 +100,18 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
+      connection.setAutoCommit(false);
       rdbEngine.setReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
     } catch (SQLException e) {
+      try {
+        if (connection != null) {
+          connection.rollback();
+        }
+      } catch (SQLException ex) {
+        e.addSuppressed(ex);
+      }
+
       close(connection);
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_SELECTION.buildMessage(e.getMessage()), e);

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcService.java
@@ -44,13 +44,20 @@ public class JdbcService {
   private final OperationChecker operationChecker;
   private final RdbEngineStrategy rdbEngine;
   private final QueryBuilder queryBuilder;
+  private final int scanFetchSize;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public JdbcService(
       TableMetadataManager tableMetadataManager,
       OperationChecker operationChecker,
-      RdbEngineStrategy rdbEngine) {
-    this(tableMetadataManager, operationChecker, rdbEngine, new QueryBuilder(rdbEngine));
+      RdbEngineStrategy rdbEngine,
+      int scanFetchSize) {
+    this(
+        tableMetadataManager,
+        operationChecker,
+        rdbEngine,
+        new QueryBuilder(rdbEngine),
+        scanFetchSize);
   }
 
   @VisibleForTesting
@@ -58,11 +65,13 @@ public class JdbcService {
       TableMetadataManager tableMetadataManager,
       OperationChecker operationChecker,
       RdbEngineStrategy rdbEngine,
-      QueryBuilder queryBuilder) {
+      QueryBuilder queryBuilder,
+      int scanFetchSize) {
     this.tableMetadataManager = Objects.requireNonNull(tableMetadataManager);
     this.operationChecker = Objects.requireNonNull(operationChecker);
     this.rdbEngine = Objects.requireNonNull(rdbEngine);
     this.queryBuilder = Objects.requireNonNull(queryBuilder);
+    this.scanFetchSize = scanFetchSize;
   }
 
   public Optional<Result> get(Get get, Connection connection)
@@ -102,7 +111,8 @@ public class JdbcService {
   }
 
   @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE")
-  public Scanner getScanner(Scan scan, Connection connection, boolean closeConnectionOnScannerClose)
+  public Scanner getScanner(
+      Scan scan, Connection connection, boolean commitAndCloseConnectionOnScannerClose)
       throws SQLException, ExecutionException {
     operationChecker.check(scan);
 
@@ -111,13 +121,14 @@ public class JdbcService {
     SelectQuery selectQuery = buildSelectQuery(scan, tableMetadata);
     PreparedStatement preparedStatement = connection.prepareStatement(selectQuery.sql());
     selectQuery.bind(preparedStatement);
+    preparedStatement.setFetchSize(scanFetchSize);
     ResultSet resultSet = preparedStatement.executeQuery();
     return new ScannerImpl(
         new ResultInterpreter(scan.getProjections(), tableMetadata, rdbEngine),
         connection,
         preparedStatement,
         resultSet,
-        closeConnectionOnScannerClose);
+        commitAndCloseConnectionOnScannerClose);
   }
 
   public List<Result> scan(Scan scan, Connection connection)

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineMysql.java
@@ -20,6 +20,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -435,5 +437,10 @@ class RdbEngineMysql extends AbstractRdbEngine {
   public RdbEngineTimeTypeStrategy<LocalDate, LocalTime, LocalDateTime, LocalDateTime>
       getTimeTypeStrategy() {
     return timeTypeEngine;
+  }
+
+  @Override
+  public Map<String, String> getConnectionProperties() {
+    return Collections.singletonMap("useCursorFetch", "true");
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/jdbc/JdbcTransactionManager.java
@@ -70,7 +70,9 @@ public class JdbcTransactionManager extends AbstractDistributedTransactionManage
             databaseConfig.getMetadataCacheExpirationTimeSecs());
 
     OperationChecker operationChecker = new OperationChecker(databaseConfig, tableMetadataManager);
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine);
+    jdbcService =
+        new JdbcService(
+            tableMetadataManager, operationChecker, rdbEngine, databaseConfig.getScanFetchSize());
   }
 
   @VisibleForTesting

--- a/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
+++ b/core/src/test/java/com/scalar/db/config/DatabaseConfigTest.java
@@ -41,6 +41,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScanFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -69,6 +70,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScanFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -97,6 +99,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScanFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -127,6 +130,7 @@ public class DatabaseConfigTest {
     assertThat(config.isCrossPartitionScanEnabled()).isTrue();
     assertThat(config.isCrossPartitionScanFilteringEnabled()).isFalse();
     assertThat(config.isCrossPartitionScanOrderingEnabled()).isFalse();
+    assertThat(config.getScanFetchSize()).isEqualTo(10);
   }
 
   @Test
@@ -401,5 +405,18 @@ public class DatabaseConfigTest {
     // Act Assert
     assertThatThrownBy(() -> new DatabaseConfig(props))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_PropertiesWithScanFetchSizeGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.SCAN_FETCH_SIZE, "1000");
+
+    // Act
+    DatabaseConfig config = new DatabaseConfig(props);
+
+    // Assert
+    assertThat(config.getScanFetchSize()).isEqualTo(1000);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/SelectStatementHandlerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 public class SelectStatementHandlerTest {
+  private static final int FETCH_SIZE = 10;
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table_name";
   private static final String ANY_NAME_1 = "name1";
@@ -55,7 +56,7 @@ public class SelectStatementHandlerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new SelectStatementHandler(session);
+    handler = new SelectStatementHandler(session, FETCH_SIZE);
   }
 
   private Get prepareGet() {
@@ -497,7 +498,7 @@ public class SelectStatementHandlerTest {
   public void handle_DriverExceptionThrown_ShouldThrowProperExecutionException() {
     // Arrange
     get = prepareGetWithClusteringKey();
-    SelectStatementHandler spy = Mockito.spy(new SelectStatementHandler(session));
+    SelectStatementHandler spy = Mockito.spy(new SelectStatementHandler(session, FETCH_SIZE));
     doReturn(prepared).when(spy).prepare(get);
     doReturn(bound).when(spy).bind(prepared, get);
 
@@ -525,7 +526,7 @@ public class SelectStatementHandlerTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new SelectStatementHandler(null))
+    assertThatThrownBy(() -> new SelectStatementHandler(null, FETCH_SIZE))
         .isInstanceOf(NullPointerException.class);
   }
 
@@ -594,5 +595,18 @@ public class SelectStatementHandlerTest {
 
     // Assert
     verify(session).prepare(expected);
+  }
+
+  @Test
+  public void execute_ShouldSetFetchSizeAndExecute() {
+    // Arrange
+    Get get = prepareGet();
+
+    // Act
+    handler.execute(bound, get);
+
+    // Assert
+    verify(bound).setFetchSize(FETCH_SIZE);
+    verify(session).execute(bound);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/StatementHandlerTest.java
@@ -9,6 +9,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class StatementHandlerTest {
+
+  private static final int FETCH_SIZE = 10;
+
   @Mock private TableMetadataManager metadataManager;
 
   @BeforeEach
@@ -19,7 +22,7 @@ public class StatementHandlerTest {
   @Test
   public void constructor_NullGiven_ShouldThrowNullPointerException() {
     // Act Assert
-    assertThatThrownBy(() -> new SelectStatementHandler(null, metadataManager))
+    assertThatThrownBy(() -> new SelectStatementHandler(null, metadataManager, FETCH_SIZE))
         .isInstanceOf(NullPointerException.class);
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/SelectStatementHandlerTestBase.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 public abstract class SelectStatementHandlerTestBase {
+  private static final int FETCH_SIZE = 10;
   private static final String ANY_NAMESPACE_NAME = "namespace";
   private static final String ANY_TABLE_NAME = "table";
   private static final String ANY_NAME_1 = "name1";
@@ -74,7 +75,7 @@ public abstract class SelectStatementHandlerTestBase {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    handler = new SelectStatementHandler(client, metadataManager, getNamespacePrefix());
+    handler = new SelectStatementHandler(client, metadataManager, getNamespacePrefix(), FETCH_SIZE);
 
     when(metadataManager.getTableMetadata(any(Operation.class))).thenReturn(metadata);
     when(metadata.getPartitionKeyNames())
@@ -1877,7 +1878,7 @@ public abstract class SelectStatementHandlerTestBase {
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.scanIndexForward()).isNull();
-    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
@@ -1927,7 +1928,7 @@ public abstract class SelectStatementHandlerTestBase {
     assertThat(actualRequest.keyConditionExpression()).isEqualTo(expectedCondition);
     assertThat(actualRequest.expressionAttributeValues()).isEqualTo(expectedBindMap);
     assertThat(actualRequest.scanIndexForward()).isNull();
-    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
@@ -1946,7 +1947,7 @@ public abstract class SelectStatementHandlerTestBase {
     ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
     verify(client).scan(captor.capture());
     ScanRequest actualRequest = captor.getValue();
-    assertThat(actualRequest.limit()).isEqualTo(ANY_LIMIT);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 
@@ -1965,7 +1966,7 @@ public abstract class SelectStatementHandlerTestBase {
     ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
     verify(client).scan(captor.capture());
     ScanRequest actualRequest = captor.getValue();
-    assertThat(actualRequest.limit()).isEqualTo(null);
+    assertThat(actualRequest.limit()).isEqualTo(FETCH_SIZE);
     assertThat(actualRequest.tableName()).isEqualTo(getFullTableName());
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcServiceTest.java
@@ -22,6 +22,7 @@ import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.ScanAll;
+import com.scalar.db.api.Scanner;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
@@ -47,6 +48,7 @@ import org.mockito.MockitoAnnotations;
 
 public class JdbcServiceTest {
 
+  private static final int SCAN_FETCH_SIZE = 10;
   private static final String NAMESPACE = "ns";
   private static final String TABLE = "tbl";
 
@@ -78,7 +80,9 @@ public class JdbcServiceTest {
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    jdbcService = new JdbcService(tableMetadataManager, operationChecker, rdbEngine, queryBuilder);
+    jdbcService =
+        new JdbcService(
+            tableMetadataManager, operationChecker, rdbEngine, queryBuilder, SCAN_FETCH_SIZE);
 
     // Arrange
     when(tableMetadataManager.getTableMetadata(any(Operation.class)))
@@ -129,11 +133,15 @@ public class JdbcServiceTest {
 
     // Act
     Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
-    jdbcService.getScanner(scan, connection);
+    Scanner scanner = jdbcService.getScanner(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(Scan.class));
     verify(queryBuilder).select(any());
+    verify(preparedStatement).setFetchSize(SCAN_FETCH_SIZE);
+
+    assertThat(scanner).isNotNull();
+    assertThat(scanner).isInstanceOf(ScannerImpl.class);
   }
 
   @Test
@@ -153,11 +161,15 @@ public class JdbcServiceTest {
 
     // Act
     Scan scan = new ScanAll().forNamespace(NAMESPACE).forTable(TABLE);
-    jdbcService.getScanner(scan, connection);
+    Scanner scanner = jdbcService.getScanner(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(ScanAll.class));
     verify(queryBuilder).select(any());
+    verify(preparedStatement).setFetchSize(SCAN_FETCH_SIZE);
+
+    assertThat(scanner).isNotNull();
+    assertThat(scanner).isInstanceOf(ScannerImpl.class);
   }
 
   @Test
@@ -184,7 +196,7 @@ public class JdbcServiceTest {
             .all()
             .where(ConditionBuilder.column("column").isEqualToInt(10))
             .build();
-    jdbcService.getScanner(scan, connection);
+    Scanner scanner = jdbcService.getScanner(scan, connection);
 
     // Assert
     verify(operationChecker).check(any(ScanAll.class));
@@ -193,6 +205,10 @@ public class JdbcServiceTest {
     verify(queryBuilder.select(any())).where(anySet());
     verify(queryBuilder.select(any())).orderBy(anyList());
     verify(queryBuilder.select(any())).limit(anyInt());
+    verify(preparedStatement).setFetchSize(SCAN_FETCH_SIZE);
+
+    assertThat(scanner).isNotNull();
+    assertThat(scanner).isInstanceOf(ScannerImpl.class);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1977,7 +1977,8 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @Test
-  public void scan_ScanLargeDataWithLimit_ShouldRetrieveExpectedValues() throws ExecutionException {
+  public void scan_ScanLargeDataWithLimit_ShouldRetrieveExpectedValues()
+      throws ExecutionException, IOException {
     // Arrange
     int recordCount = 345;
     int limit = 234;
@@ -2003,7 +2004,7 @@ public abstract class DistributedStorageIntegrationTestBase {
             .build();
 
     // Act
-    List<Result> results = storage.scan(scan).all();
+    List<Result> results = scanAll(scan);
 
     // Assert
     assertThat(results.size()).isEqualTo(limit);
@@ -2328,7 +2329,7 @@ public abstract class DistributedStorageIntegrationTestBase {
 
   @Test
   public void scan_ScanAllLargeDataWithLimit_ShouldRetrieveExpectedValues()
-      throws ExecutionException {
+      throws ExecutionException, IOException {
     // Arrange
     int recordCount = 345;
     int limit = 234;
@@ -2349,7 +2350,7 @@ public abstract class DistributedStorageIntegrationTestBase {
     Scan scan = Scan.newBuilder().namespace(namespace).table(TABLE).all().limit(limit).build();
 
     // Act
-    List<Result> results = storage.scan(scan).all();
+    List<Result> results = scanAll(scan);
 
     // Assert
     assertThat(results.size()).isEqualTo(limit);


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2731
- **Commit to backport:** 4c5686cb2b755f712cd3d8e009440d01fe60b1cf

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2731 &&
git cherry-pick --no-rerere-autoupdate -m1 4c5686cb2b755f712cd3d8e009440d01fe60b1cf
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!