### PR TITLE
Fix to use getter to get object names

### DIFF
--- a/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
+++ b/integration-test/src/main/java/com/scalar/db/api/DistributedStorageAdminIntegrationTestBase.java
@@ -737,7 +737,8 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     // Act Assert
     assertThatThrownBy(
             () ->
-                admin.createIndex(namespace1, TABLE1, "non-existing_column", getCreationOptions()))
+                admin.createIndex(
+                    namespace1, getTable1(), "non-existing_column", getCreationOptions()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -906,7 +907,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> admin.dropIndex(namespace1, "non-existing-table", COL_NAME2))
+    assertThatThrownBy(() -> admin.dropIndex(namespace1, "non-existing-table", getColumnName2()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -915,7 +916,7 @@ public abstract class DistributedStorageAdminIntegrationTestBase {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> admin.dropIndex(namespace1, TABLE1, COL_NAME2))
+    assertThatThrownBy(() -> admin.dropIndex(namespace1, getTable1(), getColumnName2()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 


### PR DESCRIPTION
## Description

This PR fixes the test to use a getter to retrieve the object name. This fix addresses on omission from the following PR:

#2908 

## Related issues and/or PRs

#2908 

## Changes made

Fix to use getter to get `TABLE1` and `COL_NAME2` in `DistributedStorageAdminIntegrationTestBase`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A