### PR TITLE
Improve read process in Consensus Commit

### DIFF
--- a/core/src/main/java/com/scalar/db/common/error/CoreError.java
+++ b/core/src/main/java/com/scalar/db/common/error/CoreError.java
@@ -1241,6 +1241,8 @@ public enum CoreError implements ScalarDbError {
       "Getting the storage information failed. Namespace: %s",
       "",
       ""),
+  CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED(
+      Category.INTERNAL_ERROR, "0057", "Recovering records failed. Details: %s", "", ""),
 
   //
   // Errors for the unknown transaction status error category

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitMutationComposer.java
@@ -6,6 +6,7 @@ import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toStateValue;
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getTransactionTableMetadata;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.ConditionBuilder;
@@ -105,7 +106,7 @@ public class CommitMutationComposer extends AbstractMutationComposer {
     // Set before image columns to null
     if (result != null) {
       TransactionTableMetadata transactionTableMetadata =
-          tableMetadataManager.getTransactionTableMetadata(base);
+          getTransactionTableMetadata(tableMetadataManager, base);
       LinkedHashSet<String> beforeImageColumnNames =
           transactionTableMetadata.getBeforeImageColumnNames();
       TableMetadata tableMetadata = transactionTableMetadata.getTableMetadata();
@@ -137,8 +138,9 @@ public class CommitMutationComposer extends AbstractMutationComposer {
       assert base instanceof Selection;
       if (result != null) {
         // for rollforward in lazy recovery
-        TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
-        return ScalarDbUtils.getPartitionKey(result, metadata.getTableMetadata());
+        TransactionTableMetadata transactionTableMetadata =
+            getTransactionTableMetadata(tableMetadataManager, base);
+        return ScalarDbUtils.getPartitionKey(result, transactionTableMetadata.getTableMetadata());
       } else {
         throw new AssertionError(
             "This path should not be reached since the EXTRA_WRITE strategy is deleted");
@@ -155,8 +157,9 @@ public class CommitMutationComposer extends AbstractMutationComposer {
       assert base instanceof Selection;
       if (result != null) {
         // for rollforward in lazy recovery
-        TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
-        return ScalarDbUtils.getClusteringKey(result, metadata.getTableMetadata());
+        TransactionTableMetadata transactionTableMetadata =
+            getTransactionTableMetadata(tableMetadataManager, base);
+        return ScalarDbUtils.getClusteringKey(result, transactionTableMetadata.getTableMetadata());
       } else {
         throw new AssertionError(
             "This path should not be reached since the EXTRA_WRITE strategy is deleted");

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommit.java
@@ -24,10 +24,8 @@ import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
 import com.scalar.db.util.ScalarDbUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
@@ -51,24 +49,19 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
   private static final Logger logger = LoggerFactory.getLogger(ConsensusCommit.class);
   private final CrudHandler crud;
   private final CommitHandler commit;
-  private final RecoveryHandler recovery;
   private final ConsensusCommitMutationOperationChecker mutationOperationChecker;
   @Nullable private final CoordinatorGroupCommitter groupCommitter;
-  private Runnable beforeRecoveryHook;
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ConsensusCommit(
       CrudHandler crud,
       CommitHandler commit,
-      RecoveryHandler recovery,
       ConsensusCommitMutationOperationChecker mutationOperationChecker,
       @Nullable CoordinatorGroupCommitter groupCommitter) {
     this.crud = checkNotNull(crud);
     this.commit = checkNotNull(commit);
-    this.recovery = checkNotNull(recovery);
     this.mutationOperationChecker = mutationOperationChecker;
     this.groupCommitter = groupCommitter;
-    this.beforeRecoveryHook = () -> {};
   }
 
   @Override
@@ -78,63 +71,18 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
 
   @Override
   public Optional<Result> get(Get get) throws CrudException {
-    get = copyAndSetTargetToIfNot(get);
-    try {
-      return crud.get(get);
-    } catch (UncommittedRecordException e) {
-      lazyRecovery(e);
-      throw e;
-    }
+    return crud.get(copyAndSetTargetToIfNot(get));
   }
 
   @Override
   public List<Result> scan(Scan scan) throws CrudException {
-    scan = copyAndSetTargetToIfNot(scan);
-    try {
-      return crud.scan(scan);
-    } catch (UncommittedRecordException e) {
-      lazyRecovery(e);
-      throw e;
-    }
+    return crud.scan(copyAndSetTargetToIfNot(scan));
   }
 
   @Override
   public Scanner getScanner(Scan scan) throws CrudException {
     scan = copyAndSetTargetToIfNot(scan);
-    Scanner scanner = crud.getScanner(scan);
-
-    return new Scanner() {
-      @Override
-      public Optional<Result> one() throws CrudException {
-        try {
-          return scanner.one();
-        } catch (UncommittedRecordException e) {
-          lazyRecovery(e);
-          throw e;
-        }
-      }
-
-      @Override
-      public List<Result> all() throws CrudException {
-        try {
-          return scanner.all();
-        } catch (UncommittedRecordException e) {
-          lazyRecovery(e);
-          throw e;
-        }
-      }
-
-      @Override
-      public void close() throws CrudException {
-        scanner.close();
-      }
-
-      @Nonnull
-      @Override
-      public Iterator<Result> iterator() {
-        return scanner.iterator();
-      }
-    };
+    return crud.getScanner(scan);
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -143,12 +91,7 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
   public void put(Put put) throws CrudException {
     put = copyAndSetTargetToIfNot(put);
     checkMutation(put);
-    try {
-      crud.put(put);
-    } catch (UncommittedRecordException e) {
-      lazyRecovery(e);
-      throw e;
-    }
+    crud.put(put);
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -165,12 +108,7 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
   public void delete(Delete delete) throws CrudException {
     delete = copyAndSetTargetToIfNot(delete);
     checkMutation(delete);
-    try {
-      crud.delete(delete);
-    } catch (UncommittedRecordException e) {
-      lazyRecovery(e);
-      throw e;
-    }
+    crud.delete(delete);
   }
 
   /** @deprecated As of release 3.13.0. Will be removed in release 5.0.0. */
@@ -196,12 +134,7 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     upsert = copyAndSetTargetToIfNot(upsert);
     Put put = ConsensusCommitUtils.createPutForUpsert(upsert);
     checkMutation(put);
-    try {
-      crud.put(put);
-    } catch (UncommittedRecordException e) {
-      lazyRecovery(e);
-      throw e;
-    }
+    crud.put(put);
   }
 
   @Override
@@ -222,9 +155,6 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
 
       // If the condition is not specified, it means that the record does not exist. In this case,
       // we do nothing
-    } catch (UncommittedRecordException e) {
-      lazyRecovery(e);
-      throw e;
     }
   }
 
@@ -257,9 +187,6 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     try {
       crud.readIfImplicitPreReadEnabled();
     } catch (CrudConflictException e) {
-      if (e instanceof UncommittedRecordException) {
-        lazyRecovery((UncommittedRecordException) e);
-      }
       throw new CommitConflictException(
           CoreError.CONSENSUS_COMMIT_CONFLICT_OCCURRED_WHILE_IMPLICIT_PRE_READ.buildMessage(),
           e,
@@ -267,6 +194,12 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
     } catch (CrudException e) {
       throw new CommitException(
           CoreError.CONSENSUS_COMMIT_EXECUTING_IMPLICIT_PRE_READ_FAILED.buildMessage(), e, getId());
+    }
+
+    try {
+      crud.waitForRecoveryCompletionIfNecessary();
+    } catch (CrudException e) {
+      throw new CommitException(e.getMessage(), e, getId());
     }
 
     commit.commit(crud.getSnapshot(), crud.isReadOnly());
@@ -293,22 +226,6 @@ public class ConsensusCommit extends AbstractDistributedTransaction {
   @VisibleForTesting
   CommitHandler getCommitHandler() {
     return commit;
-  }
-
-  @VisibleForTesting
-  RecoveryHandler getRecoveryHandler() {
-    return recovery;
-  }
-
-  @VisibleForTesting
-  void setBeforeRecoveryHook(Runnable beforeRecoveryHook) {
-    this.beforeRecoveryHook = beforeRecoveryHook;
-  }
-
-  private void lazyRecovery(UncommittedRecordException e) {
-    logger.debug("Recover uncommitted records: {}", e.getResults());
-    beforeRecoveryHook.run();
-    e.getResults().forEach(r -> recovery.recover(e.getSelection(), r));
   }
 
   private void checkMutation(Mutation mutation) throws CrudException {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfig.java
@@ -35,12 +35,9 @@ public class ConsensusCommitConfig {
 
   public static final String COORDINATOR_WRITE_OMISSION_ON_READ_ONLY_ENABLED =
       PREFIX + "coordinator.write_omission_on_read_only.enabled";
-
+  public static final String RECOVERY_EXECUTOR_COUNT = PREFIX + "recovery_executor_count";
   public static final String PARALLEL_IMPLICIT_PRE_READ =
       PREFIX + "parallel_implicit_pre_read.enabled";
-
-  public static final int DEFAULT_PARALLEL_EXECUTOR_COUNT = 128;
-
   public static final String INCLUDE_METADATA_ENABLED = PREFIX + "include_metadata.enabled";
 
   public static final String COORDINATOR_GROUP_COMMIT_PREFIX = PREFIX + "coordinator.group_commit.";
@@ -58,6 +55,9 @@ public class ConsensusCommitConfig {
       COORDINATOR_GROUP_COMMIT_PREFIX + "timeout_check_interval_millis";
   public static final String COORDINATOR_GROUP_COMMIT_METRICS_MONITOR_LOG_ENABLED =
       COORDINATOR_GROUP_COMMIT_PREFIX + "metrics_monitor_log_enabled";
+
+  public static final int DEFAULT_PARALLEL_EXECUTOR_COUNT = 128;
+  public static final int DEFAULT_RECOVERY_EXECUTOR_COUNT = 128;
 
   public static final int DEFAULT_COORDINATOR_GROUP_COMMIT_SLOT_CAPACITY = 20;
   public static final int DEFAULT_COORDINATOR_GROUP_COMMIT_GROUP_SIZE_FIX_TIMEOUT_MILLIS = 40;
@@ -77,9 +77,8 @@ public class ConsensusCommitConfig {
   private final boolean asyncRollbackEnabled;
 
   private final boolean coordinatorWriteOmissionOnReadOnlyEnabled;
-
+  private final int recoveryExecutorCount;
   private final boolean parallelImplicitPreReadEnabled;
-
   private final boolean isIncludeMetadataEnabled;
 
   private final boolean coordinatorGroupCommitEnabled;
@@ -149,9 +148,12 @@ public class ConsensusCommitConfig {
     coordinatorWriteOmissionOnReadOnlyEnabled =
         getBoolean(properties, COORDINATOR_WRITE_OMISSION_ON_READ_ONLY_ENABLED, true);
 
-    parallelImplicitPreReadEnabled = getBoolean(properties, PARALLEL_IMPLICIT_PRE_READ, true);
+    recoveryExecutorCount =
+        getInt(properties, RECOVERY_EXECUTOR_COUNT, DEFAULT_RECOVERY_EXECUTOR_COUNT);
 
     isIncludeMetadataEnabled = getBoolean(properties, INCLUDE_METADATA_ENABLED, false);
+
+    parallelImplicitPreReadEnabled = getBoolean(properties, PARALLEL_IMPLICIT_PRE_READ, true);
 
     coordinatorGroupCommitEnabled = getBoolean(properties, COORDINATOR_GROUP_COMMIT_ENABLED, false);
     coordinatorGroupCommitSlotCapacity =
@@ -221,6 +223,10 @@ public class ConsensusCommitConfig {
 
   public boolean isCoordinatorWriteOmissionOnReadOnlyEnabled() {
     return coordinatorWriteOmissionOnReadOnlyEnabled;
+  }
+
+  public int getRecoveryExecutorCount() {
+    return recoveryExecutorCount;
   }
 
   public boolean isParallelImplicitPreReadEnabled() {

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitUtils.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.Insert;
 import com.scalar.db.api.MutationCondition;
+import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutBuilder;
 import com.scalar.db.api.TableMetadata;
@@ -12,8 +13,11 @@ import com.scalar.db.api.UpdateIf;
 import com.scalar.db.api.UpdateIfExists;
 import com.scalar.db.api.Upsert;
 import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.transaction.UnsatisfiedConditionException;
+import com.scalar.db.io.Column;
 import com.scalar.db.io.DataType;
+import com.scalar.db.io.IntColumn;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -313,5 +317,39 @@ public final class ConsensusCommitUtils {
     } else {
       return currentTxVersion + 1;
     }
+  }
+
+  static void extractAfterImageColumnsFromBeforeImage(
+      Map<String, Column<?>> columns,
+      TransactionResult result,
+      Set<String> beforeImageColumnNames) {
+    result
+        .getColumns()
+        .forEach(
+            (k, v) -> {
+              if (beforeImageColumnNames.contains(k)) {
+                String columnName = k.substring(Attribute.BEFORE_PREFIX.length());
+                if (columnName.equals(Attribute.VERSION) && v.getIntValue() == 0) {
+                  // Since we use version 0 instead of copying NULL for before_version when updating
+                  // a NULL-transaction-metadata record, we conversely change 0 to NULL for
+                  // rollback. See also PrepareMutationComposer.
+                  columns.put(columnName, IntColumn.ofNull(Attribute.VERSION));
+                } else {
+                  columns.put(columnName, v.copyWith(columnName));
+                }
+              }
+            });
+  }
+
+  static TransactionTableMetadata getTransactionTableMetadata(
+      TransactionTableMetadataManager tableMetadataManager, Operation operation)
+      throws ExecutionException {
+    TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(operation);
+    if (metadata == null) {
+      assert operation.forFullTableName().isPresent();
+      throw new IllegalArgumentException(
+          CoreError.TABLE_NOT_FOUND.buildMessage(operation.forFullTableName().get()));
+    }
+    return metadata;
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CrudHandler.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +50,7 @@ public class CrudHandler {
   private static final Logger logger = LoggerFactory.getLogger(CrudHandler.class);
   private final DistributedStorage storage;
   private final Snapshot snapshot;
+  private final RecoveryExecutor recoveryExecutor;
   private final TransactionTableMetadataManager tableMetadataManager;
   private final boolean isIncludeMetadataEnabled;
   private final MutationConditionsValidator mutationConditionsValidator;
@@ -65,11 +65,13 @@ public class CrudHandler {
   private final boolean oneOperation;
 
   private final List<ConsensusCommitScanner> scanners = new ArrayList<>();
+  private final List<RecoveryExecutor.Result> recoveryResults = new ArrayList<>();
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CrudHandler(
       DistributedStorage storage,
       Snapshot snapshot,
+      RecoveryExecutor recoveryExecutor,
       TransactionTableMetadataManager tableMetadataManager,
       boolean isIncludeMetadataEnabled,
       ParallelExecutor parallelExecutor,
@@ -77,10 +79,11 @@ public class CrudHandler {
       boolean oneOperation) {
     this.storage = checkNotNull(storage);
     this.snapshot = checkNotNull(snapshot);
-    this.tableMetadataManager = tableMetadataManager;
+    this.recoveryExecutor = checkNotNull(recoveryExecutor);
+    this.tableMetadataManager = checkNotNull(tableMetadataManager);
     this.isIncludeMetadataEnabled = isIncludeMetadataEnabled;
     this.mutationConditionsValidator = new MutationConditionsValidator(snapshot.getId());
-    this.parallelExecutor = parallelExecutor;
+    this.parallelExecutor = checkNotNull(parallelExecutor);
     this.readOnly = readOnly;
     this.oneOperation = oneOperation;
   }
@@ -89,6 +92,7 @@ public class CrudHandler {
   CrudHandler(
       DistributedStorage storage,
       Snapshot snapshot,
+      RecoveryExecutor recoveryExecutor,
       TransactionTableMetadataManager tableMetadataManager,
       boolean isIncludeMetadataEnabled,
       MutationConditionsValidator mutationConditionsValidator,
@@ -97,10 +101,11 @@ public class CrudHandler {
       boolean oneOperation) {
     this.storage = checkNotNull(storage);
     this.snapshot = checkNotNull(snapshot);
-    this.tableMetadataManager = tableMetadataManager;
+    this.recoveryExecutor = checkNotNull(recoveryExecutor);
+    this.tableMetadataManager = checkNotNull(tableMetadataManager);
     this.isIncludeMetadataEnabled = isIncludeMetadataEnabled;
-    this.mutationConditionsValidator = mutationConditionsValidator;
-    this.parallelExecutor = parallelExecutor;
+    this.mutationConditionsValidator = checkNotNull(mutationConditionsValidator);
+    this.parallelExecutor = checkNotNull(parallelExecutor);
     this.readOnly = readOnly;
     this.oneOperation = oneOperation;
   }
@@ -146,11 +151,15 @@ public class CrudHandler {
   Optional<TransactionResult> read(@Nullable Snapshot.Key key, Get get) throws CrudException {
     Optional<TransactionResult> result = getFromStorage(get);
     if (result.isPresent() && !result.get().isCommitted()) {
-      throw new UncommittedRecordException(
-          get,
-          result.get(),
-          CoreError.CONSENSUS_COMMIT_READ_UNCOMMITTED_RECORD.buildMessage(),
-          snapshot.getId());
+      // Lazy recovery
+
+      if (key == null) {
+        // Only for a Get with index, the argument `key` is null. In that case, create a key from
+        // the result
+        key = new Snapshot.Key(get, result.get());
+      }
+
+      result = executeRecovery(key, get, result.get());
     }
 
     if (!get.getConjunctions().isEmpty()) {
@@ -186,6 +195,14 @@ public class CrudHandler {
     return result;
   }
 
+  private Optional<TransactionResult> executeRecovery(
+      Snapshot.Key key, Selection selection, TransactionResult result) throws CrudException {
+    RecoveryExecutor.Result recoveryResult =
+        recoveryExecutor.execute(key, selection, result, snapshot.getId());
+    recoveryResults.add(recoveryResult);
+    return recoveryResult.recoveredResult;
+  }
+
   public List<Result> scan(Scan originalScan) throws CrudException {
     List<String> originalProjections = new ArrayList<>(originalScan.getProjections());
     Scan scan = (Scan) prepareStorageSelection(originalScan);
@@ -211,8 +228,8 @@ public class CrudHandler {
     Scanner scanner = null;
     try {
       if (scan.getLimit() > 0) {
-        // Since the conjunctions may delete some records from the scan result, it is necessary to
-        // perform the scan without a limit.
+        // Since recovery and conjunctions may delete some records from the scan result, it is
+        // necessary to perform the scan without a limit.
         scanner = scanFromStorage(Scan.newBuilder(scan).limit(0).build());
       } else {
         scanner = scanFromStorage(scan);
@@ -257,15 +274,14 @@ public class CrudHandler {
 
   private Optional<TransactionResult> processScanResult(
       Snapshot.Key key, Scan scan, TransactionResult result) throws CrudException {
+    Optional<TransactionResult> ret;
     if (!result.isCommitted()) {
-      throw new UncommittedRecordException(
-          scan,
-          result,
-          CoreError.CONSENSUS_COMMIT_READ_UNCOMMITTED_RECORD.buildMessage(),
-          snapshot.getId());
+      // Lazy recovery
+      ret = executeRecovery(key, scan, result);
+    } else {
+      ret = Optional.of(result);
     }
 
-    Optional<TransactionResult> ret = Optional.of(result);
     if (!scan.getConjunctions().isEmpty()) {
       // Because we also get records whose before images match the conjunctions, we need to check if
       // the current status of the records actually match the conjunctions.
@@ -428,7 +444,7 @@ public class CrudHandler {
     }
   }
 
-  private Get createGet(Snapshot.Key key) throws CrudException {
+  private Get createGet(Snapshot.Key key) {
     GetBuilder.BuildableGet buildableGet =
         Get.newBuilder()
             .namespace(key.getNamespace())
@@ -436,6 +452,49 @@ public class CrudHandler {
             .partitionKey(key.getPartitionKey());
     key.getClusteringKey().ifPresent(buildableGet::clusteringKey);
     return (Get) prepareStorageSelection(buildableGet.build());
+  }
+
+  public void waitForRecoveryCompletionIfNecessary() throws CrudException {
+    for (RecoveryExecutor.Result recoveryResult : recoveryResults) {
+      try {
+        if (snapshot.containsKeyInWriteSet(recoveryResult.key)
+            || snapshot.containsKeyInDeleteSet(recoveryResult.key)
+            || snapshot.isValidationRequired()) {
+          recoveryResult.recoveryFuture.get();
+        }
+      } catch (java.util.concurrent.ExecutionException e) {
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(
+                e.getCause().getMessage()),
+            e.getCause(),
+            snapshot.getId());
+      } catch (Exception e) {
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+            e,
+            snapshot.getId());
+      }
+    }
+  }
+
+  @VisibleForTesting
+  void waitForRecoveryCompletion() throws CrudException {
+    for (RecoveryExecutor.Result recoveryResult : recoveryResults) {
+      try {
+        recoveryResult.recoveryFuture.get();
+      } catch (java.util.concurrent.ExecutionException e) {
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(
+                e.getCause().getMessage()),
+            e.getCause(),
+            snapshot.getId());
+      } catch (Exception e) {
+        throw new CrudException(
+            CoreError.CONSENSUS_COMMIT_RECOVERING_RECORDS_FAILED.buildMessage(e.getMessage()),
+            e,
+            snapshot.getId());
+      }
+    }
   }
 
   // Although this class is not thread-safe, this method is actually thread-safe because the storage
@@ -594,15 +653,8 @@ public class CrudHandler {
     return converted;
   }
 
-  private Selection prepareStorageSelection(Selection selection) throws CrudException {
+  private Selection prepareStorageSelection(Selection selection) {
     selection.clearProjections();
-    // Retrieve only the after images columns when including the metadata is disabled, otherwise
-    // retrieve all the columns
-    if (!isIncludeMetadataEnabled) {
-      LinkedHashSet<String> afterImageColumnNames =
-          getTransactionTableMetadata(selection).getAfterImageColumnNames();
-      selection.withProjections(afterImageColumnNames);
-    }
     selection.withConsistency(Consistency.LINEARIZABLE);
     return selection;
   }
@@ -610,16 +662,7 @@ public class CrudHandler {
   private TransactionTableMetadata getTransactionTableMetadata(Operation operation)
       throws CrudException {
     try {
-      TransactionTableMetadata metadata =
-          tableMetadataManager.getTransactionTableMetadata(operation);
-      if (metadata == null) {
-        assert operation.forNamespace().isPresent() && operation.forTable().isPresent();
-        throw new IllegalArgumentException(
-            CoreError.TABLE_NOT_FOUND.buildMessage(
-                ScalarDbUtils.getFullTableName(
-                    operation.forNamespace().get(), operation.forTable().get())));
-      }
-      return metadata;
+      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, operation);
     } catch (ExecutionException e) {
       throw new CrudException(
           CoreError.GETTING_TABLE_METADATA_FAILED.buildMessage(), e, snapshot.getId());
@@ -627,18 +670,8 @@ public class CrudHandler {
   }
 
   private TableMetadata getTableMetadata(Operation operation) throws CrudException {
-    try {
-      TransactionTableMetadata metadata =
-          tableMetadataManager.getTransactionTableMetadata(operation);
-      if (metadata == null) {
-        assert operation.forFullTableName().isPresent();
-        throw new IllegalArgumentException(
-            CoreError.TABLE_NOT_FOUND.buildMessage(operation.forFullTableName().get()));
-      }
-      return metadata.getTableMetadata();
-    } catch (ExecutionException e) {
-      throw new CrudException(e.getMessage(), e, snapshot.getId());
-    }
+    TransactionTableMetadata metadata = getTransactionTableMetadata(operation);
+    return metadata.getTableMetadata();
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP")
@@ -673,8 +706,8 @@ public class CrudHandler {
       this.originalProjections = originalProjections;
 
       if (scan.getLimit() > 0) {
-        // Since the conjunctions may delete some records from the scan result, it is necessary to
-        // perform the scan without a limit.
+        // Since recovery and conjunctions may delete some records, it is necessary to perform the
+        // scan without a limit.
         scanner = scanFromStorage(Scan.newBuilder(scan).limit(0).build());
       } else {
         scanner = scanFromStorage(scan);

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/PrepareMutationComposer.java
@@ -3,6 +3,7 @@ package com.scalar.db.transaction.consensuscommit;
 import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitOperationAttributes.isInsertModeEnabled;
 import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getNextTxVersion;
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.getTransactionTableMetadata;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.ConditionBuilder;
@@ -146,8 +147,9 @@ public class PrepareMutationComposer extends AbstractMutationComposer {
   }
 
   private boolean isBeforeRequired(Mutation base, String columnName) throws ExecutionException {
-    TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
-    return !metadata.getPrimaryKeyColumnNames().contains(columnName)
-        && metadata.getAfterImageColumnNames().contains(columnName);
+    TransactionTableMetadata transactionTableMetadata =
+        getTransactionTableMetadata(tableMetadataManager, base);
+    return !transactionTableMetadata.getPrimaryKeyColumnNames().contains(columnName)
+        && transactionTableMetadata.getAfterImageColumnNames().contains(columnName);
   }
 }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutor.java
@@ -1,0 +1,277 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.extractAfterImageColumnsFromBeforeImage;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Selection;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.common.ResultImpl;
+import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.DateColumn;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import com.scalar.db.io.TimeColumn;
+import com.scalar.db.io.TimestampColumn;
+import com.scalar.db.io.TimestampTZColumn;
+import com.scalar.db.util.ScalarDbUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class RecoveryExecutor implements AutoCloseable {
+
+  private final Coordinator coordinator;
+  private final RecoveryHandler recovery;
+  private final TransactionTableMetadataManager tableMetadataManager;
+  private final ExecutorService executorService;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public RecoveryExecutor(
+      Coordinator coordinator,
+      RecoveryHandler recovery,
+      TransactionTableMetadataManager tableMetadataManager,
+      int threadPoolSize) {
+    this.coordinator = Objects.requireNonNull(coordinator);
+    this.recovery = Objects.requireNonNull(recovery);
+    this.tableMetadataManager = Objects.requireNonNull(tableMetadataManager);
+    executorService =
+        Executors.newFixedThreadPool(
+            threadPoolSize,
+            new ThreadFactoryBuilder()
+                .setNameFormat("recovery-executor-%d")
+                .setDaemon(true)
+                .build());
+  }
+
+  public Result execute(
+      Snapshot.Key key, Selection selection, TransactionResult result, String transactionId)
+      throws CrudException {
+    assert !result.isCommitted();
+
+    Optional<Coordinator.State> state = getCoordinatorState(result.getId());
+
+    Optional<TransactionResult> recoveredResult =
+        createRecoveredResult(state, selection, result, transactionId);
+
+    // Recover the record
+    Future<Void> future =
+        executorService.submit(
+            () -> {
+              recovery.recover(selection, result, state);
+              return null;
+            });
+
+    return new Result(key, recoveredResult, future);
+  }
+
+  private Optional<Coordinator.State> getCoordinatorState(String transactionId)
+      throws CrudException {
+    try {
+      return coordinator.getState(transactionId);
+    } catch (CoordinatorException e) {
+      throw new CrudException(e.getMessage(), e, transactionId);
+    }
+  }
+
+  private Optional<TransactionResult> createRecoveredResult(
+      Optional<Coordinator.State> state,
+      Selection selection,
+      TransactionResult result,
+      String transactionId)
+      throws CrudException {
+    throwUncommittedRecordExceptionIfTransactionNotExpired(state, selection, result, transactionId);
+
+    if (!state.isPresent() || state.get().getState() == TransactionState.ABORTED) {
+      return createRolledBackRecord(selection, result, transactionId);
+    } else {
+      assert state.get().getState() == TransactionState.COMMITTED;
+      return createRolledForwardResult(selection, result, transactionId);
+    }
+  }
+
+  private void throwUncommittedRecordExceptionIfTransactionNotExpired(
+      Optional<Coordinator.State> state,
+      Selection selection,
+      TransactionResult result,
+      String transactionId)
+      throws UncommittedRecordException {
+    if (!state.isPresent() && !recovery.isTransactionExpired(result)) {
+      throw new UncommittedRecordException(
+          selection,
+          result,
+          CoreError.CONSENSUS_COMMIT_READ_UNCOMMITTED_RECORD.buildMessage(),
+          transactionId);
+    }
+  }
+
+  private Optional<TransactionResult> createRolledBackRecord(
+      Selection selection, TransactionResult result, String transactionId) throws CrudException {
+    if (!result.hasBeforeImage()) {
+      return Optional.empty();
+    }
+
+    TransactionTableMetadata transactionTableMetadata =
+        getTransactionTableMetadata(selection, transactionId);
+    LinkedHashSet<String> beforeImageColumnNames =
+        transactionTableMetadata.getBeforeImageColumnNames();
+    TableMetadata tableMetadata = transactionTableMetadata.getTableMetadata();
+
+    Map<String, Column<?>> columns = new HashMap<>();
+
+    extractAfterImageColumnsFromBeforeImage(columns, result, beforeImageColumnNames);
+
+    Key partitionKey = ScalarDbUtils.getPartitionKey(result, tableMetadata);
+    partitionKey.getColumns().forEach(c -> columns.put(c.getName(), c));
+
+    Optional<Key> clusteringKey = ScalarDbUtils.getClusteringKey(result, tableMetadata);
+    clusteringKey.ifPresent(k -> k.getColumns().forEach(c -> columns.put(c.getName(), c)));
+
+    addNullBeforeImageColumns(columns, beforeImageColumnNames, tableMetadata);
+
+    return Optional.of(new TransactionResult(new ResultImpl(columns, tableMetadata)));
+  }
+
+  private Optional<TransactionResult> createRolledForwardResult(
+      Selection selection, TransactionResult result, String transactionId) throws CrudException {
+    if (result.getState() == TransactionState.DELETED) {
+      return Optional.empty();
+    }
+
+    assert result.getState() == TransactionState.PREPARED;
+
+    TransactionTableMetadata transactionTableMetadata =
+        getTransactionTableMetadata(selection, transactionId);
+    TableMetadata tableMetadata = transactionTableMetadata.getTableMetadata();
+
+    Map<String, Column<?>> columns = new HashMap<>();
+    result
+        .getColumns()
+        .forEach(
+            (columnName, column) -> {
+              if (columnName.equals(Attribute.STATE)) {
+                // Set the state to COMMITTED
+                columns.put(
+                    Attribute.STATE,
+                    IntColumn.of(Attribute.STATE, TransactionState.COMMITTED.get()));
+              } else {
+                columns.put(columnName, column);
+              }
+            });
+
+    long committedAt = getCommittedAt();
+    columns.put(Attribute.COMMITTED_AT, BigIntColumn.of(Attribute.COMMITTED_AT, committedAt));
+
+    addNullBeforeImageColumns(
+        columns, transactionTableMetadata.getBeforeImageColumnNames(), tableMetadata);
+
+    return Optional.of(new TransactionResult(new ResultImpl(columns, tableMetadata)));
+  }
+
+  @VisibleForTesting
+  long getCommittedAt() {
+    // Use the current time as the committedAt timestamp. Note that this is not the actual
+    // committedAt timestamp of the record
+    return System.currentTimeMillis();
+  }
+
+  private void addNullBeforeImageColumns(
+      Map<String, Column<?>> columns,
+      LinkedHashSet<String> beforeImageColumnNames,
+      TableMetadata tableMetadata) {
+    for (String beforeImageColumnName : beforeImageColumnNames) {
+      DataType columnDataType = tableMetadata.getColumnDataType(beforeImageColumnName);
+      switch (columnDataType) {
+        case BOOLEAN:
+          columns.put(beforeImageColumnName, BooleanColumn.ofNull(beforeImageColumnName));
+          break;
+        case INT:
+          columns.put(beforeImageColumnName, IntColumn.ofNull(beforeImageColumnName));
+          break;
+        case BIGINT:
+          columns.put(beforeImageColumnName, BigIntColumn.ofNull(beforeImageColumnName));
+          break;
+        case FLOAT:
+          columns.put(beforeImageColumnName, FloatColumn.ofNull(beforeImageColumnName));
+          break;
+        case DOUBLE:
+          columns.put(beforeImageColumnName, DoubleColumn.ofNull(beforeImageColumnName));
+          break;
+        case TEXT:
+          columns.put(beforeImageColumnName, TextColumn.ofNull(beforeImageColumnName));
+          break;
+        case BLOB:
+          columns.put(beforeImageColumnName, BlobColumn.ofNull(beforeImageColumnName));
+          break;
+        case DATE:
+          columns.put(beforeImageColumnName, DateColumn.ofNull(beforeImageColumnName));
+          break;
+        case TIME:
+          columns.put(beforeImageColumnName, TimeColumn.ofNull(beforeImageColumnName));
+          break;
+        case TIMESTAMP:
+          columns.put(beforeImageColumnName, TimestampColumn.ofNull(beforeImageColumnName));
+          break;
+        case TIMESTAMPTZ:
+          columns.put(beforeImageColumnName, TimestampTZColumn.ofNull(beforeImageColumnName));
+          break;
+        default:
+          throw new AssertionError("Unknown data type: " + columnDataType);
+      }
+    }
+  }
+
+  private TransactionTableMetadata getTransactionTableMetadata(
+      Operation operation, String transactionId) throws CrudException {
+    try {
+      return ConsensusCommitUtils.getTransactionTableMetadata(tableMetadataManager, operation);
+    } catch (ExecutionException e) {
+      throw new CrudException(
+          CoreError.GETTING_TABLE_METADATA_FAILED.buildMessage(), e, transactionId);
+    }
+  }
+
+  @Override
+  public void close() {
+    executorService.shutdown();
+    Uninterruptibles.awaitTerminationUninterruptibly(executorService);
+  }
+
+  public static class Result {
+    public final Snapshot.Key key;
+
+    // The recovered result
+    public final Optional<TransactionResult> recoveredResult;
+
+    // The future that completes when the recovery is done
+    public final Future<Void> recoveryFuture;
+
+    public Result(
+        Snapshot.Key key,
+        Optional<TransactionResult> recoveredResult,
+        Future<Void> recoveryFuture) {
+      this.key = key;
+      this.recoveredResult = recoveredResult;
+      this.recoveryFuture = recoveryFuture;
+    }
+  }
+}

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/RollbackMutationComposer.java
@@ -5,6 +5,7 @@ import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
 import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toIdValue;
 import static com.scalar.db.transaction.consensuscommit.Attribute.toStateValue;
+import static com.scalar.db.transaction.consensuscommit.ConsensusCommitUtils.*;
 
 import com.scalar.db.api.ConditionBuilder;
 import com.scalar.db.api.ConditionalExpression;
@@ -22,13 +23,12 @@ import com.scalar.db.api.TableMetadata;
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Column;
-import com.scalar.db.io.IntColumn;
 import com.scalar.db.io.Key;
 import com.scalar.db.util.ScalarDbUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -46,23 +46,28 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
     this.storage = storage;
   }
 
-  /** rollback in either prepare phase in commit or lazy recovery phase in read */
+  /** Rollback in either prepare phase in commit or lazy recovery phase in read. */
   @Override
   public void add(Operation base, @Nullable TransactionResult result) throws ExecutionException {
-    // We always re-read the latest record here because of the following reasons:
-    // 1. for usual rollback, we need to check the latest status of the record
-    // 2. for rollback in lazy recovery, the result doesn't have before image columns
-    TransactionResult latest = getLatestResult(base, result).orElse(null);
-    if (latest == null) {
-      // the record was not prepared (yet) by this transaction or has already been rollback deleted
-      return;
-    }
-    if (!Objects.equals(latest.getId(), id)) {
-      // This is the case for the record that was not prepared (yet) by this transaction or has
-      // already been rolled back. We need to use Objects.equals() here since the transaction ID of
-      // the latest record can be NULL (and different from this transaction's ID) when the record
-      // has already been rolled back to the deemed committed state by another transaction.
-      return;
+    TransactionResult latest;
+    if (result == null || !Objects.equals(result.getId(), id)) {
+      // For rollback in prepare phase, we need to check the latest status of the record.
+      latest = getLatestResult(base, result).orElse(null);
+      if (latest == null) {
+        // The record was not prepared (yet) by this transaction or has already been rollback
+        // deleted.
+        return;
+      }
+      if (!Objects.equals(latest.getId(), id)) {
+        // This is the case for the record that was not prepared (yet) by this transaction or has
+        // already been rolled back. We need to use Objects.equals() here since the transaction ID
+        // of the latest record can be NULL (and different from this transaction's ID) when the
+        // record has already been rolled back to the deemed committed state by another transaction.
+        return;
+      }
+    } else {
+      // For rollback in lazy recovery, we can use the result directly.
+      latest = result;
     }
 
     if (latest.hasBeforeImage()) {
@@ -79,28 +84,10 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
             || result.getState().equals(TransactionState.DELETED));
 
     TransactionTableMetadata transactionTableMetadata =
-        tableMetadataManager.getTransactionTableMetadata(base);
+        getTransactionTableMetadata(tableMetadataManager, base);
     LinkedHashSet<String> beforeImageColumnNames =
         transactionTableMetadata.getBeforeImageColumnNames();
     TableMetadata tableMetadata = transactionTableMetadata.getTableMetadata();
-
-    List<Column<?>> columns = new ArrayList<>();
-    result
-        .getColumns()
-        .forEach(
-            (k, v) -> {
-              if (beforeImageColumnNames.contains(k)) {
-                String key = k.substring(Attribute.BEFORE_PREFIX.length());
-                if (key.equals(Attribute.VERSION) && v.getIntValue() == 0) {
-                  // Since we use version 0 instead of copying NULL for before_version when updating
-                  // a NULL-transaction-metadata record, we conversely change 0 to NULL for
-                  // rollback. See also PrepareMutationComposer.
-                  columns.add(IntColumn.ofNull(Attribute.VERSION));
-                } else {
-                  columns.add(v.copyWith(key));
-                }
-              }
-            });
 
     Key partitionKey = ScalarDbUtils.getPartitionKey(result, tableMetadata);
     Optional<Key> clusteringKey = ScalarDbUtils.getClusteringKey(result, tableMetadata);
@@ -116,7 +103,10 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
                     .build())
             .consistency(Consistency.LINEARIZABLE);
     clusteringKey.ifPresent(putBuilder::clusteringKey);
-    columns.forEach(putBuilder::value);
+
+    Map<String, Column<?>> columns = new HashMap<>();
+    extractAfterImageColumnsFromBeforeImage(columns, result, beforeImageColumnNames);
+    columns.values().forEach(putBuilder::value);
 
     // Set before image columns to null
     setBeforeImageColumnsToNull(putBuilder, beforeImageColumnNames, tableMetadata);
@@ -129,10 +119,11 @@ public class RollbackMutationComposer extends AbstractMutationComposer {
         && (result.getState().equals(TransactionState.PREPARED)
             || result.getState().equals(TransactionState.DELETED));
 
-    TransactionTableMetadata metadata = tableMetadataManager.getTransactionTableMetadata(base);
-    Key partitionKey = ScalarDbUtils.getPartitionKey(result, metadata.getTableMetadata());
-    Optional<Key> clusteringKey =
-        ScalarDbUtils.getClusteringKey(result, metadata.getTableMetadata());
+    TransactionTableMetadata transactionTableMetadata =
+        getTransactionTableMetadata(tableMetadataManager, base);
+    TableMetadata tableMetadata = transactionTableMetadata.getTableMetadata();
+    Key partitionKey = ScalarDbUtils.getPartitionKey(result, tableMetadata);
+    Optional<Key> clusteringKey = ScalarDbUtils.getClusteringKey(result, tableMetadata);
 
     return new Delete(partitionKey, clusteringKey.orElse(null))
         .forNamespace(base.forNamespace().get())

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManager.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/TransactionTableMetadataManager.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -50,6 +51,7 @@ public class TransactionTableMetadataManager {
    * @return a table metadata. null if the table is not found.
    * @throws ExecutionException if the operation fails
    */
+  @Nullable
   public TransactionTableMetadata getTransactionTableMetadata(Operation operation)
       throws ExecutionException {
     if (!operation.forNamespace().isPresent() || !operation.forTable().isPresent()) {
@@ -67,6 +69,7 @@ public class TransactionTableMetadataManager {
    * @return a table metadata. null if the table is not found.
    * @throws ExecutionException if the operation fails
    */
+  @Nullable
   public TransactionTableMetadata getTransactionTableMetadata(String namespace, String table)
       throws ExecutionException {
     try {

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitConfigTest.java
@@ -27,8 +27,9 @@ public class ConsensusCommitConfigTest {
     assertThat(config.isParallelRollbackEnabled()).isTrue();
     assertThat(config.isAsyncCommitEnabled()).isFalse();
     assertThat(config.isAsyncRollbackEnabled()).isFalse();
-    assertThat(config.isParallelImplicitPreReadEnabled()).isTrue();
     assertThat(config.isCoordinatorWriteOmissionOnReadOnlyEnabled()).isTrue();
+    assertThat(config.getRecoveryExecutorCount()).isEqualTo(128);
+    assertThat(config.isParallelImplicitPreReadEnabled()).isTrue();
     assertThat(config.isIncludeMetadataEnabled()).isFalse();
   }
 
@@ -157,6 +158,19 @@ public class ConsensusCommitConfigTest {
   @Test
   public void
       constructor_PropertiesWithCoordinatorWriteOmissionOnReadOnlyEnabledGiven_ShouldLoadProperly() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ConsensusCommitConfig.RECOVERY_EXECUTOR_COUNT, "256");
+
+    // Act
+    ConsensusCommitConfig config = new ConsensusCommitConfig(new DatabaseConfig(props));
+
+    // Assert
+    assertThat(config.getRecoveryExecutorCount()).isEqualTo(256);
+  }
+
+  @Test
+  public void constructor_PropertiesWithRecoveryExecutorCountGiven_ShouldLoadProperly() {
     // Arrange
     Properties props = new Properties();
     props.setProperty(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitManagerTest.java
@@ -63,7 +63,7 @@ public class ConsensusCommitManagerTest {
   @Mock private ConsensusCommitConfig consensusCommitConfig;
   @Mock private Coordinator coordinator;
   @Mock private ParallelExecutor parallelExecutor;
-  @Mock private RecoveryHandler recovery;
+  @Mock private RecoveryExecutor recoveryExecutor;
   @Mock private CommitHandler commit;
 
   private ConsensusCommitManager manager;
@@ -80,7 +80,7 @@ public class ConsensusCommitManagerTest {
             databaseConfig,
             coordinator,
             parallelExecutor,
-            recovery,
+            recoveryExecutor,
             commit,
             null);
 
@@ -131,7 +131,7 @@ public class ConsensusCommitManagerTest {
             databaseConfig,
             coordinator,
             parallelExecutor,
-            recovery,
+            recoveryExecutor,
             commit,
             groupCommitter);
 
@@ -162,7 +162,7 @@ public class ConsensusCommitManagerTest {
             databaseConfig,
             coordinator,
             parallelExecutor,
-            recovery,
+            recoveryExecutor,
             commit,
             groupCommitter);
 
@@ -196,9 +196,6 @@ public class ConsensusCommitManagerTest {
     assertThat(transaction1.getCommitHandler())
         .isEqualTo(transaction2.getCommitHandler())
         .isEqualTo(commit);
-    assertThat(transaction1.getRecoveryHandler())
-        .isEqualTo(transaction2.getRecoveryHandler())
-        .isEqualTo(recovery);
   }
 
   @Test
@@ -309,9 +306,6 @@ public class ConsensusCommitManagerTest {
     assertThat(transaction1.getCommitHandler())
         .isEqualTo(transaction2.getCommitHandler())
         .isEqualTo(commit);
-    assertThat(transaction1.getRecoveryHandler())
-        .isEqualTo(transaction2.getRecoveryHandler())
-        .isEqualTo(recovery);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitTest.java
@@ -57,7 +57,6 @@ public class ConsensusCommitTest {
   @Mock private Snapshot snapshot;
   @Mock private CrudHandler crud;
   @Mock private CommitHandler commit;
-  @Mock private RecoveryHandler recovery;
 
   @SuppressWarnings("unused")
   @Mock
@@ -117,24 +116,7 @@ public class ConsensusCommitTest {
 
     // Assert
     assertThat(actual).isPresent();
-    verify(recovery, never()).recover(get, result);
     verify(crud).get(get);
-  }
-
-  @Test
-  public void get_GetForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Get get = prepareGet();
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    when(crud.get(get)).thenThrow(toThrow);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.get(get)).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -151,22 +133,6 @@ public class ConsensusCommitTest {
     // Assert
     assertThat(actual.size()).isEqualTo(1);
     verify(crud).scan(scan);
-  }
-
-  @Test
-  public void scan_ScanForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    when(crud.scan(scan)).thenThrow(toThrow);
-    when(toThrow.getSelection()).thenReturn(scan);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.scan(scan)).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(scan, result);
   }
 
   @Test
@@ -190,29 +156,6 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void
-      getScannerAndScannerOne_UncommittedRecordExceptionThrownByScannerOne_ShouldRecoverRecord()
-          throws CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    TransactionResult result = mock(TransactionResult.class);
-    when(toThrow.getSelection()).thenReturn(scan);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
-    when(scanner.one()).thenThrow(toThrow);
-    when(crud.getScanner(scan)).thenReturn(scanner);
-
-    // Act Assert
-    TransactionCrudOperable.Scanner actualScanner = consensus.getScanner(scan);
-    assertThatThrownBy(actualScanner::one).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(scan, result);
-  }
-
-  @Test
   public void getScannerAndScannerAll_ShouldCallCrudHandlerGetScannerAndScannerAll()
       throws CrudException {
     // Arrange
@@ -231,29 +174,6 @@ public class ConsensusCommitTest {
     assertThat(actualResults).containsExactly(result1, result2);
     verify(crud).getScanner(scan);
     verify(scanner).all();
-  }
-
-  @Test
-  public void
-      getScannerAndScannerAll_UncommittedRecordExceptionThrownByScannerAll_ShouldRecoverRecord()
-          throws CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    TransactionResult result = mock(TransactionResult.class);
-    when(toThrow.getSelection()).thenReturn(scan);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
-    when(scanner.all()).thenThrow(toThrow);
-    when(crud.getScanner(scan)).thenReturn(scanner);
-
-    // Act Assert
-    TransactionCrudOperable.Scanner actualScanner = consensus.getScanner(scan);
-    assertThatThrownBy(actualScanner::all).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(scan, result);
   }
 
   @Test
@@ -286,25 +206,6 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void put_PutGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
-      throws CrudException {
-    // Arrange
-    Put put = preparePut();
-    Get get = prepareGet();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).put(put);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.put(put)).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
-  }
-
-  @Test
   public void delete_DeleteGiven_ShouldCallCrudHandlerDelete()
       throws CrudException, ExecutionException {
     // Arrange
@@ -332,26 +233,6 @@ public class ConsensusCommitTest {
     // Assert
     verify(crud, times(2)).delete(delete);
     verify(mutationOperationChecker, times(2)).check(delete);
-  }
-
-  @Test
-  public void delete_DeleteGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
-      throws CrudException {
-    // Arrange
-    Delete delete = prepareDelete();
-    Get get = prepareGet();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).delete(delete);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.delete(delete))
-        .isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -412,47 +293,6 @@ public class ConsensusCommitTest {
             .build();
     verify(crud).put(expectedPut);
     verify(mutationOperationChecker).check(expectedPut);
-  }
-
-  @Test
-  public void upsert_UpsertForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Upsert upsert =
-        Upsert.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .build();
-    Put put =
-        Put.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .enableImplicitPreRead()
-            .build();
-    Get get =
-        Get.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .build();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).put(put);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.upsert(upsert))
-        .isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -644,48 +484,6 @@ public class ConsensusCommitTest {
   }
 
   @Test
-  public void update_UpdateForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Update update =
-        Update.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .build();
-    Put put =
-        Put.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .condition(ConditionBuilder.putIfExists())
-            .enableImplicitPreRead()
-            .build();
-    Get get =
-        Get.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .build();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).put(put);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.update(update))
-        .isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
-  }
-
-  @Test
   public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete()
       throws CrudException, ExecutionException {
     // Arrange
@@ -716,7 +514,9 @@ public class ConsensusCommitTest {
     consensus.commit();
 
     // Assert
+    verify(crud).areAllScannersClosed();
     verify(crud).readIfImplicitPreReadEnabled();
+    verify(crud).waitForRecoveryCompletionIfNecessary();
     verify(commit).commit(snapshot, false);
   }
 
@@ -732,7 +532,9 @@ public class ConsensusCommitTest {
     consensus.commit();
 
     // Assert
+    verify(crud).areAllScannersClosed();
     verify(crud).readIfImplicitPreReadEnabled();
+    verify(crud).waitForRecoveryCompletionIfNecessary();
     verify(commit).commit(snapshot, true);
   }
 
@@ -746,28 +548,6 @@ public class ConsensusCommitTest {
 
     // Act Assert
     assertThatThrownBy(() -> consensus.commit()).isInstanceOf(CommitConflictException.class);
-  }
-
-  @Test
-  public void
-      commit_ProcessedCrudGiven_UncommittedRecordExceptionThrownWhileImplicitPreRead_ShouldPerformLazyRecoveryAndThrowCommitConflictException()
-          throws CrudException {
-    // Arrange
-    when(crud.getSnapshot()).thenReturn(snapshot);
-
-    Get get = mock(Get.class);
-    TransactionResult result = mock(TransactionResult.class);
-
-    UncommittedRecordException uncommittedRecordException = mock(UncommittedRecordException.class);
-    when(uncommittedRecordException.getSelection()).thenReturn(get);
-    when(uncommittedRecordException.getResults()).thenReturn(Collections.singletonList(result));
-
-    doThrow(uncommittedRecordException).when(crud).readIfImplicitPreReadEnabled();
-
-    // Act Assert
-    assertThatThrownBy(() -> consensus.commit()).isInstanceOf(CommitConflictException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -789,6 +569,18 @@ public class ConsensusCommitTest {
 
     // Act Assert
     assertThatThrownBy(() -> consensus.commit()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void
+      commit_CrudExceptionThrownByCrudHandlerWaitForRecoveryCompletionIfNecessary_ShouldThrowCommitException()
+          throws CrudException {
+    // Arrange
+    when(crud.getSnapshot()).thenReturn(snapshot);
+    doThrow(CrudException.class).when(crud).waitForRecoveryCompletionIfNecessary();
+
+    // Act Assert
+    assertThatThrownBy(() -> consensus.commit()).isInstanceOf(CommitException.class);
   }
 
   @Test
@@ -814,7 +606,7 @@ public class ConsensusCommitTest {
     doReturn(snapshot).when(crud).getSnapshot();
     CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
     ConsensusCommit consensusWithGroupCommit =
-        new ConsensusCommit(crud, commit, recovery, mutationOperationChecker, groupCommitter);
+        new ConsensusCommit(crud, commit, mutationOperationChecker, groupCommitter);
 
     // Act
     consensusWithGroupCommit.rollback();
@@ -837,7 +629,7 @@ public class ConsensusCommitTest {
     doReturn(true).when(crud).isReadOnly();
     CoordinatorGroupCommitter groupCommitter = mock(CoordinatorGroupCommitter.class);
     ConsensusCommit consensusWithGroupCommit =
-        new ConsensusCommit(crud, commit, recovery, mutationOperationChecker, groupCommitter);
+        new ConsensusCommit(crud, commit, mutationOperationChecker, groupCommitter);
 
     // Act
     consensusWithGroupCommit.rollback();

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/RecoveryExecutorTest.java
@@ -1,0 +1,481 @@
+package com.scalar.db.transaction.consensuscommit;
+
+import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_COMMITTED_AT;
+import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_ID;
+import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_PREFIX;
+import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_PREPARED_AT;
+import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_STATE;
+import static com.scalar.db.transaction.consensuscommit.Attribute.BEFORE_VERSION;
+import static com.scalar.db.transaction.consensuscommit.Attribute.COMMITTED_AT;
+import static com.scalar.db.transaction.consensuscommit.Attribute.ID;
+import static com.scalar.db.transaction.consensuscommit.Attribute.PREPARED_AT;
+import static com.scalar.db.transaction.consensuscommit.Attribute.STATE;
+import static com.scalar.db.transaction.consensuscommit.Attribute.VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.scalar.db.api.Selection;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.api.TransactionState;
+import com.scalar.db.common.ResultImpl;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.db.io.BigIntColumn;
+import com.scalar.db.io.BlobColumn;
+import com.scalar.db.io.BooleanColumn;
+import com.scalar.db.io.Column;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.DateColumn;
+import com.scalar.db.io.DoubleColumn;
+import com.scalar.db.io.FloatColumn;
+import com.scalar.db.io.IntColumn;
+import com.scalar.db.io.TextColumn;
+import com.scalar.db.io.TimeColumn;
+import com.scalar.db.io.TimestampColumn;
+import com.scalar.db.io.TimestampTZColumn;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RecoveryExecutorTest {
+
+  private static final String ANY_NAMESPACE_NAME = "namespace";
+  private static final String ANY_TABLE_NAME = "table";
+  private static final String ANY_ID_1 = "id1";
+  private static final String ANY_ID_2 = "id2";
+  private static final String ANY_ID_3 = "id3";
+  private static final long ANY_TIME_MILLIS_1 = 100;
+  private static final long ANY_TIME_MILLIS_2 = 200;
+  private static final long ANY_TIME_MILLIS_3 = 300;
+  private static final long ANY_TIME_MILLIS_4 = 400;
+  private static final String ANY_NAME_1 = "name1";
+  private static final String ANY_NAME_2 = "name2";
+  private static final String ANY_NAME_3 = "name3";
+  private static final String ANY_NAME_4 = "name4";
+  private static final String ANY_NAME_5 = "name5";
+  private static final String ANY_NAME_6 = "name6";
+  private static final String ANY_NAME_7 = "name7";
+  private static final String ANY_NAME_8 = "name8";
+  private static final String ANY_NAME_9 = "name9";
+  private static final String ANY_NAME_10 = "name10";
+  private static final String ANY_NAME_11 = "name11";
+  private static final String ANY_NAME_12 = "name12";
+  private static final String ANY_NAME_13 = "name13";
+  private static final String ANY_TEXT_1 = "text1";
+  private static final String ANY_TEXT_2 = "text2";
+  private static final String ANY_TEXT_3 = "text3";
+  private static final String ANY_TEXT_4 = "text4";
+  private static final int ANY_INT_1 = 100;
+  private static final int ANY_INT_2 = 200;
+  private static final long ANY_BIGINT_1 = 1000L;
+  private static final long ANY_BIGINT_2 = 2000L;
+  private static final float ANY_FLOAT_1 = 1.23f;
+  private static final float ANY_FLOAT_2 = 4.56f;
+  private static final double ANY_DOUBLE_1 = 7.89;
+  private static final double ANY_DOUBLE_2 = 0.12;
+  private static final byte[] ANY_BLOB_1 = new byte[] {1, 2, 3};
+  private static final byte[] ANY_BLOB_2 = new byte[] {4, 5, 6};
+  private static final LocalDate ANY_DATE_1 = LocalDate.of(2020, 1, 1);
+  private static final LocalDate ANY_DATE_2 = LocalDate.of(2021, 1, 1);
+  private static final LocalTime ANY_TIME_1 = LocalTime.of(12, 0, 0);
+  private static final LocalTime ANY_TIME_2 = LocalTime.of(13, 0, 0);
+  private static final LocalDateTime ANY_TIMESTAMP_1 = LocalDateTime.of(2020, 1, 1, 12, 0, 0);
+  private static final LocalDateTime ANY_TIMESTAMP_2 = LocalDateTime.of(2021, 1, 1, 13, 0, 0);
+  private static final Instant ANY_TIMESTAMPTZ_1 =
+      LocalDateTime.of(2020, 1, 1, 12, 0, 0).toInstant(ZoneOffset.UTC);
+  private static final Instant ANY_TIMESTAMPTZ_2 =
+      LocalDateTime.of(2021, 1, 1, 13, 0, 0).toInstant(ZoneOffset.UTC);
+
+  private static final TableMetadata TABLE_METADATA =
+      ConsensusCommitUtils.buildTransactionTableMetadata(
+          TableMetadata.newBuilder()
+              .addColumn(ANY_NAME_1, DataType.TEXT)
+              .addColumn(ANY_NAME_2, DataType.TEXT)
+              .addColumn(ANY_NAME_3, DataType.INT)
+              .addColumn(ANY_NAME_4, DataType.BOOLEAN)
+              .addColumn(ANY_NAME_5, DataType.BIGINT)
+              .addColumn(ANY_NAME_6, DataType.FLOAT)
+              .addColumn(ANY_NAME_7, DataType.DOUBLE)
+              .addColumn(ANY_NAME_8, DataType.TEXT)
+              .addColumn(ANY_NAME_9, DataType.BLOB)
+              .addColumn(ANY_NAME_10, DataType.DATE)
+              .addColumn(ANY_NAME_11, DataType.TIME)
+              .addColumn(ANY_NAME_12, DataType.TIMESTAMP)
+              .addColumn(ANY_NAME_13, DataType.TIMESTAMPTZ)
+              .addPartitionKey(ANY_NAME_1)
+              .addClusteringKey(ANY_NAME_2)
+              .build());
+
+  @Mock private Coordinator coordinator;
+  @Mock private RecoveryHandler recovery;
+  @Mock private TransactionTableMetadataManager tableMetadataManager;
+  @Mock private Snapshot.Key snapshotKey;
+  @Mock private Selection selection;
+
+  private RecoveryExecutor executor;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    executor = new RecoveryExecutor(coordinator, recovery, tableMetadataManager, 1);
+
+    // Arrange
+    when(tableMetadataManager.getTransactionTableMetadata(selection))
+        .thenReturn(new TransactionTableMetadata(TABLE_METADATA));
+
+    when(selection.forNamespace()).thenReturn(Optional.of(ANY_NAMESPACE_NAME));
+    when(selection.forTable()).thenReturn(Optional.of(ANY_TABLE_NAME));
+    when(selection.forFullTableName())
+        .thenReturn(Optional.of(ANY_NAMESPACE_NAME + "." + ANY_TABLE_NAME));
+  }
+
+  private TransactionResult prepareResult(TransactionState state) {
+    ImmutableMap<String, Column<?>> columns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
+            .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
+            .put(ANY_NAME_4, BooleanColumn.of(ANY_NAME_4, true))
+            .put(ANY_NAME_5, BigIntColumn.of(ANY_NAME_5, ANY_BIGINT_2))
+            .put(ANY_NAME_6, FloatColumn.of(ANY_NAME_6, ANY_FLOAT_2))
+            .put(ANY_NAME_7, DoubleColumn.of(ANY_NAME_7, ANY_DOUBLE_2))
+            .put(ANY_NAME_8, TextColumn.of(ANY_NAME_8, ANY_TEXT_4))
+            .put(ANY_NAME_9, BlobColumn.of(ANY_NAME_9, ANY_BLOB_2))
+            .put(ANY_NAME_10, DateColumn.of(ANY_NAME_10, ANY_DATE_2))
+            .put(ANY_NAME_11, TimeColumn.of(ANY_NAME_11, ANY_TIME_2))
+            .put(ANY_NAME_12, TimestampColumn.of(ANY_NAME_12, ANY_TIMESTAMP_2))
+            .put(ANY_NAME_13, TimestampTZColumn.of(ANY_NAME_13, ANY_TIMESTAMPTZ_2))
+            .put(ID, TextColumn.of(ID, ANY_ID_2))
+            .put(PREPARED_AT, BigIntColumn.of(PREPARED_AT, ANY_TIME_MILLIS_3))
+            .put(STATE, IntColumn.of(STATE, state.get()))
+            .put(VERSION, IntColumn.of(VERSION, 1))
+            .put(BEFORE_PREFIX + ANY_NAME_3, IntColumn.of(BEFORE_PREFIX + ANY_NAME_3, ANY_INT_1))
+            .put(BEFORE_PREFIX + ANY_NAME_4, BooleanColumn.of(BEFORE_PREFIX + ANY_NAME_4, false))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_5,
+                BigIntColumn.of(BEFORE_PREFIX + ANY_NAME_5, ANY_BIGINT_1))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_6, FloatColumn.of(BEFORE_PREFIX + ANY_NAME_6, ANY_FLOAT_1))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_7,
+                DoubleColumn.of(BEFORE_PREFIX + ANY_NAME_7, ANY_DOUBLE_1))
+            .put(BEFORE_PREFIX + ANY_NAME_8, TextColumn.of(BEFORE_PREFIX + ANY_NAME_8, ANY_TEXT_3))
+            .put(BEFORE_PREFIX + ANY_NAME_9, BlobColumn.of(BEFORE_PREFIX + ANY_NAME_9, ANY_BLOB_1))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_10, DateColumn.of(BEFORE_PREFIX + ANY_NAME_10, ANY_DATE_1))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_11, TimeColumn.of(BEFORE_PREFIX + ANY_NAME_11, ANY_TIME_1))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_12,
+                TimestampColumn.of(BEFORE_PREFIX + ANY_NAME_12, ANY_TIMESTAMP_1))
+            .put(
+                BEFORE_PREFIX + ANY_NAME_13,
+                TimestampTZColumn.of(BEFORE_PREFIX + ANY_NAME_13, ANY_TIMESTAMPTZ_1))
+            .put(BEFORE_ID, TextColumn.of(BEFORE_ID, ANY_ID_1))
+            .put(BEFORE_PREPARED_AT, BigIntColumn.of(BEFORE_PREPARED_AT, ANY_TIME_MILLIS_1))
+            .put(BEFORE_COMMITTED_AT, BigIntColumn.of(BEFORE_COMMITTED_AT, ANY_TIME_MILLIS_2))
+            .put(BEFORE_STATE, IntColumn.of(BEFORE_STATE, TransactionState.COMMITTED.get()))
+            .put(BEFORE_VERSION, IntColumn.of(BEFORE_VERSION, 1))
+            .build();
+    return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
+  }
+
+  private TransactionResult prepareResultWithoutBeforeImage(TransactionState state) {
+    ImmutableMap<String, Column<?>> columns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
+            .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
+            .put(ANY_NAME_4, BooleanColumn.of(ANY_NAME_4, true))
+            .put(ANY_NAME_5, BigIntColumn.of(ANY_NAME_5, ANY_BIGINT_2))
+            .put(ANY_NAME_6, FloatColumn.of(ANY_NAME_6, ANY_FLOAT_2))
+            .put(ANY_NAME_7, DoubleColumn.of(ANY_NAME_7, ANY_DOUBLE_2))
+            .put(ANY_NAME_8, TextColumn.of(ANY_NAME_8, ANY_TEXT_4))
+            .put(ANY_NAME_9, BlobColumn.of(ANY_NAME_9, ANY_BLOB_2))
+            .put(ANY_NAME_10, DateColumn.of(ANY_NAME_10, ANY_DATE_2))
+            .put(ANY_NAME_11, TimeColumn.of(ANY_NAME_11, ANY_TIME_2))
+            .put(ANY_NAME_12, TimestampColumn.of(ANY_NAME_12, ANY_TIMESTAMP_2))
+            .put(ANY_NAME_13, TimestampTZColumn.of(ANY_NAME_13, ANY_TIMESTAMPTZ_2))
+            .put(ID, TextColumn.of(ID, ANY_ID_2))
+            .put(PREPARED_AT, BigIntColumn.of(PREPARED_AT, ANY_TIME_MILLIS_3))
+            .put(STATE, IntColumn.of(STATE, state.get()))
+            .put(VERSION, IntColumn.of(VERSION, 1))
+            .put(BEFORE_PREFIX + ANY_NAME_3, IntColumn.ofNull(BEFORE_PREFIX + ANY_NAME_3))
+            .put(BEFORE_PREFIX + ANY_NAME_4, BooleanColumn.ofNull(BEFORE_PREFIX + ANY_NAME_4))
+            .put(BEFORE_PREFIX + ANY_NAME_5, BigIntColumn.ofNull(BEFORE_PREFIX + ANY_NAME_5))
+            .put(BEFORE_PREFIX + ANY_NAME_6, FloatColumn.ofNull(BEFORE_PREFIX + ANY_NAME_6))
+            .put(BEFORE_PREFIX + ANY_NAME_7, DoubleColumn.ofNull(BEFORE_PREFIX + ANY_NAME_7))
+            .put(BEFORE_PREFIX + ANY_NAME_8, TextColumn.ofNull(BEFORE_PREFIX + ANY_NAME_8))
+            .put(BEFORE_PREFIX + ANY_NAME_9, BlobColumn.ofNull(BEFORE_PREFIX + ANY_NAME_9))
+            .put(BEFORE_PREFIX + ANY_NAME_10, DateColumn.ofNull(BEFORE_PREFIX + ANY_NAME_10))
+            .put(BEFORE_PREFIX + ANY_NAME_11, TimeColumn.ofNull(BEFORE_PREFIX + ANY_NAME_11))
+            .put(BEFORE_PREFIX + ANY_NAME_12, TimestampColumn.ofNull(BEFORE_PREFIX + ANY_NAME_12))
+            .put(BEFORE_PREFIX + ANY_NAME_13, TimestampTZColumn.ofNull(BEFORE_PREFIX + ANY_NAME_13))
+            .put(BEFORE_ID, TextColumn.ofNull(BEFORE_ID))
+            .put(BEFORE_PREPARED_AT, BigIntColumn.ofNull(BEFORE_PREPARED_AT))
+            .put(BEFORE_COMMITTED_AT, BigIntColumn.ofNull(BEFORE_COMMITTED_AT))
+            .put(BEFORE_STATE, IntColumn.ofNull(BEFORE_STATE))
+            .put(BEFORE_VERSION, IntColumn.ofNull(BEFORE_VERSION))
+            .build();
+    return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
+  }
+
+  private TransactionResult prepareRolledBackResult() {
+    ImmutableMap<String, Column<?>> columns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
+            .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_1))
+            .put(ANY_NAME_4, BooleanColumn.of(ANY_NAME_4, false))
+            .put(ANY_NAME_5, BigIntColumn.of(ANY_NAME_5, ANY_BIGINT_1))
+            .put(ANY_NAME_6, FloatColumn.of(ANY_NAME_6, ANY_FLOAT_1))
+            .put(ANY_NAME_7, DoubleColumn.of(ANY_NAME_7, ANY_DOUBLE_1))
+            .put(ANY_NAME_8, TextColumn.of(ANY_NAME_8, ANY_TEXT_3))
+            .put(ANY_NAME_9, BlobColumn.of(ANY_NAME_9, ANY_BLOB_1))
+            .put(ANY_NAME_10, DateColumn.of(ANY_NAME_10, ANY_DATE_1))
+            .put(ANY_NAME_11, TimeColumn.of(ANY_NAME_11, ANY_TIME_1))
+            .put(ANY_NAME_12, TimestampColumn.of(ANY_NAME_12, ANY_TIMESTAMP_1))
+            .put(ANY_NAME_13, TimestampTZColumn.of(ANY_NAME_13, ANY_TIMESTAMPTZ_1))
+            .put(ID, TextColumn.of(ID, ANY_ID_1))
+            .put(PREPARED_AT, BigIntColumn.of(PREPARED_AT, ANY_TIME_MILLIS_1))
+            .put(COMMITTED_AT, BigIntColumn.of(COMMITTED_AT, ANY_TIME_MILLIS_2))
+            .put(STATE, IntColumn.of(STATE, TransactionState.COMMITTED.get()))
+            .put(VERSION, IntColumn.of(VERSION, 1))
+            .put(BEFORE_PREFIX + ANY_NAME_3, IntColumn.ofNull(BEFORE_PREFIX + ANY_NAME_3))
+            .put(BEFORE_PREFIX + ANY_NAME_4, BooleanColumn.ofNull(BEFORE_PREFIX + ANY_NAME_4))
+            .put(BEFORE_PREFIX + ANY_NAME_5, BigIntColumn.ofNull(BEFORE_PREFIX + ANY_NAME_5))
+            .put(BEFORE_PREFIX + ANY_NAME_6, FloatColumn.ofNull(BEFORE_PREFIX + ANY_NAME_6))
+            .put(BEFORE_PREFIX + ANY_NAME_7, DoubleColumn.ofNull(BEFORE_PREFIX + ANY_NAME_7))
+            .put(BEFORE_PREFIX + ANY_NAME_8, TextColumn.ofNull(BEFORE_PREFIX + ANY_NAME_8))
+            .put(BEFORE_PREFIX + ANY_NAME_9, BlobColumn.ofNull(BEFORE_PREFIX + ANY_NAME_9))
+            .put(BEFORE_PREFIX + ANY_NAME_10, DateColumn.ofNull(BEFORE_PREFIX + ANY_NAME_10))
+            .put(BEFORE_PREFIX + ANY_NAME_11, TimeColumn.ofNull(BEFORE_PREFIX + ANY_NAME_11))
+            .put(BEFORE_PREFIX + ANY_NAME_12, TimestampColumn.ofNull(BEFORE_PREFIX + ANY_NAME_12))
+            .put(BEFORE_PREFIX + ANY_NAME_13, TimestampTZColumn.ofNull(BEFORE_PREFIX + ANY_NAME_13))
+            .put(BEFORE_ID, TextColumn.ofNull(BEFORE_ID))
+            .put(BEFORE_PREPARED_AT, BigIntColumn.ofNull(BEFORE_PREPARED_AT))
+            .put(BEFORE_COMMITTED_AT, BigIntColumn.ofNull(BEFORE_COMMITTED_AT))
+            .put(BEFORE_STATE, IntColumn.ofNull(BEFORE_STATE))
+            .put(BEFORE_VERSION, IntColumn.ofNull(BEFORE_VERSION))
+            .build();
+    return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
+  }
+
+  private TransactionResult prepareRolledForwardResult() {
+    ImmutableMap<String, Column<?>> columns =
+        ImmutableMap.<String, Column<?>>builder()
+            .put(ANY_NAME_1, TextColumn.of(ANY_NAME_1, ANY_TEXT_1))
+            .put(ANY_NAME_2, TextColumn.of(ANY_NAME_2, ANY_TEXT_2))
+            .put(ANY_NAME_3, IntColumn.of(ANY_NAME_3, ANY_INT_2))
+            .put(ANY_NAME_4, BooleanColumn.of(ANY_NAME_4, true))
+            .put(ANY_NAME_5, BigIntColumn.of(ANY_NAME_5, ANY_BIGINT_2))
+            .put(ANY_NAME_6, FloatColumn.of(ANY_NAME_6, ANY_FLOAT_2))
+            .put(ANY_NAME_7, DoubleColumn.of(ANY_NAME_7, ANY_DOUBLE_2))
+            .put(ANY_NAME_8, TextColumn.of(ANY_NAME_8, ANY_TEXT_4))
+            .put(ANY_NAME_9, BlobColumn.of(ANY_NAME_9, ANY_BLOB_2))
+            .put(ANY_NAME_10, DateColumn.of(ANY_NAME_10, ANY_DATE_2))
+            .put(ANY_NAME_11, TimeColumn.of(ANY_NAME_11, ANY_TIME_2))
+            .put(ANY_NAME_12, TimestampColumn.of(ANY_NAME_12, ANY_TIMESTAMP_2))
+            .put(ANY_NAME_13, TimestampTZColumn.of(ANY_NAME_13, ANY_TIMESTAMPTZ_2))
+            .put(ID, TextColumn.of(ID, ANY_ID_2))
+            .put(PREPARED_AT, BigIntColumn.of(PREPARED_AT, ANY_TIME_MILLIS_3))
+            .put(COMMITTED_AT, BigIntColumn.of(COMMITTED_AT, ANY_TIME_MILLIS_4))
+            .put(STATE, IntColumn.of(STATE, TransactionState.COMMITTED.get()))
+            .put(VERSION, IntColumn.of(VERSION, 1))
+            .put(BEFORE_PREFIX + ANY_NAME_3, IntColumn.ofNull(BEFORE_PREFIX + ANY_NAME_3))
+            .put(BEFORE_PREFIX + ANY_NAME_4, BooleanColumn.ofNull(BEFORE_PREFIX + ANY_NAME_4))
+            .put(BEFORE_PREFIX + ANY_NAME_5, BigIntColumn.ofNull(BEFORE_PREFIX + ANY_NAME_5))
+            .put(BEFORE_PREFIX + ANY_NAME_6, FloatColumn.ofNull(BEFORE_PREFIX + ANY_NAME_6))
+            .put(BEFORE_PREFIX + ANY_NAME_7, DoubleColumn.ofNull(BEFORE_PREFIX + ANY_NAME_7))
+            .put(BEFORE_PREFIX + ANY_NAME_8, TextColumn.ofNull(BEFORE_PREFIX + ANY_NAME_8))
+            .put(BEFORE_PREFIX + ANY_NAME_9, BlobColumn.ofNull(BEFORE_PREFIX + ANY_NAME_9))
+            .put(BEFORE_PREFIX + ANY_NAME_10, DateColumn.ofNull(BEFORE_PREFIX + ANY_NAME_10))
+            .put(BEFORE_PREFIX + ANY_NAME_11, TimeColumn.ofNull(BEFORE_PREFIX + ANY_NAME_11))
+            .put(BEFORE_PREFIX + ANY_NAME_12, TimestampColumn.ofNull(BEFORE_PREFIX + ANY_NAME_12))
+            .put(BEFORE_PREFIX + ANY_NAME_13, TimestampTZColumn.ofNull(BEFORE_PREFIX + ANY_NAME_13))
+            .put(BEFORE_ID, TextColumn.ofNull(BEFORE_ID))
+            .put(BEFORE_PREPARED_AT, BigIntColumn.ofNull(BEFORE_PREPARED_AT))
+            .put(BEFORE_COMMITTED_AT, BigIntColumn.ofNull(BEFORE_COMMITTED_AT))
+            .put(BEFORE_STATE, IntColumn.ofNull(BEFORE_STATE))
+            .put(BEFORE_VERSION, IntColumn.ofNull(BEFORE_VERSION))
+            .build();
+    return new TransactionResult(new ResultImpl(columns, TABLE_METADATA));
+  }
+
+  @Test
+  public void execute_CoordinatorExceptionByCoordinatorState_ShouldThrowCrudException()
+      throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult transactionResult = mock(TransactionResult.class);
+    when(transactionResult.getId()).thenReturn(ANY_ID_1);
+    when(coordinator.getState(ANY_ID_1)).thenThrow(new CoordinatorException("error"));
+
+    // Act Assert
+    assertThatThrownBy(() -> executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3))
+        .isInstanceOf(CrudException.class);
+
+    // Verify no recovery attempted
+    verify(recovery, never()).recover(any(), any(), any());
+  }
+
+  @Test
+  public void
+      execute_TransactionNotExpiredAndNoCoordinatorState_ShouldThrowUncommittedRecordException()
+          throws CoordinatorException, ExecutionException {
+    // Arrange
+    TransactionResult transactionResult = mock(TransactionResult.class);
+    when(transactionResult.getId()).thenReturn(ANY_ID_1);
+    when(coordinator.getState(ANY_ID_1)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(() -> executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3))
+        .isInstanceOf(UncommittedRecordException.class);
+
+    // Verify no recovery attempted
+    verify(recovery, never()).recover(any(), any(), any());
+  }
+
+  @Test
+  public void execute_TransactionExpiredAndNoCoordinatorState_ShouldRollback() throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3);
+
+    // Wait for recovery to complete
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
+  }
+
+  @Test
+  public void
+      execute_TransactionExpiredAndNoCoordinatorState_RecordWithoutBeforeImage_ShouldRollback()
+          throws Exception {
+    // Arrange
+    TransactionResult transactionResult =
+        prepareResultWithoutBeforeImage(TransactionState.PREPARED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.empty());
+    when(recovery.isTransactionExpired(transactionResult)).thenReturn(true);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3);
+
+    // Wait for recovery to complete
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).isEmpty();
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.empty()));
+  }
+
+  @Test
+  public void execute_CoordinatorStateIsAborted_ShouldRollback() throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3);
+
+    // Wait for recovery to complete
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).hasValue(prepareRolledBackResult());
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+  }
+
+  @Test
+  public void execute_CoordinatorStateIsAborted_RecordWithoutBeforeImage_ShouldRollback()
+      throws Exception {
+    // Arrange
+    TransactionResult transactionResult =
+        prepareResultWithoutBeforeImage(TransactionState.PREPARED);
+    Coordinator.State abortedState = new Coordinator.State(ANY_ID_2, TransactionState.ABORTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(abortedState));
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3);
+
+    // Wait for recovery to complete
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).isEmpty();
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(abortedState)));
+  }
+
+  @Test
+  public void execute_CoordinatorStateIsCommitted_RecordWithPreparedState_ShouldCommit()
+      throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.PREPARED);
+    Coordinator.State commitState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
+
+    executor = spy(executor);
+    doReturn(ANY_TIME_MILLIS_4).when(executor).getCommittedAt();
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3);
+
+    // Wait for recovery to complete
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).hasValue(prepareRolledForwardResult());
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
+  }
+
+  @Test
+  public void execute_CoordinatorStateIsCommitted_RecordWithDeletedState_ShouldCommit()
+      throws Exception {
+    // Arrange
+    TransactionResult transactionResult = prepareResult(TransactionState.DELETED);
+    Coordinator.State commitState = new Coordinator.State(ANY_ID_2, TransactionState.COMMITTED);
+    when(coordinator.getState(ANY_ID_2)).thenReturn(Optional.of(commitState));
+
+    executor = spy(executor);
+
+    // Act
+    RecoveryExecutor.Result result =
+        executor.execute(snapshotKey, selection, transactionResult, ANY_ID_3);
+
+    // Wait for recovery to complete
+    result.recoveryFuture.get();
+
+    // Assert
+    assertThat(result.recoveredResult).isNotPresent();
+    verify(recovery).recover(eq(selection), eq(transactionResult), eq(Optional.of(commitState)));
+  }
+}

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitManagerTest.java
@@ -62,7 +62,7 @@ public class TwoPhaseConsensusCommitManagerTest {
   @Mock private DatabaseConfig databaseConfig;
   @Mock private Coordinator coordinator;
   @Mock private ParallelExecutor parallelExecutor;
-  @Mock private RecoveryHandler recovery;
+  @Mock private RecoveryExecutor recoveryExecutor;
   @Mock private CommitHandler commit;
 
   private TwoPhaseConsensusCommitManager manager;
@@ -82,7 +82,7 @@ public class TwoPhaseConsensusCommitManagerTest {
             databaseConfig,
             coordinator,
             parallelExecutor,
-            recovery,
+            recoveryExecutor,
             commit);
   }
 
@@ -127,9 +127,6 @@ public class TwoPhaseConsensusCommitManagerTest {
     assertThat(transaction1.getCommitHandler())
         .isEqualTo(transaction2.getCommitHandler())
         .isEqualTo(commit);
-    assertThat(transaction1.getRecoveryHandler())
-        .isEqualTo(transaction2.getRecoveryHandler())
-        .isEqualTo(recovery);
   }
 
   @Test
@@ -206,9 +203,6 @@ public class TwoPhaseConsensusCommitManagerTest {
     assertThat(transaction1.getCommitHandler())
         .isEqualTo(transaction2.getCommitHandler())
         .isEqualTo(commit);
-    assertThat(transaction1.getRecoveryHandler())
-        .isEqualTo(transaction2.getRecoveryHandler())
-        .isEqualTo(recovery);
   }
 
   @Test

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/TwoPhaseConsensusCommitTest.java
@@ -59,7 +59,6 @@ public class TwoPhaseConsensusCommitTest {
   @Mock private Snapshot snapshot;
   @Mock private CrudHandler crud;
   @Mock private CommitHandler commit;
-  @Mock private RecoveryHandler recovery;
   @Mock private ConsensusCommitMutationOperationChecker mutationOperationChecker;
   private TwoPhaseConsensusCommit transaction;
 
@@ -67,8 +66,8 @@ public class TwoPhaseConsensusCommitTest {
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
 
-    // Arrange
-    transaction = new TwoPhaseConsensusCommit(crud, commit, recovery, mutationOperationChecker);
+    // Arrange1
+    transaction = new TwoPhaseConsensusCommit(crud, commit, mutationOperationChecker);
 
     when(crud.areAllScannersClosed()).thenReturn(true);
   }
@@ -116,26 +115,7 @@ public class TwoPhaseConsensusCommitTest {
 
     // Assert
     assertThat(actual).isPresent();
-    verify(recovery, never()).recover(get, result);
     verify(crud).get(get);
-  }
-
-  @Test
-  public void get_GetForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Get get = prepareGet();
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    when(crud.get(get)).thenThrow(toThrow);
-    when(crud.getSnapshot()).thenReturn(snapshot);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act
-    assertThatThrownBy(() -> transaction.get(get)).isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -153,22 +133,6 @@ public class TwoPhaseConsensusCommitTest {
     // Assert
     assertThat(actual.size()).isEqualTo(1);
     verify(crud).scan(scan);
-  }
-
-  @Test
-  public void scan_ScanForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    when(crud.scan(scan)).thenThrow(toThrow);
-    when(toThrow.getSelection()).thenReturn(scan);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.scan(scan)).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(scan, result);
   }
 
   @Test
@@ -192,29 +156,6 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void
-      getScannerAndScannerOne_UncommittedRecordExceptionThrownByScannerOne_ShouldRecoverRecord()
-          throws CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    TransactionResult result = mock(TransactionResult.class);
-    when(toThrow.getSelection()).thenReturn(scan);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
-    when(scanner.one()).thenThrow(toThrow);
-    when(crud.getScanner(scan)).thenReturn(scanner);
-
-    // Act Assert
-    TransactionCrudOperable.Scanner actualScanner = transaction.getScanner(scan);
-    assertThatThrownBy(actualScanner::one).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(scan, result);
-  }
-
-  @Test
   public void getScannerAndScannerAll_ShouldCallCrudHandlerGetScannerAndScannerAll()
       throws CrudException {
     // Arrange
@@ -233,29 +174,6 @@ public class TwoPhaseConsensusCommitTest {
     assertThat(actualResults).containsExactly(result1, result2);
     verify(crud).getScanner(scan);
     verify(scanner).all();
-  }
-
-  @Test
-  public void
-      getScannerAndScannerAll_UncommittedRecordExceptionThrownByScannerAll_ShouldRecoverRecord()
-          throws CrudException {
-    // Arrange
-    Scan scan = prepareScan();
-
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    TransactionResult result = mock(TransactionResult.class);
-    when(toThrow.getSelection()).thenReturn(scan);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    TransactionCrudOperable.Scanner scanner = mock(TransactionCrudOperable.Scanner.class);
-    when(scanner.all()).thenThrow(toThrow);
-    when(crud.getScanner(scan)).thenReturn(scanner);
-
-    // Act Assert
-    TransactionCrudOperable.Scanner actualScanner = transaction.getScanner(scan);
-    assertThatThrownBy(actualScanner::all).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(scan, result);
   }
 
   @Test
@@ -288,25 +206,6 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void put_PutGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
-      throws CrudException {
-    // Arrange
-    Put put = preparePut();
-    Get get = prepareGet();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).put(put);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.put(put)).isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
-  }
-
-  @Test
   public void delete_DeleteGiven_ShouldCallCrudHandlerDelete()
       throws CrudException, ExecutionException {
     // Arrange
@@ -334,26 +233,6 @@ public class TwoPhaseConsensusCommitTest {
     // Assert
     verify(crud, times(2)).delete(delete);
     verify(mutationOperationChecker, times(2)).check(delete);
-  }
-
-  @Test
-  public void delete_DeleteGivenAndUncommittedRecordExceptionThrown_ShouldRecoverRecord()
-      throws CrudException {
-    // Arrange
-    Delete delete = prepareDelete();
-    Get get = prepareGet();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).delete(delete);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.delete(delete))
-        .isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -414,47 +293,6 @@ public class TwoPhaseConsensusCommitTest {
             .build();
     verify(crud).put(expectedPut);
     verify(mutationOperationChecker).check(expectedPut);
-  }
-
-  @Test
-  public void upsert_UpsertForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Upsert upsert =
-        Upsert.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .build();
-    Put put =
-        Put.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .enableImplicitPreRead()
-            .build();
-    Get get =
-        Get.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .build();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).put(put);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.upsert(upsert))
-        .isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -646,48 +484,6 @@ public class TwoPhaseConsensusCommitTest {
   }
 
   @Test
-  public void update_UpdateForUncommittedRecordGiven_ShouldRecoverRecord() throws CrudException {
-    // Arrange
-    Update update =
-        Update.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .build();
-    Put put =
-        Put.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .textValue(ANY_NAME_3, ANY_TEXT_3)
-            .condition(ConditionBuilder.putIfExists())
-            .enableImplicitPreRead()
-            .build();
-    Get get =
-        Get.newBuilder()
-            .namespace(ANY_NAMESPACE)
-            .table(ANY_TABLE_NAME)
-            .partitionKey(Key.ofText(ANY_NAME_1, ANY_TEXT_1))
-            .clusteringKey(Key.ofText(ANY_NAME_2, ANY_TEXT_2))
-            .build();
-
-    TransactionResult result = mock(TransactionResult.class);
-    UncommittedRecordException toThrow = mock(UncommittedRecordException.class);
-    doThrow(toThrow).when(crud).put(put);
-    when(toThrow.getSelection()).thenReturn(get);
-    when(toThrow.getResults()).thenReturn(Collections.singletonList(result));
-
-    // Act Assert
-    assertThatThrownBy(() -> transaction.update(update))
-        .isInstanceOf(UncommittedRecordException.class);
-
-    verify(recovery).recover(get, result);
-  }
-
-  @Test
   public void mutate_PutAndDeleteGiven_ShouldCallCrudHandlerPutAndDelete()
       throws CrudException, ExecutionException {
     // Arrange
@@ -715,7 +511,9 @@ public class TwoPhaseConsensusCommitTest {
     transaction.prepare();
 
     // Assert
+    verify(crud).areAllScannersClosed();
     verify(crud).readIfImplicitPreReadEnabled();
+    verify(crud).waitForRecoveryCompletionIfNecessary();
     verify(commit).prepareRecords(snapshot);
   }
 
@@ -729,28 +527,6 @@ public class TwoPhaseConsensusCommitTest {
 
     // Act Assert
     assertThatThrownBy(transaction::prepare).isInstanceOf(PreparationConflictException.class);
-  }
-
-  @Test
-  public void
-      prepare_ProcessedCrudGiven_UncommittedRecordExceptionThrownWhileImplicitPreRead_ShouldPerformLazyRecoveryAndThrowPreparationConflictException()
-          throws CrudException {
-    // Arrange
-    when(crud.getSnapshot()).thenReturn(snapshot);
-
-    Get get = mock(Get.class);
-    TransactionResult result = mock(TransactionResult.class);
-
-    UncommittedRecordException uncommittedRecordException = mock(UncommittedRecordException.class);
-    when(uncommittedRecordException.getSelection()).thenReturn(get);
-    when(uncommittedRecordException.getResults()).thenReturn(Collections.singletonList(result));
-
-    doThrow(uncommittedRecordException).when(crud).readIfImplicitPreReadEnabled();
-
-    // Act Assert
-    assertThatThrownBy(transaction::prepare).isInstanceOf(PreparationConflictException.class);
-
-    verify(recovery).recover(get, result);
   }
 
   @Test
@@ -772,6 +548,18 @@ public class TwoPhaseConsensusCommitTest {
 
     // Act Assert
     assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void
+      prepare_CrudExceptionThrownByCrudHandlerWaitForRecoveryCompletionIfNecessary_ShouldThrowPreparationException()
+          throws CrudException {
+    // Arrange
+    when(crud.getSnapshot()).thenReturn(snapshot);
+    doThrow(CrudException.class).when(crud).waitForRecoveryCompletionIfNecessary();
+
+    // Act Assert
+    assertThatThrownBy(() -> transaction.prepare()).isInstanceOf(PreparationException.class);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitNullMetadataIntegrationTestBase.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.scalar.db.api.Consistency;
@@ -75,6 +74,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   private DistributedStorage storage;
   private Coordinator coordinator;
   private RecoveryHandler recovery;
+  private RecoveryExecutor recoveryExecutor;
   @Nullable private CoordinatorGroupCommitter groupCommitter;
 
   @BeforeAll
@@ -138,6 +138,12 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
+    recoveryExecutor =
+        new RecoveryExecutor(
+            coordinator,
+            recovery,
+            tableMetadataManager,
+            consensusCommitConfig.getRecoveryExecutorCount());
     groupCommitter = CoordinatorGroupCommitter.from(consensusCommitConfig).orElse(null);
     CommitHandler commit = spy(createCommitHandler(tableMetadataManager, groupCommitter));
     manager =
@@ -148,7 +154,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
             databaseConfig,
             coordinator,
             parallelExecutor,
-            recovery,
+            recoveryExecutor,
             commit,
             groupCommitter);
   }
@@ -183,6 +189,7 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     consensusCommitAdmin.close();
     originalStorage.close();
     parallelExecutor.close();
+    recoveryExecutor.close();
   }
 
   private void dropTables() throws ExecutionException {
@@ -489,19 +496,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
@@ -512,12 +506,20 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isGreaterThan(0);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
   @Test
@@ -543,19 +545,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
@@ -566,12 +555,20 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isNull();
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(0);
     assertThat(result.getCommittedAt()).isEqualTo(0);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
   @Test
@@ -608,12 +605,12 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
             })
         .isInstanceOf(UncommittedRecordException.class);
 
+    transaction.rollback();
+
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
-
-    transaction.commit();
   }
 
   @Test
@@ -644,20 +641,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
@@ -668,12 +651,21 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isNull();
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(0);
     assertThat(result.getCommittedAt()).isEqualTo(0);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
   @Test
@@ -693,161 +685,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
         scan);
   }
 
-  private void
-      selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          Selection s) throws ExecutionException, CoordinatorException, TransactionException {
-    // Arrange
-    long current = System.currentTimeMillis();
-    populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage,
-        namespace1,
-        TABLE_1,
-        TransactionState.PREPARED,
-        current,
-        TransactionState.COMMITTED);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
-
-    // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2))
-        .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
-    transaction.commit();
-
-    assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(1);
-    assertThat(result.getCommittedAt()).isGreaterThan(0);
-  }
-
-  @Test
-  public void
-      get_GetGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        get);
-  }
-
-  @Test
-  public void
-      scan_ScanGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scan);
-  }
-
-  private void
-      selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          Selection s) throws ExecutionException, CoordinatorException, TransactionException {
-    // Arrange
-    long current = System.currentTimeMillis();
-    populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.PREPARED, current, TransactionState.ABORTED);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
-
-    // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    // rollback called twice but executed once actually
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
-    transaction.commit();
-
-    assertThat(result.getId()).isNull();
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(0);
-    assertThat(result.getCommittedAt()).isEqualTo(0);
-  }
-
-  @Test
-  public void
-      get_GetGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        get);
-  }
-
-  @Test
-  public void
-      scan_ScanGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scan);
-  }
-
   private void selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
       Selection s) throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
