### PR TITLE
Update Scheduled Vulnerability Check and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,13 +74,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "github-actions"
-    target-branch: "3.12"
-    groups:
-      actions on branch 3.12:
-        patterns:
-          - "*"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/scheduled-vuln-check.yaml
+++ b/.github/workflows/scheduled-vuln-check.yaml
@@ -16,15 +16,6 @@ jobs:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
 
-  call-vuln-check-for-v3_12:
-    uses: ./.github/workflows/vuln-check.yaml
-    with:
-      target-ref: v3.12
-      find-latest-release: true
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-
   call-vuln-check-for-v3_13:
     uses: ./.github/workflows/vuln-check.yaml
     with:


### PR DESCRIPTION
## Description

This PR removes `3.12` from the Scheduled Vulnerability Check and Dependabot configuration, as it has reached End of Maintenance Support.

## Related issues and/or PRs

N/A

## Changes made

- Removed `3.12` from the Scheduled Vulnerability Check and Dependabot configuration

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
