### PR TITLE
Allow multiple calls to rollback()

### DIFF
--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -144,9 +144,12 @@ public class StateManagedDistributedTransactionManager
 
     @Override
     public void rollback() throws RollbackException {
-      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+      if (status == Status.ROLLED_BACK) {
+        return;
+      }
+      if (status == Status.COMMITTED) {
         throw new IllegalStateException(
-            CoreError.TRANSACTION_ALREADY_COMMITTED_OR_ROLLED_BACK.buildMessage(status));
+            CoreError.TRANSACTION_ALREADY_COMMITTED.buildMessage(status));
       }
       try {
         super.rollback();
@@ -157,9 +160,12 @@ public class StateManagedDistributedTransactionManager
 
     @Override
     public void abort() throws AbortException {
-      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+      if (status == Status.ROLLED_BACK) {
+        return;
+      }
+      if (status == Status.COMMITTED) {
         throw new IllegalStateException(
-            CoreError.TRANSACTION_ALREADY_COMMITTED_OR_ROLLED_BACK.buildMessage(status));
+            CoreError.TRANSACTION_ALREADY_COMMITTED.buildMessage(status));
       }
       try {
         super.abort();

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -181,9 +181,12 @@ public class StateManagedTwoPhaseCommitTransactionManager
 
     @Override
     public void rollback() throws RollbackException {
-      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+      if (status == Status.ROLLED_BACK) {
+        return;
+      }
+      if (status == Status.COMMITTED) {
         throw new IllegalStateException(
-            CoreError.TRANSACTION_ALREADY_COMMITTED_OR_ROLLED_BACK.buildMessage(status));
+            CoreError.TRANSACTION_ALREADY_COMMITTED.buildMessage(status));
       }
       try {
         super.rollback();
@@ -194,9 +197,12 @@ public class StateManagedTwoPhaseCommitTransactionManager
 
     @Override
     public void abort() throws AbortException {
-      if (status == Status.COMMITTED || status == Status.ROLLED_BACK) {
+      if (status == Status.ROLLED_BACK) {
+        return;
+      }
+      if (status == Status.COMMITTED) {
         throw new IllegalStateException(
-            CoreError.TRANSACTION_ALREADY_COMMITTED_OR_ROLLED_BACK.buildMessage(status));
+            CoreError.TRANSACTION_ALREADY_COMMITTED.buildMessage(status));
       }
       try {
         super.abort();

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -214,10 +214,10 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0042", "Invalid ID specified. ID: %d", "", ""),
   TRANSACTION_NOT_ACTIVE(
       Category.USER_ERROR, "0043", "The transaction is not active. Status: %s", "", ""),
-  TRANSACTION_ALREADY_COMMITTED_OR_ROLLED_BACK(
+  TRANSACTION_ALREADY_COMMITTED(
       Category.USER_ERROR,
       "0044",
-      "The transaction has already been committed or rolled back. Status: %s",
+      "The transaction has already been committed. Status: %s",
       "",
       ""),
   TRANSACTION_NOT_PREPARED(


### PR DESCRIPTION
## Description

This PR updates the code to allow multiple calls to the `rollback()` method of transaction objects, making it more convenient for application developers.

## Related issues and/or PRs

N/A

## Changes made

- Update `StateManagedDistributedTransactionManager` and `StateManagedTwoPhaseCommitTransactionManager` to allow multiple calls to the `rollback()` method.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
