### PR TITLE
Prevent overwriting read set in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -164,11 +164,10 @@ public class CrudHandler {
     }
 
     if (result.isPresent() || get.getConjunctions().isEmpty()) {
-      // Keep the read set latest to create before image by using the latest record (result)
-      // because another conflicting transaction might have updated the record after this
-      // transaction read it first. However, we update it only if a get operation has no
-      // conjunction or the result exists. This is because we don’t know whether the record
-      // actually exists or not due to the conjunction.
+      // We put the result into the read set only if a get operation has no conjunction or the
+      // result exists. This is because we don’t know whether the record actually exists or not
+      // due to the conjunction.
+
       if (key != null) {
         putIntoReadSetInSnapshot(key, result);
       } else {
@@ -277,9 +276,6 @@ public class CrudHandler {
     }
 
     if (ret.isPresent()) {
-      // We always update the read set to create before image by using the latest record (result)
-      // because another conflicting transaction might have updated the record after this
-      // transaction read it first.
       putIntoReadSetInSnapshot(key, ret);
     }
 
@@ -319,7 +315,7 @@ public class CrudHandler {
 
   private void putIntoReadSetInSnapshot(Snapshot.Key key, Optional<TransactionResult> result) {
     // In read-only mode, we don't need to put the result into the read set
-    if (!readOnly) {
+    if (!readOnly && !snapshot.containsKeyInReadSet(key)) {
       snapshot.putIntoReadSet(key, result);
     }
   }

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -1,6 +1,7 @@
 package com.scalar.db.transaction.consensuscommit;
 
 import static com.scalar.db.api.ConditionBuilder.column;
+import static com.scalar.db.api.ConditionBuilder.updateIf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -45,6 +46,7 @@ import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.CrudConflictException;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.exception.transaction.PreparationConflictException;
+import com.scalar.db.exception.transaction.RollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.io.DataType;
@@ -5891,6 +5893,91 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     assertThat(results.get(1).getInt(ACCOUNT_ID)).isEqualTo(0);
     assertThat(results.get(1).getInt(ACCOUNT_TYPE)).isEqualTo(2);
     assertThat(results.get(1).getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @Test
+  public void
+      commit_ConflictingExternalUpdate_DifferentGetButSameRecordReturned_ShouldThrowCommitConflictExceptionAndPreserveExternalChanges()
+          throws UnknownTransactionStatusException, CrudException, RollbackException {
+    // Arrange
+    manager.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, INITIAL_BALANCE)
+            .build());
+
+    // Act Assert
+    DistributedTransaction transaction = manager.begin();
+
+    // Retrieve the record
+    Optional<Result> result =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .build());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    // Update the balance of the record
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .condition(updateIf(column(BALANCE).isEqualToInt(INITIAL_BALANCE)).build())
+            .intValue(BALANCE, 100)
+            .build());
+
+    // Update the balance of the record by another transaction
+    manager.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, 200)
+            .build());
+
+    // Retrieve the record again, but use a different Get object (with a where clause)
+    result =
+        transaction.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .where(column(BALANCE).isEqualToInt(200))
+                .build());
+
+    assertThat(result).isNotPresent();
+
+    assertThatThrownBy(transaction::commit).isInstanceOf(CommitConflictException.class);
+    transaction.rollback();
+
+    // Assert
+    result =
+        manager.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .build());
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(ACCOUNT_ID)).isEqualTo(0);
+    assertThat(result.get().getInt(ACCOUNT_TYPE)).isEqualTo(0);
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(200);
   }
 
   @Test


### PR DESCRIPTION
## Description

Currently, we always update the read set when the same record is read multiple times from storage. However, this behavior can lead to anomalies like lost updates.

You can reproduce the issue with the following test:
https://github.com/scalar-labs/scalardb/pull/2797/files#diff-7d8b7163e906546d45d9a7b662f97eb671e39030217ab77ef22325b0f74c2b5eR5898-R5981

In the test, two slightly different Get operations are used to force reading the same record multiple times from storage and bypass snapshot reads.

## Related issues and/or PRs

N/A

## Changes made

- Updated the code to prevent overwriting read set.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed an issue in Consensus Commit where reading the same record multiple times from storage could cause anomalies like lost updates. The read set is no longer updated on repeated reads to resolve this issue.
