### PR TITLE
Increase heap size for jreleaserDeploy task

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -42,7 +42,7 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
-        run: ./gradlew jreleaserDeploy
+        run: ./gradlew jreleaserDeploy -Dorg.gradle.jvmargs="-Xmx4g"
 
       - name: Upload JReleaser outputs
         if: always()

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -53,7 +53,7 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
-        run: ./gradlew jreleaserDeploy
+        run: ./gradlew jreleaserDeploy -Dorg.gradle.jvmargs="-Xmx4g"
 
       - name: Upload JReleaser outputs
         if: always()


### PR DESCRIPTION
## Description

When publishing artifacts to Maven Central using the `jreleaserDeploy` task, we encountered an OOM error. To address this, this PR increases the heap size allocated to the `jreleaserDeploy` task.

## Related issues and/or PRs

N/A

## Changes made

- Increased the heap size for the `jreleaserDeploy` task.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