@@ -862,26 +699,21 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     if (s instanceof Get) {
       assertThat(transaction.get((Get) s).isPresent()).isFalse();
     } else {
       List<Result> results = transaction.scan((Scan) s);
       assertThat(results.size()).isEqualTo(0);
     }
+
     transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
   @Test
@@ -907,19 +739,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
@@ -930,12 +749,20 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isNull();
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(0);
     assertThat(result.getCommittedAt()).isEqualTo(0);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
   @Test
@@ -972,12 +799,12 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
             })
         .isInstanceOf(UncommittedRecordException.class);
 
+    transaction.rollback();
+
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
-
-    transaction.commit();
   }
 
   @Test
@@ -1008,20 +835,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
@@ -1032,12 +845,21 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isNull();
     Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(0);
     assertThat(result.getCommittedAt()).isEqualTo(0);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ANY_ID_1, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
   @Test
@@ -1054,152 +876,6 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
           throws ExecutionException, CoordinatorException, TransactionException {
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        scan);
-  }
-
-  private void
-      selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          Selection s) throws ExecutionException, CoordinatorException, TransactionException {
-    // Arrange
-    long current = System.currentTimeMillis();
-    populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage,
-        namespace1,
-        TABLE_1,
-        TransactionState.DELETED,
-        current,
-        TransactionState.COMMITTED);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
-
-    // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2))
-        .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
-    if (s instanceof Get) {
-      assertThat(transaction.get((Get) s).isPresent()).isFalse();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(0);
-    }
-    transaction.commit();
-  }
-
-  @Test
-  public void
-      get_GetGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        get);
-  }
-
-  @Test
-  public void
-      scan_ScanGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scan);
-  }
-
-  private void
-      selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          Selection s) throws ExecutionException, CoordinatorException, TransactionException {
-    // Arrange
-    long current = System.currentTimeMillis();
-    populatePreparedRecordWithNullMetadataAndCoordinatorStateRecord(
-        storage, namespace1, TABLE_1, TransactionState.DELETED, current, TransactionState.ABORTED);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
-
-    // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    // rollback called twice but executed once actually
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
-    transaction.commit();
-
-    assertThat(result.getId()).isNull();
-    Assertions.assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(0);
-    assertThat(result.getCommittedAt()).isEqualTo(0);
-  }
-
-  @Test
-  public void
-      get_GetGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        get);
-  }
-
-  @Test
-  public void
-      scan_ScanGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
         scan);
   }
 
