### PR TITLE
Backport to branch(3.14) : Fix error handling for mutations in Cassandra

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cassandra/BatchHandler.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/BatchHandler.java
@@ -11,8 +11,8 @@ import com.datastax.driver.core.exceptions.WriteTimeoutException;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Mutation;
 import com.scalar.db.common.error.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
@@ -48,12 +48,11 @@ public class BatchHandler {
    * must be for the same partition.
    *
    * @param mutations a list of {@code Mutation}s to execute
-   * @throws RetriableExecutionException if it fails, but it can be retried
    * @throws NoMutationException if at least one of conditional {@code Mutation}s fails because it
    *     didn't meet the condition
+   * @throws ExecutionException if the execution fails
    */
-  public void handle(List<? extends Mutation> mutations)
-      throws RetriableExecutionException, NoMutationException {
+  public void handle(List<? extends Mutation> mutations) throws ExecutionException {
     try {
       ResultSet results = execute(mutations);
       // it's for conditional update. non-conditional update always return true
@@ -64,17 +63,18 @@ public class BatchHandler {
       logger.warn("Write timeout happened during batch mutate operation", e);
       WriteType writeType = e.getWriteType();
       if (writeType == WriteType.BATCH_LOG) {
-        throw new RetriableExecutionException(
-            CoreError.CASSANDRA_LOGGING_FAILED_IN_BATCH.buildMessage(), e);
+        // A timeout occurred while the coordinator was waiting for the batch log replicas to
+        // acknowledge the log. Thus, the batch may or may not be applied.
+        throw new ExecutionException(CoreError.CASSANDRA_LOGGING_FAILED_IN_BATCH.buildMessage(), e);
       } else if (writeType == WriteType.BATCH) {
         logger.warn("Logging succeeded, but mutations in the batch partially failed", e);
       } else {
-        throw new RetriableExecutionException(
+        throw new ExecutionException(
             CoreError.CASSANDRA_OPERATION_FAILED_IN_BATCH.buildMessage(writeType), e);
       }
     } catch (RuntimeException e) {
       logger.warn(e.getMessage(), e);
-      throw new RetriableExecutionException(
+      throw new ExecutionException(
           CoreError.CASSANDRA_ERROR_OCCURRED_IN_BATCH.buildMessage(e.getMessage()), e);
     }
   }

--- a/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/BatchHandlerTest.java
@@ -20,8 +20,8 @@ import com.scalar.db.api.Mutation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIfExists;
 import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.Key;
 import java.util.Arrays;
 import java.util.List;
@@ -178,7 +178,7 @@ public class BatchHandlerTest {
   }
 
   @Test
-  public void handle_WTEThrownInLoggingInBatchExecution_ShouldThrowRetriableExecutionException() {
+  public void handle_WTEThrownInLoggingInBatchExecution_ShouldThrowExecutionException() {
     // Arrange
     configureBehavior();
     mutations = prepareConditionalPuts();
@@ -188,7 +188,7 @@ public class BatchHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> batch.handle(mutations))
-        .isInstanceOf(RetriableExecutionException.class)
+        .isInstanceOf(ExecutionException.class)
         .hasCause(e);
   }
 
@@ -206,7 +206,7 @@ public class BatchHandlerTest {
   }
 
   @Test
-  public void handle_WTEThrownInCasInBatchExecution_ShouldThrowRetriableExecutionException() {
+  public void handle_WTEThrownInCasInBatchExecution_ShouldThrowExecutionException() {
     // Arrange
     configureBehavior();
     mutations = prepareConditionalPuts();
@@ -216,13 +216,12 @@ public class BatchHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> batch.handle(mutations))
-        .isInstanceOf(RetriableExecutionException.class)
+        .isInstanceOf(ExecutionException.class)
         .hasCause(e);
   }
 
   @Test
-  public void
-      handle_WTEThrownInSimpleWriteInBatchExecution_ShouldThrowRetriableExecutionException() {
+  public void handle_WTEThrownInSimpleWriteInBatchExecution_ShouldThrowExecutionException() {
     // Arrange
     configureBehavior();
     mutations = prepareConditionalPuts();
@@ -232,12 +231,12 @@ public class BatchHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> batch.handle(mutations))
-        .isInstanceOf(RetriableExecutionException.class)
+        .isInstanceOf(ExecutionException.class)
         .hasCause(e);
   }
 
   @Test
-  public void handle_DriverExceptionThrownInExecution_ShouldThrowRetriableExecutionException() {
+  public void handle_DriverExceptionThrownInExecution_ShouldThrowExecutionException() {
     // Arrange
     configureBehavior();
     mutations = prepareConditionalPuts();
@@ -246,7 +245,7 @@ public class BatchHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> batch.handle(mutations))
-        .isInstanceOf(RetriableExecutionException.class)
+        .isInstanceOf(ExecutionException.class)
         .hasCause(e);
   }
 

--- a/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/InsertStatementHandlerTest.java
@@ -28,7 +28,6 @@ import com.scalar.db.api.Put;
 import com.scalar.db.api.PutIfNotExists;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.exception.storage.NoMutationException;
-import com.scalar.db.exception.storage.RetriableExecutionException;
 import com.scalar.db.io.Key;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -330,7 +329,7 @@ public class InsertStatementHandlerTest {
   }
 
   @Test
-  public void handle_WTEWithCasThrown_ShouldThrowProperExecutionException() {
+  public void handle_WTEWithCasThrown_ShouldThrowExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
     put.withCondition(new PutIfNotExists());
@@ -342,13 +341,12 @@ public class InsertStatementHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> spy.handle(put))
-        .isInstanceOf(RetriableExecutionException.class)
+        .isInstanceOf(ExecutionException.class)
         .hasCause(toThrow);
   }
 
   @Test
-  public void
-      handle_PutWithConditionGivenAndWTEWithSimpleThrown_ShouldThrowProperExecutionException() {
+  public void handle_PutWithConditionGivenAndWTEWithSimpleThrown_ShouldThrowExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
     put.withCondition(new PutIfNotExists());
@@ -366,7 +364,7 @@ public class InsertStatementHandlerTest {
 
   @Test
   public void
-      handle_PutWithoutConditionGivenAndWTEWithSimpleThrown_ShouldThrowProperExecutionException() {
+      handle_PutWithoutConditionGivenAndWTEWithSimpleThrown_ShouldThrowExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
     spy = prepareSpiedInsertStatementHandler();
@@ -377,12 +375,12 @@ public class InsertStatementHandlerTest {
 
     // Act Assert
     assertThatThrownBy(() -> spy.handle(put))
-        .isInstanceOf(RetriableExecutionException.class)
+        .isInstanceOf(ExecutionException.class)
         .hasCause(toThrow);
   }
 
   @Test
-  public void handle_DriverExceptionThrown_ShouldThrowProperExecutionException() {
+  public void handle_DriverExceptionThrown_ShouldThrowExecutionException() {
     // Arrange
     put = preparePutWithClusteringKey();
     spy = prepareSpiedInsertStatementHandler();


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2827
- **Commit to backport:** e49e38c86c916a0260a0cadec9d5823eadf6eb44

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.14-pull-2827 &&
git cherry-pick --no-rerere-autoupdate -m1 e49e38c86c916a0260a0cadec9d5823eadf6eb44
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!