### PR TITLE
Backport to branch(3) : Add support for beginning transactions in read-only mode

### DIFF
--- a/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedTransactionManager.java
@@ -82,6 +82,34 @@ public interface DistributedTransactionManager
       throws TransactionNotFoundException, TransactionException;
 
   /**
+   * Begins a new transaction in read-only mode.
+   *
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to begin due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to begin due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to begin the
+   *     transaction due to nontransient faults
+   */
+  DistributedTransaction beginReadOnly() throws TransactionNotFoundException, TransactionException;
+
+  /**
+   * Begins a new transaction with the specified transaction ID in read-only mode. It is users'
+   * responsibility to guarantee uniqueness of the ID, so it is not recommended to use this method
+   * unless you know exactly what you are doing.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to begin due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to begin due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to begin the
+   *     transaction due to nontransient faults
+   */
+  DistributedTransaction beginReadOnly(String txId)
+      throws TransactionNotFoundException, TransactionException;
+
+  /**
    * Starts a new transaction. This method is an alias of {@link #begin()}.
    *
    * @return {@link DistributedTransaction}
@@ -110,6 +138,39 @@ public interface DistributedTransactionManager
   default DistributedTransaction start(String txId)
       throws TransactionNotFoundException, TransactionException {
     return begin(txId);
+  }
+
+  /**
+   * Starts a new transaction in read-only mode. This method is an alias of {@link
+   * #beginReadOnly()}.
+   *
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to start due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to start due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to start the
+   *     transaction due to nontransient faults
+   */
+  default DistributedTransaction startReadOnly()
+      throws TransactionNotFoundException, TransactionException {
+    return beginReadOnly();
+  }
+
+  /**
+   * Starts a new transaction with the specified transaction ID in read-only mode. This method is an
+   * alias of {@link #beginReadOnly(String)}.
+   *
+   * @param txId an user-provided unique transaction ID
+   * @return {@link DistributedTransaction}
+   * @throws TransactionNotFoundException if the transaction fails to start due to transient faults.
+   *     You can retry the transaction
+   * @throws TransactionException if the transaction fails to start due to transient or nontransient
+   *     faults. You can try retrying the transaction, but you may not be able to start the
+   *     transaction due to nontransient faults
+   */
+  default DistributedTransaction startReadOnly(String txId)
+      throws TransactionNotFoundException, TransactionException {
+    return beginReadOnly(txId);
   }
 
   /**

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedDistributedTransactionManager.java
@@ -26,9 +26,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ThreadSafe
 public class ActiveTransactionManagedDistributedTransactionManager
     extends DecoratedDistributedTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/ActiveTransactionManagedTwoPhaseCommitTransactionManager.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ThreadSafe
 public class ActiveTransactionManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/DecoratedDistributedTransactionManager.java
@@ -77,6 +77,16 @@ public abstract class DecoratedDistributedTransactionManager
   }
 
   @Override
+  public DistributedTransaction beginReadOnly() throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.beginReadOnly());
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.beginReadOnly(txId));
+  }
+
+  @Override
   public DistributedTransaction start() throws TransactionException {
     return decorateTransactionOnBeginOrStart(transactionManager.start());
   }
@@ -84,6 +94,16 @@ public abstract class DecoratedDistributedTransactionManager
   @Override
   public DistributedTransaction start(String txId) throws TransactionException {
     return decorateTransactionOnBeginOrStart(transactionManager.start(txId));
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly(String txId) throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.startReadOnly(txId));
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly() throws TransactionException {
+    return decorateTransactionOnBeginOrStart(transactionManager.startReadOnly());
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */

