### PR TITLE
Update ScalarDB dependency version to 3.16.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install it in your application using your build tool such as Gradle and 
 To add a dependency on ScalarDB using Gradle, use the following:
 ```gradle
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.15.2'
+    implementation 'com.scalar-labs:scalardb:3.16.0'
 }
 ```
 
@@ -46,7 +46,7 @@ To add a dependency using Maven:
 <dependency>
   <groupId>com.scalar-labs</groupId>
   <artifactId>scalardb</artifactId>
-  <version>3.15.2</version>
+  <version>3.16.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description

This PR updates the ScalarDB dependency version to 3.16.0 in README, as ScalarDB 3.16.0 has been released.

## Related issues and/or PRs

N/A

## Changes made

- Updated ScalarDB dependency version to 3.16.0.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
