### PR TITLE
Pass necessary secrets to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,11 @@ jobs:
     uses: ./.github/workflows/upload-artifacts.yaml
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
-      SIGNING_SECRET_KEY_RING: ${{ secrets.SIGNING_SECRET_KEY_RING }}
-      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      MAVEN_CENTRAL_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+      MAVEN_CENTRAL_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
+      MAVEN_CENTRAL_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
 
   create-release:
     needs: upload-artifacts

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -6,11 +6,15 @@ on:
     secrets:
       CR_PAT:
         required: true
-      SIGNING_SECRET_KEY_RING:
+      MAVEN_CENTRAL_USERNAME:
         required: true
-      SIGNING_KEY_ID:
+      MAVEN_CENTRAL_PASSWORD:
         required: true
-      SIGNING_PASSWORD:
+      MAVEN_CENTRAL_GPG_PASSPHRASE:
+        required: true
+      MAVEN_CENTRAL_GPG_PUBLIC_KEY:
+        required: true
+      MAVEN_CENTRAL_GPG_SECRET_KEY:
         required: true
 
 jobs:


### PR DESCRIPTION
## Description

In https://github.com/scalar-labs/scalardb/pull/2849, I forgot to pass the necessary secrets to the `upload-artifacts` workflow. This PR addresses the issue.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2849

## Changes made

- Updated the workflows to pass or receive the necessary secrets.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