@@ -1434,28 +1110,10 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   }
 
   @Test
-  public void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scanAll);
-  }
-
-  @Test
   public void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward()
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(scanAll);
-  }
-
-  @Test
-  public void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scanAll);
   }
 
   @Test
@@ -1484,28 +1142,10 @@ public abstract class ConsensusCommitNullMetadataIntegrationTestBase {
   }
 
   @Test
-  public void
-      scanAll_ScanAllGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scanAll);
-  }
-
-  @Test
   public void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward()
       throws ExecutionException, CoordinatorException, TransactionException {
     Scan scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(scanAll);
-  }
-
-  @Test
-  public void
-      scanAll_ScanAllGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly()
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scanAll);
   }
 
   @Test

--- a/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/transaction/consensuscommit/ConsensusCommitSpecificIntegrationTestBase.java
@@ -66,6 +66,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -75,7 +76,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class ConsensusCommitSpecificIntegrationTestBase {
@@ -109,6 +112,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   private DistributedStorage storage;
   private Coordinator coordinator;
   private RecoveryHandler recovery;
+  private RecoveryExecutor recoveryExecutor;
   private CommitHandler commit;
   @Nullable private CoordinatorGroupCommitter groupCommitter;
 
@@ -175,6 +179,12 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     TransactionTableMetadataManager tableMetadataManager =
         new TransactionTableMetadataManager(admin, -1);
     recovery = spy(new RecoveryHandler(storage, coordinator, tableMetadataManager));
+    recoveryExecutor =
+        new RecoveryExecutor(
+            coordinator,
+            recovery,
+            tableMetadataManager,
+            consensusCommitConfig.getRecoveryExecutorCount());
     groupCommitter = CoordinatorGroupCommitter.from(consensusCommitConfig).orElse(null);
     commit = spy(createCommitHandler(tableMetadataManager, groupCommitter));
     manager =
@@ -185,7 +195,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             databaseConfig,
             coordinator,
             parallelExecutor,
-            recovery,
+            recoveryExecutor,
             commit,
             groupCommitter);
   }
