### PR TITLE
Backport to branch(3.14) : Fix potential connection leak when using `jdbc` storage and Scan operation fails because the target table doesn't exist

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcDatabase.java
@@ -102,6 +102,17 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       close(connection);
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_SELECTION.buildMessage(e.getMessage()), e);
+    } catch (Exception e) {
+      try {
+        if (connection != null) {
+          connection.rollback();
+        }
+      } catch (SQLException ex) {
+        e.addSuppressed(ex);
+      }
+
+      close(connection);
+      throw e;
     }
   }
 
@@ -171,6 +182,9 @@ public class JdbcDatabase extends AbstractDistributedStorage {
       close(connection);
       throw new ExecutionException(
           CoreError.JDBC_ERROR_OCCURRED_IN_MUTATION.buildMessage(e.getMessage()), e);
+    } catch (Exception e) {
+      close(connection);
+      throw e;
     }
 
     try {

--- a/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
+++ b/core/src/test/java/com/scalar/db/storage/jdbc/JdbcDatabaseTest.java
@@ -2,6 +2,9 @@ package com.scalar.db.storage.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -122,6 +125,25 @@ public class JdbcDatabaseTest {
               jdbcDatabase.scan(scan);
             })
         .isInstanceOf(ExecutionException.class);
+    verify(connection).close();
+  }
+
+  @Test
+  public void
+      whenScanOperationExecutedAndJdbcServiceThrowsIllegalArgumentException_shouldCloseConnectionAndThrowIllegalArgumentException()
+          throws Exception {
+    // Arrange
+    Exception cause = new IllegalArgumentException("Table not found");
+    // Simulate the table not found scenario.
+    when(jdbcService.getScanner(any(), any())).thenThrow(cause);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              Scan scan = new Scan(new Key("p1", "val")).forNamespace(NAMESPACE).forTable(TABLE);
+              jdbcDatabase.scan(scan);
+            })
+        .isInstanceOf(IllegalArgumentException.class);
     verify(connection).close();
   }
 
@@ -328,6 +350,32 @@ public class JdbcDatabaseTest {
               jdbcDatabase.mutate(Arrays.asList(put, delete));
             })
         .isInstanceOf(RetriableExecutionException.class);
+    verify(connection).close();
+  }
+
+  @Test
+  public void mutate_WhenSettingAutoCommitFails_ShouldThrowExceptionAndCloseConnection()
+      throws SQLException, ExecutionException {
+    // Arrange
+    Exception exception = new RuntimeException("Failed to set auto-commit");
+    doThrow(exception).when(connection).setAutoCommit(anyBoolean());
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> {
+              Put put =
+                  new Put(new Key("p1", "val1"))
+                      .withValue("v1", "val2")
+                      .forNamespace(NAMESPACE)
+                      .forTable(TABLE);
+              Delete delete =
+                  new Delete(new Key("p1", "val1")).forNamespace(NAMESPACE).forTable(TABLE);
+              jdbcDatabase.mutate(Arrays.asList(put, delete));
+            })
+        .isEqualTo(exception);
+    verify(connection).setAutoCommit(false);
+    verify(jdbcService, never()).mutate(any(), any());
+    verify(connection, never()).rollback();
     verify(connection).close();
   }
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2766
- **Commit to backport:** 644578b1fd323bc784b4fa93bce76317e90c4302

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.14-pull-2766 &&
git cherry-pick --no-rerere-autoupdate -m1 644578b1fd323bc784b4fa93bce76317e90c4302
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!