### PR TITLE
Create index if not exists in repairTable of CosmosAdmin and DynamoAdmin

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cosmos/CosmosAdmin.java
@@ -588,6 +588,7 @@ public class CosmosAdmin implements DistributedStorageAdmin {
       throws ExecutionException {
     try {
       createTableInternal(namespace, table, metadata, true);
+      updateIndexingPolicy(namespace, table, metadata);
     } catch (IllegalArgumentException e) {
       throw e;
     } catch (Exception e) {

--- a/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/dynamo/DynamoAdmin.java
@@ -1341,6 +1341,9 @@ public class DynamoAdmin implements DistributedStorageAdmin {
       throws ExecutionException {
     try {
       createTableInternal(nonPrefixedNamespace, table, metadata, true, options);
+      for (String indexColumnName : metadata.getSecondaryIndexNames()) {
+        createIndex(nonPrefixedNamespace, table, indexColumnName, options);
+      }
     } catch (RuntimeException e) {
       throw new ExecutionException(
           String.format(

--- a/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/jdbc/JdbcAdmin.java
@@ -889,7 +889,8 @@ public class JdbcAdmin implements DistributedStorageAdmin {
     }
   }
 
-  private void createIndex(
+  @VisibleForTesting
+  void createIndex(
       Connection connection, String schema, String table, String indexedColumn, boolean ifNotExists)
       throws SQLException {
     String indexName = getIndexName(schema, table, indexedColumn);

--- a/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
+++ b/core/src/test/java/com/scalar/db/storage/dynamo/DynamoAdminTestBase.java
@@ -1271,6 +1271,74 @@ public abstract class DynamoAdminTestBase {
   }
 
   @Test
+  public void repairTable_WhenTableAlreadyExistsWithoutIndex_ShouldCreateIndex()
+      throws ExecutionException {
+    // Arrange
+    TableMetadata metadata =
+        TableMetadata.newBuilder()
+            .addPartitionKey("c1")
+            .addColumn("c1", DataType.TEXT)
+            .addColumn("c2", DataType.INT)
+            .addColumn("c3", DataType.INT)
+            .addSecondaryIndex("c3")
+            .build();
+    // The table to repair exists
+    when(client.describeTable(DescribeTableRequest.builder().tableName(getFullTableName()).build()))
+        .thenReturn(tableIsActiveResponse);
+    // The metadata table exists
+    when(client.describeTable(
+            DescribeTableRequest.builder().tableName(getFullMetadataTableName()).build()))
+        .thenReturn(tableIsActiveResponse);
+    // Continuous backup check
+    when(client.describeContinuousBackups(any(DescribeContinuousBackupsRequest.class)))
+        .thenReturn(backupIsEnabledResponse);
+    // Table metadata to return in createIndex
+    GetItemResponse getItemResponse = mock(GetItemResponse.class);
+    when(client.getItem(any(GetItemRequest.class))).thenReturn(getItemResponse);
+    when(getItemResponse.item())
+        .thenReturn(
+            ImmutableMap.<String, AttributeValue>builder()
+                .put(
+                    DynamoAdmin.METADATA_ATTR_TABLE,
+                    AttributeValue.builder().s(getFullTableName()).build())
+                .put(
+                    DynamoAdmin.METADATA_ATTR_COLUMNS,
+                    AttributeValue.builder()
+                        .m(
+                            ImmutableMap.<String, AttributeValue>builder()
+                                .put("c1", AttributeValue.builder().s("text").build())
+                                .put("c2", AttributeValue.builder().s("int").build())
+                                .put("c3", AttributeValue.builder().s("int").build())
+                                .build())
+                        .build())
+                .put(
+                    DynamoAdmin.METADATA_ATTR_PARTITION_KEY,
+                    AttributeValue.builder().l(AttributeValue.builder().s("c1").build()).build())
+                .put(
+                    DynamoAdmin.METADATA_ATTR_SECONDARY_INDEX,
+                    AttributeValue.builder().ss("c3").build())
+                .build());
+    // For waitForTableCreation in createIndex
+    DescribeTableResponse describeTableResponse = mock(DescribeTableResponse.class);
+    when(client.describeTable(any(DescribeTableRequest.class))).thenReturn(describeTableResponse);
+    TableDescription tableDescription = mock(TableDescription.class);
+    when(describeTableResponse.table()).thenReturn(tableDescription);
+    GlobalSecondaryIndexDescription globalSecondaryIndexDescription =
+        mock(GlobalSecondaryIndexDescription.class);
+    when(tableDescription.globalSecondaryIndexes())
+        .thenReturn(Collections.singletonList(globalSecondaryIndexDescription));
+    String indexName = getFullTableName() + ".global_index.c3";
+    when(globalSecondaryIndexDescription.indexName()).thenReturn(indexName);
+    when(globalSecondaryIndexDescription.indexStatus()).thenReturn(IndexStatus.ACTIVE);
+
+    // Act
+    admin.repairTable(NAMESPACE, TABLE, metadata, ImmutableMap.of());
+
+    // Assert
+    verify(client, times(1)).updateTable(any(UpdateTableRequest.class));
+  }
+
+  @Test
   public void addNewColumnToTable_ShouldWorkProperly() throws ExecutionException {
     // Arrange
     String currentColumn = "c1";


### PR DESCRIPTION
## Description

This PR fixes an issue where the `repairTable` operation in `DynamoAdmin` and `CosmosAdmin` did not create indexes when the table already existed. Also, to ensure the `repairTable` creates indexes when the table metadata specifies them, this PR adds unit tests for the `repairTable`.

## Related issues and/or PRs

N/A

## Changes made

- Updated the `repairTable` method in `DynamoAdmin` and `CosmosAdmin` to create indexes when the table metadata specifies them.
- Added unit tests for the `repairTable` method to ensure indexes are created when specified in the metadata.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A