@@ -203,6 +213,7 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
   @AfterEach
   public void tearDown() {
+    recoveryExecutor.close();
     if (groupCommitter != null) {
       groupCommitter.close();
     }
@@ -338,8 +349,16 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     DELAYED_GROUP_COMMIT
   }
 
+  static Stream<Arguments> commitTypeAndIsolation() {
+    return Arrays.stream(CommitType.values())
+        .flatMap(
+            commitType ->
+                Arrays.stream(Isolation.values())
+                    .map(isolation -> Arguments.of(commitType, isolation)));
+  }
+
   private void selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-      Selection s, CommitType commitType)
+      Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
       throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long current = System.currentTimeMillis();
@@ -352,60 +371,74 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
             current,
             TransactionState.COMMITTED,
             commitType);
-    DistributedTransaction transaction = manager.begin();
+    DistributedTransaction transaction = manager.begin(isolation);
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
       result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
-      List<Result> results = transaction.scan((Scan) s);
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ongoingTxId);
     assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(2);
     assertThat(result.getCommittedAt()).isGreaterThan(0);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void get_GetGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-        get, commitType);
+        get, commitType, isolation, false);
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void scan_ScanGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-        scan, commitType);
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
+        scan, commitType, isolation, true);
   }
 
   private void selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