--- a/core/src/main/java/com/scalar/db/common/ReadOnlyDistributedTransaction.java
+++ b/core/src/main/java/com/scalar/db/common/ReadOnlyDistributedTransaction.java
@@ -1,0 +1,75 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.Insert;
+import com.scalar.db.api.Mutation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Update;
+import com.scalar.db.api.Upsert;
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.transaction.CrudException;
+import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class ReadOnlyDistributedTransaction extends DecoratedDistributedTransaction {
+
+  public ReadOnlyDistributedTransaction(DistributedTransaction transaction) {
+    super(transaction);
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void put(Put put) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void put(List<Put> puts) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void insert(Insert insert) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void upsert(Upsert upsert) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void update(Update update) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void delete(Delete delete) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
+  @Deprecated
+  @Override
+  public void delete(List<Delete> deletes) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+
+  @Override
+  public void mutate(List<? extends Mutation> mutations) throws CrudException {
+    throw new IllegalStateException(
+        CoreError.MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION.buildMessage(getId()));
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedDistributedTransactionManager.java
@@ -20,7 +20,9 @@ import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class StateManagedDistributedTransactionManager
     extends DecoratedDistributedTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/common/StateManagedTwoPhaseCommitTransactionManager.java
@@ -22,7 +22,9 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationException;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class StateManagedTwoPhaseCommitTransactionManager
     extends DecoratedTwoPhaseCommitTransactionManager {
 

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -930,6 +930,12 @@ public enum CoreError implements ScalarDbError {
       Category.USER_ERROR, "0209", "Number of max threads must be greater than 0", "", ""),
   DATA_LOADER_INVALID_DATA_CHUNK_QUEUE_SIZE(
       Category.USER_ERROR, "0210", "Data chunk queue size must be greater than 0", "", ""),
+  MUTATION_NOT_ALLOWED_IN_READ_ONLY_TRANSACTION(
+      Category.USER_ERROR,
+      "0211",
+      "Mutations are not allowed in read-only transactions. Transaction ID: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category

--- a/core/src/main/java/com/scalar/db/service/TransactionService.java
+++ b/core/src/main/java/com/scalar/db/service/TransactionService.java
@@ -82,6 +82,16 @@ public class TransactionService implements DistributedTransactionManager {
   }
 
   @Override
+  public DistributedTransaction beginReadOnly() throws TransactionException {
+    return manager.beginReadOnly();
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) throws TransactionException {
+    return manager.beginReadOnly(txId);
+  }
+
+  @Override
   public DistributedTransaction start() throws TransactionException {
     return manager.start();
   }
@@ -89,6 +99,16 @@ public class TransactionService implements DistributedTransactionManager {
   @Override
   public DistributedTransaction start(String txId) throws TransactionException {
     return manager.start(txId);
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly() throws TransactionException {
+    return manager.startReadOnly();
+  }
+
+  @Override
+  public DistributedTransaction startReadOnly(String txId) throws TransactionException {
+    return manager.startReadOnly(txId);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */

--- a/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/SelectStatementHandler.java
@@ -58,6 +58,7 @@ public class SelectStatementHandler {
    * @param client {@code DynamoDbClient}
    * @param metadataManager {@code TableMetadataManager}
    * @param namespacePrefix a namespace prefix
+   * @param fetchSize the number of items to fetch in each request
    */
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public SelectStatementHandler(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -394,7 +394,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     boolean tableExists = false;
 
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       if (!namespaceExistsInternal(connection, metadataSchema)) {
         return null;
@@ -461,7 +461,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       String catalogName = rdbEngine.getCatalogName(namespace);
       String schemaName = rdbEngine.getSchemaName(namespace);
@@ -550,7 +550,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             + enclose(METADATA_COL_FULL_TABLE_NAME)
             + " LIKE ?";
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       try (PreparedStatement preparedStatement =
           connection.prepareStatement(selectTablesOfNamespaceStatement)) {
@@ -583,7 +583,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
 
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       return namespaceExistsInternal(connection, namespace);
     } catch (SQLException e) {
@@ -814,7 +814,7 @@ public class JdbcAdmin implements DistributedStorageAdmin {
             + " FROM "
             + encloseFullTableName(metadataSchema, METADATA_TABLE);
     try (Connection connection = dataSource.getConnection()) {
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
 
       try (Statement stmt = connection.createStatement();
           ResultSet rs = stmt.executeQuery(selectAllTableNames)) {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -84,7 +84,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
       return jdbcService.get(get, connection);
     } catch (SQLException e) {
       throw new ExecutionException(
@@ -101,7 +101,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
     try {
       connection = dataSource.getConnection();
       connection.setAutoCommit(false);
-      rdbEngine.setReadOnly(connection, true);
+      rdbEngine.setConnectionToReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
     } catch (SQLException e) {
       try {

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineSqlite.java
@@ -339,7 +339,7 @@ public class RdbEngineSqlite extends AbstractRdbEngine {
   }
 
   @Override
-  public void setReadOnly(Connection connection, boolean readOnly) {
+  public void setConnectionToReadOnly(Connection connection, boolean readOnly) {
     // Do nothing. SQLite does not support read-only mode.
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/RdbEngineStrategy.java
@@ -228,7 +228,8 @@ public interface RdbEngineStrategy {
     // Do nothing
   }
 
-  default void setReadOnly(Connection connection, boolean readOnly) throws SQLException {
+  default void setConnectionToReadOnly(Connection connection, boolean readOnly)
+      throws SQLException {
     connection.setReadOnly(readOnly);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManager.java
@@ -22,6 +22,7 @@ import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.AbstractDistributedTransactionManager;
 import com.scalar.db.common.AbstractTransactionManagerCrudOperableScanner;
+import com.scalar.db.common.ReadOnlyDistributedTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CrudConflictException;
@@ -137,12 +138,24 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
 
   @Override
   public DistributedTransaction begin() {
-    return begin(config.getIsolation());
+    String txId = UUID.randomUUID().toString();
+    return begin(txId);
   }
 
   @Override
   public DistributedTransaction begin(String txId) {
-    return begin(txId, config.getIsolation());
+    return begin(txId, config.getIsolation(), false);
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly() {
+    String txId = UUID.randomUUID().toString();
+    return beginReadOnly(txId);
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) {
+    return begin(txId, config.getIsolation(), true);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -156,7 +169,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   @Deprecated
   @Override
   public DistributedTransaction start(String txId, com.scalar.db.api.Isolation isolation) {
-    return begin(txId, Isolation.valueOf(isolation.name()));
+    return begin(txId, Isolation.valueOf(isolation.name()), false);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -179,7 +192,7 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
   @Override
   public DistributedTransaction start(
       String txId, com.scalar.db.api.SerializableStrategy strategy) {
-    return begin(txId, Isolation.SERIALIZABLE);
+    return begin(txId, Isolation.SERIALIZABLE, false);
   }
 
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
@@ -189,17 +202,23 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
       String txId,
       com.scalar.db.api.Isolation isolation,
       com.scalar.db.api.SerializableStrategy strategy) {
-    return begin(txId, Isolation.valueOf(isolation.name()));
+    return begin(txId, Isolation.valueOf(isolation.name()), false);
   }
 
   @VisibleForTesting
   DistributedTransaction begin(Isolation isolation) {
     String txId = UUID.randomUUID().toString();
-    return begin(txId, isolation);
+    return begin(txId, isolation, false);
   }
 
   @VisibleForTesting
-  DistributedTransaction begin(String txId, Isolation isolation) {
+  DistributedTransaction beginReadOnly(Isolation isolation) {
+    String txId = UUID.randomUUID().toString();
+    return begin(txId, isolation, true);
+  }
+
+  @VisibleForTesting
+  DistributedTransaction begin(String txId, Isolation isolation, boolean readOnly) {
     checkArgument(!Strings.isNullOrEmpty(txId));
     checkNotNull(isolation);
     if (isGroupCommitEnabled()) {
@@ -214,27 +233,35 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
     Snapshot snapshot = new Snapshot(txId, isolation, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(
-            storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled, parallelExecutor);
-    ConsensusCommit consensus =
+            storage,
+            snapshot,
+            tableMetadataManager,
+            isIncludeMetadataEnabled,
+            parallelExecutor,
+            readOnly);
+    DistributedTransaction transaction =
         new ConsensusCommit(crud, commit, recovery, mutationOperationChecker, groupCommitter);
-    getNamespace().ifPresent(consensus::withNamespace);
-    getTable().ifPresent(consensus::withTable);
-    return consensus;
+    if (readOnly) {
+      transaction = new ReadOnlyDistributedTransaction(transaction);
+    }
+    getNamespace().ifPresent(transaction::withNamespace);
+    getTable().ifPresent(transaction::withTable);
+    return transaction;
   }
 
   @Override
   public Optional<Result> get(Get get) throws CrudException, UnknownTransactionStatusException {
-    return executeTransaction(t -> t.get(copyAndSetTargetToIfNot(get)));
+    return executeTransaction(t -> t.get(copyAndSetTargetToIfNot(get)), true);
   }
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException, UnknownTransactionStatusException {
-    return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)));
+    return executeTransaction(t -> t.scan(copyAndSetTargetToIfNot(scan)), true);
   }
 
   @Override
   public Scanner getScanner(Scan scan) throws CrudException {
-    DistributedTransaction transaction = begin();
+    DistributedTransaction transaction = beginReadOnly();
 
     TransactionCrudOperable.Scanner scanner;
     try {
@@ -321,7 +348,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.put(copyAndSetTargetToIfNot(put));
           return null;
-        });
+        },
+        false);
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -332,7 +360,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.put(copyAndSetTargetToIfNot(puts));
           return null;
-        });
+        },
+        false);
   }
 
   @Override
@@ -341,7 +370,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.insert(copyAndSetTargetToIfNot(insert));
           return null;
-        });
+        },
+        false);
   }
 
   @Override
@@ -350,7 +380,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.upsert(copyAndSetTargetToIfNot(upsert));
           return null;
-        });
+        },
+        false);
   }
 
   @Override
@@ -359,7 +390,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.update(copyAndSetTargetToIfNot(update));
           return null;
-        });
+        },
+        false);
   }
 
   @Override
@@ -368,7 +400,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.delete(copyAndSetTargetToIfNot(delete));
           return null;
-        });
+        },
+        false);
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -379,7 +412,8 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.delete(copyAndSetTargetToIfNot(deletes));
           return null;
