### PR TITLE
Add Docker support for ScalarDB Data Loader CLI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,8 +67,12 @@ jobs:
         run: |
           mkdir -p /tmp/gradle_test_reports/core
           mkdir -p /tmp/gradle_test_reports/schema-loader
+          mkdir -p /tmp/gradle_test_reports/data-loader/core
+          mkdir -p /tmp/gradle_test_reports/data-loader/cli
           cp -a core/build/reports/tests/test /tmp/gradle_test_reports/core/
           cp -a schema-loader/build/reports/tests/test /tmp/gradle_test_reports/schema-loader/
+          cp -a data-loader/core/build/reports/tests/test /tmp/gradle_test_reports/data-loader/core/
+          cp -a data-loader/cli/build/reports/tests/test /tmp/gradle_test_reports/data-loader/cli/
 
       - name: Upload Gradle test reports
         if: always()
@@ -83,9 +87,13 @@ jobs:
           mkdir -p /tmp/gradle_spotbugs_reports/core
           mkdir -p /tmp/gradle_spotbugs_reports/schema-loader
           mkdir -p /tmp/gradle_spotbugs_reports/integration-test
+          mkdir -p /tmp/gradle_spotbugs_reports/data-loader/core
+          mkdir -p /tmp/gradle_spotbugs_reports/data-loader/cli
           cp -a core/build/reports/spotbugs /tmp/gradle_spotbugs_reports/core/
           cp -a schema-loader/build/reports/spotbugs /tmp/gradle_spotbugs_reports/schema-loader/
           cp -a integration-test/build/reports/spotbugs /tmp/gradle_spotbugs_reports/integration-test/
+          cp -a data-loader/core/build/reports/spotbugs /tmp/gradle_spotbugs_reports/data-loader/core/
+          cp -a data-loader/cli/build/reports/spotbugs /tmp/gradle_spotbugs_reports/data-loader/cli/
 
       - name: Upload Spotbugs reports
         if: always()
@@ -112,6 +120,9 @@ jobs:
 
       - name: Dockerfile Lint for ScalarDB Schema Loader
         run: ./gradlew schema-loader:dockerfileLint
+
+      - name: Dockerfile Lint for ScalarDB Data Loader CLI
+        run: ./gradlew data-loader:cli:dockerfileLint
 
   integration-test-for-cassandra-3-0:
     name: Cassandra 3.0 integration test (${{ matrix.mode.label }})

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -77,3 +77,16 @@ jobs:
           asset_path: schema-loader/build/libs/scalardb-schema-loader-${{ steps.version.outputs.version }}.jar
           asset_name: scalardb-schema-loader-${{ steps.version.outputs.version }}.jar
           asset_content_type: application/java-archive
+
+      - name: Build scalardb-data-loader-cli jar
+        run: ./gradlew :data-loader:cli:shadowJar
+
+      - name: Upload scalardb-data-loader-cli jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: data-loader/cli/build/libs/scalardb-data-loader-cli-${{ steps.version.outputs.version }}.jar
+          asset_name: scalardb-data-loader-cli-${{ steps.version.outputs.version }}.jar
+          asset_content_type: application/java-archive

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -56,3 +56,4 @@ jobs:
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: |
           docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardb-data-loader-cli:${{ steps.version.outputs.version }}

--- a/.github/workflows/remove-untagged-images.yaml
+++ b/.github/workflows/remove-untagged-images.yaml
@@ -25,3 +25,9 @@ jobs:
         with:
           github-token: ${{ secrets.CR_PAT }}
           package-name: scalardb-schema-loader
+
+      - name: scalardb-data-loader-cli
+        uses: camargo/delete-untagged-action@v1
+        with:
+          github-token: ${{ secrets.CR_PAT }}
+          package-name: scalardb-data-loader-cli

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: Push containers
         run: |
           docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardb-data-loader-cli:${{ steps.version.outputs.version }}
 
       - name: Upload scalardb, scalardb-schema-loader, scalardb-data-loader-core, and scalardb-integration-test to Maven Central Repository
         run: |

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -25,7 +25,7 @@ jobs:
     with:
       target-ref: ${{ inputs.target-ref }}
       find-latest-release: ${{ inputs.find-latest-release }}