-      Selection s, CommitType commitType)
+      Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
       throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long current = System.currentTimeMillis();
@@ -417,65 +450,81 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         current,
         TransactionState.ABORTED,
         commitType);
-    DistributedTransaction transaction = manager.begin();
+    DistributedTransaction transaction = manager.begin(isolation);
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
       result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
-      List<Result> results = transaction.scan((Scan) s);
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void get_GetGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
-      CommitType commitType) throws TransactionException, ExecutionException, CoordinatorException {
+      CommitType commitType, Isolation isolation)
+      throws TransactionException, ExecutionException, CoordinatorException {
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(get, commitType);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
+        get, commitType, isolation, false);
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void scan_ScanGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
-      CommitType commitType) throws TransactionException, ExecutionException, CoordinatorException {
+      CommitType commitType, Isolation isolation)
+      throws TransactionException, ExecutionException, CoordinatorException {
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(scan, commitType);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws TransactionException, ExecutionException, CoordinatorException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
+        scan, commitType, isolation, true);
   }
 
   private void
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          Selection s, CommitType commitType)
+          Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long prepared_at = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
         storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
-    DistributedTransaction transaction = manager.begin();
+    DistributedTransaction transaction = manager.begin(isolation);
 
     // Act
     assertThatThrownBy(
@@ -483,136 +532,294 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
               if (s instanceof Get) {
                 transaction.get((Get) s);
               } else {
-                transaction.scan((Scan) s);
+                if (!useScanner) {
+                  transaction.scan((Scan) s);
+                } else {
+                  try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+                    scanner.all();
+                  }
+                }
               }
             })
         .isInstanceOf(UncommittedRecordException.class);
 