-        });
+        },
+        false);
   }
 
   @Override
@@ -389,13 +423,21 @@ public class ConsensusCommitManager extends AbstractDistributedTransactionManage
         t -> {
           t.mutate(copyAndSetTargetToIfNot(mutations));
           return null;
-        });
+        },
+        false);
   }
 
   private <R> R executeTransaction(
-      ThrowableFunction<DistributedTransaction, R, TransactionException> throwableFunction)
+      ThrowableFunction<DistributedTransaction, R, TransactionException> throwableFunction,
+      boolean readOnly)
       throws CrudException, UnknownTransactionStatusException {
-    DistributedTransaction transaction = begin();
+    DistributedTransaction transaction;
+    if (readOnly) {
+      transaction = beginReadOnly();
+    } else {
+      transaction = begin();
+    }
+
     try {
       R result = throwableFunction.apply(transaction);
       transaction.commit();

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/Snapshot.java
@@ -58,14 +58,28 @@ public class Snapshot {
   private final Isolation isolation;
   private final TransactionTableMetadataManager tableMetadataManager;
   private final ParallelExecutor parallelExecutor;
-  private final ConcurrentMap<Key, Optional<TransactionResult>> readSet;
-  private final ConcurrentMap<Get, Optional<TransactionResult>> getSet;
-  private final Map<Scan, LinkedHashMap<Key, TransactionResult>> scanSet;
-  private final Map<Key, Put> writeSet;
-  private final Map<Key, Delete> deleteSet;
 
-  // The scanner set used to store information about scanners that are not fully scanned
+  // The read set stores information about the records that are read in this transaction. This is
+  // used as a previous version for write operations.
+  private final ConcurrentMap<Key, Optional<TransactionResult>> readSet;
+
+  // The get set stores information about the records retrieved by Get operations in this
+  // transaction. This is used for validation and snapshot read.
+  private final ConcurrentMap<Get, Optional<TransactionResult>> getSet;
+
+  // The scan set stores information about the records retrieved by Scan operations in this
+  // transaction. This is used for validation and snapshot read.
+  private final Map<Scan, LinkedHashMap<Key, TransactionResult>> scanSet;
+
+  // The scanner set stores information about scanners that are not fully scanned. This is used for
+  // validation.
   private final List<ScannerInfo> scannerSet;
+
+  // The write set stores information about writes in this transaction.
+  private final Map<Key, Put> writeSet;
+
+  // The delete set stores information about deletes in this transaction.
+  private final Map<Key, Delete> deleteSet;
 
   public Snapshot(
       String id,

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManager.java
@@ -170,7 +170,12 @@ public class TwoPhaseConsensusCommitManager extends AbstractTwoPhaseCommitTransa
     Snapshot snapshot = new Snapshot(txId, isolation, tableMetadataManager, parallelExecutor);
     CrudHandler crud =
         new CrudHandler(
-            storage, snapshot, tableMetadataManager, isIncludeMetadataEnabled, parallelExecutor);
+            storage,
+            snapshot,
+            tableMetadataManager,
+            isIncludeMetadataEnabled,
+            parallelExecutor,
+            false);
 
     TwoPhaseConsensusCommit transaction =
         new TwoPhaseConsensusCommit(crud, commit, recovery, mutationOperationChecker);

--- a/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionManager.java
@@ -76,6 +76,20 @@ public class SingleCrudOperationTransactionManager extends AbstractDistributedTr
             .buildMessage());
   }
 
+  @Override
+  public DistributedTransaction beginReadOnly() throws TransactionException {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_BEGINNING_TRANSACTION_NOT_ALLOWED
+            .buildMessage());
+  }
+
+  @Override
+  public DistributedTransaction beginReadOnly(String txId) throws TransactionException {
+    throw new UnsupportedOperationException(
+        CoreError.SINGLE_CRUD_OPERATION_TRANSACTION_BEGINNING_TRANSACTION_NOT_ALLOWED
+            .buildMessage());
+  }
+
   /** @deprecated As of release 2.4.0. Will be removed in release 4.0.0. */
   @Deprecated
   @Override

