### PR TITLE
Backport to branch(3.14) : Fix CVE-2025-49146

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
         awssdkVersion = '2.28.6'
         commonsDbcp2Version = '2.12.0'
         mysqlDriverVersion = '8.4.0'
-        postgresqlDriverVersion = '42.7.4'
+        postgresqlDriverVersion = '42.7.7'
         oracleDriverVersion = '21.15.0.0'
         sqlserverDriverVersion = '11.2.3.jre8'
         sqliteDriverVersion = '3.46.1.3'


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2772
- **Commit to backport:** 4054e6b568cc4bfb1224f5261058b24b828a3f33

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.14-pull-2772 &&
git cherry-pick --no-rerere-autoupdate -m1 4054e6b568cc4bfb1224f5261058b24b828a3f33
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!