+    transaction.rollback();
+
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
-
-    transaction.commit();
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void
       get_GetGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          CommitType commitType)
+          CommitType commitType, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-        get, commitType);
+        get, commitType, isolation, false);
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void
       scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          CommitType commitType)
+          CommitType commitType, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-        scan, commitType);
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        scan, commitType, isolation, true);
   }
 
   private void
       selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          Selection s, CommitType commitType)
+          Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
             storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
-    DistributedTransaction transaction = manager.begin();
+    DistributedTransaction transaction = manager.begin(isolation);
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
       result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
-      List<Result> results = transaction.scan((Scan) s);
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
-    transaction.commit();
 
     assertThat(result.getId()).isEqualTo(ANY_ID_1);
     assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
     assertThat(result.getVersion()).isEqualTo(1);
     assertThat(result.getCommittedAt()).isEqualTo(1);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void get_GetGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        get, commitType);
+        get, commitType, isolation, false);
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void
       scan_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          CommitType commitType)
+          CommitType commitType, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        scan, commitType);
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        scan, commitType, isolation, true);
+  }
+
+  private void selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+      Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        current,
+        TransactionState.COMMITTED,
+        commitType);
+    DistributedTransaction transaction = manager.begin(isolation);
+
+    // Act
+    if (s instanceof Get) {
+      assertThat(transaction.get((Get) s).isPresent()).isFalse();
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      assertThat(results.size()).isEqualTo(0);
+    }
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void get_GetGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+        get, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void scan_ScanGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+        scan, commitType, isolation, true);
+  }
+
+  private void selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+      Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.DELETED,
+        current,
+        TransactionState.ABORTED,
+        commitType);
+    DistributedTransaction transaction = manager.begin(isolation);
+
+    // Act
+    TransactionResult result;
+    if (s instanceof Get) {
+      Optional<Result> r = transaction.get((Get) s);
+      assertThat(r).isPresent();
+      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
+    } else {
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
+      assertThat(results.size()).isEqualTo(1);
+      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
+    }
+
+    assertThat(result.getId()).isEqualTo(ANY_ID_1);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getVersion()).isEqualTo(1);
+    assertThat(result.getCommittedAt()).isEqualTo(1);
+
+    transaction.commit();
+
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void get_GetGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+        get, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void scan_ScanGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+        scan, commitType, isolation, true);
   }
 
   private void