--- a/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/jdbc/JdbcTransactionManagerTest.java
@@ -25,6 +25,7 @@ import com.scalar.db.api.TransactionManagerCrudOperable;
 import com.scalar.db.api.Update;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.ActiveTransactionManagedDistributedTransactionManager;
+import com.scalar.db.common.ReadOnlyDistributedTransaction;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.AbortException;
@@ -132,6 +133,77 @@ public class JdbcTransactionManagerTest {
   }
 
   @Test
+  public void begin_WithoutTxId_ShouldCreateNewTransaction() throws Exception {
+    // Arrange
+    Connection connection = mock(Connection.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    // Act
+    DistributedTransaction actual = manager.begin();
+
+    // Assert
+    verify(dataSource).getConnection();
+    assertThat(actual).isInstanceOf(JdbcTransaction.class);
+  }
+
+  @Test
+  public void begin_WithTxId_ShouldCreateTransactionWithGivenId() throws Exception {
+    // Arrange
+    Connection connection = mock(Connection.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    String txId = "my-tx-id";
+
+    // Act
+    DistributedTransaction actual = manager.begin(txId);
+
+    // Assert
+    verify(dataSource).getConnection();
+    assertThat(actual).isInstanceOf(JdbcTransaction.class);
+    assertThat(actual.getId()).isEqualTo(txId);
+  }
+
+  @Test
+  public void beginReadOnly_WithoutTxId_ShouldCreateReadOnlyTransaction() throws Exception {
+    // Arrange
+    Connection connection = mock(Connection.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+
+    // Act
+    DistributedTransaction actual = manager.beginReadOnly();
+
+    // Assert
+    verify(dataSource).getConnection();
+    verify(connection).setReadOnly(true);
+    assertThat(actual).isInstanceOf(ReadOnlyDistributedTransaction.class);
+  }
+
+  @Test
+  public void beginReadOnly_WithTxId_ShouldCreateReadOnlyTransactionWithGivenId() throws Exception {
+    // Arrange
+    Connection connection = mock(Connection.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    String txId = "my-tx-id";
+
+    // Act
+    DistributedTransaction result = manager.beginReadOnly(txId);
+
+    // Assert
+    verify(dataSource).getConnection();
+    verify(connection).setReadOnly(true);
+    assertThat(result).isInstanceOf(ReadOnlyDistributedTransaction.class);
+    assertThat(result.getId()).isEqualTo(txId);
+  }
+
+  @Test
+  public void begin_SQLExceptionThrown_ShouldThrowTransactionException() throws Exception {
+    // Arrange
+    when(dataSource.getConnection()).thenThrow(SQLException.class);
+
+    // Act Assert
+    assertThatThrownBy(() -> manager.begin()).isInstanceOf(TransactionException.class);
+  }
+
+  @Test
   public void get_withConflictError_shouldThrowCrudConflictException()
       throws SQLException, ExecutionException {
     // Arrange
@@ -187,7 +259,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -217,7 +289,7 @@ public class JdbcTransactionManagerTest {
     assertThat(actual.one()).isEmpty();
     actual.close();
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(transaction).commit();
     verify(scanner).close();
   }
@@ -228,7 +300,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -255,7 +327,7 @@ public class JdbcTransactionManagerTest {
     assertThat(actual.all()).isEmpty();
     actual.close();
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(transaction).commit();
     verify(scanner).close();
   }
@@ -267,7 +339,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -302,7 +374,7 @@ public class JdbcTransactionManagerTest {
     assertThat(iterator.hasNext()).isFalse();
     actual.close();
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(transaction).commit();
     verify(scanner).close();
   }
@@ -313,14 +385,14 @@ public class JdbcTransactionManagerTest {
           throws TransactionException {
     // Arrange
     JdbcTransactionManager spied = spy(manager);
-    doThrow(TransactionNotFoundException.class).when(spied).begin();
+    doThrow(TransactionNotFoundException.class).when(spied).beginReadOnly();
 
     Scan scan = mock(Scan.class);
 
     // Act Assert
     assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudConflictException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
   }
 
   @Test
@@ -328,14 +400,14 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     JdbcTransactionManager spied = spy(manager);
-    doThrow(TransactionException.class).when(spied).begin();
+    doThrow(TransactionException.class).when(spied).beginReadOnly();
 
     Scan scan = mock(Scan.class);
 
     // Act Assert
     assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
   }
 
   @Test
@@ -346,7 +418,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -360,7 +432,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.getScanner(scan)).isInstanceOf(CrudException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(transaction).rollback();
   }
 
@@ -372,7 +444,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -390,7 +462,7 @@ public class JdbcTransactionManagerTest {
     TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
     assertThatThrownBy(actual::one).isInstanceOf(CrudException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(scanner).close();
     verify(transaction).rollback();
   }
@@ -402,7 +474,7 @@ public class JdbcTransactionManagerTest {
     // Arrange
     DistributedTransaction transaction = mock(DistributedTransaction.class);
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -420,7 +492,7 @@ public class JdbcTransactionManagerTest {
     TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
     assertThatThrownBy(actual::all).isInstanceOf(CrudException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(scanner).close();
     verify(transaction).rollback();
   }
@@ -432,7 +504,7 @@ public class JdbcTransactionManagerTest {
     // Arrange
     DistributedTransaction transaction = mock(DistributedTransaction.class);
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder()
@@ -450,7 +522,7 @@ public class JdbcTransactionManagerTest {
     TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
     assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(scanner).close();
     verify(transaction).rollback();
   }
@@ -463,7 +535,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
     doThrow(CommitConflictException.class).when(transaction).commit();
 
     Scan scan =
@@ -480,7 +552,7 @@ public class JdbcTransactionManagerTest {
     TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
     assertThatThrownBy(actual::close).isInstanceOf(CrudConflictException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(scanner).close();
     verify(transaction).rollback();
   }
@@ -493,7 +565,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
     doThrow(UnknownTransactionStatusException.class).when(transaction).commit();
 
     Scan scan =
@@ -510,7 +582,7 @@ public class JdbcTransactionManagerTest {
     TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
     assertThatThrownBy(actual::close).isInstanceOf(UnknownTransactionStatusException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(scanner).close();
   }
 
@@ -522,7 +594,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin();
+    doReturn(transaction).when(spied).beginReadOnly();
     doThrow(CommitException.class).when(transaction).commit();
 
     Scan scan =
@@ -539,7 +611,7 @@ public class JdbcTransactionManagerTest {
     TransactionManagerCrudOperable.Scanner actual = spied.getScanner(scan);
     assertThatThrownBy(actual::close).isInstanceOf(CrudException.class);
 
-    verify(spied).begin();
+    verify(spied).beginReadOnly();
     verify(scanner).close();
     verify(transaction).rollback();
   }
@@ -994,7 +1066,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1006,7 +1078,7 @@ public class JdbcTransactionManagerTest {
     Optional<Result> actual = spied.get(get);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
     verify(transaction).get(get);
     verify(transaction).commit();
     assertThat(actual).isEqualTo(Optional.of(result));
@@ -1018,7 +1090,7 @@ public class JdbcTransactionManagerTest {
           throws TransactionException {
     // Arrange
     JdbcTransactionManager spied = spy(manager);
-    doThrow(TransactionNotFoundException.class).when(spied).begin(any());
+    doThrow(TransactionNotFoundException.class).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1026,7 +1098,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.get(get)).isInstanceOf(CrudConflictException.class);
 
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
   }
 
   @Test
@@ -1034,7 +1106,7 @@ public class JdbcTransactionManagerTest {
       throws TransactionException {
     // Arrange
     JdbcTransactionManager spied = spy(manager);
-    doThrow(TransactionException.class).when(spied).begin(any());
+    doThrow(TransactionException.class).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1042,7 +1114,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.get(get)).isInstanceOf(CrudException.class);
 
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
   }
 
   @Test
@@ -1052,7 +1124,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1061,7 +1133,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.get(get)).isInstanceOf(CrudException.class);
 
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
     verify(transaction).get(get);
     verify(transaction).rollback();
   }
@@ -1074,7 +1146,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1083,7 +1155,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.get(get)).isInstanceOf(CrudConflictException.class);
 
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
     verify(transaction).get(get);
     verify(transaction).rollback();
   }
@@ -1096,7 +1168,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1105,7 +1177,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.get(get)).isInstanceOf(UnknownTransactionStatusException.class);
 
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
     verify(transaction).get(get);
     verify(transaction).commit();
   }
@@ -1117,7 +1189,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Get get =
         Get.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1126,7 +1198,7 @@ public class JdbcTransactionManagerTest {
     // Act Assert
     assertThatThrownBy(() -> spied.get(get)).isInstanceOf(CrudException.class);
 
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
     verify(transaction).get(get);
     verify(transaction).commit();
   }
@@ -1137,7 +1209,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).beginReadOnly();
 
     Scan scan =
         Scan.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1150,7 +1222,7 @@ public class JdbcTransactionManagerTest {
     List<Result> actual = spied.scan(scan);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).beginReadOnly();
     verify(transaction).scan(scan);
     verify(transaction).commit();
     assertThat(actual).isEqualTo(results);
@@ -1162,7 +1234,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     Put put =
         Put.newBuilder()
@@ -1176,7 +1248,7 @@ public class JdbcTransactionManagerTest {
     spied.put(put);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).put(put);
     verify(transaction).commit();
   }
@@ -1187,7 +1259,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     List<Put> puts =
         Arrays.asList(
@@ -1214,7 +1286,7 @@ public class JdbcTransactionManagerTest {
     spied.put(puts);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).put(puts);
     verify(transaction).commit();
   }
@@ -1225,7 +1297,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     Insert insert =
         Insert.newBuilder()
@@ -1239,7 +1311,7 @@ public class JdbcTransactionManagerTest {
     spied.insert(insert);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).insert(insert);
     verify(transaction).commit();
   }
@@ -1250,7 +1322,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     Upsert upsert =
         Upsert.newBuilder()
@@ -1264,7 +1336,7 @@ public class JdbcTransactionManagerTest {
     spied.upsert(upsert);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).upsert(upsert);
     verify(transaction).commit();
   }
@@ -1275,7 +1347,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     Update update =
         Update.newBuilder()
@@ -1289,7 +1361,7 @@ public class JdbcTransactionManagerTest {
     spied.update(update);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).update(update);
     verify(transaction).commit();
   }
