### PR TITLE
Fix CVE-2025-49146

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
         awssdkVersion = '2.30.2'
         commonsDbcp2Version = '2.13.0'
         mysqlDriverVersion = '8.4.0'
-        postgresqlDriverVersion = '42.7.5'
+        postgresqlDriverVersion = '42.7.7'
         oracleDriverVersion = '23.6.0.24.10'
         sqlserverDriverVersion = '12.8.1.jre8'
         sqliteDriverVersion = '3.48.0.0'


### PR DESCRIPTION
## Description

This PR fixes CVE-2025-49146 by bumping up the PostgreSQL driver to `42.7.7`.

## Related issues and/or PRs

N/A

## Changes made



## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Upgraded the PostgreSQL driver to fix security issues. CVE-2025-49146