-      selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          Selection s, CommitType commitType)
+      selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
-    long current = System.currentTimeMillis();
-    String ongoingTxId =
-        populatePreparedRecordAndCoordinatorStateRecord(
-            storage,
-            namespace1,
-            TABLE_1,
-            TransactionState.PREPARED,
-            current,
-            TransactionState.COMMITTED,
-            commitType);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
+    long prepared_at = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+    DistributedTransaction transaction = manager.begin(isolation);
 
     // Act
     assertThatThrownBy(
@@ -620,59 +827,193 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
               if (s instanceof Get) {
                 transaction.get((Get) s);
               } else {
-                transaction.scan((Scan) s);
+                if (!useScanner) {
+                  transaction.scan((Scan) s);
+                } else {
+                  try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+                    scanner.all();
+                  }
+                }
               }
             })
         .isInstanceOf(UncommittedRecordException.class);
 
+    transaction.rollback();
+
     // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2))
-        .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(coordinator, never()).putState(any(Coordinator.State.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      get_GetGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Get get = prepareGet(0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        get, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      scan_ScanGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        scan, commitType, isolation, true);
+  }
+
+  private void
+      selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+          Selection s, CommitType commitType, Isolation isolation, boolean useScanner)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+    DistributedTransaction transaction = manager.begin(isolation);
+
+    // Act
     TransactionResult result;
     if (s instanceof Get) {
       Optional<Result> r = transaction.get((Get) s);
       assertThat(r).isPresent();
       result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
     } else {
-      List<Result> results = transaction.scan((Scan) s);
+      List<Result> results;
+      if (!useScanner) {
+        results = transaction.scan((Scan) s);
+      } else {
+        try (TransactionCrudOperable.Scanner scanner = transaction.getScanner((Scan) s)) {
+          results = scanner.all();
+        }
+      }
       assertThat(results.size()).isEqualTo(1);
       result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
     }
+
+    assertThat(result.getId()).isEqualTo(ANY_ID_1);
+    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
+    assertThat(result.getVersion()).isEqualTo(1);
+    assertThat(result.getCommittedAt()).isEqualTo(1);
+
     transaction.commit();
 
-    assertThat(result.getId()).isEqualTo(ongoingTxId);
-    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(2);
-    assertThat(result.getCommittedAt()).isGreaterThan(0);
+    // Wait for the recovery to complete
+    ((ConsensusCommit) transaction).getCrudHandler().waitForRecoveryCompletion();
+
+    // Assert
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      get_GetGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void get_GetGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
     Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        get, commitType);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        get, commitType, isolation, false);
   }
 
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void scan_ScanGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        scan, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void
-      scan_ScanGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          CommitType commitType)
+      getScanner_ScanGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+          CommitType commitType, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
     Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scan, commitType);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        scan, commitType, isolation, true);
   }
 
-  private void
-      selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          Selection s, CommitType commitType)
+  @ParameterizedTest
+  @EnumSource(CommitType.class)
+  public void
+      update_UpdateGivenForPreparedWhenCoordinatorStateCommitted_ShouldUpdateAfterRollforward(
+          CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    long current = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage,
+        namespace1,
+        TABLE_1,
+        TransactionState.PREPARED,
+        current,
+        TransactionState.COMMITTED,
+        commitType);
+
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
+
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(NEW_BALANCE);
+
+    int expectedBalance = result.get().getInt(BALANCE) + 100;
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expectedBalance)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> actual = manager.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CommitType.class)
+  public void update_UpdateGivenForPreparedWhenCoordinatorStateAborted_ShouldUpdateAfterRollback(
+      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -684,80 +1025,133 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         TransactionState.ABORTED,
         commitType);
 
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
 
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    int expectedBalance = result.get().getInt(BALANCE) + 100;
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expectedBalance)
+            .build());
+
+    transaction.commit();
+
+    // Assert
+    Optional<Result> actual = manager.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CommitType.class)
+  public void
+      update_UpdateGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowUncommittedRecordException(
+          CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    long prepared_at = System.currentTimeMillis();
+    populatePreparedRecordAndCoordinatorStateRecord(
+        storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
+
+    DistributedTransaction transaction = manager.begin();
 
     // Act
     assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
+            () ->
+                transaction.update(
+                    Update.newBuilder()
+                        .namespace(namespace1)
+                        .table(TABLE_1)
+                        .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                        .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                        .intValue(BALANCE, 100)
+                        .build()))
         .isInstanceOf(UncommittedRecordException.class);
 
+    transaction.rollback();
+
     // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    // rollback called twice but executed once actually
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
+    verify(coordinator, never()).putState(any(Coordinator.State.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CommitType.class)
+  public void
+      update_UpdateGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldUpdateAfterAbortTransaction(
+          CommitType commitType)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    // Arrange
+    long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
+    String ongoingTxId =
+        populatePreparedRecordAndCoordinatorStateRecord(
+            storage, namespace1, TABLE_1, TransactionState.PREPARED, prepared_at, null, commitType);
+
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
+
+    DistributedTransaction transaction = manager.begin();
+
+    // Act
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    int expectedBalance = result.get().getInt(BALANCE) + 100;
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expectedBalance)
+            .build());
+
     transaction.commit();
 
