### PR TITLE
Fix potential connection leak when using `jdbc` storage and Scan operation fails because the target table doesn't exist

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -105,7 +105,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       connection.setAutoCommit(false);
       rdbEngine.setConnectionToReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
-    } catch (SQLException e) {
+    } catch (Exception e) {
       try {
         if (connection != null) {
           connection.rollback();

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -105,7 +105,7 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       connection.setAutoCommit(false);
       rdbEngine.setConnectionToReadOnly(connection, true);
       return jdbcService.getScanner(scan, connection);
-    } catch (Exception e) {
+    } catch (SQLException e) {
       try {
         if (connection != null) {
           connection.rollback();
@@ -117,6 +117,11 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       close(connection);
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_SELECTION.buildMessage(e.getMessage()), e);
+    } catch (Exception e) {
+      if (connection != null) {
+        close(connection);
+      }
+      throw e;
     }
   }
 

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -118,9 +118,15 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_SELECTION.buildMessage(e.getMessage()), e);
     } catch (Exception e) {
-      if (connection != null) {
-        close(connection);
+      try {
+        if (connection != null) {
+          connection.rollback();
+        }
+      } catch (SQLException ex) {
+        e.addSuppressed(ex);
       }
+
+      close(connection);
       throw e;
     }
   }

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -197,6 +197,9 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       close(connection);
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);
+    } catch (Exception e) {
+      close(connection);
+      throw e;
     }
 
     try {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -140,7 +140,7 @@ public class JdbcDatabaseTest {
 
   @Test
   public void
-      whenScanOperationExecutedAndJdbcServiceThrowsIllegalArgumentException_shouldThrowExecutionException()
+      whenScanOperationExecutedAndJdbcServiceThrowsIllegalArgumentException_shouldCloseConnectionAndThrowIllegalArgumentException()
           throws Exception {
     // Arrange
     Exception cause = new IllegalArgumentException("Table not found");
@@ -153,11 +153,7 @@ public class JdbcDatabaseTest {
               Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
               jdbcDatabase.scan(scan);
             })
-        .isInstanceOf(ExecutionException.class)
-        .hasCause(cause);
-    verify(connection).setAutoCommit(false);
-    verify(connection).setReadOnly(true);
-    verify(connection).rollback();
+        .isInstanceOf(IllegalArgumentException.class);
     verify(connection).close();
   }
 

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -140,6 +140,29 @@ public class JdbcDatabaseTest {
 
   @Test
   public void
+      whenScanOperationExecutedAndJdbcServiceThrowsIllegalArgumentException_shouldThrowExecutionException()
+          throws Exception {
+    // Arrange
+    Exception cause = new IllegalArgumentException("Table not found");
+    // Simulate the table not found scenario.
+    when(jdbcService.getScanner(any(), any())).thenThrow(cause);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              jdbcDatabase.scan(scan);
+            })
+        .isInstanceOf(ExecutionException.class)
+        .hasCause(cause);
+    verify(connection).setAutoCommit(false);
+    verify(connection).setReadOnly(true);
+    verify(connection).rollback();
+    verify(connection).close();
+  }
+
+  @Test
+  public void
       whenScanOperationExecutedAndScannerClosed_SQLExceptionThrownByConnectionCommit_shouldThrowIOException()
           throws Exception {
     // Arrange


### PR DESCRIPTION
## Description

I found the current `com.scalar.db.storage.jdbc.JdbcDatabase#scan` doesn't close the connection when the target table doesn't exist. This PR fixes the issue.

## Related issues and/or PRs

None

## Changes made

- Close the connection for Scan operation in `JdbcDatabase.scan()` whenever an exception is thrown not only when SQLException is thrown, since `IllegalArgumentException` can be thrown when the target table doesn't exist

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

Fixed potential connection leak when using `jdbc` storage and Scan operation fails because the target table doesn't exist
