### PR TITLE
Introduce StorageInfo

### DIFF
--- a/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraMutationAtomicityUnitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cassandra/CassandraMutationAtomicityUnitIntegrationTest.java
@@ -1,0 +1,20 @@
+package com.scalar.db.storage.cassandra;
+
+import com.scalar.db.api.DistributedStorageMutationAtomicityUnitIntegrationTestBase;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+public class CassandraMutationAtomicityUnitIntegrationTest
+    extends DistributedStorageMutationAtomicityUnitIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return CassandraEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return Collections.singletonMap(CassandraAdmin.REPLICATION_FACTOR, "1");
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMutationAtomicityUnitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/cosmos/CosmosMutationAtomicityUnitIntegrationTest.java
@@ -1,0 +1,25 @@
+package com.scalar.db.storage.cosmos;
+
+import com.scalar.db.api.DistributedStorageMutationAtomicityUnitIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+
+public class CosmosMutationAtomicityUnitIntegrationTest
+    extends DistributedStorageMutationAtomicityUnitIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return CosmosEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return CosmosEnv.getCreationOptions();
+  }
+
+  @Disabled("This test fails. It might be a bug")
+  @Override
+  public void
+      mutate_MutationsWithinRecordGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit() {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMutationAtomicityUnitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/dynamo/DynamoMutationAtomicityUnitIntegrationTest.java
@@ -1,0 +1,25 @@
+package com.scalar.db.storage.dynamo;
+
+import com.scalar.db.api.DistributedStorageMutationAtomicityUnitIntegrationTestBase;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Disabled;
+
+public class DynamoMutationAtomicityUnitIntegrationTest
+    extends DistributedStorageMutationAtomicityUnitIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return DynamoEnv.getProperties(testName);
+  }
+
+  @Override
+  protected Map<String, String> getCreationOptions() {
+    return DynamoEnv.getCreationOptions();
+  }
+
+  @Disabled("Transaction request cannot include multiple operations on one item in DynamoDB")
+  @Override
+  public void
+      mutate_MutationsWithinRecordGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit() {}
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMutationAtomicityUnitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/jdbc/JdbcDatabaseMutationAtomicityUnitIntegrationTest.java
@@ -1,0 +1,13 @@
+package com.scalar.db.storage.jdbc;
+
+import com.scalar.db.api.DistributedStorageMutationAtomicityUnitIntegrationTestBase;
+import java.util.Properties;
+
+public class JdbcDatabaseMutationAtomicityUnitIntegrationTest
+    extends DistributedStorageMutationAtomicityUnitIntegrationTestBase {
+
+  @Override
+  protected Properties getProperties(String testName) {
+    return JdbcEnv.getProperties(testName);
+  }
+}