-    assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(1);
-    assertThat(result.getCommittedAt()).isEqualTo(1);
+    // Assert
+    Optional<Result> actual = manager.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @EnumSource(CommitType.class)
   public void
-      get_GetGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
+      insert_InsertGivenForDeletedWhenCoordinatorStateCommitted_ShouldInsertAfterRollforward(
           CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      scan_ScanGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scan, commitType);
-  }
-
-  private void selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-      Selection s, CommitType commitType)
-      throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -768,52 +1162,47 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         current,
         TransactionState.COMMITTED,
         commitType);
+
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
+
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isFalse();
+
+    int expectedBalance = 100;
+
+    transaction.insert(
+        Insert.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expectedBalance)
+            .build());
+
+    transaction.commit();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
+    Optional<Result> actual = manager.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery).rollforwardRecord(any(Selection.class), any(TransactionResult.class));
-    if (s instanceof Get) {
-      assertThat(transaction.get((Get) s).isPresent()).isFalse();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(0);
-    }
-    transaction.commit();
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @EnumSource(CommitType.class)
-  public void get_GetGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+  public void update_UpdateGivenForDeletedWhenCoordinatorStateAborted_ShouldUpdateAfterRollback(
       CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-        get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void scan_ScanGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-        scan, commitType);
-  }
-
-  private void selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
-      Selection s, CommitType commitType)
-      throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long current = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
@@ -824,330 +1213,126 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         current,
         TransactionState.ABORTED,
         commitType);
+
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
+
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
 
-    // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
+    int expectedBalance = result.get().getInt(BALANCE) + 100;
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expectedBalance)
+            .build());
+
     transaction.commit();
 
-    assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(1);
-    assertThat(result.getCommittedAt()).isEqualTo(1);
+    // Assert
+    Optional<Result> actual = manager.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
+    verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @EnumSource(CommitType.class)
-  public void get_GetGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void scan_ScanGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(scan, commitType);
-  }
-
-  private void
-      selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          Selection s, CommitType commitType)
+  public void
+      update_UpdateGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldThrowUncommittedRecordException(
+          CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long prepared_at = System.currentTimeMillis();
     populatePreparedRecordAndCoordinatorStateRecord(
         storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+
     DistributedTransaction transaction = manager.begin();
 
     // Act
     assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
+            () ->
+                transaction.update(
+                    Update.newBuilder()
+                        .namespace(namespace1)
+                        .table(TABLE_1)
+                        .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                        .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                        .intValue(BALANCE, 100)
+                        .build()))
         .isInstanceOf(UncommittedRecordException.class);
 
+    transaction.rollback();
+
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
+    verify(recovery, never()).recover(any(Selection.class), any(TransactionResult.class), any());
     verify(recovery, never()).rollbackRecord(any(Selection.class), any(TransactionResult.class));
     verify(coordinator, never()).putState(any(Coordinator.State.class));
-
-    transaction.commit();
   }
 
-  @ParameterizedTest()
+  @ParameterizedTest
   @EnumSource(CommitType.class)
   public void
-      get_GetGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+      update_UpdateGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldUpdateAfterAbortTransaction(
           CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-        get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      scan_ScanGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-        scan, commitType);
-  }
-
-  private void
-      selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          Selection s, CommitType commitType)
           throws ExecutionException, CoordinatorException, TransactionException {
     // Arrange
     long prepared_at = System.currentTimeMillis() - RecoveryHandler.TRANSACTION_LIFETIME_MILLIS - 1;
     String ongoingTxId =
         populatePreparedRecordAndCoordinatorStateRecord(
             storage, namespace1, TABLE_1, TransactionState.DELETED, prepared_at, null, commitType);
+
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .build();
+
     DistributedTransaction transaction = manager.begin();
 
     // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
+    Optional<Result> result = transaction.get(get);
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().getInt(BALANCE)).isEqualTo(INITIAL_BALANCE);
+
+    int expectedBalance = result.get().getInt(BALANCE) + 100;
+
+    transaction.update(
+        Update.newBuilder()
+            .namespace(namespace1)
+            .table(TABLE_1)
+            .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+            .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+            .intValue(BALANCE, expectedBalance)
+            .build());
+
+    transaction.commit();
 
     // Assert
-    verify(recovery).recover(any(Selection.class), any(TransactionResult.class));
+    Optional<Result> actual = manager.get(get);
+    assertThat(actual.isPresent()).isTrue();
+    assertThat(actual.get().getInt(BALANCE)).isEqualTo(expectedBalance);
+
+    verify(recovery).recover(any(Selection.class), any(TransactionResult.class), any());
     verify(coordinator).putState(new Coordinator.State(ongoingTxId, TransactionState.ABORTED));
     verify(recovery).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
-    transaction.commit();
-
-    assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(1);
-    assertThat(result.getCommittedAt()).isEqualTo(1);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void get_GetGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void scan_ScanGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        scan, commitType);
-  }
-
-  private void
-      selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          Selection s, CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    // Arrange
-    long current = System.currentTimeMillis();
-    populatePreparedRecordAndCoordinatorStateRecord(
-        storage,
-        namespace1,
-        TABLE_1,
-        TransactionState.DELETED,
-        current,
-        TransactionState.COMMITTED,
-        commitType);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
-
-    // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2))
-        .rollforwardRecord(any(Selection.class), any(TransactionResult.class));
-    if (s instanceof Get) {
-      assertThat(transaction.get((Get) s).isPresent()).isFalse();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(0);
-    }
-    transaction.commit();
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      get_GetGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      scan_ScanGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scan, commitType);
-  }
-
-  private void
-      selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          Selection s, CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    // Arrange
-    long current = System.currentTimeMillis();
-    populatePreparedRecordAndCoordinatorStateRecord(
-        storage,
-        namespace1,
-        TABLE_1,
-        TransactionState.DELETED,
-        current,
-        TransactionState.ABORTED,
-        commitType);
-
-    ConsensusCommit transaction = (ConsensusCommit) manager.begin();
-
-    transaction.setBeforeRecoveryHook(
-        () ->
-            assertThatThrownBy(
-                    () -> {
-                      DistributedTransaction another = manager.begin();
-                      if (s instanceof Get) {
-                        another.get((Get) s);
-                      } else {
-                        another.scan((Scan) s);
-                      }
-                      another.commit();
-                    })
-                .isInstanceOf(UncommittedRecordException.class));
-
-    // Act
-    assertThatThrownBy(
-            () -> {
-              if (s instanceof Get) {
-                transaction.get((Get) s);
-              } else {
-                transaction.scan((Scan) s);
-              }
-            })
-        .isInstanceOf(UncommittedRecordException.class);
-
-    // Assert
-    verify(recovery, times(2)).recover(any(Selection.class), any(TransactionResult.class));
-    verify(recovery, times(2)).rollbackRecord(any(Selection.class), any(TransactionResult.class));
-    // rollback called twice but executed once actually
-    TransactionResult result;
-    if (s instanceof Get) {
-      Optional<Result> r = transaction.get((Get) s);
-      assertThat(r).isPresent();
-      result = (TransactionResult) ((FilteredResult) r.get()).getOriginalResult();
-    } else {
-      List<Result> results = transaction.scan((Scan) s);
-      assertThat(results.size()).isEqualTo(1);
-      result = (TransactionResult) ((FilteredResult) results.get(0)).getOriginalResult();
-    }
-    transaction.commit();
-
-    assertThat(result.getId()).isEqualTo(ANY_ID_1);
-    assertThat(result.getState()).isEqualTo(TransactionState.COMMITTED);
-    assertThat(result.getVersion()).isEqualTo(1);
-    assertThat(result.getCommittedAt()).isEqualTo(1);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      get_GetGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Get get = prepareGet(0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        get, commitType);
-  }
-
-  @ParameterizedTest()
-  @EnumSource(CommitType.class)
-  public void
-      scan_ScanGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    Scan scan = prepareScan(0, 0, 0, namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scan, commitType);
   }
 
   @Test
@@ -2812,68 +2997,6 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
         .isEqualTo(TransactionState.COMMITTED);
   }
 
-  @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
-        scanAll, commitType);
-  }
-
-  @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scanAll, commitType);
-  }
-
-  @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
-        scanAll, commitType);
-  }
-
-  @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scanAll, commitType);
-  }
-
-  @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        scanAll, commitType);
-  }
-
-  @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void
-      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
-    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-        scanAll, commitType);
-  }
-
   @Test
   public void scanAll_ScanAllGivenForNonExisting_ShouldReturnEmpty() throws TransactionException {
     // Arrange
@@ -2893,65 +3016,171 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(CommitType.class)
+  @MethodSource("commitTypeAndIsolation")
+  public void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+        scanAll, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanAllGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateAborted_ShouldRollback(
+        scanAll, commitType, isolation, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void scanAll_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+        scanAll, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanAllGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateCommitted_ShouldRollforward(
+        scanAll, commitType, isolation, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        scanAll, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        scanAll, commitType, isolation, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      scanAll_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        scanAll, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanAllGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForDeletedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        scanAll, commitType, isolation, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
-      CommitType commitType) throws TransactionException, ExecutionException, CoordinatorException {
+      CommitType commitType, Isolation isolation)
+      throws TransactionException, ExecutionException, CoordinatorException {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
-        scanAll, commitType);
+        scanAll, commitType, isolation, false);
   }
 
   @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void
-      scanAll_ScanAllGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanAllGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
+      CommitType commitType, Isolation isolation)
+      throws TransactionException, ExecutionException, CoordinatorException {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateAbortedAndRolledBackByAnother_ShouldRollbackProperly(
-        scanAll, commitType);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateAborted_ShouldRollback(
+        scanAll, commitType, isolation, true);
   }
 
   @ParameterizedTest
-  @EnumSource(CommitType.class)
+  @MethodSource("commitTypeAndIsolation")
   public void scanAll_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-      CommitType commitType) throws ExecutionException, CoordinatorException, TransactionException {
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
-        scanAll, commitType);
+        scanAll, commitType, isolation, false);
   }
 
   @ParameterizedTest
-  @EnumSource(CommitType.class)
-  public void
-      scanAll_ScanAllGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-          CommitType commitType)
-          throws ExecutionException, CoordinatorException, TransactionException {
+  @MethodSource("commitTypeAndIsolation")
+  public void getScanner_ScanAllGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
+      CommitType commitType, Isolation isolation)
+      throws ExecutionException, CoordinatorException, TransactionException {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
-    selection_SelectionGivenForPreparedWhenCoordinatorStateCommittedAndRolledForwardByAnother_ShouldRollforwardProperly(
-        scanAll, commitType);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateCommitted_ShouldRollforward(
+        scanAll, commitType, isolation, true);
   }
 
   @ParameterizedTest
-  @EnumSource(CommitType.class)
+  @MethodSource("commitTypeAndIsolation")
   public void
       scanAll_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-          CommitType commitType)
+          CommitType commitType, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
-        scanAll, commitType);
+        scanAll, commitType, isolation, false);
   }
 
   @ParameterizedTest
-  @EnumSource(CommitType.class)
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndExpired_ShouldAbortTransaction(
+        scanAll, commitType, isolation, true);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
   public void
       scanAll_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-          CommitType commitType)
+          CommitType commitType, Isolation isolation)
           throws ExecutionException, CoordinatorException, TransactionException {
     ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
     selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
-        scanAll, commitType);
+        scanAll, commitType, isolation, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitTypeAndIsolation")
+  public void
+      getScanner_ScanAllGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+          CommitType commitType, Isolation isolation)
+          throws ExecutionException, CoordinatorException, TransactionException {
+    ScanAll scanAll = prepareScanAll(namespace1, TABLE_1);
+    selection_SelectionGivenForPreparedWhenCoordinatorStateNotExistAndNotExpired_ShouldNotAbortTransaction(
+        scanAll, commitType, isolation, true);
   }
 
   @Test
@@ -5317,23 +5546,15 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     originalStorage.mutate(prepareMutationComposer.get());
 
     // Act Assert
-    Optional<Result> actual;
-    while (true) {
-      try {
-        actual =
-            manager.get(
-                Get.newBuilder()
-                    .namespace(namespace1)
-                    .table(TABLE_1)
-                    .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-                    .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
-                    .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-                    .build());
-        break;
-      } catch (CrudConflictException e) {
-        // Retry on conflict
-      }
-    }
+    Optional<Result> actual =
+        manager.get(
+            Get.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .clusteringKey(Key.ofInt(ACCOUNT_TYPE, 0))
+                .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                .build());
 
     assertThat(actual).isPresent();
     assertThat(actual.get().getInt(ACCOUNT_ID)).isEqualTo(0);
@@ -5454,22 +5675,14 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
     originalStorage.mutate(prepareMutationComposer.get());
 
     // Act Assert
-    List<Result> results;
-    while (true) {
-      try {
-        results =
-            manager.scan(
-                Scan.newBuilder()
-                    .namespace(namespace1)
-                    .table(TABLE_1)
-                    .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-                    .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-                    .build());
-        break;
-      } catch (CrudConflictException e) {
-        // Retry on conflict
-      }
-    }
+    List<Result> results =
+        manager.scan(
+            Scan.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                .build());
 
     assertThat(results).hasSize(2);
     assertThat(results.get(0).getInt(ACCOUNT_ID)).isEqualTo(0);
@@ -5696,20 +5909,15 @@ public abstract class ConsensusCommitSpecificIntegrationTestBase {
 
     // Act Assert
     List<Result> results;
-    while (true) {
-      try (TransactionManagerCrudOperable.Scanner scanner =
-          manager.getScanner(
-              Scan.newBuilder()
-                  .namespace(namespace1)
-                  .table(TABLE_1)
-                  .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
-                  .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
-                  .build())) {
-        results = scanner.all();
-        break;
-      } catch (CrudConflictException e) {
-        // Retry on conflict
-      }
+    try (TransactionManagerCrudOperable.Scanner scanner =
+        manager.getScanner(
+            Scan.newBuilder()
+                .namespace(namespace1)
+                .table(TABLE_1)
+                .partitionKey(Key.ofInt(ACCOUNT_ID, 0))
+                .where(column(BALANCE).isEqualToInt(INITIAL_BALANCE))
+                .build())) {
+      results = scanner.all();
     }
 
     assertThat(results).hasSize(2);


### PR DESCRIPTION
## Description

This PR improves the read process in Consensus Commit.

The improved read algorithm is as follows:

1. If reading a record with status `COMMITTED`, return the record as before.  
2. If reading a record with status `PREPARED` or `DELETED`, then check the Coordinator table:
   - If the transaction status is `COMMITTED`, start lazy recovery and return the after image.
   - If the transaction status is `ABORTED`, start lazy recovery and return the before image.
   - If there is no status record for the transaction in the Coordinator table:
     - If the transaction is expired, start lazy recovery and return the before image.
     - If the transaction is not expired, throw an `UncommittedRecordException`.

Additionally, this PR updates the code to perform lazy recovery in background threads. In cases where the recovered record needs to be written in the transaction, or where serializable validation (under SERIALIZABLE isolation level) is required, we need to wait for all lazy recoveries to complete before committing the transaction.

## Related issues and/or PRs

N/A

## Changes made

- 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

