### PR TITLE
Backport to branch(3.16) : Use JReleaser to release artifacts in Maven Central

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -30,16 +30,28 @@ jobs:
           VERSION=$(./gradlew :core:properties -q | grep "version:" | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Upload SNAPSHOT versions for scalardb, scalardb-schema-loader, scalardb-data-loader-core, and scalardb-integration-test to Maven Snapshot Repository
+      - name: Prepare SNAPSHOT versions of artifacts in staging-deploy directories
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
-        run: |
-          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publish \
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
-          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+        run: ./gradlew publish
+
+      - name: Upload SNAPSHOT versions of artifacts to Maven Snapshot repository
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        env:
+          JRELEASER_NEXUS2_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
+        run: ./gradlew jreleaserDeploy
+
+      - name: Upload JReleaser outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release
+          path: |
+            build/jreleaser/trace.log
+            build/jreleaser/output.properties
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -43,6 +43,27 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Prepare artifacts in staging-deploy directories
+        run: ./gradlew publish
+
+      - name: Upload artifacts to Maven Central Repository
+        env:
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
+        run: ./gradlew jreleaserDeploy
+
+      - name: Upload JReleaser outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release
+          path: |
+            build/jreleaser/trace.log
+            build/jreleaser/output.properties
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -57,13 +78,3 @@ jobs:
         run: |
           docker push ghcr.io/scalar-labs/scalardb-schema-loader:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardb-data-loader-cli:${{ steps.version.outputs.version }}
-
-      - name: Upload scalardb, scalardb-schema-loader, scalardb-data-loader-core, and scalardb-integration-test to Maven Central Repository
-        run: |
-          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > ~/.gradle/secring.gpg
-          ./gradlew publish \
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="$(echo ~/.gradle/secring.gpg)" \
-          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,15 @@
-buildscript {
-    repositories {
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-    dependencies {
-        classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.13.0'
-    }
+plugins {
+    id "com.diffplug.spotless" version "6.13.0"
+    id "org.jreleaser" version "1.19.0"
 }
+
+ext {
+    projectGroup = 'com.scalar-labs'
+    projectVersion = '3.16.1-SNAPSHOT'
+}
+
+group = projectGroup
+version = projectVersion
 
 subprojects {
     apply plugin: 'java'
@@ -18,7 +20,7 @@ subprojects {
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'com.scalar.db.jdk-configuration'
 
-    project.version = '3.16.1-SNAPSHOT'
+    project.version = projectVersion
 
     ext {
         guiceVersion = '5.1.0'
@@ -35,7 +37,7 @@ subprojects {
         sqlserverDriverVersion = '12.8.1.jre8'
         sqliteDriverVersion = '3.50.1.0'
         yugabyteDriverVersion = '42.7.3-yb-4'
-        db2DriverVersion= '12.1.2.0'
+        db2DriverVersion = '12.1.2.0'
         mariadDbDriverVersion = '3.5.3'
         picocliVersion = '4.7.7'
         commonsTextVersion = '1.13.1'
@@ -66,7 +68,7 @@ subprojects {
         testLogging.showStandardStreams = true
     }
 
-    group = "com.scalar-labs"
+    group = projectGroup
 
     java {
         withJavadocJar()
@@ -92,3 +94,38 @@ subprojects {
     }
 }
 
+jreleaser {
+    gitRootSearch = true
+
+    signing {
+        active = 'ALWAYS'
+        armored = true
+    }
+
+    deploy {
+        maven {
+            def stagingRepositories = ['core/build/staging-deploy',
+                                       'integration-test/build/staging-deploy',
+                                       'schema-loader/build/staging-deploy',
+                                       'data-loader/core/build/staging-deploy']
+            mavenCentral {
+                sonatype {
+                    active = 'RELEASE'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    stagingRepositories.each { stagingRepository(it) }
+                }
+            }
+            nexus2 {
+                'snapshot-deploy' {
+                    active = 'SNAPSHOT'
+                    snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
+                    applyMavenCentralRules = true
+                    snapshotSupported = true
+                    closeRepository = true
+                    releaseRepository = true
+                    stagingRepositories.each { stagingRepository(it) }
+                }
+            }
+        }
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.github.spotbugs-base' version "${spotbugsPluginVersion}"
     id 'net.ltgt.errorprone' version "${errorpronePluginVersion}"
     id 'maven-publish'
-    id 'signing'
     id 'base'
 }
 
@@ -353,18 +352,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = project.properties['ossrhUsername'] ?: ""
-                password = project.properties['ossrhPassword'] ?: ""
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    required { project.gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
 }

--- a/data-loader/core/build.gradle
+++ b/data-loader/core/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version "${shadowPluginVersion}"
     id 'com.github.spotbugs' version "${spotbugsPluginVersion}"
     id 'maven-publish'
-    id 'signing'
     id 'base'
 }
 
@@ -89,18 +88,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = project.properties['ossrhUsername'] ?: ""
-                password = project.properties['ossrhPassword'] ?: ""
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    required { project.gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
 }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.github.spotbugs' version "${spotbugsPluginVersion}"
     id 'net.ltgt.errorprone' version "${errorpronePluginVersion}"
     id 'maven-publish'
-    id 'signing'
     id 'base'
 }
 
@@ -100,18 +99,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = project.properties['ossrhUsername'] ?: ""
-                password = project.properties['ossrhPassword'] ?: ""
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    required { project.gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
 }

--- a/schema-loader/build.gradle
+++ b/schema-loader/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version "${shadowPluginVersion}"
     id 'com.github.spotbugs' version "${spotbugsPluginVersion}"
     id 'maven-publish'
-    id 'signing'
     id 'base'
 }
 
@@ -135,18 +134,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = project.properties['ossrhUsername'] ?: ""
-                password = project.properties['ossrhPassword'] ?: ""
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    required { project.gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardb/pull/2849
- **Commit to backport:** 7e746c503069bef778aca63a49335189bd94b7a4

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.16-pull-2849 &&
git cherry-pick --no-rerere-autoupdate -m1 7e746c503069bef778aca63a49335189bd94b7a4
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!