@@ -1300,7 +1372,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     Delete delete =
         Delete.newBuilder().namespace("ns").table("tbl").partitionKey(Key.ofInt("pk", 0)).build();
@@ -1309,7 +1381,7 @@ public class JdbcTransactionManagerTest {
     spied.delete(delete);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).delete(delete);
     verify(transaction).commit();
   }
@@ -1320,7 +1392,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     List<Delete> deletes =
         Arrays.asList(
@@ -1344,7 +1416,7 @@ public class JdbcTransactionManagerTest {
     spied.delete(deletes);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).delete(deletes);
     verify(transaction).commit();
   }
@@ -1355,7 +1427,7 @@ public class JdbcTransactionManagerTest {
     DistributedTransaction transaction = mock(DistributedTransaction.class);
 
     JdbcTransactionManager spied = spy(manager);
-    doReturn(transaction).when(spied).begin(any());
+    doReturn(transaction).when(spied).begin();
 
     List<Mutation> mutations =
         Arrays.asList(
@@ -1393,7 +1465,7 @@ public class JdbcTransactionManagerTest {
     spied.mutate(mutations);
 
     // Assert
-    verify(spied).begin(any());
+    verify(spied).begin();
     verify(transaction).mutate(mutations);
     verify(transaction).commit();
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedTransactionIntegrationTestBase.java
@@ -198,6 +198,22 @@ public abstract class DistributedTransactionIntegrationTestBase {
   }
 
   @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.beginReadOnly();
+    Get get = prepareGet(2, 3);
+
+    // Act
+    Optional<Result> result = transaction.get(get);
+    transaction.commit();
+
+    // Assert
+    assertResult(2, 3, result);
+  }
+
+  @Test
   public void get_GetWithProjectionGivenForCommittedRecord_ShouldReturnRecord()
       throws TransactionException {
     // Arrange
@@ -282,6 +298,26 @@ public abstract class DistributedTransactionIntegrationTestBase {
     // Arrange
     populateRecords();
     DistributedTransaction transaction = manager.start();
+    Scan scan = prepareScan(1, 0, 2);
+
+    // Act
+    List<Result> results = scanOrGetScanner(transaction, scan, scanType);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(3);
+    assertResult(1, 0, results.get(0));
+    assertResult(1, 1, results.get(1));
+    assertResult(1, 2, results.get(2));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
+      ScanType scanType) throws TransactionException {
+    // Arrange
+    populateRecords();
+    DistributedTransaction transaction = manager.beginReadOnly();
     Scan scan = prepareScan(1, 0, 2);
 
     // Act

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -59,7 +59,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -236,8 +235,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(result.isPresent()).isTrue();
-    Assertions.assertThat(
-            ((TransactionResult) ((FilteredResult) result.get()).getOriginalResult()).getState())
+    assertThat(((TransactionResult) ((FilteredResult) result.get()).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
 
@@ -254,7 +252,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(results.size()).isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             ((TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
@@ -375,7 +373,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ongoingTxId);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(2);
     assertThat(result.getCommittedAt()).isGreaterThan(0);
   }
@@ -450,7 +448,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
   }
@@ -581,7 +579,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
   }
@@ -676,7 +674,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ongoingTxId);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(2);
     assertThat(result.getCommittedAt()).isGreaterThan(0);
   }
@@ -772,7 +770,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
   }
@@ -917,7 +915,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
   }