-      images: '[["ScalarDB Schema Loader", "scalardb-schema-loader"]]'
+      images: '[["ScalarDB Schema Loader", "scalardb-schema-loader"], ["ScalarDB Data Loader CLI", "scalardb-data-loader-cli"]]'
       version-command: "./gradlew :core:properties -q | grep version: | awk '{print $2}'"
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}

--- a/data-loader/cli/Dockerfile
+++ b/data-loader/cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jre-jammy
 
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 COPY scalardb-data-loader-*.jar /app.jar

--- a/data-loader/cli/Dockerfile
+++ b/data-loader/cli/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:8-jre-jammy
+
+RUN apt-get update && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY scalardb-data-loader-*.jar /app.jar
+
+RUN groupadd -r --gid 201 scalar && \
+    useradd -r --uid 201 -g scalar scalar
+
+USER 201
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -59,3 +59,23 @@ spotbugsTest.reports {
     html.enabled = true
 }
 spotbugsTest.excludeFilter = file("${project.rootDir}/gradle/spotbugs-exclude.xml")
+
+task dockerfileLint(type: Exec) {
+    description 'Lint the Dockerfile'
+    commandLine "${project.rootDir}/ci/dockerfile_lint.sh"
+}
+
+task copyFilesToDockerBuildContextDir(type: Copy) {
+    description 'Copy files to a temporary folder to build the Docker image'
+    dependsOn shadowJar
+    from("Dockerfile")
+    from(tasks.shadowJar.archiveFile)
+    into('build/docker')
+}
+
+task docker(type: Exec) {
+    description 'Build ScalarDB Data Loader Docker image'
+    dependsOn copyFilesToDockerBuildContextDir
+    workingDir 'build/docker'
+    commandLine 'docker', 'build', "--tag=ghcr.io/scalar-labs/scalardb-data-loader:${project.version}", "."
+}

--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -77,5 +77,5 @@ task docker(type: Exec) {
     description 'Build ScalarDB Data Loader Docker image'
     dependsOn copyFilesToDockerBuildContextDir
     workingDir 'build/docker'
-    commandLine 'docker', 'build', "--tag=ghcr.io/scalar-labs/scalardb-data-loader:${project.version}", "."
+    commandLine 'docker', 'build', "--tag=ghcr.io/scalar-labs/scalardb-data-loader-cli:${project.version}", "."
 }

--- a/data-loader/cli/build.gradle
+++ b/data-loader/cli/build.gradle
@@ -74,7 +74,7 @@ task copyFilesToDockerBuildContextDir(type: Copy) {
 }
 
 task docker(type: Exec) {
-    description 'Build ScalarDB Data Loader Docker image'
+    description 'Build ScalarDB Data Loader Docker CLI image'
     dependsOn copyFilesToDockerBuildContextDir
     workingDir 'build/docker'
     commandLine 'docker', 'build', "--tag=ghcr.io/scalar-labs/scalardb-data-loader-cli:${project.version}", "."


### PR DESCRIPTION

## Description

This PR adds Docker support for the ScalarDB Data Loader CLI. Also, make it part of the CI workflows. PTAL. Thank you.

## Related issues and/or PRs

N/A

## Changes made

- Added a new Dockerfile for the ScalarDB Data Loader CLI
- Updated the `build.gradle` file for the data-loader CLI to support Docker builds
- Modified GitHub workflow files to include the data-loader CLI in the CI/CD pipeline:
  - Updated release-snapshot.yaml to build and push the data-loader CLI Docker image
  - Updated upload-artifacts.yaml to include the data-loader CLI in the artifact upload process
  - Updated create-release.yaml to build and upload the data-loader CLI JAR file
  - Updated vuln-check.yaml to include the data-loader CLI in vulnerability scanning

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes

N/A

## Release notes

Added Docker support for the ScalarDB Data Loader CLI, enabling containerized deployment of the data loading functionality.