### PR TITLE
Fix behavior of group commit with one-phase commit

### DIFF
--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -58,6 +58,23 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   }
 
   @Override
+  boolean canOnePhaseCommit(Snapshot snapshot) throws CommitException {
+    try {
+      return super.canOnePhaseCommit(snapshot);
+    } catch (Exception e) {
+      cancelGroupCommitIfNeeded(snapshot.getId());
+      throw e;
+    }
+  }
+
+  @Override
+  void onePhaseCommitRecords(Snapshot snapshot)
+      throws CommitConflictException, UnknownTransactionStatusException {
+    cancelGroupCommitIfNeeded(snapshot.getId());
+    super.onePhaseCommitRecords(snapshot);
+  }
+
+  @Override
   protected void onFailureBeforeCommit(Snapshot snapshot) {
     cancelGroupCommitIfNeeded(snapshot.getId());
   }

--- a/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
+++ b/core/src/main/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommit.java
@@ -61,7 +61,7 @@ public class CommitHandlerWithGroupCommit extends CommitHandler {
   boolean canOnePhaseCommit(Snapshot snapshot) throws CommitException {
     try {
       return super.canOnePhaseCommit(snapshot);
-    } catch (Exception e) {
+    } catch (CommitException e) {
       cancelGroupCommitIfNeeded(snapshot.getId());
       throw e;
     }

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerTest.java
@@ -90,6 +90,11 @@ public class CommitHandlerTest {
         false);
   }
 
+  protected CommitHandler createCommitHandlerWithOnePhaseCommit() {
+    return new CommitHandler(
+        storage, coordinator, tableMetadataManager, parallelExecutor, mutationsGrouper, true, true);
+  }
+
   @BeforeEach
   void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
@@ -1068,8 +1073,9 @@ public class CommitHandlerTest {
   }
 
   @Test
-  public void canOnePhaseCommit_WhenMutationsGrouperThrowsException_ShouldThrowCommitException()
-      throws ExecutionException {
+  public void
+      canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException()
+          throws ExecutionException {
     // Arrange
     CommitHandler handler = createCommitHandlerWithOnePhaseCommit();
     Snapshot snapshot = prepareSnapshot();
@@ -1178,11 +1184,6 @@ public class CommitHandlerTest {
         .isInstanceOf(UnknownTransactionStatusException.class);
 
     verify(handler).onFailureBeforeCommit(snapshot);
-  }
-
-  private CommitHandler createCommitHandlerWithOnePhaseCommit() {
-    return new CommitHandler(
-        storage, coordinator, tableMetadataManager, parallelExecutor, mutationsGrouper, true, true);
   }
 
   protected void doThrowExceptionWhenCoordinatorPutState(

--- a/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
+++ b/core/src/test/java/com/scalar/db/transaction/consensuscommit/CommitHandlerWithGroupCommitTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import com.scalar.db.api.TransactionState;
 import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CommitConflictException;
 import com.scalar.db.exception.transaction.CommitException;
 import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
 import com.scalar.db.exception.transaction.ValidationConflictException;
@@ -22,7 +23,6 @@ import com.scalar.db.transaction.consensuscommit.CoordinatorGroupCommitter.Coord
 import com.scalar.db.util.groupcommit.GroupCommitConfig;
 import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -72,6 +72,20 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
         new MutationsGrouper(storageInfoProvider),
         coordinatorWriteOmissionOnReadOnlyEnabled,
         false,
+        groupCommitter);
+  }
+
+  @Override
+  protected CommitHandler createCommitHandlerWithOnePhaseCommit() {
+    createGroupCommitterIfNotExists();
+    return new CommitHandlerWithGroupCommit(
+        storage,
+        coordinator,
+        tableMetadataManager,
+        parallelExecutor,
+        mutationsGrouper,
+        true,
+        true,
         groupCommitter);
   }
 
@@ -199,72 +213,121 @@ class CommitHandlerWithGroupCommitTest extends CommitHandlerTest {
     verify(groupCommitter, never()).remove(anyId());
   }
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
   @Test
-  public void canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse() {}
+  @Override
+  public void onePhaseCommitRecords_WhenSuccessful_ShouldMutateUsingComposerMutations()
+      throws CommitConflictException, UnknownTransactionStatusException, ExecutionException {
+    super.onePhaseCommitRecords_WhenSuccessful_ShouldMutateUsingComposerMutations();
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
-  public void canOnePhaseCommit_WhenValidationRequired_ShouldReturnFalse() {}
+    // Assert
+    verify(groupCommitter).remove(anyId());
+  }
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
   @Test
-  public void canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse() {}
-
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
   @Override
-  @Test
-  public void canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse() {}
-
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
-  public void canOnePhaseCommit_WhenMutationsCanBeGrouped_ShouldReturnTrue() {}
-
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
-  public void canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse() {}
-
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
-  public void canOnePhaseCommit_WhenMutationsGrouperThrowsException_ShouldThrowCommitException() {}
-
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
-  public void onePhaseCommitRecords_WhenSuccessful_ShouldMutateUsingComposerMutations() {}
-
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
   public void
-      onePhaseCommitRecords_WhenNoMutationExceptionThrown_ShouldThrowCommitConflictException() {}
+      onePhaseCommitRecords_WhenNoMutationExceptionThrown_ShouldThrowCommitConflictException()
+          throws ExecutionException {
+    super.onePhaseCommitRecords_WhenNoMutationExceptionThrown_ShouldThrowCommitConflictException();
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
+    // Assert
+    verify(groupCommitter).remove(anyId());
+  }
+
   @Test
+  @Override
   public void
-      onePhaseCommitRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowCommitConflictException() {}
+      onePhaseCommitRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowCommitConflictException()
+          throws ExecutionException {
+    super
+        .onePhaseCommitRecords_WhenRetriableExecutionExceptionThrown_ShouldThrowCommitConflictException();
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
+    // Assert
+    verify(groupCommitter).remove(anyId());
+  }
+
   @Test
+  @Override
   public void
-      onePhaseCommitRecords_WhenExecutionExceptionThrown_ShouldThrowUnknownTransactionStatusException() {}
+      onePhaseCommitRecords_WhenExecutionExceptionThrown_ShouldThrowUnknownTransactionStatusException()
+          throws ExecutionException {
+    super
+        .onePhaseCommitRecords_WhenExecutionExceptionThrown_ShouldThrowUnknownTransactionStatusException();
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
-  @Test
-  public void commit_OnePhaseCommitted_ShouldNotThrowAnyException() {}
+    // Assert
+    verify(groupCommitter).remove(anyId());
+  }
 
-  @Disabled("Enabling both one-phase commit and group commit is not supported")
-  @Override
   @Test
+  @Override
+  public void canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse() throws Exception {
+    super.canOnePhaseCommit_WhenOnePhaseCommitDisabled_ShouldReturnFalse();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void canOnePhaseCommit_WhenValidationRequired_ShouldReturnFalse() throws Exception {
+    super.canOnePhaseCommit_WhenValidationRequired_ShouldReturnFalse();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse() throws Exception {
+    super.canOnePhaseCommit_WhenNoWritesAndDeletes_ShouldReturnFalse();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse()
+      throws Exception {
+    super.canOnePhaseCommit_WhenDeleteWithoutExistingRecord_ShouldReturnFalse();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void canOnePhaseCommit_WhenMutationsCanBeGrouped_ShouldReturnTrue() throws Exception {
+    super.canOnePhaseCommit_WhenMutationsCanBeGrouped_ShouldReturnTrue();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse() throws Exception {
+    super.canOnePhaseCommit_WhenMutationsCannotBeGrouped_ShouldReturnFalse();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
   public void
-      commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException() {}
+      canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException()
+          throws ExecutionException {
+    super
+        .canOnePhaseCommit_WhenMutationsGrouperThrowsExecutionException_ShouldThrowCommitException();
+
+    // Assert
+    verify(groupCommitter).remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void commit_OnePhaseCommitted_ShouldNotThrowAnyException()
+      throws CommitException, UnknownTransactionStatusException {
+    super.commit_OnePhaseCommitted_ShouldNotThrowAnyException();
+    groupCommitter.remove(anyId());
+  }
+
+  @Test
+  @Override
+  public void
+      commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException()
+          throws CommitException, UnknownTransactionStatusException {
+    super
+        .commit_OnePhaseCommitted_UnknownTransactionStatusExceptionThrown_ShouldThrowUnknownTransactionStatusException();
+    groupCommitter.remove(anyId());
+  }
 }


### PR DESCRIPTION
## Description

When I implemented the one-phase commit optimization, I somehow thought that we couldn’t support enabling both group commit and one-phase commit. However, on second thought, I realized that we actually can. This PR addresses that.

## Related issues and/or PRs

N/A

## Changes made

- Updated the logic to cancel group commit in the following situations:
  - When canOnePhaseCommit() throws an `Exception`
  - When a one-phase commit is performed

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed a bug where group commit did not work correctly with one-phase commit.