@@ -1048,7 +1046,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
   }
@@ -1227,7 +1225,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
   }
@@ -1312,7 +1310,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(r).isPresent();
     TransactionResult result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(result)).isEqualTo(expected);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
   }
 
@@ -1341,7 +1339,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(r).isPresent();
     TransactionResult result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(result)).isEqualTo(expected);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
   }
 
@@ -1371,7 +1369,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(r).isPresent();
     TransactionResult actual = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(actual)).isEqualTo(expected);
-    Assertions.assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(actual.getVersion()).isEqualTo(2);
   }
 
@@ -1402,7 +1400,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(r).isPresent();
     TransactionResult actual = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(actual)).isEqualTo(expected);
-    Assertions.assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(actual.getVersion()).isEqualTo(2);
   }
 
@@ -1447,7 +1445,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(r).isPresent();
     TransactionResult result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(result)).isEqualTo(expected);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
   }
 
@@ -1481,7 +1479,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(r).isPresent();
     TransactionResult actual = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     assertThat(getBalance(actual)).isEqualTo(expected);
-    Assertions.assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(actual.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(actual.getVersion()).isEqualTo(1);
   }
 
@@ -2921,7 +2919,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Assert
     assertThat(results.size()).isEqualTo(1);
-    Assertions.assertThat(
+    assertThat(
             ((TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult()).getState())
         .isEqualTo(TransactionState.COMMITTED);
   }
@@ -4887,6 +4885,567 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(actual2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
     assertThat(actual2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
     assertThat(actual2.get().getInt(BALANCE)).isEqualTo(2);
+  }
+
+  @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_WithSerializable_ShouldReturnRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+
+    // Act
+    Optional<Result> result = transaction.get(get);
+    transaction.commit();
+
+    // Assert
+    assertThat(result.isPresent()).isTrue();
+    assertThat(((TransactionResult) ((FilteredResult) result.get()).getOriginalResult()).getState())
+        .isEqualTo(TransactionState.COMMITTED);
+  }
+
+  @Test
+  public void
+      get_GetGivenForCommittedRecord_InReadOnlyMode_WhenRecordUpdatedByAnotherTransaction_ShouldNotThrowAnyException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly();
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+
+    // Act Assert
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE);
+
+    DistributedTransaction another = manager.begin();
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    another.commit();
+
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      get_GetGivenForCommittedRecord_InReadOnlyMode_WhenRecordUpdatedByAnotherTransaction_WithSerializable_ShouldThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+
+    // Act Assert
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(getBalance(result.get())).isEqualTo(INITIAL_BALANCE);
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void scan_ScanGivenForCommittedRecord_InReadOnlyMode_WithSerializable_ShouldReturnRecord()
+      throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+
+    // Act
+    List<Result> results = transaction.scan(scan);
+    transaction.commit();
+
+    // Assert
+    assertThat(results.size()).isEqualTo(4);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(3).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(3).getInt(ACCOUNT_TYPE)).isEqualTo(3);
+    assertThat(getBalance(results.get(3))).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @Test
+  public void
+      scan_ScanGivenForCommittedRecord_InReadOnlyMode_WhenRecordUpdatedByAnotherTransaction_ShouldNotThrowAnyException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly();
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+
+    // Act Assert
+    List<Result> results = transaction.scan(scan);
+
+    assertThat(results.size()).isEqualTo(4);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(3).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(3).getInt(ACCOUNT_TYPE)).isEqualTo(3);
+    assertThat(getBalance(results.get(3))).isEqualTo(INITIAL_BALANCE);
+
+    DistributedTransaction another = manager.begin();
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    another.commit();
+
+    transaction.commit();
+  }
+
+  @Test
+  public void
+      scan_ScanGivenForCommittedRecord_InReadOnlyMode_WhenRecordInsertedByAnotherTransaction_ShouldNotThrowAnyException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly();
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+
+    // Act Assert
+    List<Result> results = transaction.scan(scan);
+
+    assertThat(results.size()).isEqualTo(4);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(3).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(3).getInt(ACCOUNT_TYPE)).isEqualTo(3);
+    assertThat(getBalance(results.get(3))).isEqualTo(INITIAL_BALANCE);
+
+    DistributedTransaction another = manager.begin();
+    another.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 5))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    another.commit();
+
+    transaction.commit();
+  }
+
+  @Test
+  public void
+      scan_ScanGivenForCommittedRecord_InReadOnlyMode_WhenRecordUpdatedByAnotherTransaction_WithSerializable_ShouldThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+
+    // Act Assert
+    List<Result> results = transaction.scan(scan);
+
+    assertThat(results.size()).isEqualTo(4);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(3).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(3).getInt(ACCOUNT_TYPE)).isEqualTo(3);
+    assertThat(getBalance(results.get(3))).isEqualTo(INITIAL_BALANCE);
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      scan_ScanGivenForCommittedRecord_InReadOnlyMode_WhenRecordInsertedByAnotherTransaction_WithSerializable_ShouldThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    populateRecords(namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+
+    // Act Assert
+    List<Result> results = transaction.scan(scan);
+
+    assertThat(results.size()).isEqualTo(4);
+    assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(0).getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(getBalance(results.get(0))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(getBalance(results.get(1))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(2).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(2).getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(getBalance(results.get(2))).isEqualTo(INITIAL_BALANCE);
+
+    assertThat(results.get(3).getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(results.get(3).getInt(ACCOUNT_TYPE)).isEqualTo(3);
+    assertThat(getBalance(results.get(3))).isEqualTo(INITIAL_BALANCE);
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 5))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void getScanner_InReadOnlyMode_WithSerializable_ShouldNotThrowAnyException()
+      throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      getScanner_InReadOnlyMode_WhenRecordUpdatedByAnotherTransaction_ShouldNotThrowAnyException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly();
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin();
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    another.commit();
+
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      getScanner_InReadOnlyMode_WhenRecordInsertedByAnotherTransaction_ShouldNotThrowAnyException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly();
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin();
+    another.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    another.commit();
+
+    assertThatCode(transaction::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void
+      getScanner_InReadOnlyMode_WhenRecordUpdatedByAnotherTransaction_WithSerializable_ShouldThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 1)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+  }
+
+  @Test
+  public void
+      getScanner_InReadOnlyMode_WhenRecordInsertedByAnotherTransaction_WithSerializable_ShouldThrowCommitConflictException()
+          throws TransactionException {
+    // Arrange
+    manager.mutate(
+        Arrays.asList(
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 1))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build(),
+            Insert.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 2))
+                .intValue(BALANCE, INITIAL_BALANCE)
+                .build()));
+
+    Scan scan = prepareScan(0, namespace1, TABLE_1);
+    DistributedTransaction transaction = manager.beginReadOnly(Isolation.SERIALIZABLE);
+
+    // Act Assert
+    TransactionCrudOperable.Scanner scanner = transaction.getScanner(scan);
+    Optional<Result> result1 = scanner.one();
+    assertThat(result1).isNotEmpty();
+    assertThat(result1.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result1.get().getInt(ACCOUNT_TYPE)).isEqualTo(1);
+    assertThat(result1.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    Optional<Result> result2 = scanner.one();
+    assertThat(result2).isNotEmpty();
+    assertThat(result2.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result2.get().getInt(ACCOUNT_TYPE)).isEqualTo(2);
+    assertThat(result2.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    scanner.close();
+
+    DistributedTransaction another = manager.begin(Isolation.SERIALIZABLE);
+    another.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+    another.commit();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
   }
 
   private DistributedTransaction prepareTransfer(

--- a/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/singlecrudoperation/SingleCrudOperationTransactionIntegrationTestBase.java
@@ -58,6 +58,11 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override
   @Test
+  public void get_GetGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecord() {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @Test
   public void get_GetWithProjectionGivenForCommittedRecord_ShouldReturnRecord() {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
@@ -75,6 +80,13 @@ public abstract class SingleCrudOperationTransactionIntegrationTestBase
   @ParameterizedTest
   @EnumSource(ScanType.class)
   public void scanOrGetScanner_ScanGivenForCommittedRecord_ShouldReturnRecords(ScanType scanType) {}
+
+  @Disabled("Single CRUD operation transactions don't support beginning a transaction")
+  @Override
+  @ParameterizedTest
+  @EnumSource(ScanType.class)
+  public void scanOrGetScanner_ScanGivenForCommittedRecord_InReadOnlyMode_ShouldReturnRecords(
+      ScanType scanType) {}
 
   @Disabled("Single CRUD operation transactions don't support beginning a transaction")
   @Override


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2749
- **Commit to backport:** 88ccee8a5566bc8c6aa0fde68efcf67ee2b61162

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-2749 &&
git cherry-pick --no-rerere-autoupdate -m1 88ccee8a5566bc8c6aa0fde68efcf67ee2b61162
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!