--- a/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageMutationAtomicityUnitIntegrationTest.java
+++ b/core/src/integration-test/java/com/scalar/db/storage/multistorage/MultiStorageMutationAtomicityUnitIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.scalar.db.storage.multistorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.api.DistributedStorageMutationAtomicityUnitIntegrationTestBase;
+import com.scalar.db.api.Put;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.Key;
+import java.util.Arrays;
+import java.util.Properties;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MultiStorageMutationAtomicityUnitIntegrationTest
+    extends DistributedStorageMutationAtomicityUnitIntegrationTestBase {
+
+  @Override
+  public Properties getProperties(String testName) {
+    Properties properties = new Properties();
+    properties.setProperty(DatabaseConfig.STORAGE, "multi-storage");
+
+    // Define storages, jdbc and cassandra
+    properties.setProperty(MultiStorageConfig.STORAGES, "jdbc,cassandra");
+
+    Properties propertiesForJdbc = MultiStorageEnv.getPropertiesForJdbc(testName);
+    for (String propertyName : propertiesForJdbc.stringPropertyNames()) {
+      properties.setProperty(
+          MultiStorageConfig.STORAGES
+              + ".jdbc."
+              + propertyName.substring(DatabaseConfig.PREFIX.length()),
+          propertiesForJdbc.getProperty(propertyName));
+    }
+
+    Properties propertiesForCassandra = MultiStorageEnv.getPropertiesForCassandra(testName);
+    for (String propertyName : propertiesForCassandra.stringPropertyNames()) {
+      properties.setProperty(
+          MultiStorageConfig.STORAGES
+              + ".cassandra."
+              + propertyName.substring(DatabaseConfig.PREFIX.length()),
+          propertiesForCassandra.getProperty(propertyName));
+    }
+
+    // Define namespace mappings
+    properties.setProperty(
+        MultiStorageConfig.NAMESPACE_MAPPING,
+        NAMESPACE1 + ":jdbc," + NAMESPACE2 + ":jdbc," + NAMESPACE3 + ":cassandra");
+
+    // The default storage is jdbc
+    properties.setProperty(MultiStorageConfig.DEFAULT_STORAGE, "jdbc");
+
+    // Add testName as a metadata schema suffix
+    properties.setProperty(
+        DatabaseConfig.SYSTEM_NAMESPACE_NAME,
+        DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME + "_" + testName);
+
+    return properties;
+  }
+
+  @Test
+  public void mutate_MutationsAcrossStorageGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit()
+      throws ExecutionException {
+    // Arrange
+    Put put1 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME3, 1)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(namespace3)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 1))
+            .clusteringKey(Key.ofInt(COL_NAME2, 2))
+            .intValue(COL_NAME3, 2)
+            .build();
+
+    // Act
+    Exception exception =
+        Assertions.catchException(() -> storage.mutate(Arrays.asList(put1, put2)));
+
+    // Assert
+    assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -185,7 +185,7 @@ public interface DistributedStorage extends AutoCloseable {
    * StorageInfo#getMutationAtomicityUnit()}. For example, if the atomicity unit of the storage is
    * {@link StorageInfo.MutationAtomicityUnit#PARTITION}, the mutations must occur within the same
    * partition. Also note that the maximum number of mutations that can be performed atomically is
-   * defined by {@link StorageInfo#getMaxAtomicMutationCount()}.
+   * defined by {@link StorageInfo#getMaxAtomicMutationsCount()}.
    *
    * <p>To retrieve storage information, use {@link DistributedStorageAdmin#getStorageInfo(String)}.
    *

--- a/core/src/main/java/com/scalar/db/api/DistributedStorage.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorage.java
@@ -181,6 +181,14 @@ public interface DistributedStorage extends AutoCloseable {
   /**
    * Mutates entries of the underlying storage with the specified list of {@link Mutation} commands.
    *
+   * <p>Note that this method only supports mutations within the atomicity unit specified by {@link
+   * StorageInfo#getMutationAtomicityUnit()}. For example, if the atomicity unit of the storage is
+   * {@link StorageInfo.MutationAtomicityUnit#PARTITION}, the mutations must occur within the same
+   * partition. Also note that the maximum number of mutations that can be performed atomically is
+   * defined by {@link StorageInfo#getMaxAtomicMutationCount()}.
+   *
+   * <p>To retrieve storage information, use {@link DistributedStorageAdmin#getStorageInfo(String)}.
+   *
    * @param mutations a list of {@code Mutation} commands
    * @throws ExecutionException if the operation fails
    */

--- a/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/api/DistributedStorageAdmin.java
@@ -88,6 +88,15 @@ public interface DistributedStorageAdmin extends Admin, AutoCloseable {
   void addRawColumnToTable(String namespace, String table, String columnName, DataType columnType)
       throws ExecutionException;
 
+  /**
+   * Returns the storage information.
+   *
+   * @param namespace the namespace to get the storage information for
+   * @return the storage information
+   * @throws ExecutionException if the operation fails
+   */
+  StorageInfo getStorageInfo(String namespace) throws ExecutionException;
+
   /** Closes connections to the storage. */
   @Override
   void close();

--- a/core/src/main/java/com/scalar/db/api/StorageInfo.java
+++ b/core/src/main/java/com/scalar/db/api/StorageInfo.java
@@ -1,0 +1,62 @@
+package com.scalar.db.api;
+
+public interface StorageInfo {
+  /**
+   * Returns the storage name.
+   *
+   * @return the storage name
+   */
+  String getStorageName();
+
+  /**
+   * Returns the mutation atomicity unit of the storage.
+   *
+   * @return the mutation atomicity unit of the storage
+   */
+  MutationAtomicityUnit getMutationAtomicityUnit();
+
+  /**
+   * Returns the maximum number of mutations that can be performed atomically in the storage.
+   *
+   * @return the maximum number of mutations that can be performed atomically in the storage
+   */
+  int getMaxAtomicMutationCount();
+
+  /**
+   * The mutation atomicity unit of the storage.
+   *
+   * <p>This enum defines the atomicity unit for mutations in the storage. It determines the scope
+   * of atomicity for mutations such as put and delete.
+   */
+  enum MutationAtomicityUnit {
+    /**
+     * The atomicity unit is at the record level, meaning that mutations are performed atomically
+     * for each record.
+     */
+    RECORD,
+
+    /**
+     * The atomicity unit is at the partition level, meaning that mutations are performed atomically
+     * for each partition.
+     */
+    PARTITION,
+
+    /**
+     * The atomicity unit is at the table level, meaning that mutations are performed atomically for
+     * each table.
+     */
+    TABLE,
+
+    /**
+     * The atomicity unit is at the namespace level, meaning that mutations are performed atomically
+     * for each namespace.
+     */
+    NAMESPACE,
+
+    /**
+     * The atomicity unit is at the storage level, meaning that mutations are performed atomically
+     * for the entire storage.
+     */
+    STORAGE
+  }
+}

--- a/core/src/main/java/com/scalar/db/api/StorageInfo.java
+++ b/core/src/main/java/com/scalar/db/api/StorageInfo.java
@@ -20,7 +20,7 @@ public interface StorageInfo {
    *
    * @return the maximum number of mutations that can be performed atomically in the storage
    */
-  int getMaxAtomicMutationCount();
+  int getMaxAtomicMutationsCount();
 
   /**
    * The mutation atomicity unit of the storage.

--- a/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/common/CheckedDistributedStorageAdmin.java
@@ -1,6 +1,7 @@
 package com.scalar.db.common;
 
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
@@ -370,6 +371,20 @@ public class CheckedDistributedStorageAdmin implements DistributedStorageAdmin {
       admin.upgrade(options);
     } catch (ExecutionException e) {
       throw new ExecutionException(CoreError.UPGRADING_SCALAR_DB_ENV_FAILED.buildMessage(), e);
+    }
+  }
+
+  @Override
+  public StorageInfo getStorageInfo(String namespace) throws ExecutionException {
+    if (!namespaceExists(namespace)) {
+      throw new IllegalArgumentException(CoreError.NAMESPACE_NOT_FOUND.buildMessage(namespace));
+    }
+
+    try {
+      return admin.getStorageInfo(namespace);
+    } catch (ExecutionException e) {
+      throw new ExecutionException(
+          CoreError.GETTING_STORAGE_INFO_FAILED.buildMessage(namespace), e);
     }
   }
 

--- a/core/src/main/java/com/scalar/db/common/StorageInfoImpl.java
+++ b/core/src/main/java/com/scalar/db/common/StorageInfoImpl.java
@@ -10,13 +10,15 @@ public class StorageInfoImpl implements StorageInfo {
 
   private final String storageName;
   private final MutationAtomicityUnit mutationAtomicityUnit;
-  private final int maxAtomicMutationCount;
+  private final int maxAtomicMutationsCount;
 
   public StorageInfoImpl(
-      String storageName, MutationAtomicityUnit mutationAtomicityUnit, int maxAtomicMutationCount) {
+      String storageName,
+      MutationAtomicityUnit mutationAtomicityUnit,
+      int maxAtomicMutationsCount) {
     this.storageName = storageName;
     this.mutationAtomicityUnit = mutationAtomicityUnit;
-    this.maxAtomicMutationCount = maxAtomicMutationCount;
+    this.maxAtomicMutationsCount = maxAtomicMutationsCount;
   }
 
   @Override
@@ -30,8 +32,8 @@ public class StorageInfoImpl implements StorageInfo {
   }
 
   @Override
-  public int getMaxAtomicMutationCount() {
-    return maxAtomicMutationCount;
+  public int getMaxAtomicMutationsCount() {
+    return maxAtomicMutationsCount;
   }
 
   @Override
@@ -43,14 +45,14 @@ public class StorageInfoImpl implements StorageInfo {
       return false;
     }
     StorageInfoImpl that = (StorageInfoImpl) o;
-    return getMaxAtomicMutationCount() == that.getMaxAtomicMutationCount()
+    return getMaxAtomicMutationsCount() == that.getMaxAtomicMutationsCount()
         && Objects.equals(getStorageName(), that.getStorageName())
         && getMutationAtomicityUnit() == that.getMutationAtomicityUnit();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStorageName(), getMutationAtomicityUnit(), getMaxAtomicMutationCount());
+    return Objects.hash(getStorageName(), getMutationAtomicityUnit(), getMaxAtomicMutationsCount());
   }
 
   @Override
@@ -58,7 +60,7 @@ public class StorageInfoImpl implements StorageInfo {
     return MoreObjects.toStringHelper(this)
         .add("storageName", storageName)
         .add("mutationAtomicityUnit", mutationAtomicityUnit)
-        .add("maxAtomicMutationCount", maxAtomicMutationCount)
+        .add("maxAtomicMutationsCount", maxAtomicMutationsCount)
         .toString();
   }
 }

--- a/core/src/main/java/com/scalar/db/common/StorageInfoImpl.java
+++ b/core/src/main/java/com/scalar/db/common/StorageInfoImpl.java
@@ -1,0 +1,64 @@
+package com.scalar.db.common;
+
+import com.google.common.base.MoreObjects;
+import com.scalar.db.api.StorageInfo;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class StorageInfoImpl implements StorageInfo {
+
+  private final String storageName;
+  private final MutationAtomicityUnit mutationAtomicityUnit;
+  private final int maxAtomicMutationCount;
+
+  public StorageInfoImpl(
+      String storageName, MutationAtomicityUnit mutationAtomicityUnit, int maxAtomicMutationCount) {
+    this.storageName = storageName;
+    this.mutationAtomicityUnit = mutationAtomicityUnit;
+    this.maxAtomicMutationCount = maxAtomicMutationCount;
+  }
+
+  @Override
+  public String getStorageName() {
+    return storageName;
+  }
+
+  @Override
+  public MutationAtomicityUnit getMutationAtomicityUnit() {
+    return mutationAtomicityUnit;
+  }
+
+  @Override
+  public int getMaxAtomicMutationCount() {
+    return maxAtomicMutationCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof StorageInfoImpl)) {
+      return false;
+    }
+    StorageInfoImpl that = (StorageInfoImpl) o;
+    return getMaxAtomicMutationCount() == that.getMaxAtomicMutationCount()
+        && Objects.equals(getStorageName(), that.getStorageName())
+        && getMutationAtomicityUnit() == that.getMutationAtomicityUnit();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getStorageName(), getMutationAtomicityUnit(), getMaxAtomicMutationCount());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("storageName", storageName)
+        .add("mutationAtomicityUnit", mutationAtomicityUnit)
+        .add("maxAtomicMutationCount", maxAtomicMutationCount)
+        .toString();
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/StorageInfoProvider.java
+++ b/core/src/main/java/com/scalar/db/common/StorageInfoProvider.java
@@ -1,0 +1,42 @@
+package com.scalar.db.common;
+
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.StorageInfo;
+import com.scalar.db.exception.storage.ExecutionException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class StorageInfoProvider {
+
+  private final DistributedStorageAdmin admin;
+
+  // Cache to store storage information. A map namespace to StorageInfo.
+  private final ConcurrentMap<String, StorageInfo> storageInfoCache = new ConcurrentHashMap<>();
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public StorageInfoProvider(DistributedStorageAdmin admin) {
+    this.admin = admin;
+  }
+
+  public StorageInfo getStorageInfo(String namespace) throws ExecutionException {
+    try {
+      return storageInfoCache.computeIfAbsent(namespace, this::getStorageInfoInternal);
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof ExecutionException) {
+        throw (ExecutionException) e.getCause();
+      }
+      throw e;
+    }
+  }
+
+  private StorageInfo getStorageInfoInternal(String namespace) {
+    try {
+      return admin.getStorageInfo(namespace);
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -100,7 +100,7 @@ public enum CoreError implements ScalarDbError {
   OPERATION_CHECK_ERROR_MULTI_PARTITION_MUTATION(
       Category.USER_ERROR,
       "0019",
-      "Mutations that span multiple partitions are not supported. Mutations: %s",
+      "The storage does not support mutations across multiple partitions. Storage: %s; Mutations: %s",
       "",
       ""),
   OPERATION_CHECK_ERROR_PARTITION_KEY(
@@ -936,6 +936,30 @@ public enum CoreError implements ScalarDbError {
       "Mutations are not allowed in read-only transactions. Transaction ID: %s",
       "",
       ""),
+  OPERATION_CHECK_ERROR_MULTI_RECORD_MUTATION(
+      Category.USER_ERROR,
+      "0212",
+      "The storage does not support mutations across multiple records. Storage: %s; Mutations: %s",
+      "",
+      ""),
+  OPERATION_CHECK_ERROR_MULTI_TABLE_MUTATION(
+      Category.USER_ERROR,
+      "0213",
+      "The storage does not support mutations across multiple tables. Storage: %s; Mutations: %s",
+      "",
+      ""),
+  OPERATION_CHECK_ERROR_MULTI_NAMESPACE_MUTATION(
+      Category.USER_ERROR,
+      "0214",
+      "The storage does not support mutations across multiple namespaces. Storage: %s; Mutations: %s",
+      "",
+      ""),
+  OPERATION_CHECK_ERROR_MULTI_STORAGE_MUTATION(
+      Category.USER_ERROR,
+      "0215",
+      "Mutations across multiple storages are not allowed. Mutations: %s",
+      "",
+      ""),
 
   //
   // Errors for the concurrency error category
@@ -1211,6 +1235,12 @@ public enum CoreError implements ScalarDbError {
       Category.INTERNAL_ERROR, "0054", "Getting the scanner failed. Details: %s", "", ""),
   JDBC_CLOSING_SCANNER_FAILED(
       Category.INTERNAL_ERROR, "0055", "Closing the scanner failed. Details: %s", "", ""),
+  GETTING_STORAGE_INFO_FAILED(
+      Category.INTERNAL_ERROR,
+      "0056",
+      "Getting the storage information failed. Namespace: %s",
+      "",
+      ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/service/AdminService.java
+++ b/core/src/main/java/com/scalar/db/service/AdminService.java
@@ -2,6 +2,7 @@ package com.scalar.db.service;
 
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
@@ -131,6 +132,11 @@ public class AdminService implements DistributedStorageAdmin {
   @Override
   public void upgrade(Map<String, String> options) throws ExecutionException {
     admin.upgrade(options);
+  }
+
+  @Override
+  public StorageInfo getStorageInfo(String namespace) throws ExecutionException {
+    return admin.getStorageInfo(namespace);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/Cassandra.java
@@ -15,6 +15,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.common.AbstractDistributedStorage;
 import com.scalar.db.common.FilterableScanner;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
@@ -65,11 +66,11 @@ public class Cassandra extends AbstractDistributedStorage {
     batch = new BatchHandler(session, handlers);
     logger.info("Cassandra object is created properly");
 
+    CassandraAdmin cassandraAdmin = new CassandraAdmin(clusterManager, config);
     metadataManager =
-        new TableMetadataManager(
-            new CassandraAdmin(clusterManager, config),
-            config.getMetadataCacheExpirationTimeSecs());
-    operationChecker = new OperationChecker(config, metadataManager);
+        new TableMetadataManager(cassandraAdmin, config.getMetadataCacheExpirationTimeSecs());
+    operationChecker =
+        new OperationChecker(config, metadataManager, new StorageInfoProvider(cassandraAdmin));
   }
 
   @VisibleForTesting

--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -21,7 +21,9 @@ import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -47,6 +49,13 @@ public class CassandraAdmin implements DistributedStorageAdmin {
   public static final String NAMESPACES_NAME_COL = "name";
   private static final String DEFAULT_REPLICATION_FACTOR = "3";
   @VisibleForTesting static final String INDEX_NAME_PREFIX = "index";
+  private static final StorageInfo STORAGE_INFO =
+      new StorageInfoImpl(
+          "cassandra",
+          StorageInfo.MutationAtomicityUnit.PARTITION,
+          // No limit on the number of mutations
+          Integer.MAX_VALUE);
+
   private final ClusterManager clusterManager;
   private final String metadataKeyspace;
 
@@ -568,6 +577,11 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     for (String name : secondaryIndexNames) {
       createIndexInternal(keyspace, table, name, ifNotExists);
     }
+  }
+
+  @Override
+  public StorageInfo getStorageInfo(String namespace) {
+    return STORAGE_INFO;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/Cosmos.java
@@ -15,6 +15,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.common.AbstractDistributedStorage;
 import com.scalar.db.common.FilterableScanner;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
@@ -57,10 +58,12 @@ public class Cosmos extends AbstractDistributedStorage {
 
     client = CosmosUtils.buildCosmosClient(config);
 
+    CosmosAdmin cosmosAdmin = new CosmosAdmin(client, config);
     TableMetadataManager metadataManager =
-        new TableMetadataManager(
-            new CosmosAdmin(client, config), databaseConfig.getMetadataCacheExpirationTimeSecs());
-    operationChecker = new CosmosOperationChecker(databaseConfig, metadataManager);
+        new TableMetadataManager(cosmosAdmin, databaseConfig.getMetadataCacheExpirationTimeSecs());
+    operationChecker =
+        new CosmosOperationChecker(
+            databaseConfig, metadataManager, new StorageInfoProvider(cosmosAdmin));
 
     selectStatementHandler =
         new SelectStatementHandler(client, metadataManager, databaseConfig.getScanFetchSize());

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -24,7 +24,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -64,6 +66,12 @@ public class CosmosAdmin implements DistributedStorageAdmin {
   @VisibleForTesting public static final String STORED_PROCEDURE_FILE_NAME = "mutate.js";
   private static final String STORED_PROCEDURE_PATH =
       "cosmosdb_stored_procedure/" + STORED_PROCEDURE_FILE_NAME;
+  private static final StorageInfo STORAGE_INFO =
+      new StorageInfoImpl(
+          "cosmos",
+          StorageInfo.MutationAtomicityUnit.PARTITION,
+          // No limit on the number of mutations
+          Integer.MAX_VALUE);
 
   private final CosmosClient client;
   private final String metadataDatabase;
@@ -740,5 +748,10 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       throw e;
     }
     return true;
+  }
+
+  @Override
+  public StorageInfo getStorageInfo(String namespace) {
+    return STORAGE_INFO;
   }
 }

--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosOperationChecker.java
@@ -8,6 +8,7 @@ import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
@@ -90,8 +91,10 @@ public class CosmosOperationChecker extends OperationChecker {
       };
 
   public CosmosOperationChecker(
-      DatabaseConfig databaseConfig, TableMetadataManager metadataManager) {
-    super(databaseConfig, metadataManager);
+      DatabaseConfig databaseConfig,
+      TableMetadataManager metadataManager,
+      StorageInfoProvider storageInfoProvider) {
+    super(databaseConfig, metadataManager, storageInfoProvider);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/Dynamo.java
@@ -14,6 +14,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.common.AbstractDistributedStorage;
 import com.scalar.db.common.FilterableScanner;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.OperationChecker;
 import com.scalar.db.common.error.CoreError;
@@ -71,10 +72,12 @@ public class Dynamo extends AbstractDistributedStorage {
             .region(Region.of(config.getRegion()))
             .build();
 
+    DynamoAdmin dynamoAdmin = new DynamoAdmin(client, config);
     TableMetadataManager metadataManager =
-        new TableMetadataManager(
-            new DynamoAdmin(client, config), databaseConfig.getMetadataCacheExpirationTimeSecs());
-    operationChecker = new DynamoOperationChecker(databaseConfig, metadataManager);
+        new TableMetadataManager(dynamoAdmin, databaseConfig.getMetadataCacheExpirationTimeSecs());
+    operationChecker =
+        new DynamoOperationChecker(
+            databaseConfig, metadataManager, new StorageInfoProvider(dynamoAdmin));
 
     selectStatementHandler =
         new SelectStatementHandler(

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -7,7 +7,9 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
@@ -153,6 +155,12 @@ public class DynamoAdmin implements DistributedStorageAdmin {
           .put(SCALING_TYPE_INDEX_READ, MetricType.DYNAMO_DB_READ_CAPACITY_UTILIZATION)
           .put(SCALING_TYPE_INDEX_WRITE, MetricType.DYNAMO_DB_WRITE_CAPACITY_UTILIZATION)
           .build();
+  private static final StorageInfo STORAGE_INFO =
+      new StorageInfoImpl(
+          "dynamo",
+          StorageInfo.MutationAtomicityUnit.STORAGE,
+          // DynamoDB has a limit of 100 items per transactional batch write operation
+          100);
 
   private final DynamoDbClient client;
   private final ApplicationAutoScalingClient applicationAutoScalingClient;
@@ -1501,6 +1509,11 @@ public class DynamoAdmin implements DistributedStorageAdmin {
 
   private String getFullTableName(Namespace namespace, String table) {
     return ScalarDbUtils.getFullTableName(namespace.prefixed(), table);
+  }
+
+  @Override
+  public StorageInfo getStorageInfo(String namespace) {
+    return STORAGE_INFO;
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoOperationChecker.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoOperationChecker.java
@@ -5,6 +5,7 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.common.checker.ColumnChecker;
 import com.scalar.db.common.checker.OperationChecker;
@@ -17,8 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class DynamoOperationChecker extends OperationChecker {
   public DynamoOperationChecker(
-      DatabaseConfig databaseConfig, TableMetadataManager metadataManager) {
-    super(databaseConfig, metadataManager);
+      DatabaseConfig databaseConfig,
+      TableMetadataManager metadataManager,
+      StorageInfoProvider storageInfoProvider) {
+    super(databaseConfig, metadataManager, storageInfoProvider);
   }
 
   @Override

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -12,7 +12,9 @@ import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering;
 import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
 import com.scalar.db.common.error.CoreError;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -59,6 +61,12 @@ public class JdbcAdmin implements DistributedStorageAdmin {
   @VisibleForTesting static final String NAMESPACE_COL_NAMESPACE_NAME = "namespace_name";
   private static final Logger logger = LoggerFactory.getLogger(JdbcAdmin.class);
   private static final String INDEX_NAME_PREFIX = "index";
+  private static final StorageInfo STORAGE_INFO =
+      new StorageInfoImpl(
+          "jdbc",
+          StorageInfo.MutationAtomicityUnit.STORAGE,
+          // No limit on the number of mutations
+          Integer.MAX_VALUE);
 
   private final RdbEngineStrategy rdbEngine;
   private final BasicDataSource dataSource;
@@ -1160,6 +1168,11 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     } catch (SQLException e) {
       throw new ExecutionException("Importing the namespace names of existing tables failed", e);
     }
+  }
+
+  @Override
+  public StorageInfo getStorageInfo(String namespace) {
+    return STORAGE_INFO;
   }
 
   @FunctionalInterface

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorage.java
@@ -36,7 +36,9 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class MultiStorage extends AbstractDistributedStorage {
 
-  private final Map<String, DistributedStorage> tableStorageMap;
+  /** @deprecated Will be removed in 5.0.0. */
+  @Deprecated private final Map<String, DistributedStorage> tableStorageMap;
+
   private final Map<String, DistributedStorage> namespaceStorageMap;
   private final DistributedStorage defaultStorage;
   private final List<DistributedStorage> storages;
@@ -140,6 +142,8 @@ public class MultiStorage extends AbstractDistributedStorage {
   }
 
   private DistributedStorage getStorage(Operation operation) {
+    assert operation.forFullTableName().isPresent() && operation.forNamespace().isPresent();
+
     String fullTaleName = operation.forFullTableName().get();
     DistributedStorage storage = tableStorageMap.get(fullTaleName);
     if (storage != null) {

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -327,10 +327,10 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
 
   @VisibleForTesting
   static class AdminHolder {
-    public final String storageName;
-    public final DistributedStorageAdmin admin;
+    private final String storageName;
+    private final DistributedStorageAdmin admin;
 
-    public AdminHolder(String storageName, DistributedStorageAdmin admin) {
+    AdminHolder(String storageName, DistributedStorageAdmin admin) {
       this.storageName = storageName;
       this.admin = admin;
     }

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -288,7 +288,7 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
       return new StorageInfoImpl(
           holder.storageName,
           storageInfo.getMutationAtomicityUnit(),
-          storageInfo.getMaxAtomicMutationCount());
+          storageInfo.getMaxAtomicMutationsCount());
     } catch (RuntimeException e) {
       if (e.getCause() instanceof ExecutionException) {
         throw (ExecutionException) e.getCause();

--- a/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/multistorage/MultiStorageAdmin.java
@@ -4,7 +4,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
@@ -15,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -28,9 +31,11 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class MultiStorageAdmin implements DistributedStorageAdmin {
 
-  private final Map<String, DistributedStorageAdmin> tableAdminMap;
-  private final Map<String, DistributedStorageAdmin> namespaceAdminMap;
-  private final DistributedStorageAdmin defaultAdmin;
+  /** @deprecated Will be removed in 5.0.0. */
+  @Deprecated private final Map<String, DistributedStorageAdmin> tableAdminMap;
+
+  private final Map<String, AdminHolder> namespaceAdminMap;
+  private final AdminHolder defaultAdmin;
   private final List<DistributedStorageAdmin> admins;
 
   @Inject
@@ -44,7 +49,7 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
         .forEach(
             (storageName, properties) -> {
               StorageFactory factory = StorageFactory.create(properties);
-              DistributedStorageAdmin admin = factory.getAdmin();
+              DistributedStorageAdmin admin = factory.getStorageAdmin();
               nameAdminMap.put(storageName, admin);
               admins.add(admin);
             });
@@ -59,23 +64,28 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
         .getNamespaceStorageMap()
         .forEach(
             (namespace, storageName) ->
-                namespaceAdminMap.put(namespace, nameAdminMap.get(storageName)));
+                namespaceAdminMap.put(
+                    namespace, new AdminHolder(storageName, nameAdminMap.get(storageName))));
 
-    defaultAdmin = nameAdminMap.get(config.getDefaultStorage());
+    defaultAdmin =
+        new AdminHolder(config.getDefaultStorage(), nameAdminMap.get(config.getDefaultStorage()));
   }
 
   @VisibleForTesting
   MultiStorageAdmin(
       Map<String, DistributedStorageAdmin> tableAdminMap,
-      Map<String, DistributedStorageAdmin> namespaceAdminMap,
-      DistributedStorageAdmin defaultAdmin) {
+      Map<String, AdminHolder> namespaceAdminMap,
+      AdminHolder defaultAdmin) {
     this.tableAdminMap = tableAdminMap;
     this.namespaceAdminMap = namespaceAdminMap;
     this.defaultAdmin = defaultAdmin;
     ImmutableSet.Builder<DistributedStorageAdmin> adminsSet = ImmutableSet.builder();
     adminsSet.addAll(tableAdminMap.values());
-    adminsSet.addAll(namespaceAdminMap.values());
-    adminsSet.add(defaultAdmin);
+    adminsSet.addAll(
+        namespaceAdminMap.values().stream()
+            .map(holder -> holder.admin)
+            .collect(Collectors.toSet()));
+    adminsSet.add(defaultAdmin.admin);
     this.admins = adminsSet.build().asList();
   }
 
@@ -243,16 +253,18 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
     //     => returned
     // - ns4 and ns5 are in the default storage (cosmos)
     //     => returned
-    Set<String> namespaceNames = new HashSet<>(defaultAdmin.getNamespaceNames());
+    Set<String> namespaceNames = new HashSet<>(defaultAdmin.admin.getNamespaceNames());
 
     Set<DistributedStorageAdmin> adminsWithoutDefaultAdmin =
-        new HashSet<>(namespaceAdminMap.values());
-    adminsWithoutDefaultAdmin.remove(defaultAdmin);
+        namespaceAdminMap.values().stream().map(holder -> holder.admin).collect(Collectors.toSet());
+    adminsWithoutDefaultAdmin.remove(defaultAdmin.admin);
+
     for (DistributedStorageAdmin admin : adminsWithoutDefaultAdmin) {
       Set<String> existingNamespaces = admin.getNamespaceNames();
       // Filter out namespace not in the mapping
       for (String existingNamespace : existingNamespaces) {
-        if (admin.equals(namespaceAdminMap.get(existingNamespace))) {
+        AdminHolder holder = namespaceAdminMap.get(existingNamespace);
+        if (holder != null && admin.equals(holder.admin)) {
           namespaceNames.add(existingNamespace);
         }
       }
@@ -263,14 +275,38 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
 
   @Override
   public void upgrade(Map<String, String> options) throws ExecutionException {
-    for (DistributedStorageAdmin admin : namespaceAdminMap.values()) {
-      admin.upgrade(options);
+    for (AdminHolder admin : namespaceAdminMap.values()) {
+      admin.admin.upgrade(options);
     }
   }
 
+  @Override
+  public StorageInfo getStorageInfo(String namespace) throws ExecutionException {
+    try {
+      AdminHolder holder = getAdminHolder(namespace);
+      StorageInfo storageInfo = holder.admin.getStorageInfo(namespace);
+      return new StorageInfoImpl(
+          holder.storageName,
+          storageInfo.getMutationAtomicityUnit(),
+          storageInfo.getMaxAtomicMutationCount());
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof ExecutionException) {
+        throw (ExecutionException) e.getCause();
+      }
+      throw e;
+    }
+  }
+
+  private AdminHolder getAdminHolder(String namespace) {
+    AdminHolder adminHolder = namespaceAdminMap.get(namespace);
+    if (adminHolder != null) {
+      return adminHolder;
+    }
+    return defaultAdmin;
+  }
+
   private DistributedStorageAdmin getAdmin(String namespace) {
-    DistributedStorageAdmin admin = namespaceAdminMap.get(namespace);
-    return admin != null ? admin : defaultAdmin;
+    return getAdminHolder(namespace).admin;
   }
 
   private DistributedStorageAdmin getAdmin(String namespace, String table) {
@@ -286,6 +322,17 @@ public class MultiStorageAdmin implements DistributedStorageAdmin {
   public void close() {
     for (DistributedStorageAdmin admin : admins) {
       admin.close();
+    }
+  }
+
+  @VisibleForTesting
+  static class AdminHolder {
+    public final String storageName;
+    public final DistributedStorageAdmin admin;
+
+    public AdminHolder(String storageName, DistributedStorageAdmin admin) {
+      this.storageName = storageName;
+      this.admin = admin;
     }
   }
 }

--- a/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cosmos/CosmosOperationCheckerTest.java
@@ -17,7 +17,10 @@ import com.scalar.db.api.Get;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.exception.storage.ExecutionException;
@@ -37,6 +40,8 @@ public class CosmosOperationCheckerTest {
   private static final String CKEY1 = "c1";
   private static final String COL1 = "v1";
   private static final String COL2 = "v2";
+  private static final StorageInfo STORAGE_INFO =
+      new StorageInfoImpl("cosmos", StorageInfo.MutationAtomicityUnit.PARTITION, Integer.MAX_VALUE);
 
   private static final TableMetadata TABLE_METADATA1 =
       TableMetadata.newBuilder()
@@ -59,13 +64,15 @@ public class CosmosOperationCheckerTest {
 
   @Mock private DatabaseConfig databaseConfig;
   @Mock private TableMetadataManager metadataManager;
+  @Mock private StorageInfoProvider storageInfoProvider;
   private CosmosOperationChecker operationChecker;
 
   @BeforeEach
   public void setUp() throws Exception {
     openMocks(this).close();
 
-    operationChecker = new CosmosOperationChecker(databaseConfig, metadataManager);
+    operationChecker =
+        new CosmosOperationChecker(databaseConfig, metadataManager, storageInfoProvider);
   }
 
   @Test
@@ -218,6 +225,7 @@ public class CosmosOperationCheckerTest {
       throws ExecutionException {
     // Arrange
     when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA1);
+    when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
 
     Put put =
         Put.newBuilder()
@@ -320,6 +328,7 @@ public class CosmosOperationCheckerTest {
       throws ExecutionException {
     // Arrange
     when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA1);
+    when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
 
     Delete delete =
         Delete.newBuilder()
@@ -657,6 +666,7 @@ public class CosmosOperationCheckerTest {
           throws ExecutionException {
     // Arrange
     when(metadataManager.getTableMetadata(any())).thenReturn(TABLE_METADATA2);
+    when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
 
     Put put1 =
         Put.newBuilder()

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationCheckerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoOperationCheckerTest.java
@@ -15,7 +15,10 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.MutationCondition;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
+import com.scalar.db.common.StorageInfoProvider;
 import com.scalar.db.common.TableMetadataManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.io.DataType;
@@ -35,8 +38,12 @@ public class DynamoOperationCheckerTest {
   private static final String COL2 = "v2";
   private static final String COL3 = "v3";
   private static final String COL4 = "v4";
+  private static final StorageInfo STORAGE_INFO =
+      new StorageInfoImpl("dynamo", StorageInfo.MutationAtomicityUnit.STORAGE, 100);
+
   @Mock private DatabaseConfig databaseConfig;
   @Mock private TableMetadataManager metadataManager;
+  @Mock private StorageInfoProvider storageInfoProvider;
   private DynamoOperationChecker operationChecker;
 
   @BeforeEach
@@ -57,7 +64,9 @@ public class DynamoOperationCheckerTest {
             .addSecondaryIndex(COL4)
             .build();
     when(metadataManager.getTableMetadata(any())).thenReturn(tableMetadata);
-    operationChecker = new DynamoOperationChecker(databaseConfig, metadataManager);
+    when(storageInfoProvider.getStorageInfo(any())).thenReturn(STORAGE_INFO);
+    operationChecker =
+        new DynamoOperationChecker(databaseConfig, metadataManager, storageInfoProvider);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/multistorage/MultiStorageAdminTest.java
@@ -1,6 +1,7 @@
 package com.scalar.db.storage.multistorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,7 +9,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.StorageInfo;
 import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.StorageInfoImpl;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.DataType;
 import java.util.Collections;
@@ -44,10 +47,11 @@ public class MultiStorageAdminTest {
     Map<String, DistributedStorageAdmin> tableAdminMap = new HashMap<>();
     tableAdminMap.put(NAMESPACE1 + "." + TABLE1, admin1);
     tableAdminMap.put(NAMESPACE1 + "." + TABLE2, admin2);
-    Map<String, DistributedStorageAdmin> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put(NAMESPACE2, admin2);
-    DistributedStorageAdmin defaultAdmin = admin3;
-    multiStorageAdmin = new MultiStorageAdmin(tableAdminMap, namespaceAdminMap, defaultAdmin);
+    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
+    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
+    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put(NAMESPACE2, s2);
+    multiStorageAdmin = new MultiStorageAdmin(tableAdminMap, namespaceAdminMap, s3);
   }
 
   @Test
@@ -500,13 +504,15 @@ public class MultiStorageAdminTest {
       getNamespaceNames_WithExistingNamespacesNotInMapping_ShouldReturnExistingNamespacesInMappingAndFromDefaultAdmin()
           throws ExecutionException {
     // Arrange
-    Map<String, DistributedStorageAdmin> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", admin1);
-    namespaceAdminMap.put("ns2", admin2);
-    namespaceAdminMap.put("ns3", admin2);
-    DistributedStorageAdmin defaultAdmin = admin3;
-    multiStorageAdmin =
-        new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, defaultAdmin);
+    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
+    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
+    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
+
+    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put("ns1", s1);
+    namespaceAdminMap.put("ns2", s2);
+    namespaceAdminMap.put("ns3", s2);
+    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
 
     when(admin1.getNamespaceNames()).thenReturn(ImmutableSet.of("ns1", "ns2"));
     when(admin2.getNamespaceNames()).thenReturn(ImmutableSet.of("ns3"));
@@ -526,12 +532,14 @@ public class MultiStorageAdminTest {
   public void getNamespaceNames_WithNamespaceInMappingButNotExisting_ShouldReturnEmptySet()
       throws ExecutionException {
     // Arrange
-    Map<String, DistributedStorageAdmin> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", admin1);
-    namespaceAdminMap.put("ns2", admin2);
-    DistributedStorageAdmin defaultAdmin = admin3;
-    multiStorageAdmin =
-        new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, defaultAdmin);
+    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
+    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
+    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
+
+    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put("ns1", s1);
+    namespaceAdminMap.put("ns2", s2);
+    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
 
     when(admin1.getNamespaceNames()).thenReturn(Collections.emptySet());
     when(admin2.getNamespaceNames()).thenReturn(Collections.emptySet());
@@ -551,12 +559,14 @@ public class MultiStorageAdminTest {
   public void getNamespaceNames_WithExistingNamespaceButNotInMapping_ShouldReturnEmptySet()
       throws ExecutionException {
     // Arrange
-    Map<String, DistributedStorageAdmin> namespaceAdminMap = new HashMap<>();
-    namespaceAdminMap.put("ns1", admin1);
-    namespaceAdminMap.put("ns2", admin2);
-    DistributedStorageAdmin defaultAdmin = admin3;
-    multiStorageAdmin =
-        new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, defaultAdmin);
+    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
+    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
+    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
+
+    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put("ns1", s1);
+    namespaceAdminMap.put("ns2", s2);
+    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
 
     when(admin1.getNamespaceNames()).thenReturn(ImmutableSet.of("ns2"));
     when(admin2.getNamespaceNames()).thenReturn(Collections.emptySet());
@@ -604,11 +614,14 @@ public class MultiStorageAdminTest {
   public void upgrade_ShouldCallNamespaceAndDefaultAdmins() throws ExecutionException {
     // Arrange
     Map<String, String> options = ImmutableMap.of("foo", "bar");
-    Map<String, DistributedStorageAdmin> namespaceAdminMap =
-        ImmutableMap.of("ns1", admin1, "ns2", admin2);
-    DistributedStorageAdmin defaultAdmin = admin2;
-    multiStorageAdmin =
-        new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, defaultAdmin);
+
+    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
+    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
+
+    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put("ns1", s1);
+    namespaceAdminMap.put("ns2", s2);
+    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s2);
 
     // Act
     multiStorageAdmin.upgrade(options);
@@ -646,5 +659,45 @@ public class MultiStorageAdminTest {
 
     // Assert
     verify(admin1).getImportTableMetadata(namespace, table, overrideColumnsType);
+  }
+
+  @Test
+  public void getStorageInfo_ShouldReturnProperStorageInfo() throws ExecutionException {
+    // Arrange
+    MultiStorageAdmin.AdminHolder s1 = new MultiStorageAdmin.AdminHolder("s1", admin1);
+    MultiStorageAdmin.AdminHolder s2 = new MultiStorageAdmin.AdminHolder("s2", admin2);
+    MultiStorageAdmin.AdminHolder s3 = new MultiStorageAdmin.AdminHolder("s3", admin3);
+
+    Map<String, MultiStorageAdmin.AdminHolder> namespaceAdminMap = new HashMap<>();
+    namespaceAdminMap.put("ns1", s1);
+    namespaceAdminMap.put("ns2", s2);
+    multiStorageAdmin = new MultiStorageAdmin(Collections.emptyMap(), namespaceAdminMap, s3);
+
+    when(admin1.getStorageInfo(anyString()))
+        .thenReturn(
+            new StorageInfoImpl(
+                "cassandra", StorageInfo.MutationAtomicityUnit.PARTITION, Integer.MAX_VALUE));
+    when(admin2.getStorageInfo(anyString()))
+        .thenReturn(new StorageInfoImpl("dynamo", StorageInfo.MutationAtomicityUnit.STORAGE, 100));
+    when(admin3.getStorageInfo(anyString()))
+        .thenReturn(
+            new StorageInfoImpl(
+                "jdbc", StorageInfo.MutationAtomicityUnit.STORAGE, Integer.MAX_VALUE));
+
+    // Act Assert
+    assertThat(multiStorageAdmin.getStorageInfo("ns1"))
+        .isEqualTo(
+            new StorageInfoImpl(
+                "s1", StorageInfo.MutationAtomicityUnit.PARTITION, Integer.MAX_VALUE));
+    assertThat(multiStorageAdmin.getStorageInfo("ns2"))
+        .isEqualTo(new StorageInfoImpl("s2", StorageInfo.MutationAtomicityUnit.STORAGE, 100));
+    assertThat(multiStorageAdmin.getStorageInfo("ns3"))
+        .isEqualTo(
+            new StorageInfoImpl(
+                "s3", StorageInfo.MutationAtomicityUnit.STORAGE, Integer.MAX_VALUE));
+
+    verify(admin1).getStorageInfo("ns1");
+    verify(admin2).getStorageInfo("ns2");
+    verify(admin3).getStorageInfo("ns3");
   }
 }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageIntegrationTestBase.java
@@ -1042,86 +1042,6 @@ public abstract class DistributedStorageIntegrationTestBase {
   }
 
   @Test
-  public void
-      put_MultiplePutWithDifferentPartitionsWithIfNotExistsGiven_ShouldThrowIllegalArgumentException()
-          throws IOException, ExecutionException {
-    // Arrange
-    List<Put> puts = preparePuts();
-    puts.get(0).withCondition(new PutIfNotExists());
-    puts.get(3).withCondition(new PutIfNotExists());
-    puts.get(6).withCondition(new PutIfNotExists());
-
-    // Act
-    assertThatThrownBy(() -> storage.put(Arrays.asList(puts.get(0), puts.get(3), puts.get(6))))
-        .isInstanceOf(IllegalArgumentException.class);
-
-    // Assert
-    List<Result> results;
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 0))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 3))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 6))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-  }
-
-  @Test
-  public void put_MultiplePutWithDifferentPartitionsGiven_ShouldThrowIllegalArgumentException()
-      throws IOException, ExecutionException {
-    // Arrange
-    List<Put> puts = preparePuts();
-
-    // Act
-    assertThatThrownBy(() -> storage.put(Arrays.asList(puts.get(0), puts.get(3), puts.get(6))))
-        .isInstanceOf(IllegalArgumentException.class);
-
-    // Assert
-    List<Result> results;
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 0))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 3))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 6))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-  }
-
-  @Test
   public void put_MultiplePutWithDifferentConditionsGiven_ShouldStoreProperly()
       throws IOException, ExecutionException {
     // Arrange
@@ -1542,44 +1462,6 @@ public abstract class DistributedStorageIntegrationTestBase {
     assertThat(results.get(2).getValue(COL_NAME1).get().getAsInt()).isEqualTo(0);
     assertThat(results.get(2).getValue(COL_NAME4).isPresent()).isTrue();
     assertThat(results.get(2).getValue(COL_NAME4).get().getAsInt()).isEqualTo(pKey + cKey + 2);
-  }
-
-  @Test
-  public void mutate_MultiplePutWithDifferentPartitionsGiven_ShouldThrowIllegalArgumentException()
-      throws IOException, ExecutionException {
-    // Arrange
-    List<Put> puts = preparePuts();
-
-    // Act
-    assertThatCode(() -> storage.mutate(Arrays.asList(puts.get(0), puts.get(3), puts.get(6))))
-        .isInstanceOf(IllegalArgumentException.class);
-
-    // Assert
-    List<Result> results;
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 0))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 3))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
-    results =
-        scanAll(
-            Scan.newBuilder()
-                .namespace(namespace)
-                .table(TABLE)
-                .partitionKey(Key.ofInt(COL_NAME1, 6))
-                .build());
-    assertThat(results.size()).isEqualTo(0);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMutationAtomicityUnitIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageMutationAtomicityUnitIntegrationTestBase.java
@@ -1,0 +1,564 @@
+package com.scalar.db.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import com.scalar.db.service.StorageFactory;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class DistributedStorageMutationAtomicityUnitIntegrationTestBase {
+  protected static final Logger logger =
+      LoggerFactory.getLogger(DistributedStorageMutationAtomicityUnitIntegrationTestBase.class);
+
+  protected static final String TEST_NAME = "storage_mau";
+  protected static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
+  protected static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
+  protected static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
+  protected static final String TABLE1 = "test_table1";
+  protected static final String TABLE2 = "test_table2";
+  protected static final String COL_NAME1 = "c1";
+  protected static final String COL_NAME2 = "c2";
+  protected static final String COL_NAME3 = "c3";
+  protected static final String COL_NAME4 = "c4";
+  protected static final TableMetadata TABLE_METADATA =
+      TableMetadata.newBuilder()
+          .addColumn(COL_NAME1, DataType.INT)
+          .addColumn(COL_NAME2, DataType.INT)
+          .addColumn(COL_NAME3, DataType.INT)
+          .addColumn(COL_NAME4, DataType.INT)
+          .addPartitionKey(COL_NAME1)
+          .addClusteringKey(COL_NAME2)
+          .build();
+
+  protected DistributedStorage storage;
+  protected DistributedStorageAdmin admin;
+  protected String namespace1;
+  protected String namespace2;
+  protected String namespace3;
+
+  @BeforeAll
+  public void beforeAll() throws Exception {
+    initialize(TEST_NAME);
+    StorageFactory factory = StorageFactory.create(getProperties(TEST_NAME));
+    admin = factory.getStorageAdmin();
+    namespace1 = getNamespace1();
+    namespace2 = getNamespace2();
+    namespace3 = getNamespace3();
+    createTables();
+    storage = factory.getStorage();
+  }
+
+  protected void initialize(String testName) throws Exception {}
+
+  protected abstract Properties getProperties(String testName);
+
+  protected String getNamespace1() {
+    return NAMESPACE1;
+  }
+
+  protected String getNamespace2() {
+    return NAMESPACE2;
+  }
+
+  protected String getNamespace3() {
+    return NAMESPACE3;
+  }
+
+  protected void createTables() throws ExecutionException {
+    Map<String, String> options = getCreationOptions();
+    admin.createNamespace(namespace1, true, options);
+    admin.createNamespace(namespace2, true, options);
+    admin.createNamespace(namespace3, true, options);
+    admin.createTable(namespace1, TABLE1, TABLE_METADATA, true, options);
+    admin.createTable(namespace1, TABLE2, TABLE_METADATA, true, options);
+    admin.createTable(namespace2, TABLE1, TABLE_METADATA, true, options);
+    admin.createTable(namespace3, TABLE1, TABLE_METADATA, true, options);
+  }
+
+  protected Map<String, String> getCreationOptions() {
+    return Collections.emptyMap();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    truncateTable();
+  }
+
+  protected void truncateTable() throws ExecutionException {
+    admin.truncateTable(namespace1, TABLE1);
+    admin.truncateTable(namespace1, TABLE2);
+    admin.truncateTable(namespace2, TABLE1);
+    admin.truncateTable(namespace3, TABLE1);
+  }
+
+  @AfterAll
+  public void afterAll() throws Exception {
+    try {
+      dropTable();
+    } catch (Exception e) {
+      logger.warn("Failed to drop table", e);
+    }
+
+    try {
+      if (admin != null) {
+        admin.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close admin", e);
+    }
+
+    try {
+      if (storage != null) {
+        storage.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to close storage", e);
+    }
+  }
+
+  protected void dropTable() throws ExecutionException {
+    admin.dropTable(namespace1, TABLE1);
+    admin.dropTable(namespace1, TABLE2);
+    admin.dropTable(namespace2, TABLE1);
+    admin.dropTable(namespace3, TABLE1);
+    admin.dropNamespace(namespace1);
+    admin.dropNamespace(namespace2);
+    admin.dropNamespace(namespace3);
+  }
+
+  @Test
+  public void mutate_MutationsWithinRecordGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit()
+      throws ExecutionException {
+    // Arrange
+    Put put1 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME3, 1)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME4, 2)
+            .build();
+
+    // Act
+    Exception exception =
+        Assertions.catchException(() -> storage.mutate(Arrays.asList(put1, put2)));
+
+    // Assert
+    assertThat(exception).doesNotThrowAnyException();
+
+    Optional<Result> result =
+        storage.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE1)
+                .partitionKey(Key.ofInt(COL_NAME1, 0))
+                .clusteringKey(Key.ofInt(COL_NAME2, 1))
+                .build());
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(COL_NAME1)).isEqualTo(0);
+    assertThat(result.get().getInt(COL_NAME2)).isEqualTo(1);
+    assertThat(result.get().getInt(COL_NAME3)).isEqualTo(1);
+    assertThat(result.get().getInt(COL_NAME4)).isEqualTo(2);
+  }
+
+  @Test
+  public void
+      mutate_MutationsWithinPartitionGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit()
+          throws ExecutionException {
+    // Arrange
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .intValue(COL_NAME3, 3)
+            .build());
+
+    Put put1 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME3, 1)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 2))
+            .intValue(COL_NAME3, 2)
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .build();
+
+    // Act
+    Exception exception =
+        Assertions.catchException(() -> storage.mutate(Arrays.asList(put1, put2, delete)));
+
+    // Assert
+    StorageInfo storageInfo = admin.getStorageInfo(namespace1);
+    switch (storageInfo.getMutationAtomicityUnit()) {
+      case RECORD:
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        break;
+      case PARTITION:
+      case TABLE:
+      case NAMESPACE:
+      case STORAGE:
+        assertThat(exception).doesNotThrowAnyException();
+
+        Optional<Result> result1 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 0))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 1))
+                    .build());
+        assertThat(result1).isPresent();
+        assertThat(result1.get().getInt(COL_NAME1)).isEqualTo(0);
+        assertThat(result1.get().getInt(COL_NAME2)).isEqualTo(1);
+        assertThat(result1.get().getInt(COL_NAME3)).isEqualTo(1);
+
+        Optional<Result> result2 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 0))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 2))
+                    .build());
+        assertThat(result2).isPresent();
+        assertThat(result2.get().getInt(COL_NAME1)).isEqualTo(0);
+        assertThat(result2.get().getInt(COL_NAME2)).isEqualTo(2);
+        assertThat(result2.get().getInt(COL_NAME3)).isEqualTo(2);
+
+        Optional<Result> result3 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 0))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 3))
+                    .build());
+        assertThat(result3).isEmpty();
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @Test
+  public void mutate_MutationsWithinTableGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit()
+      throws ExecutionException {
+    // Arrange
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 2))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .intValue(COL_NAME3, 3)
+            .build());
+
+    Put put1 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME3, 1)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 1))
+            .clusteringKey(Key.ofInt(COL_NAME2, 2))
+            .intValue(COL_NAME3, 2)
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 2))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .build();
+
+    // Act
+    Exception exception =
+        Assertions.catchException(() -> storage.mutate(Arrays.asList(put1, put2, delete)));
+
+    // Assert
+    StorageInfo storageInfo = admin.getStorageInfo(namespace1);
+    switch (storageInfo.getMutationAtomicityUnit()) {
+      case RECORD:
+      case PARTITION:
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        break;
+      case TABLE:
+      case NAMESPACE:
+      case STORAGE:
+        assertThat(exception).doesNotThrowAnyException();
+
+        Optional<Result> result1 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 0))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 1))
+                    .build());
+        assertThat(result1).isPresent();
+        assertThat(result1.get().getInt(COL_NAME1)).isEqualTo(0);
+        assertThat(result1.get().getInt(COL_NAME2)).isEqualTo(1);
+        assertThat(result1.get().getInt(COL_NAME3)).isEqualTo(1);
+
+        Optional<Result> result2 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 1))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 2))
+                    .build());
+        assertThat(result2).isPresent();
+        assertThat(result2.get().getInt(COL_NAME1)).isEqualTo(1);
+        assertThat(result2.get().getInt(COL_NAME2)).isEqualTo(2);
+        assertThat(result2.get().getInt(COL_NAME3)).isEqualTo(2);
+
+        Optional<Result> result3 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 2))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 3))
+                    .build());
+        assertThat(result3).isEmpty();
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @Test
+  public void
+      mutate_MutationsWithinNamespaceGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit()
+          throws ExecutionException {
+    // Arrange
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 2))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .intValue(COL_NAME3, 3)
+            .build());
+
+    Put put1 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME3, 1)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE2)
+            .partitionKey(Key.ofInt(COL_NAME1, 1))
+            .clusteringKey(Key.ofInt(COL_NAME2, 2))
+            .intValue(COL_NAME3, 2)
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 2))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .build();
+
+    // Act
+    Exception exception =
+        Assertions.catchException(() -> storage.mutate(Arrays.asList(put1, put2, delete)));
+
+    // Assert
+    StorageInfo storageInfo = admin.getStorageInfo(namespace1);
+    switch (storageInfo.getMutationAtomicityUnit()) {
+      case RECORD:
+      case PARTITION:
+      case TABLE:
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        break;
+      case NAMESPACE:
+      case STORAGE:
+        assertThat(exception).doesNotThrowAnyException();
+
+        Optional<Result> result1 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 0))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 1))
+                    .build());
+        assertThat(result1).isPresent();
+        assertThat(result1.get().getInt(COL_NAME1)).isEqualTo(0);
+        assertThat(result1.get().getInt(COL_NAME2)).isEqualTo(1);
+        assertThat(result1.get().getInt(COL_NAME3)).isEqualTo(1);
+
+        Optional<Result> result2 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE2)
+                    .partitionKey(Key.ofInt(COL_NAME1, 1))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 2))
+                    .build());
+        assertThat(result2).isPresent();
+        assertThat(result2.get().getInt(COL_NAME1)).isEqualTo(1);
+        assertThat(result2.get().getInt(COL_NAME2)).isEqualTo(2);
+        assertThat(result2.get().getInt(COL_NAME3)).isEqualTo(2);
+
+        Optional<Result> result3 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 2))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 3))
+                    .build());
+        assertThat(result3).isEmpty();
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @Test
+  public void mutate_MutationsWithinStorageGiven_ShouldBehaveCorrectlyBaseOnMutationAtomicityUnit()
+      throws ExecutionException {
+    // Arrange
+    storage.put(
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 2))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .intValue(COL_NAME3, 3)
+            .build());
+
+    Put put1 =
+        Put.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 0))
+            .clusteringKey(Key.ofInt(COL_NAME2, 1))
+            .intValue(COL_NAME3, 1)
+            .build();
+    Put put2 =
+        Put.newBuilder()
+            .namespace(namespace2)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 1))
+            .clusteringKey(Key.ofInt(COL_NAME2, 2))
+            .intValue(COL_NAME3, 2)
+            .build();
+    Delete delete =
+        Delete.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE1)
+            .partitionKey(Key.ofInt(COL_NAME1, 2))
+            .clusteringKey(Key.ofInt(COL_NAME2, 3))
+            .build();
+
+    // Act
+    Exception exception =
+        Assertions.catchException(() -> storage.mutate(Arrays.asList(put1, put2, delete)));
+
+    // Assert
+    StorageInfo storageInfo = admin.getStorageInfo(namespace1);
+    switch (storageInfo.getMutationAtomicityUnit()) {
+      case RECORD:
+      case PARTITION:
+      case TABLE:
+      case NAMESPACE:
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        break;
+      case STORAGE:
+        assertThat(exception).doesNotThrowAnyException();
+
+        Optional<Result> result1 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 0))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 1))
+                    .build());
+        assertThat(result1).isPresent();
+        assertThat(result1.get().getInt(COL_NAME1)).isEqualTo(0);
+        assertThat(result1.get().getInt(COL_NAME2)).isEqualTo(1);
+        assertThat(result1.get().getInt(COL_NAME3)).isEqualTo(1);
+
+        Optional<Result> result2 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace2)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 1))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 2))
+                    .build());
+        assertThat(result2).isPresent();
+        assertThat(result2.get().getInt(COL_NAME1)).isEqualTo(1);
+        assertThat(result2.get().getInt(COL_NAME2)).isEqualTo(2);
+        assertThat(result2.get().getInt(COL_NAME3)).isEqualTo(2);
+
+        Optional<Result> result3 =
+            storage.get(
+                Get.newBuilder()
+                    .namespace(namespace1)
+                    .table(TABLE1)
+                    .partitionKey(Key.ofInt(COL_NAME1, 2))
+                    .clusteringKey(Key.ofInt(COL_NAME2, 3))
+                    .build());
+        assertThat(result3).isEmpty();
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces `StorageInfo`, which provides metadata about the storage.

Currently, it includes the following information:
- Storage name
- Mutation atomicity unit: Defines the scope of atomicity for mutations.
- Maximum atomic mutation count: The maximum number of mutations that can be performed atomically in the storage.

For more details, refer to the `StorageInfo` interface.

You can get a `StorageInfo` instance via the `DistributedStorageAdmin.getStorageInfo()` method.

This PR also extends the behavior of the `DistributedStorage.mutate()` method based on the storage’s mutation atomicity unit and maximum atomic mutation count. For details, see the Javadoc for the `DistributedStorage.mutate()` method.

## Related issues and/or PRs

N/A

## Changes made

Added some inline comments. Please take a look for the details.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Introduced `StorageInfo`, which provides metadata about the storage. You can obtain a `StorageInfo` instance via the `DistributedStorageAdmin.getStorageInfo()` method.
