### PR TITLE
Fix Cassandra case insensitive issue

### DIFF
--- a/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
+++ b/core/src/main/java/com/scalar/db/storage/cassandra/CassandraAdmin.java
@@ -139,7 +139,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     String insertQuery =
         QueryBuilder.insertInto(
                 quoteIfNecessary(metadataKeyspace), quoteIfNecessary(NAMESPACES_TABLE))
-            .value(NAMESPACES_NAME_COL, quoteIfNecessary(keyspace))
+            .value(NAMESPACES_NAME_COL, keyspace)
             .toString();
     clusterManager.getSession().execute(insertQuery);
   }
@@ -180,7 +180,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     String deleteQuery =
         QueryBuilder.delete()
             .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(NAMESPACES_TABLE))
-            .where(QueryBuilder.eq(NAMESPACES_NAME_COL, quoteIfNecessary(keyspace)))
+            .where(QueryBuilder.eq(NAMESPACES_NAME_COL, keyspace))
             .toString();
     clusterManager.getSession().execute(deleteQuery);
   }
@@ -349,7 +349,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
       String query =
           QueryBuilder.select(NAMESPACES_NAME_COL)
               .from(quoteIfNecessary(metadataKeyspace), quoteIfNecessary(NAMESPACES_TABLE))
-              .where(QueryBuilder.eq(NAMESPACES_NAME_COL, quoteIfNecessary(namespace)))
+              .where(QueryBuilder.eq(NAMESPACES_NAME_COL, namespace))
               .toString();
       ResultSet resultSet = clusterManager.getSession().execute(query);
 
@@ -396,7 +396,7 @@ public class CassandraAdmin implements DistributedStorageAdmin {
     }
     try {
       String alterTableQuery =
-          SchemaBuilder.alterTable(namespace, table)
+          SchemaBuilder.alterTable(quoteIfNecessary(namespace), quoteIfNecessary(table))
               .addColumn(columnName)
               .type(toCassandraDataType(columnType))
               .getQueryString();

--- a/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
+++ b/core/src/test/java/com/scalar/db/storage/cassandra/CassandraAdminTest.java
@@ -229,7 +229,7 @@ public class CassandraAdminTest {
         QueryBuilder.insertInto(
                 quoteIfNecessary(METADATA_KEYSPACE),
                 quoteIfNecessary(CassandraAdmin.NAMESPACES_TABLE))
-            .value(CassandraAdmin.NAMESPACES_NAME_COL, quoteIfNecessary(keyspace))
+            .value(CassandraAdmin.NAMESPACES_NAME_COL, keyspace)
             .toString();
     verify(cassandraSession).execute(query);
   }
@@ -569,7 +569,7 @@ public class CassandraAdminTest {
             .from(
                 quoteIfNecessary(METADATA_KEYSPACE),
                 quoteIfNecessary(CassandraAdmin.NAMESPACES_TABLE))
-            .where(QueryBuilder.eq(CassandraAdmin.NAMESPACES_NAME_COL, quoteIfNecessary(keyspace)))
+            .where(QueryBuilder.eq(CassandraAdmin.NAMESPACES_NAME_COL, keyspace))
             .toString();
     verify(cassandraSession).execute(query);
   }

--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -36,13 +36,13 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
       LoggerFactory.getLogger(DistributedStorageAdminIntegrationTestBase.class);
 
   private static final String TEST_NAME = "storage_admin";
-  private static final String NAMESPACE1 = "int_test_" + TEST_NAME + "1";
-  private static final String NAMESPACE2 = "int_test_" + TEST_NAME + "2";
-  private static final String NAMESPACE3 = "int_test_" + TEST_NAME + "3";
-  private static final String TABLE1 = "test_table1";
-  private static final String TABLE2 = "test_table2";
-  private static final String TABLE3 = "test_table3";
-  private static final String TABLE4 = "test_table4";
+  private static final String NAMESPACE1 = "Int_test_" + TEST_NAME + "1";
+  private static final String NAMESPACE2 = "Int_test_" + TEST_NAME + "2";
+  private static final String NAMESPACE3 = "Int_test_" + TEST_NAME + "3";
+  private static final String TABLE1 = "Test_table1";
+  private static final String TABLE2 = "Test_table2";
+  private static final String TABLE3 = "Test_table3";
+  private static final String TABLE4 = "Test_table4";
   private static final String COL_NAME1 = "c1";
   private static final String COL_NAME2 = "c2";
   private static final String COL_NAME3 = "c3";


### PR DESCRIPTION
## Description

This PR fixes an issue where `CassandraAdmin` fails to alter a table due to case insensitivity in the table name.

The current implementation of `CassandraAdmin` does not handle case sensitivity correctly when altering a table, leading to a not found error. For example, if a table is created with the name `Test_table`, attempting to alter it with the name `test_table` will result in an error because the table name is not found.

The fix is to enclose the table name in `""` when altering the table, ensuring that the case is preserved. Also, this PR updated the integration tests to cover the case.

## Related issues and/or PRs

N/A

## Changes made

- Fixed to use `quoteIfNecessary` when altering a table in `CassandraAdmin`.
- Fixed to remove `quoteIfNecessary` where it is not necessary in `CassandraAdmin`.
- Updated the namespace and table names in the integration tests to cover the case sensitivity.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A